### PR TITLE
Change accent to HTML character code

### DIFF
--- a/mathml/presentation-markup/mrow/dynamic-mrow-like-001-ref.html
+++ b/mathml/presentation-markup/mrow/dynamic-mrow-like-001-ref.html
@@ -16,25 +16,25 @@
 </head>
 <body>
   <ol>
-    <li><math class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></math></li>
+    <li><math class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></math></li>
     <li><math class="testedElement"><mn>X</mn><mn>p</mn></math></li>
-    <li><math><mrow class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mrow></math></li>
+    <li><math><mrow class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mrow></math></li>
     <li><math><mrow class="testedElement"><mn>X</mn><mn>p</mn></mrow></math></li>
-    <li><math><maction class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></maction></math></li>
+    <li><math><maction class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></maction></math></li>
     <li><math><maction class="testedElement"><mn>X</mn><mn>p</mn></maction></math></li>
-    <li><math><merror class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></merror></math></li>
+    <li><math><merror class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></merror></math></li>
     <li><math><merror class="testedElement"><mn>X</mn><mn>p</mn></merror></math></li>
-    <li><math><mphantom class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mphantom></math></li>
+    <li><math><mphantom class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mphantom></math></li>
     <li><math><mphantom class="testedElement"><mn>X</mn><mn>p</mn></mphantom></math></li>
-    <li><math><mstyle class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mstyle></math></li>
+    <li><math><mstyle class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mstyle></math></li>
     <li><math><mstyle class="testedElement"><mn>X</mn><mn>p</mn></mstyle></math></li>
-    <li><math><semantics class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></semantics></math></li>
+    <li><math><semantics class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></semantics></math></li>
     <li><math><semantics class="testedElement"><mn>X</mn><mn>p</mn></semantics></math></li>
-    <li><math><unknown class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></unknown></math></li>
+    <li><math><unknown class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></unknown></math></li>
     <li><math><unknown class="testedElement"><mn>X</mn><mn>p</mn></unknown></math></li>
-    <li><math><none class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></none></math></li>
+    <li><math><none class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></none></math></li>
     <li><math><none class="testedElement"><mn>X</mn><mn>p</mn></none></math></li>
-    <li><math><mprescripts class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mprescripts></math></li>
+    <li><math><mprescripts class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mprescripts></math></li>
     <li><math><mprescripts class="testedElement"><mn>X</mn><mn>p</mn></mprescripts></math></li>
   </ol>
 </body>

--- a/mathml/presentation-markup/mrow/dynamic-mrow-like-001.html
+++ b/mathml/presentation-markup/mrow/dynamic-mrow-like-001.html
@@ -30,7 +30,7 @@
               mn.textContent = "X";
               e.appendChild(mn);
               mn = FragmentHelper.createElement("mn");
-              mn.textContent = "É";
+              mn.textContent = "&#x00C9;";
               e.appendChild(mn);
               mn = FragmentHelper.createElement("mn");
               mn.textContent = "p";
@@ -48,25 +48,25 @@
 <body>
   <ol>
     <li><math class="testedElement"></math></li>
-    <li><math class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></math></li>
+    <li><math class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></math></li>
     <li><math><mrow class="testedElement"></mrow></math></li>
-    <li><math><mrow class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mrow></math></li>
+    <li><math><mrow class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mrow></math></li>
     <li><math><maction class="testedElement"></maction></math></li>
-    <li><math><maction class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></maction></math></li>
+    <li><math><maction class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></maction></math></li>
     <li><math><merror class="testedElement"></merror></math></li>
-    <li><math><merror class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></merror></math></li>
+    <li><math><merror class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></merror></math></li>
     <li><math><mphantom class="testedElement"></mphantom></math></li>
-    <li><math><mphantom class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mphantom></math></li>
+    <li><math><mphantom class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mphantom></math></li>
     <li><math><mstyle class="testedElement"></mstyle></math></li>
-    <li><math><mstyle class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mstyle></math></li>
+    <li><math><mstyle class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mstyle></math></li>
     <li><math><semantics class="testedElement"></semantics></math></li>
-    <li><math><semantics class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></semantics></math></li>
+    <li><math><semantics class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></semantics></math></li>
     <li><math><unknown class="testedElement"></unknown></math></li>
-    <li><math><unknown class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></unknown></math></li>
+    <li><math><unknown class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></unknown></math></li>
     <li><math><none class="testedElement"></none></math></li>
-    <li><math><none class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></none></math></li>
+    <li><math><none class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></none></math></li>
     <li><math><mprescripts class="testedElement"></mprescripts></math></li>
-    <li><math><mprescripts class="testedElement"><mn>X</mn><mn>p</mn><mn>É</mn></mprescripts></math></li>
+    <li><math><mprescripts class="testedElement"><mn>X</mn><mn>p</mn><mn>&#x00C9;</mn></mprescripts></math></li>
   </ol>
 </body>
 </html>


### PR DESCRIPTION
Making changes to tests with characters other than ASCII is [breaking Firefox try server](https://bugzilla.mozilla.org/show_bug.cgi?id=1974708). We need to add some test cases here for `a` and `mfenced`, but it is not possible even if we were to use this patch there, since the accented characters would still be on the diff.