### PR TITLE
script: Only enforce rowSpan >= 1 in actual quirks mode

### DIFF
--- a/css/css-tables/tentative/table-limited-quirks.html
+++ b/css/css-tables/tentative/table-limited-quirks.html
@@ -65,6 +65,14 @@
   <td data-expected-width=184><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"></td>
 </table>
 
+<p><a href="https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows">The "let <i>cell grows downward</i> be false" quirk</a> does NOT apply to limited-quirks mode</p>
+<table>
+  <tr style="height: 100px">
+    <td id="rowspan" rowspan="0" data-expected-height=208>208 height</td>
+  </tr>
+  <tr style="height: 100px"></tr>
+</table>
+
 <script>
   let pngSrc="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACWAQMAAAChElVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABlBMVEUAgAD///8UPy9PAAAAAWJLR0QB/wIt3gAAAAd0SU1FB+MBDwkdA1Cz/EMAAAAbSURBVEjH7cGBAAAAAMOg+VPf4ARVAQAAAM8ADzwAAeM8wQsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDEtMTVUMTc6Mjk6MDMtMDg6MDCYDy9IAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAxLTE1VDE3OjI5OjAzLTA4OjAw6VKX9AAAAABJRU5ErkJggg=="
 ;
@@ -74,5 +82,8 @@
   test(_ => {
     assert_equals(window.getComputedStyle(document.querySelector("#italic")).fontStyle, "italic");
   }, "decoration propagates into table");
+  test(_ => {
+    assert_equals(document.querySelector("#rowspan").rowSpan, 0);
+  }, "rowspan can be zero");
   document.fonts.ready.then(() => checkLayout("table"));
 </script>

--- a/css/css-tables/tentative/table-quirks.html
+++ b/css/css-tables/tentative/table-quirks.html
@@ -63,6 +63,15 @@
   <td data-expected-width=290><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"></td>
 </table>
 
+<p><a href="https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows">The "let <i>cell grows downward</i> be false" quirk</a></p>
+<p class="error">Chrome LayoutNG and Safari ignore the quirk, FF does not.</p>
+<table>
+  <tr style="height: 100px">
+    <td id="rowspan" rowspan="0" data-expected-height=100>100 height</td>
+  </tr>
+  <tr style="height: 100px"></tr>
+</table>
+
 <script>
   let pngSrc="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACWAQMAAAChElVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABlBMVEUAgAD///8UPy9PAAAAAWJLR0QB/wIt3gAAAAd0SU1FB+MBDwkdA1Cz/EMAAAAbSURBVEjH7cGBAAAAAMOg+VPf4ARVAQAAAM8ADzwAAeM8wQsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDEtMTVUMTc6Mjk6MDMtMDg6MDCYDy9IAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAxLTE1VDE3OjI5OjAzLTA4OjAw6VKX9AAAAABJRU5ErkJggg=="
 ;
@@ -72,5 +81,8 @@
   test(_ => {
     assert_equals(window.getComputedStyle(document.querySelector("#notitalic")).fontStyle, "normal");
   }, "decoration does not propagate into table");
+  test(_ => {
+    assert_equals(document.querySelector("#rowspan").rowSpan, 1);
+  }, "rowspan can't be zero");
   document.fonts.ready.then(() => checkLayout("table"));
 </script>


### PR DESCRIPTION
We were also enforcing that in limited-quirks mode, but no other browser does that. In fact, Blink and WebKit don't have this quirk at all, so we should consider removing it too, but for now restrict it to quirks mode like Firefox.

Testing: adding new tests
Part of #<!-- nolink -->37813

Reviewed in servo/servo#37820