### PR TITLE
layout: Floor free space by 0 in solve_inline_margins_avoiding_floats()

### DIFF
--- a/css/CSS2/floats/crashtests/huge-width-after-float.html
+++ b/css/CSS2/floats/crashtests/huge-width-after-float.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/37312">
+
+<div style="float: left"></div>
+<div style="width: 10000000000px; overflow: scroll"></div>


### PR DESCRIPTION
`PlacementAmongFloats` should guarantee that the inline size of the placement rect is at least as big as the inline size of the box, resulting in a non-negative free space.

However, that may fail when dealing with huge sizes that need to be saturated to MAX_AU, so this floors the free space by zero.

Testing: New crashtest
Fixes: #<!-- nolink -->37312

Reviewed in servo/servo#37362