### PR TITLE
Disable Font anti-aliasing in chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -164,7 +164,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
 
     # Always enable ViewTransitions long callback timeout to avoid erroneous
     # failures due to implicit timeout within the API.
-    blink_features = ['ViewTransitionLongCallbackTimeoutForTesting']
+    blink_features = ['ViewTransitionLongCallbackTimeoutForTesting', 'NoFontAntialiasing']
 
     if kwargs["enable_mojojs"]:
         blink_features.extend(['MojoJS', 'MojoJSTest'])


### PR DESCRIPTION
Chrome recently implemented the `NoFontAntialiasing` feature to disable anti aliasing in all fonts for testing. This decreases the amount of false negatives where a test fails due to some small anti aliasing difference in the edges of the fonts, instead of failing the behavior that the test was actually intending to verify.

We used to have a feature flag to only disable AA for the Ahem font that was being used in the WPT runners. That feature got merged into `NoFontAntialiasing` ([Chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/6370105), [WPT PR](https://github.com/web-platform-tests/wpt/pull/51566)) and removed from the runner's arguments, but it didn't get replaced with the new feature flag. Because of this, hundreds of tests are failing in the Windows runner. See https://github.com/web-platform-tests/wpt/issues/53128

This PR adds the new `NoFontAntialiasing` to the runner's arguments.