### PR TITLE
Mark non-local-ports.sub.window.js as intermittently passing on chrome.

### DIFF
--- a/infrastructure/metadata/infrastructure/assumptions/non-local-ports.sub.window.js.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/non-local-ports.sub.window.js.ini
@@ -1,3 +1,5 @@
 [non-local-ports.sub.window.html]
   [Fetch from http-public to local http fails.]
-    expected: FAIL
+    expected:
+      if product == "chrome": [PASS, FAIL]
+      if product != "chrome": FAIL


### PR DESCRIPTION
[non-local-ports.sub.window.js test ](https://github.com/web-platform-tests/wpt/blob/master/infrastructure/assumptions/non-local-ports.sub.window.js) was [recently marked as failing in Chrome](https://github.com/web-platform-tests/wpt/pull/52428). But it looks like it still sometimes passes and that blocks now a bunch of PRs (e.g., [this](https://github.com/web-platform-tests/wpt/pull/53249), [this](https://github.com/web-platform-tests/wpt/pull/53241) or [this](https://github.com/web-platform-tests/wpt/pull/53265)). At the same time [here](https://github.com/web-platform-tests/wpt/pull/53197) for example it passed. So this PR marks this test `fail/pass` for Chrome.