### PR TITLE
Update handle_network_event to use BrowsingContextActor for HttpRequest

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -20,17 +20,14 @@ def do_delayed_imports():
         def __init__(self, session):
             self.session = session
 
-        @webdriver.client.command
         def get_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
             return self.session.send_session_command("POST", "servo/prefs/get", body)
 
-        @webdriver.client.command
         def set_prefs(self, prefs):
             body = {"prefs": prefs}
             return self.session.send_session_command("POST", "servo/prefs/set", body)
 
-        @webdriver.client.command
         def reset_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
             return self.session.send_session_command("POST", "servo/prefs/reset", body)


### PR DESCRIPTION

- Add browsing_context_actor_name parameter to handle_network_event
- Replace NetworkEventMsg in HttpRequest case with BrowsingContextActor::resource_available
- Update DevTools caller in lib.rs to pass browsing_context_actor_name

Testing: 
Fixes: https://github.com/servo/servo/issues/33556#issuecomment-2756544430

Reviewed in servo/servo#37263