### PR TITLE
Fix Typo in Comments for gitignore and serve Tools

### DIFF
--- a/tools/gitignore/gitignore.py
+++ b/tools/gitignore/gitignore.py
@@ -169,7 +169,7 @@ class PathFilter:
         if invert:
             # For exclude rules, we attach the rules to all preceeding patterns, so
             # that we can match patterns out of order and check if they were later
-            # overriden by an exclude rule
+            # overridden by an exclude rule
             assert not literal
             rule = cast(Tuple[bool, Pattern[bytes]], rule)
             if not dir_only:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -956,7 +956,7 @@ def make_hosts_file(config, host):
     ):
         rv.append("%s\t%s" % (host, domain))
 
-    # Windows interpets the IP address 0.0.0.0 as non-existent, making it an
+    # Windows interprets the IP address 0.0.0.0 as non-existent, making it an
     # appropriate alias for non-existent hosts. However, UNIX-like systems
     # interpret the same address to mean any IP address, which is inappropriate
     # for this context. These systems do not reserve any value for this


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in comments within two files:

- tools/gitignore/gitignore.py: Fixes the spelling of "overridden" in a comment.
- tools/serve/serve.py: Fixes the spelling of "interprets" in a comment.

