### PR TITLE
Enable infrastructure tests for partitioned cookies for Firefox

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/get_all_cookies.sub.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/get_all_cookies.sub.https.html.ini
@@ -1,5 +1,0 @@
-[get_all_cookies.sub.https.html]
-  [Get all HTTPS cookies]
-    expected:
-      # WPT CI uses a `firefox` version that doesn't support partitioned cookies
-      if product == "firefox" or product == "firefox_android": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/get_named_cookie.sub.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/get_named_cookie.sub.https.html.ini
@@ -1,5 +1,0 @@
-[get_named_cookie.sub.https.html]
-  [Get Named HTTPS cookie]
-    expected:
-      # WPT CI uses a `firefox` version that doesn't support partitioned cookies
-      if product == "firefox" or product == "firefox_android": FAIL


### PR DESCRIPTION
Support for partitioned cookies was enabled in Firefox in all channels, so these tests pass now.