### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=289961

### DIFF
--- a/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
+++ b/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
@@ -13,7 +13,7 @@
   grid-template-columns: min-content;
   font: 20px/1 Ahem;
   background-color: green;
-}    
+}
 .grid-item {
   width: max-content;
   color: green;

--- a/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
+++ b/css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="Grid item's min content contribution should be its max-content size">
+<style>
+.grid-box {
+  display: grid;
+  width: max-content;
+  grid-template-columns: min-content;
+  font: 20px/1 Ahem;
+  background-color: green;
+}    
+.grid-item {
+  width: max-content;
+  color: green;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="grid-box">
+    <div class="grid-item">x x x</div>
+    <div style="height: 80px;"></div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Grid\]Text overflows from 'width: max-content' container](https://bugs.webkit.org/show_bug.cgi?id=289961)