### PR TITLE
Fixes tests of CSS Values 5 progress() to test new clamping behavior

### DIFF
--- a/css/css-values/progress-serialize.html
+++ b/css/css-values/progress-serialize.html
@@ -43,6 +43,16 @@ test_serialization(
     'calc(0.5)',
     '0.5'
 );
+test_serialization(
+    'calc(0.5 * progress(200px, 0px, 100px))',
+    'calc(0.5)',
+    '0.5'
+);
+test_serialization(
+    'calc(0.5 * progress(-100px, 0px, 100px))',
+    'calc(0)',
+    '0'
+);
 test_specified_serialization(
     'width',
     'calc(50px * progress(100px, 0px, 100px))',


### PR DESCRIPTION
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=294735

Based on CSSWG resolution in https://github.com/w3c/csswg-drafts/issues/11825