### PR TITLE
Add Test for Element.attachShadow using a ShadowRoot

### DIFF
--- a/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -35,8 +35,9 @@ test(() => {
 
 test(() => {
     const host = document.body.appendChild(document.createElement('div'));
-    assert_throws_js(TypeError, () => host.attachShadow({mode: 'closed', customElementRegistry: null}))
-}, 'attachShadow() should throw for a null customElementRegistry value');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
+    assert_equals(shadowRoot.customElementRegistry, window.customElements);
+}, 'attachShadow() should use the global registry when customElementRegistry is null');
 
 </script>
 </body>

--- a/shadow-dom/attachShadow-with-ShadowRoot.html
+++ b/shadow-dom/attachShadow-with-ShadowRoot.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<head>
+    <title>Shadow DOM: Element.attachShadow with ShadowRoot</title>
+    <meta name="author" title="Jesse Jurman" href="mailto:j.r.jurman@gmail.com">
+    <meta name="assert" content="It should be possible to use an existing ShadowRoot as input for Element.attachShadow">
+    <link rel=help href="https://bugs.webkit.org/show_bug.cgi?id=295174">
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+
+<body>
+    <div id="elementSource">
+        <span>
+            <template shadowrootmode="open"></template>
+        </span>
+    </div>
+
+    <div id="elementTarget"></div>
+
+    <template id="templateSource">
+        <span>
+            <template shadowrootmode="open"></template>
+        </span>
+    </template>
+
+    <div id="templateTarget"></div>
+</body>
+
+<script>
+'use strict';
+
+// test that we can use a ShadowRoot in a template element as an input for attachShadow
+promise_test(async () => {
+    const shadowRoot = elementSource.children[0].shadowRoot;
+
+    // validate that the ShadowRoot is an object, and has properties we expect (like "mode")
+    assert_equals(typeof shadowRoot, 'object');
+    assert_equals(shadowRoot.mode, 'open');
+
+    // attach the shadowRoot to our target element
+    elementTarget.attachShadow(shadowRoot);
+
+    // validate that our target element has a shadowRoot with the same options
+    assert_equals(typeof elementTarget.shadowRoot, 'object');
+    assert_equals(elementTarget.shadowRoot.mode, 'open');
+}, 'can use ShadowRoot as options for attachShadow');
+
+// test that we can use a ShadowRoot in a template element as an input for attachShadow
+promise_test(async () => {
+    const shadowRoot = templateSource.content.children[0].shadowRoot;
+
+    // validate that the ShadowRoot is an object, and has properties we expect (like "mode")
+    assert_equals(typeof shadowRoot, 'object');
+    assert_equals(shadowRoot.mode, 'open');
+
+    // attach the shadowRoot to our target element
+    templateTarget.attachShadow(shadowRoot);
+
+    // validate that our target element has a shadowRoot with the same options
+    assert_equals(typeof templateTarget.shadowRoot, 'object');
+    assert_equals(templateTarget.shadowRoot.mode, 'open');
+}, 'can use ShadowRoot in document fragment as options for attachShadow');
+
+</script>

--- a/shadow-dom/attachShadow-with-ShadowRoot.html
+++ b/shadow-dom/attachShadow-with-ShadowRoot.html
@@ -34,7 +34,7 @@
 <script>
 'use strict';
 
-// test that we can use a ShadowRoot in a template element as an input for attachShadow
+// test that we can use a ShadowRoot as an input for attachShadow
 promise_test(async () => {
     const shadowRoot = elementSource.children[0].shadowRoot;
 


### PR DESCRIPTION
For a while now I've been using DSD ShadowRoots as the input for `Element.attachShadow`, since an existing ShadowRoot will have all the options (`.mode`, `.delegatesFocus`) needed for the `attachShadow` function. This is particularly nice for Declarative Custom Element-adjacent libraries that use DSD templates as part of the definition.

However, recently, this behavior appeared to break in WebKit, specifically when the origin ShadowRoot was in a Template Document Fragment. I discovered this in the latest Playwright version, and validated in Safari Technology Preview. This experience is not broken for other browsers, or in stable Safari. It is also not broken when the ShadowRoot template is not in a document-fragment. 

I reported the bug in WebKit's bug tracker here: https://bugs.webkit.org/show_bug.cgi?id=295174

It's not totally clear how much any of this is expected, especially since the spec doesn't really reference ShadowRoot objects as a valid source (even though they work up-until this point). Either way, it felt worthwhile to create a test to pair with the bug report.

------

Related Specs:

https://dom.spec.whatwg.org/#dictdef-shadowrootinit
https://dom.spec.whatwg.org/#dom-element-attachshadow

------

I'm still relatively new to WPT, so any feedback is appreciated. If this should be broken up, or if we decide that one (or both) of the cases are invalid, I'm happy to change or remove pieces here.