### PR TITLE
Fix Azure Pipelines, re-add pip_install.yml

### DIFF
--- a/tools/ci/azure/pip_install.yml
+++ b/tools/ci/azure/pip_install.yml
@@ -1,0 +1,6 @@
+parameters:
+  packages: ''
+
+steps:
+- script: pip --disable-pip-version-check install --upgrade ${{ parameters.packages }}
+  displayName: 'Install Python packages'


### PR DESCRIPTION
This was incorrectly removed in c86c9fd558 (https://github.com/web-platform-tests/wpt/pull/53030), because it still is referenced by `tools/ci/azure/tox_pytest.yml`. This is thus a partial revert of that commit.

It is, notably, the only template which is only used indirectly from another template.

Upsettingly, https://github.com/web-platform-tests/wpt/pull/53030 didn't show any failed checks — it simply didn't show any Azure Pipelines checks at all.