### PR TITLE
layout: Do not add empty border images to the display list

### DIFF
--- a/css/css-borders/border-image-gradient-zero-size-transform-crash.html
+++ b/css/css-borders/border-image-gradient-zero-size-transform-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+  #container {
+      border-style: dotted hidden;
+      border-image: repeating-linear-gradient(to left top, blue, red);
+      width: 0;
+      transition: all 0.5s;
+  }
+</style>
+
+<div id="container"></div>
+
+<script>
+    addEventListener("load", () => {
+        container.style.padding = "1px";
+    });
+</script>
+</body>


### PR DESCRIPTION
Zero-sized gradient border images cause WebRender to panic, so simply
don't add them to the display list.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->37432

Reviewed in servo/servo#37534