### PR TITLE
tools/wpt/tests shouldn't rely on Chrome being installed

### DIFF
--- a/tools/pytest.ini
+++ b/tools/pytest.ini
@@ -35,3 +35,5 @@ filterwarnings =
     ignore:datetime\.datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC:DeprecationWarning:taskcluster
     # mozfile not yet updated to pass a filter argument to tarfile.extract
     ignore:Python 3\.14 will, by default, filter extracted tar archives and reject files or modify their metadata\. Use the filter argument to control this behavior\.:DeprecationWarning
+    # ignore mozprofile not cleanly closing prefs
+    ignore:unclosed file.*\.js:ResourceWarning:mozprofile


### PR DESCRIPTION
We already ensure Firefox is installed for some of these tests, so
move to just using that Firefox binary for all tests.

Fixes https://github.com/web-platform-tests/wpt/issues/53300
