### PR TITLE
Integrity-Policy: Add about:blank and lack of reporting observer tests

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -289,6 +289,7 @@ SET TIMEOUT: soft-navigation-heuristics/smoke/tentative/task-attribution.html
 SET TIMEOUT: shadow-dom/Document-prototype-currentScript.html
 SET TIMEOUT: shadow-dom/scroll-to-the-fragment-in-shadow-tree.html
 SET TIMEOUT: shadow-dom/slotchange-event.html
+SET TIMEOUT: subresource-integrity/integrity-policy/script.https.html
 SET TIMEOUT: trusted-types/support/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.js
 SET TIMEOUT: trusted-types/support/DOMWindowTimers-setTimeout-setInterval.js
 SET TIMEOUT: trusted-types/support/should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker-multiple-violations.js

--- a/subresource-integrity/integrity-policy/script.https.html
+++ b/subresource-integrity/integrity-policy/script.https.html
@@ -38,7 +38,7 @@
       cross_origin: true,
       integrity: "",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
@@ -48,7 +48,7 @@
       cross_origin: true,
       integrity: "foobar-AAAAAAAAAAAAAAAAAAAa",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
@@ -58,7 +58,7 @@
       cross_origin: true,
       integrity: "",
       policy_violation: true,
-      block: false,
+      add_blocking_header: false,
       endpoints: true,
       expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true},
     },
@@ -68,7 +68,7 @@
       cross_origin: false,
       integrity: "sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
@@ -78,7 +78,7 @@
       cross_origin: false,
       integrity: "sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: false,
       expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
@@ -88,7 +88,7 @@
       cross_origin: true,
       integrity: "sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: "", ran: true},
     },
@@ -98,7 +98,7 @@
       cross_origin: true,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: "", ran: true},
     },
@@ -108,7 +108,7 @@
       cross_origin: false,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: "", ran: true},
     },
@@ -118,7 +118,7 @@
       cross_origin: true,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: "", ran: true},
     },
@@ -128,7 +128,7 @@
       cross_origin: false,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
       expected: {blocked: "", ran: true},
     },
@@ -138,7 +138,7 @@
       cross_origin: true,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: false,
       expected: {blocked: "", ran: false},
     },
@@ -148,7 +148,7 @@
       cross_origin: false,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: false,
       expected: {blocked: "", ran: false},
     }
@@ -171,7 +171,7 @@
       const reporting_uuid_3 = token();
       const reporting_endpoint = `${ORIGIN}/reporting/resources/report.py`;
       let header = "";
-      if (test_case.block) {
+      if (test_case.add_blocking_header) {
         header +=
           `header(Integrity-Policy,blocked-destinations=\\(script\\)\\, endpoints=\\(integrity-endpoint-1 integrity-endpoint-2\\))`;
       }
@@ -245,14 +245,14 @@
         assert_equals(result.body.blockedURL, test_case.expected.blocked);
         assert_true(result.body.documentURL.endsWith(iframe_url));
         assert_equals(result.body.destination, "script");
-        assert_equals(result.body.reportOnly, !test_case.block);
+        assert_equals(result.body.reportOnly, !test_case.add_blocking_header);
       } else {
         assert_equals(result.body, null, "No policy violation report should be observed");
       }
       if (test_case.endpoints && test_case.policy_violation) {
-        if (test_case.block) {
-          await check_report(reporting_endpoint, reporting_uuid_1, iframe_url, test_case.url, !test_case.block);
-          await check_report(reporting_endpoint, reporting_uuid_2, iframe_url, test_case.url, !test_case.block);
+        if (test_case.add_blocking_header) {
+          await check_report(reporting_endpoint, reporting_uuid_1, iframe_url, test_case.url, !test_case.add_blocking_header);
+          await check_report(reporting_endpoint, reporting_uuid_2, iframe_url, test_case.url, !test_case.add_blocking_header);
         }
         await check_report(reporting_endpoint, reporting_uuid_3, iframe_url, test_case.url, true);
       }

--- a/subresource-integrity/integrity-policy/script.https.html
+++ b/subresource-integrity/integrity-policy/script.https.html
@@ -40,7 +40,7 @@
       policy_violation: true,
       block: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that a script with unknown integrity algorithm did not run",
@@ -50,7 +50,7 @@
       policy_violation: true,
       block: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that a script without integrity algorithm runs and gets reported in report-only mode",
@@ -60,7 +60,7 @@
       policy_violation: true,
       block: false,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true, script_loaded: true },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true},
     },
     {
       description: "Ensure that a no-cors script gets blocked",
@@ -70,7 +70,7 @@
       policy_violation: true,
       block: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that ReportingObserver gets called without endpoints",
@@ -80,7 +80,7 @@
       policy_violation: true,
       block: true,
       endpoints: false,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that a script with integrity runs",
@@ -90,7 +90,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true, script_loaded: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a data URI script with no integrity runs",
@@ -100,7 +100,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true, script_loaded: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a no-CORS data URI script with no integrity runs",
@@ -110,7 +110,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true, script_loaded: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a blob URL script with no integrity runs",
@@ -120,7 +120,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true, script_loaded: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a no-CORS blob URL script with no integrity runs",
@@ -130,7 +130,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true, script_loaded: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that an about:blank URL script with no integrity runs",
@@ -140,7 +140,7 @@
       policy_violation: false,
       block: false,
       endpoints: false,
-      expected: {blocked: "", ran: false, script_loaded: false },
+      expected: {blocked: "", ran: false},
     },
     {
       description: "Ensure that a no-CORS about:blank URL script with no integrity runs",
@@ -150,7 +150,7 @@
       policy_violation: false,
       block: false,
       endpoints: false,
-      expected: {blocked: "", ran: false, script_loaded: true },
+      expected: {blocked: "", ran: false},
     }
   ];
   test_cases.map(test_case => {
@@ -207,7 +207,7 @@
         });
 
         // Load the script
