### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=284527

### DIFF
--- a/css/css-animations/animate-font-size-with-margin-override-ref.html
+++ b/css/css-animations/animate-font-size-with-margin-override-ref.html
@@ -1,0 +1,12 @@
+<style>
+h2 {
+    margin: 0;
+    background-color: lightblue;
+    font-size: 30px;
+}
+div { border: 2px solid green; }
+</style>
+
+<div>
+<h2>This should not have any margins.</h2>
+</div>

--- a/css/css-animations/animate-font-size-with-margin-override.html
+++ b/css/css-animations/animate-font-size-with-margin-override.html
@@ -1,3 +1,5 @@
+<link rel="help" href="https://drafts.csswg.org/css-animations">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=284527">
 <link rel="match" href="animate-font-size-with-margin-override-ref.html">
 <style>
 @keyframes anim {

--- a/css/css-animations/animate-font-size-with-margin-override.html
+++ b/css/css-animations/animate-font-size-with-margin-override.html
@@ -1,0 +1,16 @@
+<link rel="match" href="animate-font-size-with-margin-override-ref.html">
+<style>
+@keyframes anim {
+    from, to { font-size: 30px; }
+}
+h2 {
+    margin: 0;
+    background-color: lightblue;
+    animation: anim both;
+}
+div { border: 2px solid green; }
+</style>
+
+<div>
+<h2>This should not have any margins.</h2>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] https://scroll-driven-animations.style/demos/shrinking-header-shadow/css/ does not work](https://bugs.webkit.org/show_bug.cgi?id=284527)