### PR TITLE
layout: Properly handle intrinsic min/max block sizes on replaced element

### DIFF
--- a/css/css-sizing/aspect-ratio/replaced-element-047.tentative.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-047.tentative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12333">
+<link rel="help" href="https://github.com/servo/servo/issues/37433">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+
+<style>
+.red {
+  position: absolute;
+  z-index: -1;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+canvas {
+  display: block;
+  width: max-content;
+  height: 0px;
+  min-height: max-content;
+  aspect-ratio: 1;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="red"></div>
+<canvas width="100" height="50"></canvas>

--- a/css/css-sizing/aspect-ratio/replaced-element-048.tentative.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-048.tentative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12333">
+<link rel="help" href="https://github.com/servo/servo/issues/37433">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+
+<style>
+.red {
+  position: absolute;
+  z-index: -1;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+canvas {
+  display: block;
+  width: max-content;
+  height: 500px;
+  max-height: max-content;
+  aspect-ratio: 1;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="red"></div>
+<canvas width="100" height="50"></canvas>


### PR DESCRIPTION
This change aligns Servo with both Blink and WebKit in common cases.

When the `aspect-ratio` property is set to a different value than the natural ratio, then Blink and WebKit disagree, we match Blink.

Gecko doesn't support intrinsic min/max block sizes at all.

Note this patch doesn't fix the intrinsic contributions, they will need to be addressed in a follow-up patch.

Testing: Covered by WPT
Fixes: #<!-- nolink -->37433

Reviewed in servo/servo#37457