### PR TITLE
imagebitmap: Fix promises execution order for invalid Blob (reject as…

### DIFF
--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
@@ -54,19 +54,17 @@ var testFuncs = {
     reject_async: (promiseFunc, source, t) => {
         return new Promise((resolve, reject) => {
             let taskRan = false;
-            Promise.resolve().then(() => {
-                promiseFunc(source).then(
-                    t.unreached_func('Expected this call to reject'),
-                    () => {
-                        try {
-                            assert_equals(taskRan, true, 'The promise should be rejected asynchronously')
-                            resolve(t);
-                        } catch (err) {
-                            reject(err)
-                        }
-                    },
-                );
-            });
+            promiseFunc(source).then(
+                t.unreached_func('Expected this call to reject'),
+                () => {
+                    try {
+                        assert_equals(taskRan, true, 'The promise should be rejected asynchronously')
+                        resolve(t);
+                    } catch (err) {
+                        reject(err)
+                    }
+                },
+            );
             Promise.resolve().then(() => {
                 taskRan = true;
             });


### PR DESCRIPTION
The createImageBitmap() promise with invalid Blob source should be rejected asynchronously,
but current test case (reject async) doesn't allow to properly testing required scenario for invalid Blob.

For reject async it works unexpectedly OK, but in case if implementation will not follow
specification - the reject sync case will no be catched.