### PR TITLE
Fix #53165 - adds fuzziness to rounded SVG rect

### DIFF
--- a/svg/shapes/rect-03.svg
+++ b/svg/shapes/rect-03.svg
@@ -4,6 +4,7 @@
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="http://www.w3.org/TR/SVG2/shapes.html#RectElement"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="rect-03-ref.html"/>
     <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rect element with rounded corners renders correctly."/>
+    <meta name="fuzzy" content="0-30;0-100"/>
   </metadata>
   <rect x="10" y="10" width="50" height="50" rx="8" ry="8" fill="blue"/>
 </svg>

--- a/svg/shapes/rect-04.svg
+++ b/svg/shapes/rect-04.svg
@@ -4,6 +4,7 @@
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="http://www.w3.org/TR/SVG2/shapes.html#RectElement"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="rect-04-ref.html"/>
     <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rect element with rounded corners and stroke renders correctly."/>
+    <meta name="fuzzy" content="0-50;0-150"/>
   </metadata>
   <rect x="10" y="10" width="50" height="50" rx="8" ry="8" fill="none" stroke="blue" stroke-width="4"/>
 </svg>


### PR DESCRIPTION
Fix #53165 by adding fuzziness to rounded SVG Rect. The difference is barely visible. 
There is no hard constraints on SVG spec on the border radius of rectangles. The current tests are comparing html border radius with an SVG shape. 