### PR TITLE
Add mock server for geolocation coordinates for Firefox Android.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox_android.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox_android.py
@@ -197,6 +197,9 @@ class ProfileCreator(FirefoxProfileCreator):
 
         if self.test_type == "wdspec":
             profile.set_preferences({"remote.prefs.recommended": True})
+            profile.set_preferences({
+                "geo.provider.network.url": "https://web-platform.test:8444/webdriver/tests/support/http_handlers/geolocation_override.py"
+            })
         else:
             # Except for wdspec dispatch wheel scroll as widget event by default.
             profile.set_preferences({"remote.events.async.wheel.enabled": True})


### PR DESCRIPTION
In the #51956 we set mock server for Firefox Desktop, we should also set it for Android.