### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=294523

### DIFF
--- a/css/css-pseudo/parsing/marker-supported-properties.html
+++ b/css/css-pseudo/parsing/marker-supported-properties.html
@@ -63,6 +63,11 @@ test_pseudo_computed_value("::marker", "animation-play-state", "paused");
 test_pseudo_computed_value("::marker", "animation-timing-function", "linear");
 test_pseudo_computed_value("::marker", "animation-composition", "add");
 
+test_pseudo_computed_value("::marker", "animation-range", "contain 10px cover 20px");
+test_pseudo_computed_value("::marker", "animation-range-start", "contain 10px");
+test_pseudo_computed_value("::marker", "animation-range-end", "cover 20px");
+test_pseudo_computed_value("::marker", "animation-timeline", "scroll()");
+
 // ::marker supports transition properties.
 test_pseudo_computed_value("::marker", "transition", "display 1s linear 2s");
 test_pseudo_computed_value("::marker", "transition-delay", "1s");


### PR DESCRIPTION
WebKit export from bug: [\[css-pseudo\] Allow more animation properties for ::marker after scroll-animations](https://bugs.webkit.org/show_bug.cgi?id=294523)