### PR TITLE
layout: Force outside ::marker to establish a BFC

### DIFF
--- a/css/CSS2/lists/list-style-applies-to-016.html
+++ b/css/CSS2/lists/list-style-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style: square"></div>
+</div>

--- a/css/CSS2/lists/list-style-applies-to-017.html
+++ b/css/CSS2/lists/list-style-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style: square"></div>

--- a/css/CSS2/lists/list-style-image-applies-to-001.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-001.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-row-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-image-applies-to-002.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-002.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-header-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-image-applies-to-003.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-003.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-footer-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-image-applies-to-004.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-004.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-row'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-image-applies-to-005.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-005.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-column-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-image-applies-to-006.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-006.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-column'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-image-applies-to-007.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-007.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-cell'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-image-applies-to-008.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-008.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'inline'." />
         <style type="text/css">
             div

--- a/css/CSS2/lists/list-style-image-applies-to-009.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-009.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'block'." />
         <style type="text/css">
             span

--- a/css/CSS2/lists/list-style-image-applies-to-010.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-010.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'list-item'." />
         <style type="text/css">
             div

--- a/css/CSS2/lists/list-style-image-applies-to-012.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-012.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'inline-block'." />
         <style type="text/css">
             div

--- a/css/CSS2/lists/list-style-image-applies-to-013.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-013.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-image-applies-to-014.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-014.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'inline-table'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-image-applies-to-015.xht
+++ b/css/CSS2/lists/list-style-image-applies-to-015.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-caption'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-image-applies-to-016.html
+++ b/css/CSS2/lists/list-style-image-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-image">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-image-applies-to-ref-1.html">
+<meta name="assert" content="The 'list-style-image' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single blue square below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style-image: url('support/blue15x15.png')"></div>
+</div>

--- a/css/CSS2/lists/list-style-image-applies-to-017.html
+++ b/css/CSS2/lists/list-style-image-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-image">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-image-applies-to-ref-1.html">
+<meta name="assert" content="The 'list-style-image' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single blue square below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style-image: url('support/blue15x15.png')"></div>

--- a/css/CSS2/lists/list-style-image-applies-to-ref-1.html
+++ b/css/CSS2/lists/list-style-image-applies-to-ref-1.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: list-item;
+  list-style-image: url('support/blue15x15.png');
+  margin-left: 96px;
+}
+</style>
+
+<p>Test passes if there is a single blue square below.</p>
+<div>&nbsp;</div>

--- a/css/CSS2/lists/list-style-image-applies-to-ref-2.html
+++ b/css/CSS2/lists/list-style-image-applies-to-ref-2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: list-item;
+  margin-left: 96px;
+}
+</style>
+
+<p>Test passes if there is a single round dot below.</p>
+<div>&nbsp;</div>

--- a/css/CSS2/lists/list-style-position-applies-to-001.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-001.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-row-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-position-applies-to-002.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-002.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-header-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-position-applies-to-003.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-003.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-footer-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-position-applies-to-004.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-004.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-row'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-position-applies-to-005.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-005.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-column-group'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-position-applies-to-006.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-006.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-column'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-position-applies-to-007.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-007.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-cell'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-position-applies-to-008.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-008.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-3.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'inline'." />
         <style type="text/css">
             div

--- a/css/CSS2/lists/list-style-position-applies-to-009.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-009.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-3.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'block'." />
         <style type="text/css">
             span

--- a/css/CSS2/lists/list-style-position-applies-to-010.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-010.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-3.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'list-item'." />
         <style type="text/css">
             div

--- a/css/CSS2/lists/list-style-position-applies-to-012.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-012.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'inline-block'." />
         <style type="text/css">
             div

--- a/css/CSS2/lists/list-style-position-applies-to-013.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-013.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-position-applies-to-014.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-014.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'inline-table'." />
         <style type="text/css">
             #table

--- a/css/CSS2/lists/list-style-position-applies-to-015.xht
+++ b/css/CSS2/lists/list-style-position-applies-to-015.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-4.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-caption'." />
         <style type="text/css">
             #test

--- a/css/CSS2/lists/list-style-position-applies-to-016.html
+++ b/css/CSS2/lists/list-style-position-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-position">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-position-applies-to-ref-3.html">
+<meta name="assert" content="The 'list-style-position' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style-position: inside; background: orange"></div>
+</div>

--- a/css/CSS2/lists/list-style-position-applies-to-017.html
+++ b/css/CSS2/lists/list-style-position-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-position">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-position-applies-to-ref-5.html">
+<meta name="assert" content="The 'list-style-position' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style-position: inside; background: orange"></div>

--- a/css/CSS2/lists/list-style-position-applies-to-ref-1.html
+++ b/css/CSS2/lists/list-style-position-applies-to-ref-1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: inline-block;
+}
+span {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div><span></span></div>

--- a/css/CSS2/lists/list-style-position-applies-to-ref-2.html
+++ b/css/CSS2/lists/list-style-position-applies-to-ref-2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: list-item;
+  margin-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot on a white background below.</p>
+<div></div>

--- a/css/CSS2/lists/list-style-position-applies-to-ref-3.html
+++ b/css/CSS2/lists/list-style-position-applies-to-ref-3.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div></div>

--- a/css/CSS2/lists/list-style-position-applies-to-ref-4.html
+++ b/css/CSS2/lists/list-style-position-applies-to-ref-4.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 1in;
+  width: 5em;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div></div>

--- a/css/CSS2/lists/list-style-position-applies-to-ref-5.html
+++ b/css/CSS2/lists/list-style-position-applies-to-ref-5.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  padding-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div></div>

--- a/css/CSS2/lists/list-style-type-applies-to-016.html
+++ b/css/CSS2/lists/list-style-type-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style-type' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style-type: square"></div>
+</div>

--- a/css/CSS2/lists/list-style-type-applies-to-017.html
+++ b/css/CSS2/lists/list-style-type-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style-type' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style-type: square"></div>


### PR DESCRIPTION
Even though we were continuing the parent BFC, we weren't updating the SequentialLayoutState to have the correct containing block info. That caused problem in the presence of floats.

This patch establishes an independent BFC, which avoids the problem. This seems reasonable since outside markers are out-of-flow-ish, and it matches Firefox. Blink implements them as inline-blocks, so they should also establish a BFC.

Testing: Adding new tests. Some still fail because of a different issue. Also, adding an expectation for several existing tests that were missing it.
Fixes: #<!-- nolink -->37222

Reviewed in servo/servo#37252