### PR TITLE
Fix testharnessreport-servo.js to stop polluting with global variables

### DIFF
--- a/tools/wptrunner/wptrunner/testharnessreport-servo.js
+++ b/tools/wptrunner/wptrunner/testharnessreport-servo.js
@@ -1,22 +1,24 @@
-var props = {
-    output:%(output)d,
-    timeout_multiplier: %(timeout_multiplier)s,
-    explicit_timeout: %(explicit_timeout)s,
-    debug: %(debug)s
-};
-var start_loc = document.createElement('a');
-start_loc.href = location.href;
-setup(props);
+(function() {
+    var props = {
+        output:%(output)d,
+        timeout_multiplier: %(timeout_multiplier)s,
+        explicit_timeout: %(explicit_timeout)s,
+        debug: %(debug)s
+    };
+    var start_loc = document.createElement('a');
+    start_loc.href = location.href;
+    setup(props);
 
-add_completion_callback(function (tests, harness_status) {
-    var id = decodeURIComponent(start_loc.pathname) + decodeURIComponent(start_loc.search) + decodeURIComponent(start_loc.hash);
-    console.log("ALERT: RESULT: " + JSON.stringify([
-        id,
-        harness_status.status,
-        harness_status.message,
-        harness_status.stack,
-        tests.map(function(t) {
-            return [t.name, t.status, t.message, t.stack]
-        }),
-    ]));
-});
+    add_completion_callback(function (tests, harness_status) {
+        var id = decodeURIComponent(start_loc.pathname) + decodeURIComponent(start_loc.search) + decodeURIComponent(start_loc.hash);
+        console.log("ALERT: RESULT: " + JSON.stringify([
+            id,
+            harness_status.status,
+            harness_status.message,
+            harness_status.stack,
+            tests.map(function(t) {
+                return [t.name, t.status, t.message, t.stack]
+            }),
+        ]));
+    });
+})();


### PR DESCRIPTION
For example, if a test uses `let props = ...` then this was triggering an exception because testharnessreport-servo.js already created a global variable named `props`.

Testing: some wpt tests no longer result in ERROR

Reviewed in servo/servo#37817