### PR TITLE
[css-lists] Test for interference of details elements with list numbering

### DIFF
--- a/css/css-lists/ol-reversed-w-details-ref.html
+++ b/css/css-lists/ol-reversed-w-details-ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference for reversed ol containing details elements</title>
+<p>List item numbers should match the numbers in the list items.</p>
+<ol>
+ <li value="3"><details><summary>3</summary>three</details></li>
+ <li value="2"><details><summary>2</summary>two</details></li>
+ <li value="1"><details><summary>1</summary>one</details></li>
+</ol>

--- a/css/css-lists/ol-reversed-w-details.html
+++ b/css/css-lists/ol-reversed-w-details.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Reversed ol containing details elements</title>
+<link rel="help" href="https://html.spec.whatwg.org/#attr-ol-reversed">
+<link rel="help" href="https://html.spec.whatwg.org/#ordinal-value">
+<link rel="match" href="ol-reversed-w-details-ref.html">
+<meta name="assert" content="List numbering should not change when list items contain details elements.">
+<p>List item numbers should match the numbers in the list items.</p>
+<ol reversed>
+ <li><details><summary>3</summary>three</details></li>
+ <li><details><summary>2</summary>two</details></li>
+ <li><details><summary>1</summary>one</details></li>
+</ol>

--- a/css/css-lists/ol-w-details-ref.html
+++ b/css/css-lists/ol-w-details-ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference for reversed ol containing details elements</title>
+<p>List item numbers should match the numbers in the list items.</p>
+<ol>
+ <li value="1"><details><summary>1</summary>one</details></li>
+ <li value="2"><details><summary>2</summary>two</details></li>
+ <li value="3"><details><summary>3</summary>three</details></li>
+</ol>

--- a/css/css-lists/ol-w-details.html
+++ b/css/css-lists/ol-w-details.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>ol containing details elements</title>
+<link rel="help" href="https://html.spec.whatwg.org/#ordinal-value">
+<link rel="match" href="ol-w-details-ref.html">
+<meta name="assert" content="List numbering should not change when list items contain details elements.">
+<p>List item numbers should match the numbers in the list items.</p>
+<ol>
+ <li><details><summary>1</summary>one</details></li>
+ <li><details><summary>2</summary>two</details></li>
+ <li><details><summary>3</summary>three</details></li>
+</ol>


### PR DESCRIPTION
In chrome (and possibly safari) the `details` element can interfere with list item counting in reverse ordered lists.
Also added non reversed list to catch any regressions.