### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=294596

### DIFF
--- a/urlpattern/urlpattern-constructor.html
+++ b/urlpattern/urlpattern-constructor.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_throws_js(TypeError, () => { new URLPattern(new URL('https://example.org/%(')); } );
+  assert_throws_js(TypeError, () => { new URLPattern(new URL('https://example.org/%((')); } );
+  assert_throws_js(TypeError, () => { new URLPattern('(\\'); } );
+}, `Test unclosed token`);
+
+test(() => {
+  new URLPattern(undefined, undefined);
+}, `Test constructor with undefined`);
+</script>


### PR DESCRIPTION
WebKit export from bug: [Move fast/url/urlpattern invalid tests to WPT](https://bugs.webkit.org/show_bug.cgi?id=294596)