### PR TITLE
fix #53167 failures due to fuzziness on SVG shapes

### DIFF
--- a/svg/shapes/reftests/pathlength-002.svg
+++ b/svg/shapes/reftests/pathlength-002.svg
@@ -3,6 +3,9 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <meta name="fuzzy" content="0-1;20"/>
+  </metadata>
   <g id="testmeta">
     <title>Test of 'pathLength' on shapes.</title>
     <html:link rel="author"

--- a/svg/shapes/reftests/pathlength-003.svg
+++ b/svg/shapes/reftests/pathlength-003.svg
@@ -3,6 +3,9 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <meta name="fuzzy" content="0-50;4900"/>
+  </metadata>
   <g id="testmeta">
     <title>Test of 'pathLength' on shapes.</title>
     <html:link rel="author"


### PR DESCRIPTION
The visual differences in between the reftest and the SVG are not visible. 
This should improve the test for everyone, except for pathlength-003.svg for Chrome which has a real bug. 