### PR TITLE
URL: add host setter tests for empty host with port

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -1195,6 +1195,15 @@
                 "host": "test",
                 "hostname": "test"
             }
+        },
+        {
+            "href": "foo://path/to",
+            "new_value": ":80",
+            "expected": {
+                "href": "foo://path/to",
+                "host": "path",
+                "port": ""
+            }
         }
     ],
     "hostname": [


### PR DESCRIPTION
This PR adds tests to capture the following difference in host setter behavior:

```js
const NodeURL = require("url").URL;
const WhatwgURL = require("whatwg-url").URL;
const newHost = ':80';

const url = new NodeURL("foo://path/to");  
url.host = newHost;
console.log(url.href); // => foo://:80/to

const url2 = new WhatwgURL("foo://path/to");
url2.host = newHost;
console.log(url2.href); // => foo://path/to
```

According to the WHATWG URL Standard, setting host = ":80" when the host is missing should fail, rather than produce an empty host with a port.

Refs: https://github.com/ada-url/ada/pull/963