### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=294053

### DIFF
--- a/css/filter-effects/backdrop-filter-backdrop-root-filter.html
+++ b/css/filter-effects/backdrop-filter-backdrop-root-filter.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropRoot">
 <link rel=stylesheet  href="resources/backdrop-filter-backdrop-root.css">
 <link rel="match"  href="backdrop-filter-backdrop-root-filter-ref.html">
-<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-500">
+<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-2696">
 
 <!-- A Backdrop Root is formed, anywhere in the document, by:
      - An element with a filter property other than "none".

--- a/css/filter-effects/backdrop-filter-boundary.html
+++ b/css/filter-effects/backdrop-filter-boundary.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta name=fuzzy content="maxDifference=0-20;totalPixels=0-100000">
+<meta name=fuzzy content="maxDifference=0-67;totalPixels=0-100000">
 <title>backdrop-filter: Correctly apply backdrop-filter with an SVG filter</title>
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match" href="reference/backdrop-filter-boundary-ref.html">

--- a/css/filter-effects/backdrop-filter-edge-behavior-ref.html
+++ b/css/filter-effects/backdrop-filter-edge-behavior-ref.html
@@ -7,26 +7,31 @@
 
 
 <div>
-  <p>Expected: The black box inside the red box should not contain any red.</p>
+  <p>Expected: The black box inside the red box should contain some red, despite being outside of the scroller's clip</p>
 </div>
 
-<div id=backdrop></div>
-<div id=scroller></div>
+<div id=scroller>
+  <div id=backdrop></div>
+</div>
+<div id=scroller class=second></div>
 
 <style>
   #scroller {
-    position: relative;
-    top:-202px;
     width: 250px;
     height: 250px;
     border: 6px solid red;
   }
   #backdrop {
     position: relative;
+    top: -3px;
     height: 200px;
     width: 200px;
-    left: 6px;
-    top: 3px;
+    backdrop-filter: blur(10px);
     border: 1px solid black;
   }
+  .second {
+    position: relative;
+    top: -262px;
+  }
 </style>
+

--- a/css/filter-effects/backdrop-filter-edge-behavior.html
+++ b/css/filter-effects/backdrop-filter-edge-behavior.html
@@ -7,7 +7,7 @@
 <link rel="match"  href="backdrop-filter-edge-behavior-ref.html">
 
 <div>
-  <p>Expected: The black box inside the red box should not contain any red.</p>
+  <p>Expected: The black box inside the red box should contain some red, despite being outside of the scroller's clip</p>
 </div>
 
 <div id=scroller>
@@ -21,6 +21,7 @@
     width: 250px;
     height: 250px;
     overflow: scroll;
+    scrollbar-width: none;
     border: 6px solid red;
     scrollbar-width: none;
   }

--- a/css/filter-effects/backdrop-filter-edge-mirror.html
+++ b/css/filter-effects/backdrop-filter-edge-mirror.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta name=fuzzy content="maxDifference=0-10;totalPixels=0-10000">
+<meta name=fuzzy content="maxDifference=0-11;totalPixels=0-10000">
 <title>backdrop-filter: Sampled pixels beyond edge should mirror back into the content.</title>
 <link rel="author" href="mailto:flackr@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#backdrop-filter-operation">

--- a/css/filter-effects/backdrop-filter-edge-pixels-2.html
+++ b/css/filter-effects/backdrop-filter-edge-pixels-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name=fuzzy content="maxDifference=0-20;totalPixels=0-30000">
+<meta name=fuzzy content="maxDifference=0-25;totalPixels=0-30000">
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="author" href="mailto:flackr@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">

--- a/css/filter-effects/backdrop-filter-transform.html
+++ b/css/filter-effects/backdrop-filter-transform.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-1000">
+<meta name=fuzzy content="maxDifference=0-127; totalPixels=0-1000">
 <title>backdrop-filter: backdrop-filter plus transform should be applied correctly</title>
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">

--- a/css/filter-effects/backdrop-filters-brightness.html
+++ b/css/filter-effects/backdrop-filters-brightness.html
@@ -3,7 +3,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match" href="backdrop-filters-brightness-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=37500" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-37500">
 <style>
     .square {
         position: absolute;


### PR DESCRIPTION
WebKit export from bug: [Some backdrop-filter WPTs are fuzzy failures](https://bugs.webkit.org/show_bug.cgi?id=294053)