### PR TITLE
Avoid triggering local network privacy prompt on macOS

### DIFF
--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -56,8 +56,13 @@ def test_subprocess_exit(server_subprocesses, tempfile_name):
         # constructor that is also used to create the long-running processes
         # which are relevant to this functionality. Disable the check so that
         # the constructor is only used to create relevant processes.
+        config = {
+            "browser_host": "localhost",
+            "alternate_hosts": {"alt": "127.0.0.1"},
+            "check_subdomains": False,
+        }
         with open(tempfile_name, 'w') as handle:
-            json.dump({"check_subdomains": False, "bind_address": False}, handle)
+            json.dump(config, handle)
 
         # The `logger` module from the wptserver package uses a singleton
         # pattern which resists testing. In order to avoid conflicting with

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -3,8 +3,11 @@
 import errno
 import http
 import http.server
+import ipaddress
 import os
+import platform
 import socket
+import socketserver
 import ssl
 import sys
 import threading
@@ -226,6 +229,25 @@ class WebTestServer(http.server.ThreadingHTTPServer):
                 self.socket = ssl_context.wrap_socket(self.socket,
                                                       do_handshake_on_connect=False,
                                                       server_side=True)
+
+    def server_bind(self):
+        if platform.system() != "Darwin":
+            super().server_bind()
+        else:
+            # We override this on macOS to workaround gethostbyattr triggering the local
+            # network alert even when passed "localhost" (rdar://153097791); this should
+            # be the same as the superclass implementation except for the addition of
+            # our check.
+            socketserver.TCPServer.server_bind(self)
+            host, port = self.server_address[:2]
+            if (
+                ipaddress.ip_address(host).is_loopback and
+                ipaddress.ip_address(socket.gethostbyname("localhost")).is_loopback
+            ):
+                self.server_name = "localhost"
+            else:
+                self.server_name = socket.getfqdn(host)
+            self.server_port = port
 
     def finish_request(self, request, client_address):
         if isinstance(self.socket, ssl.SSLSocket):

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -234,7 +234,7 @@ class WebTestServer(http.server.ThreadingHTTPServer):
         if platform.system() != "Darwin":
             super().server_bind()
         else:
-            # We override this on macOS to workaround gethostbyattr triggering the local
+            # We override this on macOS to workaround gethostbyaddr triggering the local
             # network alert even when passed "localhost" (rdar://153097791); this should
             # be the same as the superclass implementation except for the addition of
             # our check.


### PR DESCRIPTION
This makes it possible to run all the Python tests on macOS without triggering the local network privacy prompt, and makes it possible to run wptrunner against at least Chrome, Firefox, and Safari with `bind_address=True` (the default configuration) without triggering that prompt.