### PR TITLE
Fix Typos in Comments in serve.py and wave.py

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -958,7 +958,7 @@ def make_hosts_file(config, host):
 
     # Windows interpets the IP address 0.0.0.0 as non-existent, making it an
     # appropriate alias for non-existent hosts. However, UNIX-like systems
-    # interpret the same address to mean any IP address, which is inappropraite
+    # interpret the same address to mean any IP address, which is inappropriate
     # for this context. These systems do not reserve any value for this
     # purpose, so the inavailability of the domains must be taken for granted.
     #

--- a/tools/serve/wave.py
+++ b/tools/serve/wave.py
@@ -47,7 +47,7 @@ def get_route_builder_func(report):
 
         wave_handler = WaveHandler(wave_server)
         builder.add_handler("*", web_root + "*", wave_handler)
-        # serving wave specifc testharnessreport.js
+        # serving wave specific testharnessreport.js
         file_path = os.path.join(wpt.localpaths.repo_root, "tools/wave/resources/testharnessreport.js")
         builder.add_static(
             file_path,


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in comments within the following files:
- tools/serve/serve.py: Fixed the spelling of "inappropraite" to "inappropriate".
- tools/serve/wave.py: Fixed the spelling of "secifc" to "specific".
