### PR TITLE
[SPC] Add tests for new instrument.details field

### DIFF
--- a/secure-payment-confirmation/authentication-accepted.https.html
+++ b/secure-payment-confirmation/authentication-accepted.https.html
@@ -10,7 +10,11 @@
 <script>
 'use strict';
 
-async function triggerSpc(t, dataOverrides) {
+const kChallenge = 'server challenge';
+const kPayeeOrigin = 'https://merchant.com';
+const kInstrumentDisplayName = 'Troycard';
+
+async function triggerSpc(t, instrumentDetails) {
   const authenticator = await window.test_driver.add_virtual_authenticator(
       AUTHENTICATOR_OPTS);
   t.add_cleanup(() => {
@@ -24,23 +28,21 @@ async function triggerSpc(t, dataOverrides) {
 
   const credential = await createCredential();
 
-  const challenge = 'server challenge';
-  const payeeOrigin = 'https://merchant.com';
-  const displayName = 'Troycard';
-
   let data = {
     credentialIds: [credential.rawId],
-    challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
-    payeeOrigin,
+    challenge: Uint8Array.from(kChallenge, c => c.charCodeAt(0)),
+    payeeOrigin: kPayeeOrigin,
     rpId: window.location.hostname,
     timeout: 60000,
     instrument: {
-      displayName,
+      displayName: kInstrumentDisplayName,
       icon: ICON_URL,
     },
   };
 
-  data = Object.assign(data, dataOverrides);
+  if (instrumentDetails !== undefined) {
+    data.instrument.details = instrumentDetails;
+  }
 
   const request = new PaymentRequest([{
     supportedMethods: 'secure-payment-confirmation', data
@@ -59,21 +61,21 @@ async function triggerSpc(t, dataOverrides) {
 }
 
 promise_test(async t => {
-  const clientDataJSON = await triggerSpc(t, /*dataOverrides=*/{});
+  const clientDataJSON = await triggerSpc(t);
 
   assert_equals(clientDataJSON.type, 'payment.get');
-  assert_equals(clientDataJSON.challenge, base64UrlEncode(challenge));
+  assert_equals(clientDataJSON.challenge, base64UrlEncode(kChallenge));
   assert_equals(clientDataJSON.origin, window.location.origin);
   assert_false(clientDataJSON.crossOrigin);
 
   // Payment-specific information.
   assert_equals(clientDataJSON.payment.rpId, window.location.hostname);
   assert_equals(clientDataJSON.payment.topOrigin, window.location.origin);
-  assert_equals(clientDataJSON.payment.payeeOrigin, payeeOrigin);
+  assert_equals(clientDataJSON.payment.payeeOrigin, kPayeeOrigin);
   assert_equals(clientDataJSON.payment.total.value, PAYMENT_DETAILS.total.amount.value);
   assert_equals(clientDataJSON.payment.total.currency, PAYMENT_DETAILS.total.amount.currency);
   assert_equals(clientDataJSON.payment.instrument.icon, ICON_URL);
-  assert_equals(clientDataJSON.payment.instrument.displayName, displayName);
+  assert_equals(clientDataJSON.payment.instrument.displayName, kInstrumentDisplayName);
 
   // If the User Agent still supports the legacy 'rp' output parameter, it
   // should be identical to the 'rpId' output parameter. See
@@ -88,8 +90,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const instrumentDetails = '***1234';
-  const clientDataJSON = await triggerSpc(t,
-      /*dataOverrides=*/{instrument: {details: instrumentDetails}});
+  const clientDataJSON = await triggerSpc(t, instrumentDetails);
 
   // Payment-specific information.
   assert_equals(clientDataJSON.payment.instrument.details, instrumentDetails);

--- a/secure-payment-confirmation/authentication-accepted.https.html
+++ b/secure-payment-confirmation/authentication-accepted.https.html
@@ -26,7 +26,8 @@ promise_test(async t => {
 
   const challenge = 'server challenge';
   const payeeOrigin = 'https://merchant.com';
-  const displayName = 'Troycard ***1234';
+  const displayName = 'Troycard';
+  const instrumentDetails = '***1234';
   const request = new PaymentRequest([{
     supportedMethods: 'secure-payment-confirmation',
     data: {
@@ -38,6 +39,7 @@ promise_test(async t => {
       instrument: {
         displayName,
         icon: ICON_URL,
+        details: instrumentDetails;
       },
     }
   }], PAYMENT_DETAILS);
@@ -65,6 +67,7 @@ promise_test(async t => {
   assert_equals(clientDataJSON.payment.total.currency, PAYMENT_DETAILS.total.amount.currency);
   assert_equals(clientDataJSON.payment.instrument.icon, ICON_URL);
   assert_equals(clientDataJSON.payment.instrument.displayName, displayName);
+  assert_equals(clientDataJSON.payment.instrument.details, instrumentDetails);
 
   // If the User Agent still supports the legacy 'rp' output parameter, it
   // should be identical to the 'rpId' output parameter. See

--- a/secure-payment-confirmation/authentication-accepted.https.html
+++ b/secure-payment-confirmation/authentication-accepted.https.html
@@ -10,7 +10,7 @@
 <script>
 'use strict';
 
-promise_test(async t => {
+async function triggerSpc(t, dataOverrides) {
   const authenticator = await window.test_driver.add_virtual_authenticator(
       AUTHENTICATOR_OPTS);
   t.add_cleanup(() => {
@@ -27,21 +27,23 @@ promise_test(async t => {
   const challenge = 'server challenge';
   const payeeOrigin = 'https://merchant.com';
   const displayName = 'Troycard';
-  const instrumentDetails = '***1234';
+
+  let data = {
+    credentialIds: [credential.rawId],
+    challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
+    payeeOrigin,
+    rpId: window.location.hostname,
+    timeout: 60000,
+    instrument: {
+      displayName,
+      icon: ICON_URL,
+    },
+  };
+
+  data = Object.assign(data, dataOverrides);
+
   const request = new PaymentRequest([{
-    supportedMethods: 'secure-payment-confirmation',
-    data: {
-      credentialIds: [credential.rawId],
-      challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
-      payeeOrigin,
-      rpId: window.location.hostname,
-      timeout: 60000,
-      instrument: {
-        displayName,
-        icon: ICON_URL,
-        details: instrumentDetails,
-      },
-    }
+    supportedMethods: 'secure-payment-confirmation', data
   }], PAYMENT_DETAILS);
 
   await test_driver.bless('user activation');
@@ -53,7 +55,12 @@ promise_test(async t => {
   const cred = response.details;
   assert_equals(cred.id, credential.id);
 
-  const clientDataJSON = JSON.parse(arrayBufferToString(cred.response.clientDataJSON));
+  return JSON.parse(arrayBufferToString(cred.response.clientDataJSON));
+}
+
+promise_test(async t => {
+  const clientDataJSON = await triggerSpc(t, /*dataOverrides=*/{});
+
   assert_equals(clientDataJSON.type, 'payment.get');
   assert_equals(clientDataJSON.challenge, base64UrlEncode(challenge));
   assert_equals(clientDataJSON.origin, window.location.origin);
@@ -67,7 +74,6 @@ promise_test(async t => {
   assert_equals(clientDataJSON.payment.total.currency, PAYMENT_DETAILS.total.amount.currency);
   assert_equals(clientDataJSON.payment.instrument.icon, ICON_URL);
   assert_equals(clientDataJSON.payment.instrument.displayName, displayName);
-  assert_equals(clientDataJSON.payment.instrument.details, instrumentDetails);
 
   // If the User Agent still supports the legacy 'rp' output parameter, it
   // should be identical to the 'rpId' output parameter. See
@@ -78,5 +84,14 @@ promise_test(async t => {
 
   // TODO: Verify cred.response.signature, to validate that it covers all fields
   // from clientDataJSON.
-}, 'Successful SPC authentication');
+}, 'Successful SPC authentication - mandatory fields');
+
+promise_test(async t => {
+  const instrumentDetails = '***1234';
+  const clientDataJSON = await triggerSpc(t,
+      /*dataOverrides=*/{instrument: {details: instrumentDetails}});
+
+  // Payment-specific information.
+  assert_equals(clientDataJSON.payment.instrument.details, instrumentDetails);
+}, 'Successful SPC authentication - optional fields');
 </script>

--- a/secure-payment-confirmation/authentication-accepted.https.html
+++ b/secure-payment-confirmation/authentication-accepted.https.html
@@ -39,7 +39,7 @@ promise_test(async t => {
       instrument: {
         displayName,
         icon: ICON_URL,
-        details: instrumentDetails;
+        details: instrumentDetails,
       },
     }
   }], PAYMENT_DETAILS);

--- a/secure-payment-confirmation/constructor-validate-payment-method-data.https.html
+++ b/secure-payment-confirmation/constructor-validate-payment-method-data.https.html
@@ -231,6 +231,27 @@ test(() => {
         instrument: {
           displayName: 'X',
           icon: 'https://example.test/icon.png',
+          // Details can be omitted, but if present cannot be empty.
+          details: '',
+        },
+        rpId: 'relying-party.example',
+      },
+    }], details);
+  });
+}, 'Empty instrument.details field throws exception.');
+
+test(() => {
+  assert_throws_js(TypeError, () => {
+    new PaymentRequest([{
+      supportedMethods: 'secure-payment-confirmation',
+      data: {
+        credentialIds: [Uint8Array.from('x', c => c.charCodeAt(0))],
+        challenge: Uint8Array.from('x', c => c.charCodeAt(0)),
+        payeeOrigin: window.location.origin,
+        timeout: 60000,
+        instrument: {
+          displayName: 'X',
+          icon: 'https://example.test/icon.png',
         },
         rpId: 'domains cannot have spaces.com',
       },


### PR DESCRIPTION
See https://github.com/w3c/secure-payment-confirmation/pull/298

Since Chrome only supports this on Chrome Android currently (and only in Canary), this was tested using Chrome for Android 139.0.7257.0, manually disabling testdriver, with the following command lines:

./wpt run --log-mach=- --log-mach-verbose --test-type=testharness --channel=canary --device-serial=SERIAL_HERE --timeout-multiplier=100 --binary-arg="--enable-features=SecurePaymentConfirmationUxRefresh" chrome_android TEST_NAME

Tests validated this way:

- [x] `secure-payment-confirmation/authentication-accepted.https.html`
- [x] `secure-payment-confirmation/constructor-validate-payment-method-data.https.html` <-- Failed in 139.0.7257.0, but now passes in 140.0.7275.0