### PR TITLE
canvas: Fix OffscreenCanvas transferrable test done steps

### DIFF
--- a/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html
+++ b/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html
@@ -182,9 +182,11 @@ async_test(function(t) {
 
 async_test(function(t) {
     var worker = makeWorker(t);
-    worker.addEventListener('message', t.step_func_done(function(msg) {
-        if (msg.data == true || msg.data == false)
+    worker.addEventListener('message', t.step_func(function (msg) {
+        if (msg.data == true || msg.data == false) {
             assert_true(msg.data);
+            t.done();
+        }
     }));
     worker.postMessage('test7');
 }, "Test that call transferToImageBitmap on a detached OffscreenCanvas throws an exception in a worker");

--- a/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html
+++ b/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html
@@ -113,27 +113,33 @@ async_test(function(t) {
 
 async_test(function(t) {
     var worker = makeWorker(t);
-    worker.addEventListener('message', t.step_func_done(function(msg) {
-        if (msg.data == true || msg.data == false)
+    worker.addEventListener('message', t.step_func(function (msg) {
+        if (msg.data == true || msg.data == false) {
             assert_true(msg.data);
+            t.done();
+        }
     }));
     worker.postMessage('test4');
 }, "Test that transfer an OffscreenCanvas twice throws exception in a worker.");
 
 async_test(function(t) {
     var worker = makeWorker(t);
-    worker.addEventListener('message', t.step_func_done(function(msg) {
-        if (msg.data == true || msg.data == false)
+    worker.addEventListener('message', t.step_func(function (msg) {
+        if (msg.data == true || msg.data == false) {
             assert_true(msg.data);
+            t.done();
+        }
     }));
     worker.postMessage('test5');
 }, "Test that calling getContext('2d') on a detached OffscreenCanvas throws exception in a worker.");
 
 async_test(function(t) {
     var worker = makeWorker(t);
-    worker.addEventListener('message', t.step_func_done(function(msg) {
-        if (msg.data == true || msg.data == false)
+    worker.addEventListener('message', t.step_func(function (msg) {
+        if (msg.data == true || msg.data == false) {
             assert_true(msg.data);
+            t.done();
+        }
     }));
     worker.postMessage('test6');
 }, "Test that calling getContext('webgl') on a detached OffscreenCanvas throws exception in a worker.");


### PR DESCRIPTION
All tests expect boolean (true/false) results from worker via
`self.postMessage(true/false)` in various cases with detached offscreen canvases.

However, there are some tests that call postMessage() twice.
- `self.postMessage(offscreenCanvas, [offscreenCanvas]);`
- `self.postMessage(true/false);`

And for these cases, the test results will be 'false' PASSED due to 't.step_func_done()'.

Let's replace 't.step_func_done()' with 't.spec_func() + t.done()' sequence
to get the expected test results.