### PR TITLE
Ensure that the first wheel event dispatched is sent to the initial target

### DIFF
--- a/dom/events/scrolling/wheel-event-transactions-basic.html
+++ b/dom/events/scrolling/wheel-event-transactions-basic.html
@@ -110,6 +110,8 @@ function runTest() {
     // transaction have the same target.
     await new test_driver.Actions()
       .addWheel("wheel1")
+      .scroll(testInfo.scrollX, testInfo.scrollY, 0, 10, {origin: testInfo.origin})
+      .pause(1)
       .scroll(testInfo.scrollX, testInfo.scrollY, 0, 30, {origin: testInfo.origin})
       .pause(1)
       .scroll(testInfo.scrollX, testInfo.scrollY, 0, 30, {origin: testInfo.origin})

--- a/dom/events/scrolling/wheel-event-transactions-multiple-action-chains.html
+++ b/dom/events/scrolling/wheel-event-transactions-multiple-action-chains.html
@@ -64,11 +64,20 @@ promise_test(async (t) => {
   // The first action chain should target the initial element
   await new test_driver.Actions()
     .addWheel("wheel1")
+    .scroll(40, 2, 0, 10, {origin: "viewport"})
+    .pause(1)
     .scroll(40, 2, 0, 30, {origin: "viewport"})
     .send();
 
   // Start logging event targets in the second transaction
   isFirstGroup = false;
+
+  // Ensure at least one tick occurs between wheel scrolls
+  await new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(resolve)
+    })
+  });
 
   // The second chain should target the second element and the prior wheel event
   // group should have no impact on this action chain.

--- a/dom/events/scrolling/wheel-event-transactions-target-display-change.html
+++ b/dom/events/scrolling/wheel-event-transactions-target-display-change.html
@@ -66,6 +66,8 @@ function runTest() {
 
     await new test_driver.Actions()
       .addWheel("wheel1")
+      .scroll(40, 2, 0, 10, {origin: "viewport"})
+      .pause(1)
       .scroll(40, 2, 0, 30, {origin: "viewport"})
       .pause(1)
       .scroll(40, 2, 0, 30, {origin: "viewport"})

--- a/dom/events/scrolling/wheel-event-transactions-target-elements.html
+++ b/dom/events/scrolling/wheel-event-transactions-target-elements.html
@@ -52,6 +52,8 @@ promise_test(async (t) => {
 
   await new test_driver.Actions()
     .addWheel("wheel1")
+    .scroll(12, 12, 0, 10, {origin: "viewport"})
+    .pause(1)
     .scroll(12, 12, 0, 30, {origin: "viewport"})
     .pause(1)
     .scroll(12, 12, 0, 30, {origin: "viewport"})

--- a/dom/events/scrolling/wheel-event-transactions-target-move.html
+++ b/dom/events/scrolling/wheel-event-transactions-target-move.html
@@ -58,6 +58,8 @@ promise_test(async (t) => {
 
   await new test_driver.Actions()
     .addWheel("wheel1")
+    .scroll(40, 2, 0, 10, {origin: "viewport"})
+    .pause(1)
     .scroll(40, 2, 0, 30, {origin: "viewport"})
     .pause(1)
     .scroll(40, 2, 0, 30, {origin: "viewport"})

--- a/dom/events/scrolling/wheel-event-transactions-target-removal.html
+++ b/dom/events/scrolling/wheel-event-transactions-target-removal.html
@@ -64,6 +64,8 @@ promise_test(async (t) => {
 
   await new test_driver.Actions()
     .addWheel("wheel1")
+    .scroll(40, 2, 0, 10, {origin: "viewport"})
+    .pause(1)
     .scroll(40, 2, 0, 30, {origin: "viewport"})
     .pause(1)
     .scroll(40, 2, 0, 30, {origin: "viewport"})

--- a/dom/events/scrolling/wheel-event-transactions-target-resize.html
+++ b/dom/events/scrolling/wheel-event-transactions-target-resize.html
@@ -71,6 +71,8 @@ function runTest() {
 
     await new test_driver.Actions()
       .addWheel("wheel1")
+      .scroll(2, 2, 0, 10, {origin: "viewport"})
+      .pause(1)
       .scroll(2, 2, 0, 30, {origin: "viewport"})
       .pause(1)
       .scroll(2, 2, 0, 30, {origin: "viewport"})


### PR DESCRIPTION
The UIEvents spec states:

> For maximum scroll performance, a user agent may not wait for each
> wheel event associated with the scroll to be processed...

As a result, a scroll (and scroll event) may be dispatched before the first wheel event is dispatched. To counteract this, the first wheel scroll for each test should be entirely contained in the initial element. This ensures that the test will remain vaild even in the case that the scroll is dispatched before the wheel event.