### PR TITLE
docs: recommend alternatives to timeouts and update reviewer checklist

### DIFF
--- a/docs/reviewing-tests/checklist.md
+++ b/docs/reviewing-tests/checklist.md
@@ -116,8 +116,11 @@ running the rest of the tests in the file if it isn't.
 <label><input type="checkbox">
 The test avoids patterns that make it less likely to be stable.
 In particular, tests should avoid setting internal timeouts, since the
-time taken to run it may vary on different devices; events should be used
-instead (if at all possible).
+time taken to run it may vary on different devices. Instead, tests should prefer
+event-based approaches (e.g., waiting for specific events) or using two
+`requestAnimationFrame` calls for rendering-related timing. Timeouts should
+only be used as a last resort (e.g., with `step_timeout()`), and only when
+event-based alternatives aren't feasible.
 </label>
 
 <label><input type="checkbox">

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -554,8 +554,9 @@ when there's a specific condition that needs to be met for the test to
 proceed. [`Test.step_timeout()`](#Test.step_timeout) is preferred in other cases.
 
 Note that timeouts generally need to be a few seconds long in order to
-produce stable results in all test environments.
+produce stable results in all test environments. However, the use of timeouts should be avoided whenever possible in favor of event-driven approaches. Prefer to wait for an event (e.g., `load`, `DOMContentLoaded`, or custom events) to indicate readiness, or use two `requestAnimationFrame` calls to ensure rendering steps have completed. These alternatives improve reliability and consistency across different environments.
 
+In some cases, such as reftests that compare frames after a specific animation duration (e.g., APNG tests), use of `step_timeout()` may be acceptable. When doing so, consider documenting the reason, and ensure the timeout is whitelisted if required.
 For [single page tests](#single-page-tests),
 [step_timeout](#step_timeout) is also available as a global function.
 


### PR DESCRIPTION
### Summary

This PR improves the documentation around usage of timeouts in WPT tests. It provides recommended alternatives to using `setTimeout` and updates the reviewer checklist to align with these practices.

### Changes Made

1. **`testharness-api.md`**:
   - Expanded the section under **"Timers in Tests"** to:
     - Emphasize avoiding timeouts.
     - Recommend using event-based approaches.
     - Suggest `requestAnimationFrame` (ideally two frames) for rendering-related delays.
     - Clarify when `step_timeout()` is acceptable, such as in APNG or reftest cases.
     
2. **`checklist.md`**:
   - Updated the **"Script Tests Only"** checklist item:
     - Strengthened guidance against internal timeouts.
     - Recommends event-based testing and `requestAnimationFrame` as better alternatives.
     - Clarifies that timeouts (like `step_timeout`) should only be used when necessary.

### Why

Timeouts in tests are a common source of flakiness and instability. This update addresses [Issue #20715]
 by helping test authors and reviewers adopt more stable and reliable testing patterns.

Let me know if you’d like more clarification or examples added. Thanks!