-        const script_loaded = await new Promise(resolve => {
+        await new Promise(resolve => {
           const script = document.createElement('script');
           if (test_case.cross_origin) {
             script.crossOrigin="anonymous";
@@ -215,8 +215,8 @@
           if (test_case.integrity) {
             script.integrity = test_case.integrity;
           }
-          script.onload = () => resolve(true);
-          script.onerror = () => resolve(false);
+          script.onload = resolve;
+          script.onerror = resolve;
           script.src = test_case.url;
           document.body.appendChild(script);
         });
@@ -231,11 +231,9 @@
             report_body = race_result;
           }
         }
-
-        return { body: report_body, ran: window.ran, script_loaded: script_loaded };
+        return { body: report_body, ran: window.ran };
       }, [test_case]);
       assert_equals(result.ran, test_case.expected.ran, "Ran");
-      assert_equals(result.script_loaded, test_case.expected.script_loaded, "Script loaded");
       if (test_case.policy_violation) {
         assert_not_equals(result.body, null, "Expected a policy violation report");
         assert_equals(result.body.blockedURL, test_case.expected.blocked);

--- a/subresource-integrity/integrity-policy/script.https.html
+++ b/subresource-integrity/integrity-policy/script.https.html
@@ -40,7 +40,7 @@
       policy_violation: true,
       block: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
     },
     {
       description: "Ensure that a script with unknown integrity algorithm did not run",
@@ -50,7 +50,7 @@
       policy_violation: true,
       block: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
     },
     {
       description: "Ensure that a script without integrity algorithm runs and gets reported in report-only mode",
@@ -60,7 +60,7 @@
       policy_violation: true,
       block: false,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true, script_loaded: true },
     },
     {
       description: "Ensure that a no-cors script gets blocked",
@@ -70,7 +70,7 @@
       policy_violation: true,
       block: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
     },
     {
       description: "Ensure that ReportingObserver gets called without endpoints",
@@ -80,7 +80,7 @@
       policy_violation: true,
       block: true,
       endpoints: false,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false, script_loaded: false },
     },
     {
       description: "Ensure that a script with integrity runs",
@@ -90,7 +90,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true, script_loaded: true },
     },
     {
       description: "Ensure that a data URI script with no integrity runs",
@@ -100,7 +100,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true, script_loaded: true },
     },
     {
       description: "Ensure that a no-CORS data URI script with no integrity runs",
@@ -110,7 +110,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true, script_loaded: true },
     },
     {
       description: "Ensure that a blob URL script with no integrity runs",
@@ -120,7 +120,7 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true, script_loaded: true },
     },
     {
       description: "Ensure that a no-CORS blob URL script with no integrity runs",
@@ -130,7 +130,27 @@
       policy_violation: false,
       block: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true, script_loaded: true },
