### PR TITLE
Add web test regarding innerHTML's behavior with custom element registry

### DIFF
--- a/custom-elements/registries/Element-innerHTML.html
+++ b/custom-elements/registries/Element-innerHTML.html
@@ -49,15 +49,28 @@ test((test) => {
 
     const someElement = document.createElement('some-element', {customElementRegistry: registry});
     assert_true(someElement instanceof ScopedSomeElement);
-    someElement.innerHTML = '<other-element id="foo"><other-element id="bar"><other-element id="baz"></other-element></other-element></other-element>';
+    someElement.innerHTML = `
+        <other-element id="foo">
+            <other-element id="bar">
+                <div id="baz">
+                    <other-element id="nested-ce"></other-element>
+                </div>
+            </other-element
+        </other-element>
+        <div id="bux"></div>
+        <another-element></another-element>`
+
     assert_true(someElmeents.querySelector('#foo') instanceof ScopedOtherElement);
     assert_true(someElmeents.querySelector('#bar') instanceof ScopedOtherElement);
-    assert_true(someElmeents.querySelector('#baz') instanceof ScopedOtherElement);
+    assert_true(someElmeents.querySelector('#nested-ce') instanceof ScopedOtherElement);
 
     assert_true(someElements.querySelector('#foo').customElementRegistry === registry);
     assert_true(someElements.querySelector('#bar').customElementRegistry === registry);
     assert_true(someElements.querySelector('#baz').customElementRegistry === registry);
-}, 'nested children in innerHTML on a disconnected element should use the scoped registry it was created with');
+    assert_true(someElements.querySelector('#nested-ce').customElementRegistry === registry);
+    assert_true(someElements.querySelector('#bux').customElementRegistry === registry);
+    assert_true(someElements.querySelector('another-element').customElementRegistry === registry);
+}, 'nested descendants in innerHTML on a disconnected element should use the scoped registry it was created with');
 
 test((test) => {
     const registry1 = new CustomElementRegistry;

--- a/custom-elements/registries/Element-innerHTML.html
+++ b/custom-elements/registries/Element-innerHTML.html
@@ -55,22 +55,22 @@ test((test) => {
                 <div id="baz">
                     <other-element id="nested-ce"></other-element>
                 </div>
-            </other-element
+            </other-element>
         </other-element>
         <div id="bux"></div>
-        <another-element></another-element>`
+        <another-element></another-element>`;
 
-    assert_true(someElmeents.querySelector('#foo') instanceof ScopedOtherElement);
-    assert_true(someElmeents.querySelector('#bar') instanceof ScopedOtherElement);
-    assert_true(someElmeents.querySelector('#nested-ce') instanceof ScopedOtherElement);
+    assert_true(someElement.querySelector('#foo') instanceof ScopedOtherElement);
+    assert_true(someElement.querySelector('#bar') instanceof ScopedOtherElement);
+    assert_true(someElement.querySelector('#nested-ce') instanceof ScopedOtherElement);
 
-    assert_true(someElements.querySelector('#foo').customElementRegistry === registry);
-    assert_true(someElements.querySelector('#bar').customElementRegistry === registry);
-    assert_true(someElements.querySelector('#baz').customElementRegistry === registry);
-    assert_true(someElements.querySelector('#nested-ce').customElementRegistry === registry);
-    assert_true(someElements.querySelector('#bux').customElementRegistry === registry);
-    assert_true(someElements.querySelector('another-element').customElementRegistry === registry);
-}, 'nested descendants in innerHTML on a disconnected element should use the scoped registry it was created with');
+    assert_true(someElement.querySelector('#foo').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#bar').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#baz').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#nested-ce').customElementRegistry === registry);
+    assert_true(someElement.querySelector('#bux').customElementRegistry === registry);
+    assert_true(someElement.querySelector('another-element').customElementRegistry === registry);
+}, 'nested descendants in innerHTML on a disconnected element should use the scoped registry the element was created with');
 
 test((test) => {
     const registry1 = new CustomElementRegistry;

--- a/custom-elements/registries/Element-innerHTML.html
+++ b/custom-elements/registries/Element-innerHTML.html
@@ -32,12 +32,32 @@ test((test) => {
     class ScopedOtherElement extends HTMLElement { };
     registry.define('other-element', ScopedOtherElement);
 
-    const shadowRoot = createConnectedShadowTree(test, registry);
     const someElement = document.createElement('some-element', {customElementRegistry: registry});
     assert_true(someElement instanceof ScopedSomeElement);
     someElement.innerHTML = '<other-element></other-element>';
     assert_true(someElement.querySelector('other-element') instanceof ScopedOtherElement);
 }, 'innerHTML on a disconnected element should use the scoped registry it was created with');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+
+    class ScopedSomeElement extends HTMLElement { };
+    registry.define('some-element', ScopedSomeElement);
+
+    class ScopedOtherElement extends HTMLElement { };
+    registry.define('other-element', ScopedOtherElement);
+
+    const someElement = document.createElement('some-element', {customElementRegistry: registry});
+    assert_true(someElement instanceof ScopedSomeElement);
+    someElement.innerHTML = '<other-element id="foo"><other-element id="bar"><other-element id="baz"></other-element></other-element></other-element>';
+    assert_true(someElmeents.querySelector('#foo') instanceof ScopedOtherElement);
+    assert_true(someElmeents.querySelector('#bar') instanceof ScopedOtherElement);
+    assert_true(someElmeents.querySelector('#baz') instanceof ScopedOtherElement);
+
+    assert_true(someElements.querySelector('#foo').customElementRegistry === registry);
+    assert_true(someElements.querySelector('#bar').customElementRegistry === registry);
+    assert_true(someElements.querySelector('#baz').customElementRegistry === registry);
+}, 'nested children in innerHTML on a disconnected element should use the scoped registry it was created with');
 
 test((test) => {
     const registry1 = new CustomElementRegistry;


### PR DESCRIPTION
The nested children of an element set by `innerHTML` should use the element's scoped custom element registry if provided.

@rniwa @annevk Is this the correct understanding of the spec outlined in https://github.com/whatwg/html/issues/10854?