### PR TITLE
renderer: Have the viewport meta element establish the initial zoom of new pages

### DIFF
--- a/visual-viewport/resource/viewport-apply-initial-scale-after-navigation-inner.html
+++ b/visual-viewport/resource/viewport-apply-initial-scale-after-navigation-inner.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <title>Viewport: Apply initial-scale after Navigation</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="/common/reftest-wait.js"></script>
+        <script>
+            onload = takeScreenshot;
+        </script>
+    </head>
+    <body>
+        <h1>Viewport: Apply initial-scale after Navigation</h1>
+        <p>Test passes if page opens with own initial-scale of 1.0</p>
+    </body>
+</html>

--- a/visual-viewport/viewport-apply-initial-scale-after-navigation-ref.html
+++ b/visual-viewport/viewport-apply-initial-scale-after-navigation-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Viewport: Apply initial-scale after Navigation</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <h1>Viewport: Apply initial-scale after Navigation</h1>
+        <p>Test passes if page opens with own initial-scale of 1.0</p>
+    </body>
+</html>

--- a/visual-viewport/viewport-apply-initial-scale-after-navigation.html
+++ b/visual-viewport/viewport-apply-initial-scale-after-navigation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Viewport: Apply initial-scale after Navigation</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=2.0">
+    <link rel="match" href="viewport-apply-initial-scale-after-navigation-ref.html">
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+        function runTest() {
+            const url = "resource/viewport-apply-initial-scale-after-navigation-inner.html";
+            window.location.replace(new URL(url, window.location));
+        }
+        onload = () => runTest();
+    </script>
+</head>
+</html>


### PR DESCRIPTION
This patch contains 2 components: 

1. Instead of passing `self.pinch_zoom_level().get()` while checking `zoom_result`, initialize it in `combined_magnification`. Ideally, this part shouldn't have any effect on behavior.

2. Separates the logic for PinchZoom and ViewportZoom. So, when a new page is opened, it will start with its own viewport zoom scale (rather than the previous scale multiples).
i.e `self.pinch_zoom_level().get() * 1.0 * magnification`
```rust
        let mut combined_magnification = 1.0;
        ... 
                ScrollZoomEvent::ViewportZoom(magnification) => {
                    combined_magnification *= magnification
                },
        ...        
        let pinch_zoom_result = match self.set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification)
``` 





Testing: This change adds a new WPT test.
Fixes: #<!-- nolink -->37314 

Reviewed in servo/servo#37315