### PR TITLE
Fix skipping CSP checks for styles when cloning nodes

### DIFF
--- a/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html
+++ b/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html
@@ -81,6 +81,9 @@
               assert_equals(clonedOps.style.background, "")
           });
           test(function() {
+              assert_equals(clonedOps.style.color, "red")
+          });
+          test(function() {
               assert_equals(violetOps.style.background.match(/rgb\(238, 130, 238\)/)[0], "rgb(238, 130, 238)")
           });
           test(function() {


### PR DESCRIPTION
Cloned nodes were re-parsing already-parsed style attributes. As such, they were also checking CSP, which shouldn't happen as the original node already was checked for it.

Testing: The existing WPT test now mostly passes. It had two cases which were passing in no browsers.
Fixes: Part of #<!-- nolink -->4577

Reviewed in servo/servo#37465