### PR TITLE
[css-counter-styles] Extended CJK longhand counter styles range and Separation between mandatory test and optional implementation

### DIFF
--- a/css/css-counter-styles/japanese-formal/counter-japanese-formal-extended-ref.html
+++ b/css/css-counter-styles/japanese-formal/counter-japanese-formal-extended-ref.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (萬) - ten-thousands group -->
+<div>&#x58f1;&#x842c;</div>
+<div>&#x5f10;&#x842c;</div>
+<div>&#x4f0d;&#x842c;</div>
+<div>&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x58f1;&#x842c;&#x5f10;&#x9621;&#x53c2;&#x767e;&#x56db;&#x62fe;&#x4f0d;</div>
+<div>&#x58f1;&#x842c;&#x58f1;</div>
+<div>&#x58f1;&#x842c;&#x58f1;&#x62fe;</div>
+<div>&#x58f1;&#x842c;&#x58f1;&#x767e;</div>
+<div>&#x58f1;&#x842c;&#x58f1;&#x9621;</div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div>&#x58f1;&#x5104;</div>
+<div>&#x5f10;&#x5104;</div>
+<div>&#x4f0d;&#x5104;</div>
+<div>&#x4e5d;&#x5104;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x58f1;&#x5104;&#x5f10;&#x9621;&#x53c2;&#x767e;&#x56db;&#x62fe;&#x4f0d;&#x842c;&#x516d;&#x9621;&#x4e03;&#x767e;&#x516b;&#x62fe;&#x4e5d;</div>
+<div>&#x58f1;&#x5104;&#x58f1;</div>
+<div>&#x58f1;&#x5104;&#x58f1;&#x842c;</div>
+<div>&#x58f1;&#x5104;&#x58f1;&#x62fe;&#x842c;</div>
+<div>&#x58f1;&#x5104;&#x58f1;&#x62fe;&#x842c;</div>
+<div>&#x58f1;&#x5104;&#x58f1;&#x9621;&#x842c;</div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div>&#x58f1;&#x5146;</div>
+<div>&#x5f10;&#x5146;</div>
+<div>&#x4f0d;&#x5146;</div>
+<div>&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5146;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5104;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x58f1;&#x62fe;&#x5146;</div>
+<div>&#x4f0d;&#x62fe;&#x5146;</div>
+<div>&#x4e5d;&#x62fe;&#x4e5d;&#x5146;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5104;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x58f1;&#x767e;&#x5146;</div>
+<div>&#x4f0d;&#x767e;&#x5146;</div>
+<div>&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5146;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5104;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x58f1;&#x9621;&#x5f10;&#x767e;&#x53c2;&#x62fe;&#x56db;&#x5146;&#x4f0d;&#x767e;&#x516d;&#x62fe;&#x4e03;&#x5104;&#x516b;&#x9621;&#x4e5d;&#x842c;&#x58f1;&#x767e;&#x5f10;&#x62fe;&#x53c2;</div>
+<div>&#x58f1;&#x5146;&#x58f1;</div>
+<div>&#x58f1;&#x5146;&#x58f1;&#x842c;</div>
+<div>&#x58f1;&#x5146;&#x58f1;&#x5104;</div>
+<div>&#x58f1;&#x5146;&#x58f1;&#x767e;&#x5104;</div>
+<div>&#x58f1;&#x5146;&#x58f1;&#x62fe;&#x5104;</div>
+<div>&#x58f1;&#x5146;&#x58f1;&#x9621;&#x5104;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x58f1;&#x9621;&#x58f1;&#x5146;&#x58f1;&#x9621;&#x58f1;&#x5104;&#x58f1;&#x9621;&#x58f1;&#x842c;&#x58f1;&#x9621;&#x58f1;</div>
+<div>&#x58f1;&#x9621;&#x58f1;&#x62fe;&#x5146;&#x58f1;&#x767e;&#x58f1;&#x62fe;&#x5104;&#x58f1;&#x9621;&#x58f1;&#x62fe;&#x842c;&#x58f1;&#x767e;&#x58f1;</div>
+<div>&#x58f1;&#x9621;&#x58f1;&#x767e;&#x58f1;&#x842c;&#x58f1;</div>
+<div>&#x4f0d;&#x9621;&#x4f0d;&#x5146;&#x4f0d;&#x9621;&#x4f0d;&#x5104;&#x4f0d;&#x9621;&#x4f0d;&#x842c;&#x4f0d;&#x9621;&#x4f0d;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x58f1;&#x5146;</div>
+<div>&#x58f1;&#x5104;</div>
+<div>&#x58f1;&#x767e;&#x842c;</div>
+<div>&#x58f1;&#x9621;</div>
+<div>&#x58f1;&#x62fe;&#x5146;</div>
+<div>&#x58f1;&#x767e;&#x5146;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5146;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5104;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+<div>&#x58f1;&#x9621;&#x5146;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x58f1;&#x842c;</div>
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x58f1;&#x5104;</div>
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x58f1;&#x5146;</div>
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5146;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x5104;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;&#x842c;&#x4e5d;&#x9621;&#x4e5d;&#x767e;&#x4e5d;&#x62fe;&#x4e5d;</div>
+
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x58f1;</div>

--- a/css/css-counter-styles/japanese-formal/counter-japanese-formal-extended.html
+++ b/css/css-counter-styles/japanese-formal/counter-japanese-formal-extended.html
@@ -1,35 +1,16 @@
 <!DOCTYPE html>
-<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
-<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Extended Implementation (optional)</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#extended-range-optional">
 <link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
-<link rel="match" href="counter-simp-chinese-informal-ref.html">
+<link rel="match" href="counter-japanese-formal-extended-ref.html">
 <style>
   div::after {
-    content: counter(n, simp-chinese-informal);
+    content: counter(n, japanese-formal);
   }
 </style>
-<div style="counter-reset: n 0;"></div>
-<div style="counter-reset: n 1;"></div>
-<div style="counter-reset: n 2;"></div>
-<div style="counter-reset: n 3;"></div>
-<div style="counter-reset: n 4;"></div>
-<div style="counter-reset: n 5;"></div>
-<div style="counter-reset: n 6;"></div>
-<div style="counter-reset: n 7;"></div>
-<div style="counter-reset: n 8;"></div>
-<div style="counter-reset: n 9;"></div>
 
-<div style="counter-reset: n 10;"></div>
-<div style="counter-reset: n 100;"></div>
-<div style="counter-reset: n 1000;"></div>
-
-<div style="counter-reset: n 11;"></div>
-<div style="counter-reset: n 99;"></div>
-<div style="counter-reset: n 101;"></div>
-<div style="counter-reset: n 200;"></div>
-<div style="counter-reset: n 6001;"></div>
-
-<!-- Test second group marker (万) - ten-thousands group -->
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (萬) - ten-thousands group -->
 <div style="counter-reset: n 10000;"></div>
 <div style="counter-reset: n 20000;"></div>
 <div style="counter-reset: n 50000;"></div>
@@ -42,7 +23,7 @@
 <div style="counter-reset: n 10100;"></div>
 <div style="counter-reset: n 11000;"></div>
 
-<!-- Test third group marker (亿) - hundred-millions group -->
+<!-- Test third group marker (億) - hundred-millions group -->
 <div style="counter-reset: n 100000000;"></div>
 <div style="counter-reset: n 200000000;"></div>
 <div style="counter-reset: n 500000000;"></div>
@@ -56,7 +37,7 @@
 <div style="counter-reset: n 101000000;"></div>
 <div style="counter-reset: n 110000000;"></div>
 
-<!-- Test fourth group marker (万亿) - trillions group -->
+<!-- Test fourth group marker (兆) - trillions group -->
 <div style="counter-reset: n 1000000000000;"></div>
 <div style="counter-reset: n 2000000000000;"></div>
 <div style="counter-reset: n 5000000000000;"></div>

--- a/css/css-counter-styles/japanese-formal/counter-japanese-formal-ref.html
+++ b/css/css-counter-styles/japanese-formal/counter-japanese-formal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x58f1;&#x62fe;</div>
 <div>&#x58f1;&#x767e;</div>
 <div>&#x58f1;&#x9621;</div>
-<div>&#x58f1;&#x842c;</div>
-<div>&#x58f1;&#x62fe;&#x842c;</div>
-<div>&#x58f1;&#x767e;&#x842c;</div>
-<div>&#x58f1;&#x9621;&#x842c;</div>
-<div>&#x58f1;&#x5104;</div>
-<div>&#x58f1;&#x62fe;&#x5104;</div>
 
 <div>&#x58f1;&#x62fe;&#x58f1;</div>
 <div>&#x4e5d;&#x62fe;&#x4e5d;</div>
 <div>&#x58f1;&#x767e;&#x58f1;</div>
 <div>&#x5f10;&#x767e;</div>
 <div>&#x516d;&#x9621;&#x58f1;</div>
-<div>&#x58f1;&#x842c;&#x58f1;</div>
-<div>&#x58f1;&#x842c;&#x58f1;&#x62fe;&#x58f1;</div>
-<div>&#x58f1;&#x842c;&#x58f1;&#x767e;&#x58f1;</div>
-<div>&#x58f1;&#x842c;&#x58f1;&#x9621;&#x58f1;&#x767e;&#x58f1;&#x62fe;&#x58f1;</div>
-<div>&#x58f1;&#x9621;&#x58f1;&#x767e;&#x842c;</div>
-<div>&#x58f1;&#x5104;&#x58f1;&#x842c;&#x58f1;</div>
-<div>&#x58f1;&#x5104;&#x58f1;&#x62fe;&#x58f1;&#x842c;&#x58f1;</div>
 
 <div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x58f1;</div>

