### PR TITLE
Fix scrollWidthHeight-negative-margin-002.html

### DIFF
--- a/css/cssom-view/scrollWidthHeight-negative-margin-002.html
+++ b/css/cssom-view/scrollWidthHeight-negative-margin-002.html
@@ -39,6 +39,10 @@ const paddingBox = {
   width: contentBox.width + 4 + 16,
   height: contentBox.height + 1 + 8,
 };
+function* writingModes() {
+  yield "horizontal-tb";
+  yield* ["vertical-lr", "vertical-rl"].filter(writingMode => CSS.supports("writing-mode", writingMode));
+}
 for (let display of ["flow-root", "flex", "grid"]) {
   for (let flexDirection of ["row", "row-reverse", "column", "column-reverse"]) {
     if (flexDirection != "row" && display != "flex") {
@@ -51,7 +55,7 @@ for (let display of ["flow-root", "flex", "grid"]) {
         continue;
       }
       for (let direction of ["ltr", "rtl"]) {
-        for (let writingMode of ["horizontal-tb", "vertical-lr", "vertical-rl"]) {
+        for (let writingMode of writingModes()) {
           for (let overflow of ["visible", "hidden", "auto", "clip", "scroll"]) {
             wrapper.style.display = display;
             wrapper.style.overflow = overflow;


### PR DESCRIPTION
Since we don't support `writing-mode` yet, we got different testcases with the same title, some passing and some failing. So we had to expect both PASS and FAIL, making the test useless to detect regressions.

This changes the test to only generate testcases for supported values of `writing-mode`.

Testing: This is just a test change.

Reviewed in servo/servo#37721