### PR TITLE
compositor: Always send an animating tick when a pipeline starts animating

### DIFF
--- a/css/css-transitions/support/transition-in-iframe-001-iframe.html
+++ b/css/css-transitions/support/transition-in-iframe-001-iframe.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <style>
+        html {
+            background: red;
+            transition: all 0.1s;
+        }
+    </style>
+    <script>
+        window.addEventListener("message", () => {
+            document.documentElement.style.background = "green";
+        });
+        document.documentElement.addEventListener(
+            "transitionend", () => {
+                window.parent.postMessage("complete", "*");
+            }
+        );
+    </script>
+</body>
+</html>

--- a/css/css-transitions/transition-in-iframe-001.html
+++ b/css/css-transitions/transition-in-iframe-001.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+
+<html>
+
+<title>Transitions: Transition in &lt;iframe&gt; on page with empty rAF finishes</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mrobinson@igalia.com">
+<link rel="author" href="mailto:obrufau@igalia.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<style>
+    #iframe {
+        width: 100px;
+        height: 100px;
+        border: none;
+    }
+</style>
+
+<script>
+    let rAFId = null;
+    function triggerNeverEndingUselessRAF() {
+        rAFId = requestAnimationFrame(triggerNeverEndingUselessRAF);
+    }
+
+    promise_test(async t => {
+        await waitForAtLeastOneFrame();
+        await waitForAtLeastOneFrame();
+
+        let iframe = document.createElement("iframe");
+        iframe.id = "iframe";
+        iframe.src = "support/transition-in-iframe-001-iframe.html"
+        iframe.sandbox = "allow-scripts";
+
+        iframe.addEventListener("load", async () => {
+            await waitForAtLeastOneFrame();
+            await waitForAtLeastOneFrame();
+            iframe.contentWindow.postMessage("loaded", "*");
+        });
+
+        triggerNeverEndingUselessRAF();
+        document.body.appendChild(iframe);
+
+        await new Promise(resolve => {
+            window.addEventListener("message", () => {
+                cancelAnimationFrame(rAFId);
+                resolve();
+            });
+        });
+    });
+</script>
+
+</html>


### PR DESCRIPTION
Instead of taking into account whether the entire WebView starts
animating, always send an animation tick when a pipeline moves from the
"not animating" to "animating" state. It could be that the WebView was
animating, but not painting if the animation was not producing display
lists. In that case, the required tick would never come, because it is
sent after a repaint.

Testing: Added a new WPT test.
Fixes: #<!-- nolink -->37458.

Reviewed in servo/servo#37507