--- a/css/css-counter-styles/japanese-formal/counter-japanese-formal.html
+++ b/css/css-counter-styles/japanese-formal/counter-japanese-formal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Japanese Limited-range Implementation (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-japanese">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-japanese-formal-ref.html">
 <style>
   div::after {

--- a/css/css-counter-styles/japanese-formal/counter-japanese-formal.html
+++ b/css/css-counter-styles/japanese-formal/counter-japanese-formal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;"></div>
 <div style="counter-reset: n 100;"></div>
 <div style="counter-reset: n 1000;"></div>
-<div style="counter-reset: n 10000;"></div>
-<div style="counter-reset: n 100000;"></div>
-<div style="counter-reset: n 1000000;"></div>
-<div style="counter-reset: n 10000000;"></div>
-<div style="counter-reset: n 100000000;"></div>
-<div style="counter-reset: n 1000000000;"></div>
 
 <div style="counter-reset: n 11;"></div>
 <div style="counter-reset: n 99;"></div>
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
-<div style="counter-reset: n 10001;"></div>
-<div style="counter-reset: n 10011;"></div>
-<div style="counter-reset: n 10101;"></div>
-<div style="counter-reset: n 11111;"></div>
-<div style="counter-reset: n 11000000;"></div>
-<div style="counter-reset: n 100010001;"></div>
-<div style="counter-reset: n 100110001;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/japanese-informal/counter-japanese-informal-extended-ref.html
+++ b/css/css-counter-styles/japanese-informal/counter-japanese-informal-extended-ref.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (万) - ten-thousands group -->
+<div>&#x4e00;&#x4e07;</div>
+<div>&#x4e8c;&#x4e07;</div>
+<div>&#x4e94;&#x4e07;</div>
+<div>&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x4e00;&#x4e07;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;</div>
+<div>&#x4e00;&#x4e07;&#x4e00;</div>
+<div>&#x4e00;&#x4e07;&#x5341;</div>
+<div>&#x4e00;&#x4e07;&#x4e00;&#x767e;</div>
+<div>&#x4e00;&#x4e07;&#x4e00;&#x5343;</div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div>&#x4e00;&#x5104;</div>
+<div>&#x4e8c;&#x5104;</div>
+<div>&#x4e94;&#x5104;</div>
+<div>&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x4e00;&#x5104;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x4e07;&#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x5104;&#x4e00;</div>
+<div>&#x4e00;&#x5104;&#x4e00;&#x4e07;</div>
+<div>&#x4e00;&#x5104;&#x5341;&#x4e07;</div>
+<div>&#x4e00;&#x5104;&#x5341;&#x4e07;</div>
+<div>&#x4e00;&#x5104;&#x4e00;&#x5343;&#x4e07;</div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div>&#x4e00;&#x5146;</div>
+<div>&#x4e8c;&#x5146;</div>
+<div>&#x4e94;&#x5146;</div>
+<div>&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x4e00;&#x5341;&#x5146;</div>
+<div>&#x4e94;&#x5341;&#x5146;</div>
+<div>&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x4e00;&#x767e;&#x5146;</div>
+<div>&#x4e94;&#x767e;&#x5146;</div>
+<div>&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x4e00;&#x5343;&#x4e8c;&#x767e;&#x4e09;&#x5341;&#x56db;&#x5146;&#x4e94;&#x767e;&#x516d;&#x5341;&#x4e03;&#x5104;&#x516b;&#x5343;&#x4e5d;&#x4e07;&#x4e00;&#x767e;&#x4e8c;&#x5341;&#x4e09;</div>
+<div>&#x4e00;&#x5146;&#x4e00;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x4e07;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x5104;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x767e;&#x5104;</div>
+<div>&#x4e00;&#x5146;&#x5341;&#x5104;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x5343;&#x5104;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x4e00;&#x5343;&#x4e00;&#x5146;&#x4e00;&#x5343;&#x4e00;&#x5104;&#x4e00;&#x5343;&#x4e00;&#x4e07;&#x4e00;&#x5343;&#x4e00;</div>
+<div>&#x4e00;&#x5343;&#x5341;&#x5146;&#x4e00;&#x767e;&#x5341;&#x5104;&#x4e00;&#x5343;&#x5341;&#x4e07;&#x4e00;&#x767e;&#x4e00;</div>
+<div>&#x4e00;&#x5343;&#x767e;&#x4e07;&#x4e00;</div>
+<div>&#x4e94;&#x5343;&#x4e94;&#x5146;&#x4e94;&#x5343;&#x4e94;&#x5104;&#x4e94;&#x5343;&#x4e94;&#x4e07;&#x4e94;&#x5343;&#x4e94;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x4e00;&#x5146;</div>
+<div>&#x4e00;&#x5104;</div>
+<div>&#x4e00;&#x767e;&#x4e07;</div>
+<div>&#x4e00;&#x5343;</div>
+<div>&#x5341;&#x5146;</div>
+<div>&#x4e00;&#x767e;&#x5146;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x5343;&#x5146;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e00;&#x4e07;</div>
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e00;&#x5104;</div>
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e00;&#x5146;</div>
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e00;</div>

--- a/css/css-counter-styles/japanese-informal/counter-japanese-informal-extended.html
+++ b/css/css-counter-styles/japanese-informal/counter-japanese-informal-extended.html
@@ -1,34 +1,15 @@
 <!DOCTYPE html>
-<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
-<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Extended Implementation (optional)</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#extended-range-optional">
 <link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
-<link rel="match" href="counter-simp-chinese-informal-ref.html">
+<link rel="match" href="counter-japanese-informal-extended-ref.html">
 <style>
   div::after {
-    content: counter(n, simp-chinese-informal);
+    content: counter(n, japanese-informal);
   }
 </style>
-<div style="counter-reset: n 0;"></div>
-<div style="counter-reset: n 1;"></div>
-<div style="counter-reset: n 2;"></div>
-<div style="counter-reset: n 3;"></div>
-<div style="counter-reset: n 4;"></div>
-<div style="counter-reset: n 5;"></div>
-<div style="counter-reset: n 6;"></div>
-<div style="counter-reset: n 7;"></div>
-<div style="counter-reset: n 8;"></div>
-<div style="counter-reset: n 9;"></div>
 
-<div style="counter-reset: n 10;"></div>
-<div style="counter-reset: n 100;"></div>
-<div style="counter-reset: n 1000;"></div>
-
-<div style="counter-reset: n 11;"></div>
-<div style="counter-reset: n 99;"></div>
-<div style="counter-reset: n 101;"></div>
-<div style="counter-reset: n 200;"></div>
-<div style="counter-reset: n 6001;"></div>
-
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
 <!-- Test second group marker (万) - ten-thousands group -->
 <div style="counter-reset: n 10000;"></div>
 <div style="counter-reset: n 20000;"></div>
@@ -42,7 +23,7 @@
 <div style="counter-reset: n 10100;"></div>
 <div style="counter-reset: n 11000;"></div>
 
-<!-- Test third group marker (亿) - hundred-millions group -->
+<!-- Test third group marker (億) - hundred-millions group -->
 <div style="counter-reset: n 100000000;"></div>
 <div style="counter-reset: n 200000000;"></div>
 <div style="counter-reset: n 500000000;"></div>
@@ -56,7 +37,7 @@
 <div style="counter-reset: n 101000000;"></div>
 <div style="counter-reset: n 110000000;"></div>
 
-<!-- Test fourth group marker (万亿) - trillions group -->
+<!-- Test fourth group marker (兆) - trillions group -->
 <div style="counter-reset: n 1000000000000;"></div>
 <div style="counter-reset: n 2000000000000;"></div>
 <div style="counter-reset: n 5000000000000;"></div>

--- a/css/css-counter-styles/japanese-informal/counter-japanese-informal-ref.html
+++ b/css/css-counter-styles/japanese-informal/counter-japanese-informal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x5341;</div>
 <div>&#x767e;</div>
 <div>&#x5343;</div>
-<div>&#x4e00;&#x4e07;</div>
-<div>&#x5341;&#x4e07;</div>
-<div>&#x767e;&#x4e07;</div>
-<div>&#x4e00;&#x5343;&#x4e07;</div>
-<div>&#x4e00;&#x5104;</div>
-<div>&#x5341;&#x5104;</div>
 
 <div>&#x5341;&#x4e00;</div>
 <div>&#x4e5d;&#x5341;&#x4e5d;</div>
 <div>&#x767e;&#x4e00;</div>
 <div>&#x4e8c;&#x767e;</div>
 <div>&#x516d;&#x5343;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x5341;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x767e;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x4e00;&#x5343;&#x767e;&#x5341;&#x4e00;</div>
-<div>&#x4e00;&#x5343;&#x767e;&#x4e07;</div>
-<div>&#x4e00;&#x5104;&#x4e00;&#x4e07;&#x4e00;</div>
-<div>&#x4e00;&#x5104;&#x5341;&#x4e00;&#x4e07;&#x4e00;</div>
 
 <div>&#x30de;&#x30a4;&#x30ca;&#x30b9;&#x4e00;</div>

--- a/css/css-counter-styles/japanese-informal/counter-japanese-informal.html
+++ b/css/css-counter-styles/japanese-informal/counter-japanese-informal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;"></div>
 <div style="counter-reset: n 100;"></div>
 <div style="counter-reset: n 1000;"></div>
-<div style="counter-reset: n 10000;"></div>
-<div style="counter-reset: n 100000;"></div>
-<div style="counter-reset: n 1000000;"></div>
-<div style="counter-reset: n 10000000;"></div>
-<div style="counter-reset: n 100000000;"></div>
-<div style="counter-reset: n 1000000000;"></div>
 
 <div style="counter-reset: n 11;"></div>
 <div style="counter-reset: n 99;"></div>
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
-<div style="counter-reset: n 10001;"></div>
-<div style="counter-reset: n 10011;"></div>
-<div style="counter-reset: n 10101;"></div>
-<div style="counter-reset: n 11111;"></div>
-<div style="counter-reset: n 11000000;"></div>
-<div style="counter-reset: n 100010001;"></div>
-<div style="counter-reset: n 100110001;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/japanese-informal/counter-japanese-informal.html
+++ b/css/css-counter-styles/japanese-informal/counter-japanese-informal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Japanese Limited-range Implementation (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-japanese">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-japanese-informal-ref.html">
 <style>
   div::after {

--- a/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal-extended-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal-extended-ref.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-korean">
+
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (만) - ten-thousands group -->
+<div>&#xc77c;&#xb9cc;</div>
+<div>&#xc774;&#xb9cc;</div>
+<div>&#xc624;&#xb9cc;</div>
+<div>&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#xc77c;&#xb9cc; &#xc774;&#xcc9c;&#xc0bc;&#xbc31;&#xc0ac;&#xc2ed;&#xc624;</div>
+<div>&#xc77c;&#xb9cc; &#xc77c;</div>
+<div>&#xc77c;&#xb9cc; &#xc2ed;</div>
+<div>&#xc77c;&#xb9cc; &#xbc31;</div>
+<div>&#xc77c;&#xb9cc; &#xcc9c;</div>
+
+<!-- Test third group marker (억) - hundred-millions group -->
+<div>&#xc77c;&#xc5b5;</div>
+<div>&#xc774;&#xc5b5;</div>
+<div>&#xc624;&#xc5b5;</div>
+<div>&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#xc77c;&#xc5b5; &#xc774;&#xcc9c;&#xc0bc;&#xbc31;&#xc0ac;&#xc2ed;&#xc624;&#xb9cc; &#xc721;&#xcc9c;&#xce60;&#xbc31;&#xd314;&#xc2ed;&#xad6c;</div>
+<div>&#xc77c;&#xc5b5; &#xc77c;</div>
+<div>&#xc77c;&#xc5b5; &#xc77c;&#xb9cc;</div>
+<div>&#xc77c;&#xc5b5; &#xc2ed;&#xb9cc;</div>
+<div>&#xc77c;&#xc5b5; &#xbc31;&#xb9cc;</div>
+<div>&#xc77c;&#xc5b5; &#xcc9c;&#xb9cc;</div>
+
+<!-- Test fourth group marker (조) - trillions group -->
+<div>&#xc77c;&#xc870;</div>
+<div>&#xc774;&#xc870;</div>
+<div>&#xc624;&#xc870;</div>
+<div>&#xad6c;&#xc870; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#xc2ed;&#xc870;</div>
+<div>&#xc624;&#xc2ed;&#xc870;</div>
+<div>&#xad6c;&#xc2ed;&#xad6c;&#xc870; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#xbc31;&#xc870;</div>
+<div>&#xc624;&#xbc31;&#xc870;</div>
+<div>&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc870; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#xc77c;&#xc870; &#xc774;&#xcc9c;&#xc0bc;&#xbc31;&#xc0ac;&#xc2ed;&#xc624;&#xc5b5; &#xc721;&#xcc9c;&#xce60;&#xbc31;&#xd314;&#xc2ed;&#xad6c;&#xb9cc; &#xbc31;&#xc774;&#xc2ed;&#xc0bc;</div>
+<div>&#xc77c;&#xc870; &#xc77c;</div>
+<div>&#xc77c;&#xc870; &#xc77c;&#xb9cc;</div>
+<div>&#xc77c;&#xc870; &#xbc31;&#xb9cc;</div>
+<div>&#xc77c;&#xc870; &#xcc9c;&#xb9cc;</div>
+<div>&#xc77c;&#xc870; &#xcc9c;&#xc5b5;</div>
+<div>&#xc77c;&#xc870; &#xcc9c;&#xc77c;&#xc5b5;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#xc77c;&#xc870; &#xcc9c;&#xc77c;&#xc5b5; &#xbc31;&#xc77c;&#xb9cc; &#xcc9c;&#xc77c;</div>
+<div>&#xc77c;&#xc870; &#xcc9c;&#xc2ed;&#xc5b5; &#xcc9c;&#xc2ed;&#xb9cc; &#xcc9c;&#xc2ed;&#xc77c;</div>
+<div>&#xc77c;&#xc870; &#xcc9c;&#xc5b5; &#xc2ed;&#xb9cc; &#xc77c;</div>
+<div>&#xc624;&#xc870; &#xc624;&#xcc9c;&#xc624;&#xc5b5; &#xc624;&#xbc31;&#xc624;&#xb9cc; &#xc624;&#xcc9c;&#xc624;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#xc77c;&#xc870;</div>
+<div>&#xc2ed;&#xc5b5;</div>
+<div>&#xbc31;&#xb9cc;</div>
+<div>&#xcc9c;</div>
+<div>&#xc2ed;&#xc870;</div>
+<div>&#xbc31;&#xc870;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc870; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+<div>&#xcc9c;&#xc870;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;&#xb9cc;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;&#xc5b5;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;&#xc870;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc870; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;</div>

--- a/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal-extended.html
+++ b/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal-extended.html
@@ -1,35 +1,16 @@
 <!DOCTYPE html>
-<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
-<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Extended Implementation (optional)</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#extended-range-optional">
 <link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
-<link rel="match" href="counter-simp-chinese-informal-ref.html">
+<link rel="match" href="counter-korean-hangul-formal-extended-ref.html">
 <style>
   div::after {
-    content: counter(n, simp-chinese-informal);
+    content: counter(n, korean-hangul-formal);
   }
 </style>
-<div style="counter-reset: n 0;"></div>
-<div style="counter-reset: n 1;"></div>
-<div style="counter-reset: n 2;"></div>
-<div style="counter-reset: n 3;"></div>
-<div style="counter-reset: n 4;"></div>
-<div style="counter-reset: n 5;"></div>
-<div style="counter-reset: n 6;"></div>
-<div style="counter-reset: n 7;"></div>
-<div style="counter-reset: n 8;"></div>
-<div style="counter-reset: n 9;"></div>
 
-<div style="counter-reset: n 10;"></div>
-<div style="counter-reset: n 100;"></div>
-<div style="counter-reset: n 1000;"></div>
-
-<div style="counter-reset: n 11;"></div>
-<div style="counter-reset: n 99;"></div>
-<div style="counter-reset: n 101;"></div>
-<div style="counter-reset: n 200;"></div>
-<div style="counter-reset: n 6001;"></div>
-
-<!-- Test second group marker (万) - ten-thousands group -->
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (만) - ten-thousands group -->
 <div style="counter-reset: n 10000;"></div>
 <div style="counter-reset: n 20000;"></div>
 <div style="counter-reset: n 50000;"></div>
@@ -42,7 +23,7 @@
 <div style="counter-reset: n 10100;"></div>
 <div style="counter-reset: n 11000;"></div>
 
-<!-- Test third group marker (亿) - hundred-millions group -->
+<!-- Test third group marker (억) - hundred-millions group -->
 <div style="counter-reset: n 100000000;"></div>
 <div style="counter-reset: n 200000000;"></div>
 <div style="counter-reset: n 500000000;"></div>
@@ -56,7 +37,7 @@
 <div style="counter-reset: n 101000000;"></div>
 <div style="counter-reset: n 110000000;"></div>
 
-<!-- Test fourth group marker (万亿) - trillions group -->
+<!-- Test fourth group marker (조) - trillions group -->
 <div style="counter-reset: n 1000000000000;"></div>
 <div style="counter-reset: n 2000000000000;"></div>
 <div style="counter-reset: n 5000000000000;"></div>

--- a/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal-ref.html
@@ -13,24 +13,11 @@
 <div>&#xc77c;&#xc2ed;,</div>
 <div>&#xc77c;&#xbc31;,</div>
 <div>&#xc77c;&#xcc9c;,</div>
-<div>&#xc77c;&#xb9cc;,</div>
-<div>&#xc77c;&#xc2ed;&#xb9cc;,</div>
-<div>&#xc77c;&#xbc31;&#xb9cc;,</div>
-<div>&#xc77c;&#xcc9c;&#xb9cc;,</div>
-<div>&#xc77c;&#xc5b5;,</div>
-<div>&#xc77c;&#xc2ed;&#xc5b5;,</div>
 
 <div>&#xc77c;&#xc2ed;&#xc77c;,</div>
 <div>&#xad6c;&#xc2ed;&#xad6c;,</div>
 <div>&#xc77c;&#xbc31;&#xc77c;,</div>
 <div>&#xc774;&#xbc31;,</div>
 <div>&#xc721;&#xcc9c;&#xc77c;,</div>
-<div>&#xc77c;&#xb9cc; &#xc77c;,</div>
-<div>&#xc77c;&#xb9cc; &#xc77c;&#xc2ed;&#xc77c;,</div>
-<div>&#xc77c;&#xb9cc; &#xc77c;&#xbc31;&#xc77c;,</div>
-<div>&#xc77c;&#xb9cc; &#xc77c;&#xcc9c;&#xc77c;&#xbc31;&#xc77c;&#xc2ed;&#xc77c;,</div>
-<div>&#xc77c;&#xcc9c;&#xc77c;&#xbc31;&#xb9cc;,</div>
-<div>&#xc77c;&#xc5b5; &#xc77c;&#xb9cc; &#xc77c;,</div>
-<div>&#xc77c;&#xc5b5; &#xc77c;&#xc2ed;&#xc77c;&#xb9cc; &#xc77c;,</div>
 
 <div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;,</div>

--- a/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal.html
+++ b/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;">,</div>
 <div style="counter-reset: n 100;">,</div>
 <div style="counter-reset: n 1000;">,</div>
-<div style="counter-reset: n 10000;">,</div>
-<div style="counter-reset: n 100000;">,</div>
-<div style="counter-reset: n 1000000;">,</div>
-<div style="counter-reset: n 10000000;">,</div>
-<div style="counter-reset: n 100000000;">,</div>
-<div style="counter-reset: n 1000000000;">,</div>
 
 <div style="counter-reset: n 11;">,</div>
 <div style="counter-reset: n 99;">,</div>
 <div style="counter-reset: n 101;">,</div>
 <div style="counter-reset: n 200;">,</div>
 <div style="counter-reset: n 6001;">,</div>
-<div style="counter-reset: n 10001;">,</div>
-<div style="counter-reset: n 10011;">,</div>
-<div style="counter-reset: n 10101;">,</div>
-<div style="counter-reset: n 11111;">,</div>
-<div style="counter-reset: n 11000000;">,</div>
-<div style="counter-reset: n 100010001;">,</div>
-<div style="counter-reset: n 100110001;">,</div>
 
 <div style="counter-reset: n -1;">,</div>

--- a/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal.html
+++ b/css/css-counter-styles/korean-hangul-formal/counter-korean-hangul-formal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Korean Limited-range Implementation (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-korean">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-korean-hangul-formal-ref.html">
 <style>
   div::before {

--- a/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal-extended-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal-extended-ref.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-korean">
+
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (萬) - ten-thousands group -->
+<div>&#x58f9;&#x842c;</div>
+<div>&#x8cb3;&#x842c;</div>
+<div>&#x4f0d;&#x842c;</div>
+<div>&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x58f9;&#x842c; &#x8cb3;&#x4edf;&#x53c3;&#x4f70;&#x8086;&#x62fe;&#x4f0d;</div>
+<div>&#x58f9;&#x842c; &#x58f9;</div>
+<div>&#x58f9;&#x842c; &#x62fe;</div>
+<div>&#x58f9;&#x842c; &#x58f9;&#x4f70;</div>
+<div>&#x58f9;&#x842c; &#x58f9;&#x4edf;</div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div>&#x58f9;&#x5104;</div>
+<div>&#x8cb3;&#x5104;</div>
+<div>&#x4f0d;&#x5104;</div>
+<div>&#x7396;&#x5104; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x58f9;&#x5104; &#x8cb3;&#x4edf;&#x53c3;&#x4f70;&#x8086;&#x62fe;&#x4f0d;&#x842c; &#x9678;&#x4edf;&#x67d2;&#x4f70;&#x634c;&#x62fe;&#x7396;</div>
+<div>&#x58f9;&#x5104; &#x58f9;</div>
+<div>&#x58f9;&#x5104; &#x58f9;&#x842c;</div>
+<div>&#x58f9;&#x5104; &#x62fe;&#x842c;</div>
+<div>&#x58f9;&#x5104; &#x58f9;&#x4f70;&#x842c;</div>
+<div>&#x58f9;&#x5104; &#x58f9;&#x4edf;&#x842c;</div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div>&#x58f9;&#x5146;</div>
+<div>&#x8cb3;&#x5146;</div>
+<div>&#x4f0d;&#x5146;</div>
+<div>&#x7396;&#x5146; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x62fe;&#x5146;</div>
+<div>&#x4f0d;&#x62fe;&#x5146;</div>
+<div>&#x7396;&#x62fe;&#x7396;&#x5146; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x58f9;&#x4f70;&#x5146;</div>
+<div>&#x4f0d;&#x4f70;&#x5146;</div>
+<div>&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5146; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x58f9;&#x5146; &#x8cb3;&#x4edf;&#x53c3;&#x4f70;&#x8086;&#x62fe;&#x4f0d;&#x5104; &#x9678;&#x4edf;&#x67d2;&#x4f70;&#x634c;&#x62fe;&#x7396;&#x842c; &#x58f9;&#x4f70;&#x8cb3;&#x62fe;&#x53c3;</div>
+<div>&#x58f9;&#x5146; &#x58f9;</div>
+<div>&#x58f9;&#x5146; &#x58f9;&#x842c;</div>
+<div>&#x58f9;&#x5146; &#x58f9;&#x4f70;&#x842c;</div>
+<div>&#x58f9;&#x5146; &#x58f9;&#x4edf;&#x842c;</div>
+<div>&#x58f9;&#x5146; &#x58f9;&#x4edf;&#x5104;</div>
+<div>&#x58f9;&#x5146; &#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x5104;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x58f9;&#x5146; &#x58f9;&#x4edf;&#x58f9;&#x5104; &#x58f9;&#x4edf;&#x58f9;&#x842c; &#x58f9;&#x4edf;&#x58f9;</div>
+<div>&#x58f9;&#x5146; &#x62fe;&#x5104; &#x62fe;&#x842c; &#x62fe;&#x58f9;</div>
+<div>&#x58f9;&#x5146; &#x58f9;&#x4f70;&#x5104; &#x62fe;&#x842c; &#x58f9;</div>
+<div>&#x4f0d;&#x5146; &#x4f0d;&#x4edf;&#x4f0d;&#x5104; &#x4f0d;&#x4f70;&#x4f0d;&#x842c; &#x4f0d;&#x4edf;&#x4f0d;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x58f9;&#x5146;</div>
+<div>&#x62fe;&#x5104;</div>
+<div>&#x58f9;&#x4f70;&#x842c;</div>
+<div>&#x58f9;&#x4edf;</div>
+<div>&#x62fe;&#x5146;</div>
+<div>&#x58f9;&#x4f70;&#x5146;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5146; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+<div>&#x58f9;&#x4edf;&#x5146;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x58f9;&#x842c;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x58f9;&#x5104;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x58f9;&#x5146;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5146; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c; &#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x58f9;</div>

--- a/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal-extended.html
+++ b/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal-extended.html
@@ -1,35 +1,16 @@
 <!DOCTYPE html>
-<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
-<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Extended Implementation (optional)</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#extended-range-optional">
 <link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
-<link rel="match" href="counter-simp-chinese-informal-ref.html">
+<link rel="match" href="counter-korean-hanja-formal-extended-ref.html">
 <style>
   div::after {
-    content: counter(n, simp-chinese-informal);
+    content: counter(n, korean-hanja-formal);
   }
 </style>
-<div style="counter-reset: n 0;"></div>
-<div style="counter-reset: n 1;"></div>
-<div style="counter-reset: n 2;"></div>
-<div style="counter-reset: n 3;"></div>
-<div style="counter-reset: n 4;"></div>
-<div style="counter-reset: n 5;"></div>
-<div style="counter-reset: n 6;"></div>
-<div style="counter-reset: n 7;"></div>
-<div style="counter-reset: n 8;"></div>
-<div style="counter-reset: n 9;"></div>
 
-<div style="counter-reset: n 10;"></div>
-<div style="counter-reset: n 100;"></div>
-<div style="counter-reset: n 1000;"></div>
-
-<div style="counter-reset: n 11;"></div>
-<div style="counter-reset: n 99;"></div>
-<div style="counter-reset: n 101;"></div>
-<div style="counter-reset: n 200;"></div>
-<div style="counter-reset: n 6001;"></div>
-
-<!-- Test second group marker (万) - ten-thousands group -->
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (萬) - ten-thousands group -->
 <div style="counter-reset: n 10000;"></div>
 <div style="counter-reset: n 20000;"></div>
 <div style="counter-reset: n 50000;"></div>
@@ -42,7 +23,7 @@
 <div style="counter-reset: n 10100;"></div>
 <div style="counter-reset: n 11000;"></div>
 
-<!-- Test third group marker (亿) - hundred-millions group -->
+<!-- Test third group marker (億) - hundred-millions group -->
 <div style="counter-reset: n 100000000;"></div>
 <div style="counter-reset: n 200000000;"></div>
 <div style="counter-reset: n 500000000;"></div>
@@ -56,7 +37,7 @@
 <div style="counter-reset: n 101000000;"></div>
 <div style="counter-reset: n 110000000;"></div>
 
-<!-- Test fourth group marker (万亿) - trillions group -->
+<!-- Test fourth group marker (兆) - trillions group -->
 <div style="counter-reset: n 1000000000000;"></div>
 <div style="counter-reset: n 2000000000000;"></div>
 <div style="counter-reset: n 5000000000000;"></div>

--- a/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x58f9;&#x62fe;,</div>
 <div>&#x58f9;&#x767e;,</div>
 <div>&#x58f9;&#x4edf;,</div>
-<div>&#x58f9;&#x842c;,</div>
-<div>&#x58f9;&#x62fe;&#x842c;,</div>
-<div>&#x58f9;&#x767e;&#x842c;,</div>
-<div>&#x58f9;&#x4edf;&#x842c;,</div>
-<div>&#x58f9;&#x5104;,</div>
-<div>&#x58f9;&#x62fe;&#x5104;,</div>
 
 <div>&#x58f9;&#x62fe;&#x58f9;,</div>
 <div>&#x4e5d;&#x62fe;&#x4e5d;,</div>
 <div>&#x58f9;&#x767e;&#x58f9;,</div>
 <div>&#x8cb3;&#x767e;,</div>
 <div>&#x516d;&#x4edf;&#x58f9;,</div>
-<div>&#x58f9;&#x842c; &#x58f9;,</div>
-<div>&#x58f9;&#x842c; &#x58f9;&#x62fe;&#x58f9;,</div>
-<div>&#x58f9;&#x842c; &#x58f9;&#x767e;&#x58f9;,</div>
-<div>&#x58f9;&#x842c; &#x58f9;&#x4edf;&#x58f9;&#x767e;&#x58f9;&#x62fe;&#x58f9;,</div>
-<div>&#x58f9;&#x4edf;&#x58f9;&#x767e;&#x842c;,</div>
-<div>&#x58f9;&#x5104; &#x58f9;&#x842c; &#x58f9;,</div>
-<div>&#x58f9;&#x5104; &#x58f9;&#x62fe;&#x58f9;&#x842c; &#x58f9;,</div>
 
 <div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x58f9;,</div>

--- a/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal.html
+++ b/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;">,</div>
 <div style="counter-reset: n 100;">,</div>
 <div style="counter-reset: n 1000;">,</div>
-<div style="counter-reset: n 10000;">,</div>
-<div style="counter-reset: n 100000;">,</div>
-<div style="counter-reset: n 1000000;">,</div>
-<div style="counter-reset: n 10000000;">,</div>
-<div style="counter-reset: n 100000000;">,</div>
-<div style="counter-reset: n 1000000000;">,</div>
 
 <div style="counter-reset: n 11;">,</div>
 <div style="counter-reset: n 99;">,</div>
 <div style="counter-reset: n 101;">,</div>
 <div style="counter-reset: n 200;">,</div>
 <div style="counter-reset: n 6001;">,</div>
-<div style="counter-reset: n 10001;">,</div>
-<div style="counter-reset: n 10011;">,</div>
-<div style="counter-reset: n 10101;">,</div>
-<div style="counter-reset: n 11111;">,</div>
-<div style="counter-reset: n 11000000;">,</div>
-<div style="counter-reset: n 100010001;">,</div>
-<div style="counter-reset: n 100110001;">,</div>
 
 <div style="counter-reset: n -1;">,</div>

--- a/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal.html
+++ b/css/css-counter-styles/korean-hanja-formal/counter-korean-hanja-formal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Korean Limited-range Implementation (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-korean">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-korean-hanja-formal-ref.html">
 <style>
   div::before {

--- a/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal-extended-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal-extended-ref.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-korean">
+
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
+<!-- Test second group marker (万) - ten-thousands group -->
+<div>&#x4e00;&#x4e07;</div>
+<div>&#x4e8c;&#x4e07;</div>
+<div>&#x4e94;&#x4e07;</div>
+<div>&#x4e5d;&#x4e07; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x4e00;&#x4e07; &#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;</div>
+<div>&#x4e00;&#x4e07; &#x4e00;</div>
+<div>&#x4e00;&#x4e07; &#x5341;</div>
+<div>&#x4e00;&#x4e07; &#x767e;</div>
+<div>&#x4e00;&#x4e07; &#x4e00;&#x5343;</div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div>&#x4e00;&#x5104;</div>
+<div>&#x4e8c;&#x5104;</div>
+<div>&#x4e94;&#x5104;</div>
+<div>&#x4e5d;&#x5104; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x4e00;&#x5104; &#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x4e07; &#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x5104; &#x4e00;</div>
+<div>&#x4e00;&#x5104; &#x4e00;&#x4e07;</div>
+<div>&#x4e00;&#x5104; &#x5341;&#x4e07;</div>
+<div>&#x4e00;&#x5104; &#x767e;&#x4e07;</div>
+<div>&#x4e00;&#x5104; &#x4e00;&#x5343;&#x4e07;</div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div>&#x4e00;&#x5146;</div>
+<div>&#x4e8c;&#x5146;</div>
+<div>&#x4e94;&#x5146;</div>
+<div>&#x4e5d;&#x5146; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x5341;&#x5146;</div>
+<div>&#x4e94;&#x5341;&#x5146;</div>
+<div>&#x4e5d;&#x5341;&#x4e5d;&#x5146; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x767e;&#x5146;</div>
+<div>&#x4e94;&#x767e;&#x5146;</div>
+<div>&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x4e00;&#x5146; &#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x5104; &#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;&#x4e07; &#x767e;&#x4e8c;&#x5341;&#x4e09;</div>
+<div>&#x4e00;&#x5146; &#x4e00;</div>
+<div>&#x4e00;&#x5146; &#x4e00;&#x4e07;</div>
+<div>&#x4e00;&#x5146; &#x767e;&#x4e07;</div>
+<div>&#x4e00;&#x5146; &#x4e00;&#x5343;&#x4e07;</div>
+<div>&#x4e00;&#x5146; &#x4e00;&#x5343;&#x5104;</div>
+<div>&#x4e00;&#x5146; &#x4e00;&#x5343;&#x4e00;&#x767e;&#x5104;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x4e00;&#x5146; &#x4e00;&#x5343;&#x4e00;&#x5104; &#x4e00;&#x5343;&#x4e00;&#x4e07; &#x4e00;&#x5343;&#x4e00;</div>
+<div>&#x4e00;&#x5146; &#x5341;&#x5104; &#x5341;&#x4e07; &#x5341;&#x4e00;</div>
+<div>&#x4e00;&#x5146; &#x767e;&#x5104; &#x5341;&#x4e07; &#x4e00;</div>
+<div>&#x4e94;&#x5146; &#x4e94;&#x5343;&#x4e94;&#x5104; &#x4e94;&#x767e;&#x4e94;&#x4e07; &#x4e94;&#x5343;&#x4e94;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x4e00;&#x5146;</div>
+<div>&#x5341;&#x5104;</div>
+<div>&#x767e;&#x4e07;</div>
+<div>&#x5343;</div>
+<div>&#x5341;&#x5146;</div>
+<div>&#x767e;&#x5146;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07; &#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+<div>&#x5343;&#x5146;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;&#xb9cc;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;&#xc5b5;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;&#xc870;</div>
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc870; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xc5b5; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;&#xb9cc; &#xad6c;&#xcc9c;&#xad6c;&#xbc31;&#xad6c;&#xc2ed;&#xad6c;</div>
+
+<div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#xc77c;</div>

--- a/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal-extended.html
+++ b/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal-extended.html
@@ -1,34 +1,15 @@
 <!DOCTYPE html>
-<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
-<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Extended Implementation (optional)</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/#extended-range-optional">
 <link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
-<link rel="match" href="counter-simp-chinese-informal-ref.html">
+<link rel="match" href="counter-korean-hanja-informal-extended-ref.html">
 <style>
   div::after {
-    content: counter(n, simp-chinese-informal);
+    content: counter(n, korean-hanja-informal);
   }
 </style>
-<div style="counter-reset: n 0;"></div>
-<div style="counter-reset: n 1;"></div>
-<div style="counter-reset: n 2;"></div>
-<div style="counter-reset: n 3;"></div>
-<div style="counter-reset: n 4;"></div>
-<div style="counter-reset: n 5;"></div>
-<div style="counter-reset: n 6;"></div>
-<div style="counter-reset: n 7;"></div>
-<div style="counter-reset: n 8;"></div>
-<div style="counter-reset: n 9;"></div>
 
-<div style="counter-reset: n 10;"></div>
-<div style="counter-reset: n 100;"></div>
-<div style="counter-reset: n 1000;"></div>
-
-<div style="counter-reset: n 11;"></div>
-<div style="counter-reset: n 99;"></div>
-<div style="counter-reset: n 101;"></div>
-<div style="counter-reset: n 200;"></div>
-<div style="counter-reset: n 6001;"></div>
-
+<!-- Extended range implementation tests (algorithm step 2: split into 4-digit groups) -->
 <!-- Test second group marker (万) - ten-thousands group -->
 <div style="counter-reset: n 10000;"></div>
 <div style="counter-reset: n 20000;"></div>
@@ -42,7 +23,7 @@
 <div style="counter-reset: n 10100;"></div>
 <div style="counter-reset: n 11000;"></div>
 
-<!-- Test third group marker (亿) - hundred-millions group -->
+<!-- Test third group marker (億) - hundred-millions group -->
 <div style="counter-reset: n 100000000;"></div>
 <div style="counter-reset: n 200000000;"></div>
 <div style="counter-reset: n 500000000;"></div>
@@ -56,7 +37,7 @@
 <div style="counter-reset: n 101000000;"></div>
 <div style="counter-reset: n 110000000;"></div>
 
-<!-- Test fourth group marker (万亿) - trillions group -->
+<!-- Test fourth group marker (兆) - trillions group -->
 <div style="counter-reset: n 1000000000000;"></div>
 <div style="counter-reset: n 2000000000000;"></div>
 <div style="counter-reset: n 5000000000000;"></div>

--- a/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x5341;,</div>
 <div>&#x767e;,</div>
 <div>&#x5343;,</div>
-<div>&#x842c;,</div>
-<div>&#x5341;&#x842c;,</div>
-<div>&#x767e;&#x842c;,</div>
-<div>&#x5343;&#x842c;,</div>
-<div>&#x4e00;&#x5104;,</div>
-<div>&#x5341;&#x5104;,</div>
 
 <div>&#x5341;&#x4e00;,</div>
 <div>&#x4e5d;&#x5341;&#x4e5d;,</div>
 <div>&#x767e;&#x4e00;,</div>
 <div>&#x4e8c;&#x767e;,</div>
 <div>&#x516d;&#x5343;&#x4e00;,</div>
-<div>&#x842c; &#x4e00;,</div>
-<div>&#x842c; &#x5341;&#x4e00;,</div>
-<div>&#x842c; &#x767e;&#x4e00;,</div>
-<div>&#x842c; &#x5343;&#x767e;&#x5341;&#x4e00;,</div>
-<div>&#x5343;&#x767e;&#x842c;,</div>
-<div>&#x4e00;&#x5104; &#x842c; &#x4e00;,</div>
-<div>&#x4e00;&#x5104; &#x5341;&#x4e00;&#x842c; &#x4e00;,</div>
 
 <div>&#xb9c8;&#xc774;&#xb108;&#xc2a4; &#x4e00;,</div>

--- a/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal.html
+++ b/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Korean Limited-range Implementation (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-korean">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-korean-hanja-informal-ref.html">
 <style>
   div::before {

--- a/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal.html
+++ b/css/css-counter-styles/korean-hanja-informal/counter-korean-hanja-informal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;">,</div>
 <div style="counter-reset: n 100;">,</div>
 <div style="counter-reset: n 1000;">,</div>
-<div style="counter-reset: n 10000;">,</div>
-<div style="counter-reset: n 100000;">,</div>
-<div style="counter-reset: n 1000000;">,</div>
-<div style="counter-reset: n 10000000;">,</div>
-<div style="counter-reset: n 100000000;">,</div>
-<div style="counter-reset: n 1000000000;">,</div>
 
 <div style="counter-reset: n 11;">,</div>
 <div style="counter-reset: n 99;">,</div>
 <div style="counter-reset: n 101;">,</div>
 <div style="counter-reset: n 200;">,</div>
 <div style="counter-reset: n 6001;">,</div>
-<div style="counter-reset: n 10001;">,</div>
-<div style="counter-reset: n 10011;">,</div>
-<div style="counter-reset: n 10101;">,</div>
-<div style="counter-reset: n 11111;">,</div>
-<div style="counter-reset: n 11000000;">,</div>
-<div style="counter-reset: n 100010001;">,</div>
-<div style="counter-reset: n 100110001;">,</div>
 
 <div style="counter-reset: n -1;">,</div>

--- a/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal-ref.html
@@ -20,4 +20,84 @@
 <div>&#x8d30;&#x4f70;</div>
 <div>&#x9646;&#x4edf;&#x96f6;&#x58f9;</div>
 
+<!-- Test second group marker (万) - ten-thousands group -->
+<div>&#x58f9;&#x4e07;</div>
+<div>&#x8d30;&#x4e07;</div>
+<div>&#x4f0d;&#x4e07;</div>
+<div>&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x58f9;&#x4e07;&#x8d30;&#x4edf;&#x53c1;&#x4f70;&#x8086;&#x62fe;&#x4f0d;</div>
+<div>&#x58f9;&#x4e07;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x4e07;&#x96f6;&#x62fe;</div>
+<div>&#x58f9;&#x4e07;&#x96f6;&#x58f9;&#x4f70;</div>
+<div>&#x58f9;&#x4e07;&#x58f9;&#x4edf;</div>
+
+<!-- Test third group marker (亿) - hundred-millions group -->
+<div>&#x58f9;&#x4ebf;</div>
+<div>&#x8d30;&#x4ebf;</div>
+<div>&#x4f0d;&#x4ebf;</div>
+<div>&#x7396;&#x4ebf;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x58f9;&#x4ebf;&#x8d30;&#x4edf;&#x53c1;&#x4f70;&#x8086;&#x62fe;&#x4f0d;&#x4e07;&#x9646;&#x4edf;&#x67d2;&#x4f70;&#x634c;&#x62fe;&#x7396;</div>
+<div>&#x58f9;&#x4ebf;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x4ebf;&#x96f6;&#x58f9;&#x4e07;</div>
+<div>&#x58f9;&#x4ebf;&#x96f6;&#x62fe;&#x4e07;</div>
+<div>&#x58f9;&#x4ebf;&#x96f6;&#x58f9;&#x4f70;&#x4e07;</div>
+<div>&#x58f9;&#x4ebf;&#x58f9;&#x4edf;&#x4e07;</div>
+
+<!-- Test fourth group marker (万亿) - trillions group -->
+<div>&#x58f9;&#x4e07;&#x4ebf;</div>
+<div>&#x8d30;&#x4e07;&#x4ebf;</div>
+<div>&#x4f0d;&#x4e07;&#x4ebf;</div>
+<div>&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x4ebf;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x62fe;&#x4e07;&#x4ebf;</div>
+<div>&#x4f0d;&#x62fe;&#x4e07;&#x4ebf;</div>
+<div>&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x4ebf;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x58f9;&#x4f70;&#x4e07;&#x4ebf;</div>
+<div>&#x4f0d;&#x4f70;&#x4e07;&#x4ebf;</div>
+<div>&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x4ebf;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x58f9;&#x4e07;&#x8d30;&#x4edf;&#x53c1;&#x4f70;&#x8086;&#x62fe;&#x4f0d;&#x4e07;&#x4ebf;&#x9646;&#x4edf;&#x67d2;&#x4f70;&#x634c;&#x62fe;&#x7396;&#x4e07;&#x96f6;&#x58f9;&#x4f70;&#x8d30;&#x62fe;&#x53c1;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x96f6;&#x58f9;&#x4e07;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x96f6;&#x58f9;&#x4f70;&#x4e07;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x96f6;&#x58f9;&#x4edf;&#x4e07;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x58f9;&#x4edf;&#x4ebf;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x4ebf;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x58f9;&#x4e07;&#x96f6;&#x58f9;&#x4e07;&#x4ebf;&#x58f9;&#x4edf;&#x96f6;&#x58f9;&#x4e07;&#x58f9;&#x4edf;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x4e07;&#x96f6;&#x62fe;&#x4e07;&#x4ebf;&#x58f9;&#x4edf;&#x96f6;&#x62fe;&#x4e07;&#x58f9;&#x4edf;&#x96f6;&#x62fe;&#x58f9;</div>
+<div>&#x58f9;&#x4e07;&#x4ebf;&#x58f9;&#x4edf;&#x4ebf;&#x96f6;&#x62fe;&#x4e07;&#x96f6;&#x58f9;</div>
+<div>&#x4f0d;&#x4e07;&#x96f6;&#x4f0d;&#x4e07;&#x4ebf;&#x4f0d;&#x4edf;&#x96f6;&#x4f0d;&#x4e07;&#x4f0d;&#x4edf;&#x96f6;&#x4f0d;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x58f9;&#x4e07;&#x4ebf;</div>
+<div>&#x62fe;&#x4ebf;</div>
+<div>&#x58f9;&#x4f70;&#x4e07;</div>
+<div>&#x58f9;&#x4edf;</div>
+<div>&#x62fe;&#x4e07;&#x4ebf;</div>
+<div>&#x58f9;&#x4f70;&#x4e07;&#x4ebf;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x4ebf;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+<div>&#x58f9;&#x4edf;&#x4e07;&#x4ebf;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#x8d1f;&#x58f9;&#x4e07;</div>
+<div>&#x8d1f;&#x58f9;&#x4ebf;</div>
+<div>&#x8d1f;&#x58f9;&#x4e07;&#x4ebf;</div>
+<div>&#x8d1f;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x4ebf;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x4e07;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
 <div>&#x8d1f;&#x58f9;</div>

--- a/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x58f9;&#x62fe;</div>
 <div>&#x58f9;&#x4f70;</div>
 <div>&#x58f9;&#x4edf;</div>
-<div>&#x58f9;&#x4e07;</div>
-<div>&#x58f9;&#x62fe;&#x4e07;</div>
-<div>&#x58f9;&#x4f70;&#x4e07;</div>
-<div>&#x58f9;&#x4edf;&#x4e07;</div>
-<div>&#x58f9;&#x4ebf;</div>
-<div>&#x58f9;&#x62fe;&#x4ebf;</div>
 
 <div>&#x58f9;&#x62fe;&#x58f9;</div>
 <div>&#x7396;&#x62fe;&#x7396;</div>
 <div>&#x58f9;&#x4f70;&#x96f6;&#x58f9;</div>
 <div>&#x8d30;&#x4f70;</div>
 <div>&#x9646;&#x4edf;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x4e07;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x4e07;&#x96f6;&#x58f9;&#x62fe;&#x58f9;</div>
-<div>&#x58f9;&#x4e07;&#x96f6;&#x58f9;&#x4f70;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x4e07;&#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x58f9;&#x62fe;&#x58f9;</div>
-<div>&#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x4e07;</div>
-<div>&#x58f9;&#x4ebf;&#x96f6;&#x58f9;&#x4e07;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x4ebf;&#x96f6;&#x58f9;&#x62fe;&#x58f9;&#x4e07;&#x96f6;&#x58f9;</div>
 
 <div>&#x8d1f;&#x58f9;</div>

--- a/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal.html
+++ b/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-simp-chinese-formal-ref.html">
 <style>
   div::after {
@@ -26,5 +28,85 @@
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
+
+<!-- Test second group marker (万) - ten-thousands group -->
+<div style="counter-reset: n 10000;"></div>
+<div style="counter-reset: n 20000;"></div>
+<div style="counter-reset: n 50000;"></div>
+<div style="counter-reset: n 99999;"></div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div style="counter-reset: n 12345;"></div>
+<div style="counter-reset: n 10001;"></div>
+<div style="counter-reset: n 10010;"></div>
+<div style="counter-reset: n 10100;"></div>
+<div style="counter-reset: n 11000;"></div>
+
+<!-- Test third group marker (亿) - hundred-millions group -->
+<div style="counter-reset: n 100000000;"></div>
+<div style="counter-reset: n 200000000;"></div>
+<div style="counter-reset: n 500000000;"></div>
+<div style="counter-reset: n 999999999;"></div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div style="counter-reset: n 123456789;"></div>
+<div style="counter-reset: n 100000001;"></div>
+<div style="counter-reset: n 100010000;"></div>
+<div style="counter-reset: n 100100000;"></div>
+<div style="counter-reset: n 101000000;"></div>
+<div style="counter-reset: n 110000000;"></div>
+
+<!-- Test fourth group marker (万亿) - trillions group -->
+<div style="counter-reset: n 1000000000000;"></div>
+<div style="counter-reset: n 2000000000000;"></div>
+<div style="counter-reset: n 5000000000000;"></div>
+<div style="counter-reset: n 9999999999999;"></div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div style="counter-reset: n 10000000000000;"></div>
+<div style="counter-reset: n 50000000000000;"></div>
+<div style="counter-reset: n 99999999999999;"></div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div style="counter-reset: n 100000000000000;"></div>
+<div style="counter-reset: n 500000000000000;"></div>
+<div style="counter-reset: n 999999999999999;"></div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div style="counter-reset: n 1234567890123;"></div>
+<div style="counter-reset: n 1000000000001;"></div>
+<div style="counter-reset: n 1000000010000;"></div>
+<div style="counter-reset: n 1000001000000;"></div>
+<div style="counter-reset: n 1000100000000;"></div>
+<div style="counter-reset: n 1010000000000;"></div>
+<div style="counter-reset: n 1100000000000;"></div>
+
+<!-- Test interaction between multiple groups -->
+<div style="counter-reset: n 1001001001001;"></div>
+<div style="counter-reset: n 1010101010101;"></div>
+<div style="counter-reset: n 1000100010001;"></div>
+<div style="counter-reset: n 5005005005005;"></div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div style="counter-reset: n 1000000000000;"></div>
+<div style="counter-reset: n 1000000000;"></div>
+<div style="counter-reset: n 1000000;"></div>
+<div style="counter-reset: n 1000;"></div>
+<div style="counter-reset: n 10000000000000;"></div>
+<div style="counter-reset: n 100000000000000;"></div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div style="counter-reset: n 9999999999999999;"></div>
+<div style="counter-reset: n 1000000000000000;"></div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div style="counter-reset: n 10000000000000000;"></div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div style="counter-reset: n -10000;"></div>
+<div style="counter-reset: n -100000000;"></div>
+<div style="counter-reset: n -1000000000000;"></div>
+<div style="counter-reset: n -9999999999999999;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal.html
+++ b/css/css-counter-styles/simp-chinese-formal/counter-simp-chinese-formal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;"></div>
 <div style="counter-reset: n 100;"></div>
 <div style="counter-reset: n 1000;"></div>
-<div style="counter-reset: n 10000;"></div>
-<div style="counter-reset: n 100000;"></div>
-<div style="counter-reset: n 1000000;"></div>
-<div style="counter-reset: n 10000000;"></div>
-<div style="counter-reset: n 100000000;"></div>
-<div style="counter-reset: n 1000000000;"></div>
 
 <div style="counter-reset: n 11;"></div>
 <div style="counter-reset: n 99;"></div>
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
-<div style="counter-reset: n 10001;"></div>
-<div style="counter-reset: n 10011;"></div>
-<div style="counter-reset: n 10101;"></div>
-<div style="counter-reset: n 11111;"></div>
-<div style="counter-reset: n 11000000;"></div>
-<div style="counter-reset: n 100010001;"></div>
-<div style="counter-reset: n 100110001;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/simp-chinese-informal/counter-simp-chinese-informal-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/counter-simp-chinese-informal-ref.html
@@ -20,4 +20,85 @@
 <div>&#x4e8c;&#x767e;</div>
 <div>&#x516d;&#x5343;&#x96f6;&#x4e00;</div>
 
+<!-- Test second group marker (万) - ten-thousands group -->
+<div>&#x4e00;&#x4e07;</div>
+<div>&#x4e8c;&#x4e07;</div>
+<div>&#x4e94;&#x4e07;</div>
+<div>&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x4e00;&#x4e07;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;</div>
+<div>&#x4e00;&#x4e07;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x4e07;&#x96f6;&#x5341;</div>
+<div>&#x4e00;&#x4e07;&#x96f6;&#x4e00;&#x767e;</div>
+<div>&#x4e00;&#x4e07;&#x4e00;&#x5343;</div>
+
+<!-- Test third group marker (亿) - hundred-millions group -->
+<div>&#x4e00;&#x4ebf;</div>
+<div>&#x4e8c;&#x4ebf;</div>
+<div>&#x4e94;&#x4ebf;</div>
+<div>&#x4e5d;&#x4ebf;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x4e00;&#x4ebf;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x4e07;&#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x4ebf;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x4ebf;&#x96f6;&#x4e00;&#x4e07;</div>
+<div>&#x4e00;&#x4ebf;&#x96f6;&#x5341;&#x4e07;</div>
+<div>&#x4e00;&#x4ebf;&#x96f6;&#x4e00;&#x767e;&#x4e07;</div>
+<div>&#x4e00;&#x4ebf;&#x4e00;&#x5343;&#x4e07;</div>
+
+<!-- Test fourth group marker (万亿) - trillions group -->
+<div>&#x4e00;&#x4e07;&#x4ebf;</div>
+<div>&#x4e8c;&#x4e07;&#x4ebf;</div>
+<div>&#x4e94;&#x4e07;&#x4ebf;</div>
+<div>&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4ebf;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x5341;&#x4e07;&#x4ebf;</div>
+<div>&#x4e94;&#x5341;&#x4e07;&#x4ebf;</div>
+<div>&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4ebf;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x4e00;&#x767e;&#x4e07;&#x4ebf;</div>
+<div>&#x4e94;&#x767e;&#x4e07;&#x4ebf;</div>
+<div>&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4ebf;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x4e00;&#x4e07;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x4e07;&#x4ebf;&#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;&#x4e07;&#x96f6;&#x4e00;&#x767e;&#x4e8c;&#x5341;&#x4e09;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x96f6;&#x4e00;&#x4e07;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x96f6;&#x4e00;&#x767e;&#x4e07;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x96f6;&#x4e00;&#x5343;&#x4e07;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x4e00;&#x5343;&#x4ebf;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x4e00;&#x5343;&#x4e00;&#x767e;&#x4ebf;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x4e00;&#x4e07;&#x96f6;&#x4e00;&#x4e07;&#x4ebf;&#x4e00;&#x5343;&#x96f6;&#x4e00;&#x4e07;&#x4e00;&#x5343;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x4e07;&#x96f6;&#x5341;&#x4e07;&#x4ebf;&#x4e00;&#x5343;&#x96f6;&#x5341;&#x4e07;&#x4e00;&#x5343;&#x96f6;&#x5341;&#x4e00;</div>
+<div>&#x4e00;&#x4e07;&#x4ebf;&#x4e00;&#x5343;&#x4ebf;&#x96f6;&#x5341;&#x4e07;&#x96f6;&#x4e00;</div>
+<div>&#x4e94;&#x4e07;&#x96f6;&#x4e94;&#x4e07;&#x4ebf;&#x4e94;&#x5343;&#x96f6;&#x4e94;&#x4e07;&#x4e94;&#x5343;&#x96f6;&#x4e94;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x4e00;&#x4e07;&#x4ebf;</div>
+<div>&#x5341;&#x4ebf;</div>
+<div>&#x4e00;&#x767e;&#x4e07;</div>
+<div>&#x4e00;&#x5343;</div>
+<div>&#x5341;&#x4e07;&#x4ebf;</div>
+<div>&#x4e00;&#x767e;&#x4e07;&#x4ebf;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4ebf;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x5343;&#x4e07;&#x4ebf;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#x8d1f;&#x4e00;&#x4e07;</div>
+<div>&#x8d1f;&#x4e00;&#x4ebf;</div>
+<div>&#x8d1f;&#x4e00;&#x4e07;&#x4ebf;</div>
+<div>&#x8d1f;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4ebf;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x4e07;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
 <div>&#x8d1f;&#x4e00;</div>
+

--- a/css/css-counter-styles/simp-chinese-informal/counter-simp-chinese-informal-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/counter-simp-chinese-informal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x5341;</div>
 <div>&#x4e00;&#x767e;</div>
 <div>&#x4e00;&#x5343;</div>
-<div>&#x4e00;&#x4e07;</div>
-<div>&#x5341;&#x4e07;</div>
-<div>&#x4e00;&#x767e;&#x4e07;</div>
-<div>&#x4e00;&#x5343;&#x4e07;</div>
-<div>&#x4e00;&#x4ebf;</div>
-<div>&#x5341;&#x4ebf;</div>
 
 <div>&#x5341;&#x4e00;</div>
 <div>&#x4e5d;&#x5341;&#x4e5d;</div>
 <div>&#x4e00;&#x767e;&#x96f6;&#x4e00;</div>
 <div>&#x4e8c;&#x767e;</div>
 <div>&#x516d;&#x5343;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x96f6;&#x4e00;&#x5341;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x96f6;&#x4e00;&#x767e;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x4e07;&#x4e00;&#x5343;&#x4e00;&#x767e;&#x4e00;&#x5341;&#x4e00;</div>
-<div>&#x4e00;&#x5343;&#x4e00;&#x767e;&#x4e07;</div>
-<div>&#x4e00;&#x4ebf;&#x96f6;&#x4e00;&#x4e07;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x4ebf;&#x96f6;&#x5341;&#x4e00;&#x4e07;&#x96f6;&#x4e00;</div>
 
 <div>&#x8d1f;&#x4e00;</div>

--- a/css/css-counter-styles/simp-chinese-informal/counter-simp-chinese-informal.html
+++ b/css/css-counter-styles/simp-chinese-informal/counter-simp-chinese-informal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;"></div>
 <div style="counter-reset: n 100;"></div>
 <div style="counter-reset: n 1000;"></div>
-<div style="counter-reset: n 10000;"></div>
-<div style="counter-reset: n 100000;"></div>
-<div style="counter-reset: n 1000000;"></div>
-<div style="counter-reset: n 10000000;"></div>
-<div style="counter-reset: n 100000000;"></div>
-<div style="counter-reset: n 1000000000;"></div>
 
 <div style="counter-reset: n 11;"></div>
 <div style="counter-reset: n 99;"></div>
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
-<div style="counter-reset: n 10001;"></div>
-<div style="counter-reset: n 10011;"></div>
-<div style="counter-reset: n 10101;"></div>
-<div style="counter-reset: n 11111;"></div>
-<div style="counter-reset: n 11000000;"></div>
-<div style="counter-reset: n 100010001;"></div>
-<div style="counter-reset: n 100110001;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x58f9;&#x62fe;</div>
 <div>&#x58f9;&#x4f70;</div>
 <div>&#x58f9;&#x4edf;</div>
-<div>&#x58f9;&#x842c;</div>
-<div>&#x58f9;&#x62fe;&#x842c;</div>
-<div>&#x58f9;&#x4f70;&#x842c;</div>
-<div>&#x58f9;&#x4edf;&#x842c;</div>
-<div>&#x58f9;&#x5104;</div>
-<div>&#x58f9;&#x62fe;&#x5104;</div>
 
 <div>&#x58f9;&#x62fe;&#x58f9;</div>
 <div>&#x7396;&#x62fe;&#x7396;</div>
 <div>&#x58f9;&#x4f70;&#x96f6;&#x58f9;</div>
 <div>&#x8cb3;&#x4f70;</div>
 <div>&#x9678;&#x4edf;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x842c;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x842c;&#x96f6;&#x58f9;&#x62fe;&#x58f9;</div>
-<div>&#x58f9;&#x842c;&#x96f6;&#x58f9;&#x4f70;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x842c;&#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x58f9;&#x62fe;&#x58f9;</div>
-<div>&#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x842c;</div>
-<div>&#x58f9;&#x5104;&#x96f6;&#x58f9;&#x842c;&#x96f6;&#x58f9;</div>
-<div>&#x58f9;&#x5104;&#x96f6;&#x58f9;&#x62fe;&#x58f9;&#x842c;&#x96f6;&#x58f9;</div>
 
 <div>&#x8ca0;&#x58f9;</div>

--- a/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal-ref.html
@@ -20,4 +20,85 @@
 <div>&#x8cb3;&#x4f70;</div>
 <div>&#x9678;&#x4edf;&#x96f6;&#x58f9;</div>
 
+<!-- Test second group marker (萬) - ten-thousands group -->
+<div>&#x58f9;&#x842c;</div>
+<div>&#x8cb3;&#x842c;</div>
+<div>&#x4f0d;&#x842c;</div>
+<div>&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x58f9;&#x842c;&#x8cb3;&#x4edf;&#x53c3;&#x4f70;&#x8086;&#x62fe;&#x4f0d;</div>
+<div>&#x58f9;&#x842c;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x842c;&#x96f6;&#x62fe;</div>
+<div>&#x58f9;&#x842c;&#x96f6;&#x58f9;&#x4f70;</div>
+<div>&#x58f9;&#x842c;&#x58f9;&#x4edf;</div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div>&#x58f9;&#x5104;</div>
+<div>&#x8cb3;&#x5104;</div>
+<div>&#x4f0d;&#x5104;</div>
+<div>&#x7396;&#x5104;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x58f9;&#x5104;&#x8cb3;&#x4edf;&#x53c3;&#x4f70;&#x8086;&#x62fe;&#x4f0d;&#x842c;&#x9678;&#x4edf;&#x67d2;&#x4f70;&#x634c;&#x62fe;&#x7396;</div>
+<div>&#x58f9;&#x5104;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x5104;&#x96f6;&#x58f9;&#x842c;</div>
+<div>&#x58f9;&#x5104;&#x96f6;&#x62fe;&#x842c;</div>
+<div>&#x58f9;&#x5104;&#x96f6;&#x58f9;&#x4f70;&#x842c;</div>
+<div>&#x58f9;&#x5104;&#x58f9;&#x4edf;&#x842c;</div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div>&#x58f9;&#x5146;</div>
+<div>&#x8cb3;&#x5146;</div>
+<div>&#x4f0d;&#x5146;</div>
+<div>&#x7396;&#x5146;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x62fe;&#x5146;</div>
+<div>&#x4f0d;&#x62fe;&#x5146;</div>
+<div>&#x7396;&#x62fe;&#x7396;&#x5146;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x58f9;&#x4f70;&#x5146;</div>
+<div>&#x4f0d;&#x4f70;&#x5146;</div>
+<div>&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5146;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x58f9;&#x5146;&#x8cb3;&#x4edf;&#x53c3;&#x4f70;&#x8086;&#x62fe;&#x4f0d;&#x5104;&#x9678;&#x4edf;&#x67d2;&#x4f70;&#x634c;&#x62fe;&#x7396;&#x842c;&#x96f6;&#x58f9;&#x4f70;&#x8cb3;&#x62fe;&#x53c3;</div>
+<div>&#x58f9;&#x5146;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x5146;&#x96f6;&#x58f9;&#x842c;</div>
+<div>&#x58f9;&#x5146;&#x96f6;&#x58f9;&#x4f70;&#x842c;</div>
+<div>&#x58f9;&#x5146;&#x96f6;&#x58f9;&#x4edf;&#x842c;</div>
+<div>&#x58f9;&#x5146;&#x58f9;&#x4edf;&#x5104;</div>
+<div>&#x58f9;&#x5146;&#x58f9;&#x4edf;&#x58f9;&#x4f70;&#x5104;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x58f9;&#x5146;&#x96f6;&#x58f9;&#x5104;&#x58f9;&#x4edf;&#x96f6;&#x58f9;&#x842c;&#x58f9;&#x4edf;&#x96f6;&#x58f9;</div>
+<div>&#x58f9;&#x5146;&#x96f6;&#x62fe;&#x5104;&#x58f9;&#x4edf;&#x96f6;&#x62fe;&#x842c;&#x58f9;&#x4edf;&#x96f6;&#x62fe;&#x58f9;</div>
+<div>&#x58f9;&#x5146;&#x58f9;&#x4edf;&#x5104;&#x96f6;&#x62fe;&#x842c;&#x96f6;&#x58f9;</div>
+<div>&#x4f0d;&#x5146;&#x96f6;&#x4f0d;&#x5104;&#x4f0d;&#x4edf;&#x96f6;&#x4f0d;&#x842c;&#x4f0d;&#x4edf;&#x96f6;&#x4f0d;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x58f9;&#x5146;</div>
+<div>&#x62fe;&#x5104;</div>
+<div>&#x58f9;&#x4f70;&#x842c;</div>
+<div>&#x58f9;&#x4edf;</div>
+<div>&#x62fe;&#x5146;</div>
+<div>&#x58f9;&#x4f70;&#x5146;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5146;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+<div>&#x58f9;&#x4edf;&#x5146;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#x8ca0;&#x58f9;&#x842c;</div>
+<div>&#x8ca0;&#x58f9;&#x5104;</div>
+<div>&#x8ca0;&#x58f9;&#x5146;</div>
+<div>&#x8ca0;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5146;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x5104;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;&#x842c;&#x7396;&#x4edf;&#x7396;&#x4f70;&#x7396;&#x62fe;&#x7396;</div>
+
 <div>&#x8ca0;&#x58f9;</div>
+

--- a/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal.html
+++ b/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Chinese (required)</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-trad-chinese-formal-ref.html">
 <style>
   div::after {
@@ -27,4 +29,85 @@
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
 
+<!-- Test second group marker (萬) - ten-thousands group -->
+<div style="counter-reset: n 10000;"></div>
+<div style="counter-reset: n 20000;"></div>
+<div style="counter-reset: n 50000;"></div>
+<div style="counter-reset: n 99999;"></div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div style="counter-reset: n 12345;"></div>
+<div style="counter-reset: n 10001;"></div>
+<div style="counter-reset: n 10010;"></div>
+<div style="counter-reset: n 10100;"></div>
+<div style="counter-reset: n 11000;"></div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div style="counter-reset: n 100000000;"></div>
+<div style="counter-reset: n 200000000;"></div>
+<div style="counter-reset: n 500000000;"></div>
+<div style="counter-reset: n 999999999;"></div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div style="counter-reset: n 123456789;"></div>
+<div style="counter-reset: n 100000001;"></div>
+<div style="counter-reset: n 100010000;"></div>
+<div style="counter-reset: n 100100000;"></div>
+<div style="counter-reset: n 101000000;"></div>
+<div style="counter-reset: n 110000000;"></div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div style="counter-reset: n 1000000000000;"></div>
+<div style="counter-reset: n 2000000000000;"></div>
+<div style="counter-reset: n 5000000000000;"></div>
+<div style="counter-reset: n 9999999999999;"></div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div style="counter-reset: n 10000000000000;"></div>
+<div style="counter-reset: n 50000000000000;"></div>
+<div style="counter-reset: n 99999999999999;"></div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div style="counter-reset: n 100000000000000;"></div>
+<div style="counter-reset: n 500000000000000;"></div>
+<div style="counter-reset: n 999999999999999;"></div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div style="counter-reset: n 1234567890123;"></div>
+<div style="counter-reset: n 1000000000001;"></div>
+<div style="counter-reset: n 1000000010000;"></div>
+<div style="counter-reset: n 1000001000000;"></div>
+<div style="counter-reset: n 1000100000000;"></div>
+<div style="counter-reset: n 1010000000000;"></div>
+<div style="counter-reset: n 1100000000000;"></div>
+
+<!-- Test interaction between multiple groups -->
+<div style="counter-reset: n 1001001001001;"></div>
+<div style="counter-reset: n 1010101010101;"></div>
+<div style="counter-reset: n 1000100010001;"></div>
+<div style="counter-reset: n 5005005005005;"></div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div style="counter-reset: n 1000000000000;"></div>
+<div style="counter-reset: n 1000000000;"></div>
+<div style="counter-reset: n 1000000;"></div>
+<div style="counter-reset: n 1000;"></div>
+<div style="counter-reset: n 10000000000000;"></div>
+<div style="counter-reset: n 100000000000000;"></div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div style="counter-reset: n 9999999999999999;"></div>
+<div style="counter-reset: n 1000000000000000;"></div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div style="counter-reset: n 10000000000000000;"></div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div style="counter-reset: n -10000;"></div>
+<div style="counter-reset: n -100000000;"></div>
+<div style="counter-reset: n -1000000000000;"></div>
+<div style="counter-reset: n -9999999999999999;"></div>
+
 <div style="counter-reset: n -1;"></div>
+

--- a/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal.html
+++ b/css/css-counter-styles/trad-chinese-formal/counter-trad-chinese-formal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;"></div>
 <div style="counter-reset: n 100;"></div>
 <div style="counter-reset: n 1000;"></div>
-<div style="counter-reset: n 10000;"></div>
-<div style="counter-reset: n 100000;"></div>
-<div style="counter-reset: n 1000000;"></div>
-<div style="counter-reset: n 10000000;"></div>
-<div style="counter-reset: n 100000000;"></div>
-<div style="counter-reset: n 1000000000;"></div>
 
 <div style="counter-reset: n 11;"></div>
 <div style="counter-reset: n 99;"></div>
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
-<div style="counter-reset: n 10001;"></div>
-<div style="counter-reset: n 10011;"></div>
-<div style="counter-reset: n 10101;"></div>
-<div style="counter-reset: n 11111;"></div>
-<div style="counter-reset: n 11000000;"></div>
-<div style="counter-reset: n 100010001;"></div>
-<div style="counter-reset: n 100110001;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal-ref.html
@@ -20,4 +20,84 @@
 <div>&#x4e8c;&#x767e;</div>
 <div>&#x516d;&#x5343;&#x96f6;&#x4e00;</div>
 
+<!-- Test second group marker (萬) - ten-thousands group -->
+<div>&#x4e00;&#x842c;</div>
+<div>&#x4e8c;&#x842c;</div>
+<div>&#x4e94;&#x842c;</div>
+<div>&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div>&#x4e00;&#x842c;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;</div>
+<div>&#x4e00;&#x842c;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x842c;&#x96f6;&#x5341;</div>
+<div>&#x4e00;&#x842c;&#x96f6;&#x4e00;&#x767e;</div>
+<div>&#x4e00;&#x842c;&#x4e00;&#x5343;</div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div>&#x4e00;&#x5104;</div>
+<div>&#x4e8c;&#x5104;</div>
+<div>&#x4e94;&#x5104;</div>
+<div>&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div>&#x4e00;&#x5104;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x842c;&#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x5104;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x5104;&#x96f6;&#x4e00;&#x842c;</div>
+<div>&#x4e00;&#x5104;&#x96f6;&#x5341;&#x842c;</div>
+<div>&#x4e00;&#x5104;&#x96f6;&#x4e00;&#x767e;&#x842c;</div>
+<div>&#x4e00;&#x5104;&#x4e00;&#x5343;&#x842c;</div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div>&#x4e00;&#x5146;</div>
+<div>&#x4e8c;&#x5146;</div>
+<div>&#x4e94;&#x5146;</div>
+<div>&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div>&#x5341;&#x5146;</div>
+<div>&#x4e94;&#x5341;&#x5146;</div>
+<div>&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div>&#x4e00;&#x767e;&#x5146;</div>
+<div>&#x4e94;&#x767e;&#x5146;</div>
+<div>&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div>&#x4e00;&#x5146;&#x4e8c;&#x5343;&#x4e09;&#x767e;&#x56db;&#x5341;&#x4e94;&#x5104;&#x516d;&#x5343;&#x4e03;&#x767e;&#x516b;&#x5341;&#x4e5d;&#x842c;&#x96f6;&#x4e00;&#x767e;&#x4e8c;&#x5341;&#x4e09;</div>
+<div>&#x4e00;&#x5146;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x5146;&#x96f6;&#x4e00;&#x842c;</div>
+<div>&#x4e00;&#x5146;&#x96f6;&#x4e00;&#x767e;&#x842c;</div>
+<div>&#x4e00;&#x5146;&#x96f6;&#x4e00;&#x5343;&#x842c;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x5343;&#x5104;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x5343;&#x4e00;&#x767e;&#x5104;</div>
+
+<!-- Test interaction between multiple groups -->
+<div>&#x4e00;&#x5146;&#x96f6;&#x4e00;&#x5104;&#x4e00;&#x5343;&#x96f6;&#x4e00;&#x842c;&#x4e00;&#x5343;&#x96f6;&#x4e00;</div>
+<div>&#x4e00;&#x5146;&#x96f6;&#x5341;&#x5104;&#x4e00;&#x5343;&#x96f6;&#x5341;&#x842c;&#x4e00;&#x5343;&#x96f6;&#x5341;&#x4e00;</div>
+<div>&#x4e00;&#x5146;&#x4e00;&#x5343;&#x5104;&#x96f6;&#x5341;&#x842c;&#x96f6;&#x4e00;</div>
+<div>&#x4e94;&#x5146;&#x96f6;&#x4e94;&#x5104;&#x4e94;&#x5343;&#x96f6;&#x4e94;&#x842c;&#x4e94;&#x5343;&#x96f6;&#x4e94;</div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div>&#x4e00;&#x5146;</div>
+<div>&#x5341;&#x5104;</div>
+<div>&#x4e00;&#x767e;&#x842c;</div>
+<div>&#x4e00;&#x5343;</div>
+<div>&#x5341;&#x5146;</div>
+<div>&#x4e00;&#x767e;&#x5146;</div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div>&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+<div>&#x4e00;&#x5343;&#x5146;</div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div>&#x4e00;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;&#x3007;</div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div>&#x8ca0;&#x4e00;&#x842c;</div>
+<div>&#x8ca0;&#x4e00;&#x5104;</div>
+<div>&#x8ca0;&#x4e00;&#x5146;</div>
+<div>&#x8ca0;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5146;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x5104;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;&#x842c;&#x4e5d;&#x5343;&#x4e5d;&#x767e;&#x4e5d;&#x5341;&#x4e5d;</div>
+
 <div>&#x8ca0;&#x4e00;</div>

--- a/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal-ref.html
@@ -13,24 +13,11 @@
 <div>&#x5341;</div>
 <div>&#x4e00;&#x767e;</div>
 <div>&#x4e00;&#x5343;</div>
-<div>&#x4e00;&#x842c;<div>
-<div>&#x5341;&#x842c;</div>
-<div>&#x4e00;&#x767e;&#x842c;</div>
-<div>&#x4e00;&#x5343;&#x842c;</div>
-<div>&#x4e00;&#x5104;</div>
-<div>&#x5341;&#x5104;</div>
 
 <div>&#x5341;&#x4e00;</div>
 <div>&#x4e5d;&#x5341;&#x4e5d;</div>
 <div>&#x4e00;&#x767e;&#x96f6;&#x4e00;</div>
 <div>&#x4e8c;&#x767e;</div>
 <div>&#x516d;&#x5343;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x842c;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x842c;&#x96f6;&#x4e00;&#x5341;&#x4e00;</div>
-<div>&#x4e00;&#x842c;&#x96f6;&#x4e00;&#x767e;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x842c;&#x4e00;&#x5343;&#x4e00;&#x767e;&#x4e00;&#x5341;&#x4e00;</div>
-<div>&#x4e00;&#x5343;&#x4e00;&#x767e;&#x842c;</div>
-<div>&#x4e00;&#x5104;&#x96f6;&#x4e00;&#x842c;&#x96f6;&#x4e00;</div>
-<div>&#x4e00;&#x5104;&#x96f6;&#x5341;&#x4e00;&#x842c;&#x96f6;&#x4e00;</div>
 
 <div>&#x8ca0;&#x4e00;</div>

--- a/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal.html
+++ b/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal.html
@@ -20,24 +20,11 @@
 <div style="counter-reset: n 10;"></div>
 <div style="counter-reset: n 100;"></div>
 <div style="counter-reset: n 1000;"></div>
-<div style="counter-reset: n 10000;"></div>
-<div style="counter-reset: n 100000;"></div>
-<div style="counter-reset: n 1000000;"></div>
-<div style="counter-reset: n 10000000;"></div>
-<div style="counter-reset: n 100000000;"></div>
-<div style="counter-reset: n 1000000000;"></div>
 
 <div style="counter-reset: n 11;"></div>
 <div style="counter-reset: n 99;"></div>
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
-<div style="counter-reset: n 10001;"></div>
-<div style="counter-reset: n 10011;"></div>
-<div style="counter-reset: n 10101;"></div>
-<div style="counter-reset: n 11111;"></div>
-<div style="counter-reset: n 11000000;"></div>
-<div style="counter-reset: n 100010001;"></div>
-<div style="counter-reset: n 100110001;"></div>
 
 <div style="counter-reset: n -1;"></div>

--- a/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal.html
+++ b/css/css-counter-styles/trad-chinese-informal/counter-trad-chinese-informal.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<title>CSS Counter Styles: Longhand East Asian Counter Styles Trad Chinese Informal</title>
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles/#limited-chinese">
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
 <link rel="match" href="counter-trad-chinese-informal-ref.html">
 <style>
   div::after {
@@ -26,5 +28,85 @@
 <div style="counter-reset: n 101;"></div>
 <div style="counter-reset: n 200;"></div>
 <div style="counter-reset: n 6001;"></div>
+
+<!-- Test second group marker (萬) - ten-thousands group -->
+<div style="counter-reset: n 10000;"></div>
+<div style="counter-reset: n 20000;"></div>
+<div style="counter-reset: n 50000;"></div>
+<div style="counter-reset: n 99999;"></div>
+
+<!-- Test complex patterns within ten-thousands group (algorithm step 4: digit markers) -->
+<div style="counter-reset: n 12345;"></div>
+<div style="counter-reset: n 10001;"></div>
+<div style="counter-reset: n 10010;"></div>
+<div style="counter-reset: n 10100;"></div>
+<div style="counter-reset: n 11000;"></div>
+
+<!-- Test third group marker (億) - hundred-millions group -->
+<div style="counter-reset: n 100000000;"></div>
+<div style="counter-reset: n 200000000;"></div>
+<div style="counter-reset: n 500000000;"></div>
+<div style="counter-reset: n 999999999;"></div>
+
+<!-- Test complex patterns within hundred-millions group (algorithm step 6: zero dropping) -->
+<div style="counter-reset: n 123456789;"></div>
+<div style="counter-reset: n 100000001;"></div>
+<div style="counter-reset: n 100010000;"></div>
+<div style="counter-reset: n 100100000;"></div>
+<div style="counter-reset: n 101000000;"></div>
+<div style="counter-reset: n 110000000;"></div>
+
+<!-- Test fourth group marker (兆) - trillions group -->
+<div style="counter-reset: n 1000000000000;"></div>
+<div style="counter-reset: n 2000000000000;"></div>
+<div style="counter-reset: n 5000000000000;"></div>
+<div style="counter-reset: n 9999999999999;"></div>
+
+<!-- Test extended ranges (algorithm step 3: group markers up to 10^16) -->
+<!-- Test 10^13 range (ten-trillions) -->
+<div style="counter-reset: n 10000000000000;"></div>
+<div style="counter-reset: n 50000000000000;"></div>
+<div style="counter-reset: n 99999999999999;"></div>
+
+<!-- Test 10^15 range (hundred-trillions) -->
+<div style="counter-reset: n 100000000000000;"></div>
+<div style="counter-reset: n 500000000000000;"></div>
+<div style="counter-reset: n 999999999999999;"></div>
+
+<!-- Test complex patterns in trillions group (step 5: drop ones, step 6: drop zeros) -->
+<div style="counter-reset: n 1234567890123;"></div>
+<div style="counter-reset: n 1000000000001;"></div>
+<div style="counter-reset: n 1000000010000;"></div>
+<div style="counter-reset: n 1000001000000;"></div>
+<div style="counter-reset: n 1000100000000;"></div>
+<div style="counter-reset: n 1010000000000;"></div>
+<div style="counter-reset: n 1100000000000;"></div>
+
+<!-- Test interaction between multiple groups -->
+<div style="counter-reset: n 1001001001001;"></div>
+<div style="counter-reset: n 1010101010101;"></div>
+<div style="counter-reset: n 1000100010001;"></div>
+<div style="counter-reset: n 5005005005005;"></div>
+
+<!-- Test zero dropping behavior across different groups -->
+<div style="counter-reset: n 1000000000000;"></div>
+<div style="counter-reset: n 1000000000;"></div>
+<div style="counter-reset: n 1000000;"></div>
+<div style="counter-reset: n 1000;"></div>
+<div style="counter-reset: n 10000000000000;"></div>
+<div style="counter-reset: n 100000000000000;"></div>
+
+<!-- Test boundary values at the edge of range (-10^16+1 to 10^16-1) -->
+<div style="counter-reset: n 9999999999999999;"></div>
+<div style="counter-reset: n 1000000000000000;"></div>
+
+<!-- Test out-of-range values (should fallback to cjk-decimal) -->
+<div style="counter-reset: n 10000000000000000;"></div>
+
+<!-- Test negative numbers (algorithm step 8: negative sign handling) -->
+<div style="counter-reset: n -10000;"></div>
+<div style="counter-reset: n -100000000;"></div>
+<div style="counter-reset: n -1000000000000;"></div>
+<div style="counter-reset: n -9999999999999999;"></div>
 
 <div style="counter-reset: n -1;"></div>


### PR DESCRIPTION
According to the change in https://github.com/w3c/csswg-drafts/pull/12383.
Discussed in https://github.com/w3c/csswg-drafts/issues/12300.

## Summary of the update

- Clear separation between limited(*required*) and extended(*optional*) range.
  -  limited(*required*) : counter-[cjk]-*.html
      - e.g; [counter-japanese-formal.html](https://github.com/web-platform-tests/wpt/pull/53312/files#diff-7d745ba2f9bb8db4ac70496aebed2c743cdace9f3d3425a4edc28c18bf872939)
  - extended(*optional*): counter-[cjk]-extended-*.html
    - e.g; [counter-japanese-formal-extended.html](https://github.com/web-platform-tests/wpt/pull/53312/files#diff-dfce9b315a420779230d69863af53804dbff3e23563d918aa91213be813f52b1)
- Addition of extended CJK longhand range support which covers its algorithm
  - https://www.w3.org/TR/2013/WD-css-counter-styles-3-20130718/#extended-cjk