### PR TITLE
Do not test storage object overrides desc.[[Configurable]]

### DIFF
--- a/webstorage/symbol-props.window.js
+++ b/webstorage/symbol-props.window.js
@@ -39,10 +39,10 @@
         Object.defineProperty(storage, key, { "value": "test", "configurable": false });
         assert_equals(storage[key], "test");
         var desc = Object.getOwnPropertyDescriptor(storage, key);
-        assert_true(desc.configurable, "configurable");
+        assert_false(desc.configurable, "configurable");
 
-        assert_true(delete storage[key]);
-        assert_equals(storage[key], undefined);
+        assert_false(delete storage[key]);
+        assert_equals(storage[key], "test");
     }, name + ": defineProperty not configurable");
 
     test(function() {


### PR DESCRIPTION
Browsers already implement this behaviour with the WebIDL spec being updated for this in:

https://github.com/whatwg/webidl/commit/3fb6ab4