### PR TITLE
Fix rare flakiness in `apng/animated-png-timeout.html`

### DIFF
--- a/apng/animated-png-timeout.html
+++ b/apng/animated-png-timeout.html
@@ -1,7 +1,6 @@
 <html class="reftest-wait">
 <title>APNG: Second frame displays quickly, replacing red with green.</title>
 <link rel="match" href="animated-png-timeout-ref.html"/>
-<img src=../images/apng.png onload="loaded()"/>
 <script>
   function loaded() {
     setTimeout(function() {
@@ -9,3 +8,4 @@
     }, 1000);
   }
 </script>
+<img src=../images/apng.png onload="loaded()"/>


### PR DESCRIPTION
In very slow builds (e.g., [debug Chromium][0]), it's possible for the APNG to load before its `loaded()` is defined:

```
[0601/164957.883566:INFO:CONSOLE:4] "Uncaught ReferenceError: loaded is not defined", source: http://web-platform.test:8001/apng/animated-png-timeout.html (4)
```

[0]: https://ci.chromium.org/ui/test/chromium/ninja%3A%2F%2F%3Aheadless_shell_wpt%2Fexternal%2Fwpt%2Fapng%2Fanimated-png-timeout.html?q=V%3Abuilder%3DLinux%2520Tests%2520%28dbg%29%281%29+V%3Aos%3DUbuntu-22.04+V%3Atest_suite%3Dheadless_shell_wpt_tests