### PR TITLE
[WebDriver: Set Window Rect] Make best-effort with partial input according to latest spec

### DIFF
--- a/webdriver/tests/classic/set_window_rect/set.py
+++ b/webdriver/tests/classic/set_window_rect/set.py
@@ -187,7 +187,7 @@ def test_width_height_floats(session):
 
     {"width": None, "height": None, "x": None, "y": None},
 ])
-def test_no_change(session, rect):
+def test_with_none_values(session, rect):
     original = session.window.rect
     response = set_window_rect(session, rect)
     assert_success(response, original)
@@ -208,17 +208,13 @@ def test_partial_input(session, rect):
     response = set_window_rect(session, rect)
     value = assert_success(response, session.window.rect)
 
+    assert value["width"] == rect.get("width", original["width"])
+    assert value["height"] == rect.get("height", original["height"])
     # Wayland doesn't return correct coordinates after changing window position.
-    if is_wayland() and ('x' in rect or 'y' in rect):
-        fields = ("width", "height")
-    else:
-        fields = ("x", "y", "width", "height")
+    if not is_wayland():
+        assert value["x"] == rect.get("x", original["x"])
+        assert value["y"] == rect.get("y", original["y"])
 
-    for field in fields:
-        if field in rect:
-            assert value[field] == rect[field]
-        else:
-            assert value[field] == original[field]
 
 def test_set_to_available_size(
     session, available_screen_size, minimal_screen_position

--- a/webdriver/tests/classic/set_window_rect/set.py
+++ b/webdriver/tests/classic/set_window_rect/set.py
@@ -213,7 +213,7 @@ def test_partial_input(session, rect):
         fields = ("width", "height")
     else:
         fields = ("x", "y", "width", "height")
-    
+
     for field in fields:
         if field in rect:
             assert value[field] == rect[field]

--- a/webdriver/tests/classic/set_window_rect/set.py
+++ b/webdriver/tests/classic/set_window_rect/set.py
@@ -208,17 +208,15 @@ def test_partial_input(session, rect):
     response = set_window_rect(session, rect)
     value = assert_success(response, session.window.rect)
 
+    assert value["width"] == rect.get("width", original["width"])
+    assert value["height"] == rect.get("height", original["height"])
     # Unlike X11, Wayland does not permit applications to change their window position programmatically.
-    if is_wayland() and ('x' in rect or 'y' in rect):
-        fields = ("width", "height")
+    if not is_wayland():
+        assert value["x"] == rect.get("x", original["x"])
+        assert value["y"] == rect.get("y", original["y"])
     else:
-        fields = ("x", "y", "width", "height")
-
-    for field in fields:
-        if field in rect:
-            assert value[field] == rect[field]
-        else:
-            assert value[field] == original[field]
+        value["x"] == original["x"]
+        value["y"] == original["y"]
 
 
 def test_set_to_available_size(

--- a/webdriver/tests/classic/set_window_rect/set.py
+++ b/webdriver/tests/classic/set_window_rect/set.py
@@ -208,12 +208,16 @@ def test_partial_input(session, rect):
     response = set_window_rect(session, rect)
     value = assert_success(response, session.window.rect)
 
-    assert value["width"] == rect.get("width", original["width"])
-    assert value["height"] == rect.get("height", original["height"])
-    # Wayland doesn't return correct coordinates after changing window position.
-    if not is_wayland():
-        assert value["x"] == rect.get("x", original["x"])
-        assert value["y"] == rect.get("y", original["y"])
+    if is_wayland() and ('x' in rect or 'y' in rect):
+        fields = ("width", "height")
+    else:
+        fields = ("x", "y", "width", "height")
+
+    for field in fields:
+        if field in rect:
+            assert value[field] == rect[field]
+        else:
+            assert value[field] == original[field]
 
 
 def test_set_to_available_size(

--- a/webdriver/tests/classic/set_window_rect/set.py
+++ b/webdriver/tests/classic/set_window_rect/set.py
@@ -143,7 +143,7 @@ def test_x_y_floats(session):
     response = set_window_rect(session, {"x": 150.5, "y": 250})
     value = assert_success(response)
 
-    # Wayland doesn't return correct coordinates after changing window position.
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if not is_wayland():
         assert value["x"] == 150
         assert value["y"] == 250
@@ -151,7 +151,7 @@ def test_x_y_floats(session):
     response = set_window_rect(session, {"x": 150, "y": 250.5})
     value = assert_success(response, session.window.rect)
 
-    # Wayland doesn't return correct coordinates after changing window position.
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if not is_wayland():
         assert value["x"] == 150
         assert value["y"] == 250
@@ -208,6 +208,7 @@ def test_partial_input(session, rect):
     response = set_window_rect(session, rect)
     value = assert_success(response, session.window.rect)
 
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if is_wayland() and ('x' in rect or 'y' in rect):
         fields = ("width", "height")
     else:
@@ -235,7 +236,7 @@ def test_set_to_available_size(
     response = set_window_rect(session, target_rect)
     value = assert_success(response, session.window.rect)
 
-    # Wayland doesn't return correct coordinates after changing window position.
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if not is_wayland():
         assert value == target_rect
     else:
@@ -355,7 +356,7 @@ def test_x_y(session):
     assert value["width"] == original["width"]
     assert value["height"] == original["height"]
 
-    # Wayland doesn't return correct coordinates after changing window position.
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if not is_wayland():
         assert value["x"] == original["x"] + 10
         assert value["y"] == original["y"] + 10
@@ -389,7 +390,7 @@ def test_x_as_current(session):
     assert value["width"] == original["width"]
     assert value["height"] == original["height"]
 
-    # Wayland doesn't return correct coordinates after changing window position.
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if not is_wayland():
         assert value["x"] == original["x"]
         assert value["y"] == original["y"] + 10
@@ -406,7 +407,7 @@ def test_y_as_current(session):
 
     assert value["width"] == original["width"]
     assert value["height"] == original["height"]
-    # Wayland doesn't return correct coordinates after changing window position.
+    # Unlike X11, Wayland does not permit applications to change their window position programmatically.
     if not is_wayland():
         assert value["x"] == original["x"] + 10
         assert value["y"] == original["y"]
@@ -424,7 +425,7 @@ def test_negative_x_y(session, minimal_screen_position):
         assert value["width"] == original["width"]
         assert value["height"] == original["height"]
 
-        # Wayland doesn't return correct coordinates after changing window position.
+        # Unlike X11, Wayland does not permit applications to change their window position programmatically.
         if not is_wayland():
             assert value["x"] <= minimal_screen_position[0]
             assert value["y"] <= minimal_screen_position[1]


### PR DESCRIPTION
The spec was changed in https://github.com/w3c/webdriver/pull/1830 to allow partial parameter and change with best-effort. This makes some test assertion out-dated.

This commit removes those out-dated test and move them to a new function `test_partial_input` to match the new expectation.

Fixes: https://github.com/web-platform-tests/wpt/issues/53409
The change is recommended in https://github.com/w3c/webdriver/issues/1906#issuecomment-3008542906