### PR TITLE
[css-anchor-position-1] Remove extraneous left declaration

### DIFF
--- a/css/css-anchor-position/position-try-pseudo-element.html
+++ b/css/css-anchor-position/position-try-pseudo-element.html
@@ -9,7 +9,6 @@
     position: relative;
     width: 195px;
     height: 200px;
-    left: 999999px; /* force fallback */
   }
   #target::before {
     position-try-fallbacks: --f1, --f2;


### PR DESCRIPTION
This line seems to be left over from a different test, and it makes it hard to understand what's happening.