### PR TITLE
Make wpt's test_install always install into tmp dirs

### DIFF
--- a/tools/wpt/tests/test_install.py
+++ b/tools/wpt/tests/test_install.py
@@ -7,43 +7,34 @@ import sys
 
 import pytest
 
-from tools.wpt import browser, utils, wpt
+from tools.wpt import browser, wpt
 
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-def test_install_chromium():
-    venv_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir())
+def test_install_chromium(tmp_path):
     channel = "nightly"
-    dest = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", channel)
     if sys.platform == "win32":
-        chromium_path = os.path.join(dest, "chrome-win")
+        chromium_dir = "chrome-win"
     elif sys.platform == "darwin":
-        chromium_path = os.path.join(dest, "chrome-mac")
+        chromium_dir = "chrome-mac"
     else:
-        chromium_path = os.path.join(dest, "chrome-linux")
+        chromium_dir = "chrome-linux"
 
-    if os.path.exists(chromium_path):
-        utils.rmtree(chromium_path)
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["install", "chromium", "browser"])
+        wpt.main(argv=["install", "-d", str(tmp_path), "chromium", "browser"])
     assert excinfo.value.code == 0
-    assert os.path.exists(chromium_path)
+    assert os.path.isdir(os.path.join(tmp_path, "browsers", channel, chromium_dir))
 
     chromium = browser.Chromium(logging.getLogger("Chromium"))
-    binary = chromium.find_binary(venv_path, channel)
+    binary = chromium.find_binary(str(tmp_path), channel)
     assert binary is not None and os.path.exists(binary)
-
-    utils.rmtree(chromium_path)
 
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-def test_install_chrome():
-    venv_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir())
+def test_install_chrome(tmp_path):
     channel = "dev"
-    dest = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", channel)
-
     uname = platform.uname()
     chrome_platform = {
         "Linux": "linux",
@@ -58,59 +49,46 @@ def test_install_chrome():
     else:
         bits = ""
 
-    chrome_path = os.path.join(dest, f"chrome-{chrome_platform}{bits}")
+    chrome_dir = f"chrome-{chrome_platform}{bits}"
 
-    if os.path.exists(chrome_path):
-        utils.rmtree(chrome_path)
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["install", "--channel", channel, "chrome", "browser"])
+        wpt.main(argv=["install", "-d", str(tmp_path), "--channel", channel, "chrome", "browser"])
     assert excinfo.value.code == 0
-    assert os.path.exists(chrome_path)
+    assert os.path.isdir(os.path.join(tmp_path, "browsers", channel, chrome_dir))
 
     chrome = browser.Chrome(logging.getLogger("Chrome"))
-    binary = chrome.find_binary(venv_path, channel)
+    binary = chrome.find_binary(tmp_path, channel)
     assert binary is not None and os.path.exists(binary)
-
-    utils.rmtree(chrome_path)
 
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-def test_install_chrome_chromedriver_by_version():
+def test_install_chrome_chromedriver_by_version(tmp_path):
     # This is not technically an integration test as we do not want to require Chrome Stable to run it.
     chrome = browser.Chrome(logging.getLogger("Chrome"))
     if sys.platform == "win32":
-        dest = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "Scripts")
-        chromedriver_path = os.path.join(dest, "chrome", "chromedriver.exe")
-        # By default Windows treats paths as case-insensitive
-        path_fn = lambda path: path.lower()
+        chromedriver_binary = "chromedriver.exe"
     else:
-        dest = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "bin")
-        chromedriver_path = os.path.join(dest, "chrome", "chromedriver")
-        path_fn = lambda path: path
-    if os.path.exists(chromedriver_path):
-        os.unlink(chromedriver_path)
+        chromedriver_binary = "chromedriver"
     # This is a stable version.
     binary_path = chrome.install_webdriver_by_version(
-        dest=dest, version="115.0.5790.170", channel="stable")
-    assert path_fn(binary_path) == path_fn(chromedriver_path)
-    assert os.path.exists(chromedriver_path)
-    os.unlink(chromedriver_path)
+        dest=str(tmp_path), version="115.0.5790.170", channel="stable")
+    assert os.path.samefile(
+        binary_path,
+        os.path.join(tmp_path, "chrome", chromedriver_binary),
+    )
 
 
 @pytest.mark.slow
 @pytest.mark.remote_network
 @pytest.mark.xfail(sys.platform == "win32",
                    reason="https://github.com/web-platform-tests/wpt/issues/17074")
-def test_install_firefox():
+def test_install_firefox(tmp_path):
     if sys.platform == "darwin":
-        fx_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "Firefox Nightly.app")
+        fx_binary = "Firefox Nightly.app"
     else:
-        fx_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "firefox")
-    if os.path.exists(fx_path):
-        utils.rmtree(fx_path)
+        fx_binary = "firefox"
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["install", "firefox", "browser", "--channel=nightly"])
+        wpt.main(argv=["install", "-d", str(tmp_path), "firefox", "browser", "--channel=nightly"])
     assert excinfo.value.code == 0
-    assert os.path.exists(fx_path)
-    utils.rmtree(fx_path)
+    assert os.path.exists(os.path.join(tmp_path, "browsers", "nightly", fx_binary))


### PR DESCRIPTION
This avoids mutating the venv state when running tests, which leads to
order-dependent behaviour of tests.
