### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=293470

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-hidden-with-column-spanner-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-hidden-with-column-spanner-ref.html
@@ -1,0 +1,12 @@
+<!doctype HTML>
+<html>
+<meta charset="utf8">
+<title>CSS Content Visibility: hidden column spanner</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<style>
+body {
+  width: 600px;
+  overflow: hidden;
+}
+</style>
+Test fails if you can see text below.

--- a/css/css-contain/content-visibility/content-visibility-hidden-with-column-spanner.html
+++ b/css/css-contain/content-visibility/content-visibility-hidden-with-column-spanner.html
@@ -1,0 +1,33 @@
+<!doctype HTML>
+<html>
+<meta charset="utf8">
+<title>CSS Content Visibility: hidden column spanner</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="content-visibility-hidden-with-spanner-ref.html">
+<meta name="assert" content="content-visibility hidden column spanner should stay hidden">
+<style>
+body {
+  width: 600px;
+  overflow: hidden;
+}
+.container {
+  column-count: 2;
+  width: 200px;
+  height: 100px;
+}
+.spanner {
+  column-span: all;
+}
+</style>
+Test fails if you can see text below.
+<div class=container>
+  <div id=hide_this>
+    XXX
+    <div class=spanner>PASS if not visible</div>
+    XXX
+  </div>
+</div>
+<script>
+document.body.offsetHeight;
+hide_this.style.contentVisibility = "hidden";
+</script>

--- a/css/css-contain/content-visibility/content-visibility-hidden-with-column-spanner.html
+++ b/css/css-contain/content-visibility/content-visibility-hidden-with-column-spanner.html
@@ -3,7 +3,7 @@
 <meta charset="utf8">
 <title>CSS Content Visibility: hidden column spanner</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
-<link rel="match" href="content-visibility-hidden-with-spanner-ref.html">
+<link rel="match" href="content-visibility-hidden-with-column-spanner-ref.html">
 <meta name="assert" content="content-visibility hidden column spanner should stay hidden">
 <style>
 body {


### PR DESCRIPTION
WebKit export from bug: [\[content-visibility\] Column spanner stays visible in skipped subtree](https://bugs.webkit.org/show_bug.cgi?id=293470)