### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295053

### DIFF
--- a/css/CSS2/floats/inheritance.html
+++ b/css/CSS2/floats/inheritance.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS float properties</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css2/#propdef-float">
+<link rel="help" href="https://drafts.csswg.org/css2/#propdef-clear">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_not_inherited('float', 'none', 'left');
+assert_not_inherited('clear', 'none', 'both');
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (290607@main): guichet.public.lu: Broken layout where 'Display All' is hidden behind summary list items](https://bugs.webkit.org/show_bug.cgi?id=295053)