### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278477

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-on-display-contents.html
+++ b/css/css-contain/content-visibility/content-visibility-on-display-contents.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
+<meta name="assert" content="content-visibility on display contents element does not apply since size containment does not apply to it">
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="display: contents; content-visibility: hidden;">
+  <div>
+    <div style="width: 100px; height: 100px; background-color: green;"></div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [File icons and filenames are not displayed on OneDrive website on Safari TP 201](https://bugs.webkit.org/show_bug.cgi?id=278477)