### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=294887

### DIFF
--- a/css/css-view-transitions/parsing/view-transition-name-computed.html
+++ b/css/css-view-transitions/parsing/view-transition-name-computed.html
@@ -22,6 +22,9 @@ test_computed_value("view-transition-name", "initial", "none");
 test_computed_value("view-transition-name", "inherit", "none");
 test_computed_value("view-transition-name", "revert", "none");
 test_computed_value("view-transition-name", "revert-layer", "none");
+
+test_computed_value("view-transition-name", "match-element");
+test_computed_value("view-transition-name", "maTch-element", "match-element");
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Properly serialize match-element in computed style](https://bugs.webkit.org/show_bug.cgi?id=294887)