### PR TITLE
Avoid false-negative in logical alias animation test

### DIFF
--- a/css/css-logical/animation-001.html
+++ b/css/css-logical/animation-001.html
@@ -131,26 +131,24 @@ test(t => {
   const div = addDiv(t);
   const anim = div.animate(
     {
-      marginInline: '100px',
-      margin: '200px',
+      borderBlockStart: '100px solid black',
+      borderTop: '200px solid black',
     },
     { duration: 1, easing: 'step-start' }
   );
-  assert_equals(getComputedStyle(div).marginLeft, '200px');
-  assert_equals(getComputedStyle(div).marginRight, '200px');
+  assert_equals(getComputedStyle(div).borderTopWidth, '200px');
 }, 'Physical shorthands win over logical shorthands');
 
 test(t => {
   const div = addDiv(t);
   const anim = div.animate(
     {
-      marginInline: '100px',
-      margin: 'var(--200px)',
+      borderBlockStart: '100px solid black',
+      borderTop: 'var(--200px) solid black',
     },
     { duration: 1, easing: 'step-start' }
   );
-  assert_equals(getComputedStyle(div).marginLeft, '200px');
-  assert_equals(getComputedStyle(div).marginRight, '200px');
+  assert_equals(getComputedStyle(div).borderTopWidth, '200px');
 }, 'Physical shorthands using variables win over logical shorthands');
 
 test(t => {


### PR DESCRIPTION
The spec (https://drafts.csswg.org/web-animations-1/#ref-for-computed-keyframes) states that the following steps should be used to resolve conflicts between animated properties:

>1. Longhand properties override shorthand properties (e.g. border-top-color overrides border-top).
> 
>2. Shorthand properties with fewer longhand components override those with more longhand components (e.g. border-top overrides border-color).
> 
>3. Physical properties override logical properties.
>
>4. For shorthand properties with an equal number of longhand components, properties whose IDL name (see the CSS property to IDL attribute algorithm [CSSOM]) appears earlier when sorted in ascending order by the Unicode codepoints that make up each IDL name, override those who appear later.

Before this change the test used marginInline and margin, expecting margin to win as it was a physical property where marginInline is a logical alias, however according to the spec, marginInline should actually win as it has fewer longhands (only 2 compared to margin's 4).

To properly test this we need to use two shorthands with the same number of longhands (and ideally where the logical shorthand would be favoured by step 4 above to avoid a false positive). 'border-block-start' and 'border-top' fit this criteria.