### PR TITLE
Don't suffix Safari GH Actions artifacts when there's a single chunk

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -145,4 +145,4 @@ jobs:
     needs: safari-results
     uses: ./.github/workflows/wpt_fyi_notify.yml
     with:
-      artifact-name: "${{ inputs.artifact-name }}-*"
+      artifact-name: "${{ inputs.artifact-name }}*"

--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Publish results
         uses: actions/upload-artifact@v4.1.0
         with:
-          name: ${{ inputs.artifact-name }}-${{ matrix.current-chunk }}
+          name: ${{ inputs.artifact-name }}${{ matrix.total-chunks > 1 && join(['-', matrix.current-chunk]) || ''}}
           path: |
             ${{ runner.temp }}/wpt_report_*.json
             ${{ runner.temp }}/wpt_screenshot_*.txt
@@ -127,7 +127,7 @@ jobs:
         if: inputs.safaridriver-diagnose
         uses: actions/upload-artifact@v4.1.0
         with:
-          name: ${{ inputs.artifact-name }}-safaridriver-logs-${{ matrix.current-chunk }}
+          name: ${{ inputs.artifact-name }}-safaridriver-logs${{ matrix.total-chunks > 1 && join(['-', matrix.current-chunk]) || ''}}
           path: ~/Library/Logs/com.apple.WebDriver/
           if-no-files-found: warn
       - name: Disable safaridriver diagnostics

--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Publish results
         uses: actions/upload-artifact@v4.1.0
         with:
-          name: ${{ inputs.artifact-name }}${{ matrix.total-chunks > 1 && join(['-', matrix.current-chunk]) || ''}}
+          name: ${{ inputs.artifact-name }}${{ matrix.total-chunks > 1 && format('-{0}', matrix.current-chunk) || ''}}
           path: |
             ${{ runner.temp }}/wpt_report_*.json
             ${{ runner.temp }}/wpt_screenshot_*.txt
@@ -127,7 +127,7 @@ jobs:
         if: inputs.safaridriver-diagnose
         uses: actions/upload-artifact@v4.1.0
         with:
-          name: ${{ inputs.artifact-name }}-safaridriver-logs${{ matrix.total-chunks > 1 && join(['-', matrix.current-chunk]) || ''}}
+          name: ${{ inputs.artifact-name }}-safaridriver-logs${{ matrix.total-chunks > 1 && format('-{0}', matrix.current-chunk) || ''}}
           path: ~/Library/Logs/com.apple.WebDriver/
           if-no-files-found: warn
       - name: Disable safaridriver diagnostics

--- a/.github/workflows/wpt_fyi_notify.yml
+++ b/.github/workflows/wpt_fyi_notify.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "wpt.fyi"
+        if: ${{ !cancelled() }}
         uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://wpt.fyi/api/checks/github-actions/'
@@ -26,6 +27,7 @@ jobs:
             ) }}
 
       - name: "staging.wpt.fyi"
+        if: ${{ !cancelled() }}
         uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://staging.wpt.fyi/api/checks/github-actions/'


### PR DESCRIPTION
This allows us to match the regexp that wpt.fyi uses to assign the
pr_base/pr_head labels.
