### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295355

### DIFF
--- a/css/css-ui/button-author-level-padding-applies.html
+++ b/css/css-ui/button-author-level-padding-applies.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Author-level CSS padding should apply to buttons with native appearance</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<button id="btn"></button>
+<script>
+test(() => {
+    let value = "10px";
+    btn.style.paddingLeft = value;
+    assert_equals(window.getComputedStyle(btn).paddingLeft, value);
+    btn.style.paddingTop = value;
+    assert_equals(window.getComputedStyle(btn).paddingTop, value);
+    btn.style.paddingRight = value;
+    assert_equals(window.getComputedStyle(btn).paddingRight, value);
+    btn.style.paddingBottom = value;
+    assert_equals(window.getComputedStyle(btn).paddingBottom, value);
+});
+</script>
+</body>
+</html>

--- a/css/css-ui/select-author-level-padding-applies.html
+++ b/css/css-ui/select-author-level-padding-applies.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Author-level CSS padding should apply to select controls with native appearance</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<select id="select"></select>
+<script>
+test(() => {
+    let value = "10px";
+    select.style.paddingLeft = value;
+    assert_equals(window.getComputedStyle(select).paddingLeft, value);
+    select.style.paddingTop = value;
+    assert_equals(window.getComputedStyle(select).paddingTop, value);
+    select.style.paddingRight = value;
+    assert_equals(window.getComputedStyle(select).paddingRight, value);
+    select.style.paddingBottom = value;
+    assert_equals(window.getComputedStyle(select).paddingBottom, value);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Form Control Refresh\] Author-specified padding on a <button> is being ignored](https://bugs.webkit.org/show_bug.cgi?id=295355)