### PR TITLE
cloneNode() and document's allow declarative shadow roots

### DIFF
--- a/dom/nodes/Node-cloneNode-document-allow-declarative-shadow-roots.window.js
+++ b/dom/nodes/Node-cloneNode-document-allow-declarative-shadow-roots.window.js
@@ -1,0 +1,8 @@
+"use strict";
+
+test(() => {
+  const doc = document.cloneNode(document);
+  doc.write('<div><template shadowrootmode=open>test</template></div>');
+  assert_true(!!doc.body.firstChild.shadowRoot);
+  assert_equals(doc.body.firstChild.shadowRoot.textContent, "test");
+}, "cloneNode() and document's allow declarative shadow roots");


### PR DESCRIPTION
For https://github.com/whatwg/dom/pull/1384.