+    },
+    {
+      description: "Ensure that an about:blank URL script with no integrity runs",
+      url: "about:blank",
+      cross_origin: true,
+      integrity: "",
+      policy_violation: false,
+      block: false,
+      endpoints: false,
+      expected: {blocked: "", ran: false, script_loaded: false },
+    },
+    {
+      description: "Ensure that a no-CORS about:blank URL script with no integrity runs",
+      url: "about:blank",
+      cross_origin: false,
+      integrity: "",
+      policy_violation: false,
+      block: false,
+      endpoints: false,
+      expected: {blocked: "", ran: false, script_loaded: true },
     }
   ];
   test_cases.map(test_case => {
@@ -173,22 +193,21 @@
       const ctx = new RemoteContext(iframe_uuid);
       const result = await ctx.execute_script(async (test_case) => {
         window.ran = false;
-        let report_observed_promise;
-        if (test_case.policy_violation) {
-           report_observed_promise = new Promise(r => {
-            (new ReportingObserver((reports, observer) => {
-              reports.forEach(report => {
-                if (report.body.blockedURL.endsWith(test_case.url)) {
-                  r(report.body);
-                  observer.disconnect();
-                }
-              });
-            })).observe('integrity-violation');
-          });
-        }
+
+        // Always set up report observer to catch any unexpected reports
+        const report_observed_promise = new Promise(r => {
+          (new ReportingObserver((reports, observer) => {
+            reports.forEach(report => {
+              if (report.body.blockedURL.endsWith(test_case.url)) {
+                r(report.body);
+                observer.disconnect();
+              }
+            });
+          })).observe('integrity-violation');
+        });
 
         // Load the script
-        await new Promise(resolve => {
+        const script_loaded = await new Promise(resolve => {
           const script = document.createElement('script');
           if (test_case.cross_origin) {
             script.crossOrigin="anonymous";
@@ -196,20 +215,35 @@
           if (test_case.integrity) {
             script.integrity = test_case.integrity;
           }
-          script.onload = resolve;
-          script.onerror = resolve;
+          script.onload = () => resolve(true);
+          script.onerror = () => resolve(false);
           script.src = test_case.url;
           document.body.appendChild(script);
         });
-        const report_body = await report_observed_promise;
-        return { body: report_body, ran: window.ran };
+
+        let report_body = null;
+        if (test_case.policy_violation) {
+          report_body = await report_observed_promise;
+        } else {
+          const timeout_promise = new Promise(r => setTimeout(() => r('timeout'), 100));
+          const race_result = await Promise.race([report_observed_promise, timeout_promise]);
+          if (race_result !== 'timeout') {
+            report_body = race_result;
+          }
+        }
+
+        return { body: report_body, ran: window.ran, script_loaded: script_loaded };
       }, [test_case]);
-      assert_equals(result.ran, test_case.expected.ran);
+      assert_equals(result.ran, test_case.expected.ran, "Ran");
+      assert_equals(result.script_loaded, test_case.expected.script_loaded, "Script loaded");
       if (test_case.policy_violation) {
+        assert_not_equals(result.body, null, "Expected a policy violation report");
         assert_equals(result.body.blockedURL, test_case.expected.blocked);
         assert_true(result.body.documentURL.endsWith(iframe_url));
         assert_equals(result.body.destination, "script");
         assert_equals(result.body.reportOnly, !test_case.block);
+      } else {
+        assert_equals(result.body, null, "No policy violation report should be observed");
       }
       if (test_case.endpoints && test_case.policy_violation) {
         if (test_case.block) {

--- a/subresource-integrity/integrity-policy/script.https.html
+++ b/subresource-integrity/integrity-policy/script.https.html
@@ -138,7 +138,7 @@
       cross_origin: true,
       integrity: "",
       policy_violation: false,
-      block: false,
+      block: true,
       endpoints: false,
       expected: {blocked: "", ran: false},
     },
@@ -148,7 +148,7 @@
       cross_origin: false,
       integrity: "",
       policy_violation: false,
-      block: false,
+      block: true,
       endpoints: false,
       expected: {blocked: "", ran: false},
     }
@@ -198,7 +198,13 @@
         const report_observed_promise = new Promise(r => {
           (new ReportingObserver((reports, observer) => {
             reports.forEach(report => {
-              if (report.body.blockedURL.endsWith(test_case.url)) {
+              // Match the tested URL against the stripped one:
+              // https://www.w3.org/TR/reporting-1/#strip-url-for-use-in-reports
+              // 1. If url’s scheme is not an HTTP(S) scheme, then return url’s scheme.
+              const test_url = test_case.url.startsWith("http") ?
+                test_case.url :
+                test_case.url.split(":")[0];
+              if (report.body.blockedURL.endsWith(test_url)) {
                 r(report.body);
                 observer.disconnect();
               }


### PR DESCRIPTION
Following [1], we've added about: URLs to the protocols that should be
exempt from the Integrity-Policy checks.

This aligns the test to cover that change.

[1] https://github.com/w3c/webappsec-subresource-integrity/pull/137#discussion_r2126331909