### PR TITLE
URL: add port setter tests with newlines and tabs

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -1909,6 +1909,20 @@
             "expected": {
                 "port": "4"
             }
+        },
+        {
+            "href": "https://domain.com:3000",
+            "new_value": "\n\t80\n\t80\n\t",
+            "expected": {
+                "port": "8080"
+            }
+        },
+        {
+            "href": "https://domain.com:3000",
+            "new_value": "\n\n\t\t",
+            "expected": {
+                "port": "3000"
+            }
         }
     ],
     "pathname": [


### PR DESCRIPTION
While comparing the behavior of the URL port setter between Node.js and whatwg-url, I found a difference in how inputs containing only newlines and tabs are handled.

For example, running the following code:
```js
const NodeURL = require("url").URL;
const WhatwgURL = require("whatwg-url").URL;

const url = new NodeURL("https://example.com:3000");
url.port = "\n\n\t\t";
console.log(url.port); // "" (the port is cleared in Node.js)

const url2 = new WhatwgURL("https://example.com:3000");
url2.port = "\n\n\t\t";
console.log(url2.port); // "3000" (the port remains unchanged in whatwg-url)
```

According to the WHATWG URL Standard, the port should remain unchanged when the input consists only of ASCII tab, newline, or carriage return characters. To ensure this behavior, I am adding new Web Platform Tests (WPT) for the port setter with such inputs.