### PR TITLE
ensure 'canvas.convertToBlob()' without a rendering context doesn't throw

### DIFF
--- a/html/semantics/embedded-content/the-canvas-element/toBlob-no-context.any.js
+++ b/html/semantics/embedded-content/the-canvas-element/toBlob-no-context.any.js
@@ -1,0 +1,11 @@
+promise_test(async function() {
+    var canvas = document.createElement("canvas");
+    var blob = await new Promise(resolve => canvas.toBlob(resolve));
+    assert_equals(blob.type, "image/png");
+}, "toBlob() on a canvas w/o rendering context doesn't throw");
+
+promise_test(async function() {
+    var canvas = new OffscreenCanvas(123, 456);
+    var blob = await canvas.convertToBlob();
+    assert_equals(blob.type, "image/png");
+}, "convertToBlob() on an offscreen canvas w/o rendering context doesn't throw");


### PR DESCRIPTION
Regarding whatwg/html#11417