### PR TITLE
[SPC] Update tests for new output states

### DIFF
--- a/secure-payment-confirmation/authentication-auth-another-way.https.html
+++ b/secure-payment-confirmation/authentication-auth-another-way.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Test for the 'secure-payment-confirmation' payment method authentication - user rejects case</title>
+<title>Test for the 'secure-payment-confirmation' payment method authentication - user wants to auth another way case</title>
 <link rel="help" href="https://w3c.github.io/secure-payment-confirmation/#sctn-transaction-confirmation-outcome">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -17,7 +17,7 @@ promise_test(async t => {
     return window.test_driver.remove_virtual_authenticator(authenticator);
   });
 
-  await window.test_driver.set_spc_transaction_mode("autoReject");
+  await window.test_driver.set_spc_transaction_mode("autoChooseToAuthAnotherWay");
   t.add_cleanup(() => {
     return window.test_driver.set_spc_transaction_mode("none");
   });
@@ -41,8 +41,8 @@ promise_test(async t => {
   }], PAYMENT_DETAILS);
 
   await test_driver.bless('user activation');
-  return promise_rejects_dom(t, "AbortError", request.show());
-}, 'Rejected SPC authentication without matching credential');
+  return promise_rejects_dom(t, "NotAllowedError", request.show());
+}, 'Choose to auth another way without matching credential');
 
 promise_test(async t => {
   const authenticator = await window.test_driver.add_virtual_authenticator(
@@ -51,7 +51,7 @@ promise_test(async t => {
     return window.test_driver.remove_virtual_authenticator(authenticator);
   });
 
-  await window.test_driver.set_spc_transaction_mode("autoReject");
+  await window.test_driver.set_spc_transaction_mode("autoChooseToAuthAnotherWay");
   t.add_cleanup(() => {
     return window.test_driver.set_spc_transaction_mode("none");
   });
@@ -77,6 +77,6 @@ promise_test(async t => {
   }], PAYMENT_DETAILS);
 
   await test_driver.bless('user activation');
-  return promise_rejects_dom(t, "AbortError", request.show());
-}, 'Rejected SPC authentication when credential matched');
+  return promise_rejects_dom(t, "NotAllowedError", request.show());
+}, 'Choose to auth another way when credential matched');
 </script>

--- a/secure-payment-confirmation/authentication-auth-another-way.https.html
+++ b/secure-payment-confirmation/authentication-auth-another-way.https.html
@@ -11,12 +11,6 @@
 'use strict';
 
 promise_test(async t => {
-  const authenticator = await window.test_driver.add_virtual_authenticator(
-      AUTHENTICATOR_OPTS);
-  t.add_cleanup(() => {
-    return window.test_driver.remove_virtual_authenticator(authenticator);
-  });
-
   await window.test_driver.set_spc_transaction_mode("autoChooseToAuthAnotherWay");
   t.add_cleanup(() => {
     return window.test_driver.set_spc_transaction_mode("none");


### PR DESCRIPTION
See https://github.com/w3c/secure-payment-confirmation/pull/292

Since Chrome only supports this on Chrome Android currently (and only in Canary), this was tested using Chrome for Android 139.0.7257.0, manually disabling testdriver, with the following command lines:

./wpt run --log-mach=- --log-mach-verbose --test-type=testharness --channel=canary --device-serial=SERIAL_HERE --timeout-multiplier=100 --binary-arg="--enable-features=SecurePaymentConfirmationUxRefresh" chrome_android TEST_NAME

Tests validated this way:

- [x] `secure-payment-confirmation/authentication-auth-another-way.https.html`
- [x] `secure-payment-confirmation/authentication-rejected.https.html`