### PR TITLE
Integrity-Policy: test violation report body type

### DIFF
--- a/subresource-integrity/integrity-policy/script.https.html
+++ b/subresource-integrity/integrity-policy/script.https.html
@@ -221,6 +221,6 @@
     }, test_case.description);
   });
   test(() => {
-    assert_true(!!window.IntegrityViolationReportBody); 
+    assert_true(!!window.IntegrityViolationReportBody);
   }, "ViolationReport type");
 </script>

--- a/subresource-integrity/integrity-policy/script.https.html
+++ b/subresource-integrity/integrity-policy/script.https.html
@@ -220,4 +220,7 @@
       }
     }, test_case.description);
   });
+  test(() => {
+    assert_true(!!window.IntegrityViolationReportBody); 
+  }, "ViolationReport type");
 </script>


### PR DESCRIPTION
Following https://github.com/w3c/webappsec-subresource-integrity/pull/141/ it seems like we're missing a test for the report body type, resulting in slight divergence of implementations.