### PR TITLE
[testdriver] extend testdriver with locale emulation

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -339,4 +339,5 @@ Emulation of browser APIs via [WebDriver BiDi Emulation](https://www.w3.org/TR/w
 
 ```eval_rst
 .. js:autofunction:: test_driver.bidi.emulation.set_geolocation_override
+.. js:autofunction:: test_driver.bidi.emulation.set_locale_override
 ```

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_locale_override.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_locale_override.https.html.ini
@@ -1,0 +1,3 @@
+[set_locale_override.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/testdriver/bidi/emulation/set_locale_override.https.html
+++ b/infrastructure/testdriver/bidi/emulation/set_locale_override.https.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<title>TestDriver bidi.emulation.set_locale_override method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+    /** Get the current locale */
+    function get_current_locale() {
+        return new Intl.DateTimeFormat().resolvedOptions().locale;
+    }
+
+    const SOME_LOCALE = 'de-DE';
+    const ANOTHER_LOCALE = 'es-ES';
+
+    promise_test(async () => {
+        // Get the initial locale.
+        const initial_locale = get_current_locale();
+
+        // Set the locale override
+        await test_driver.bidi.emulation.set_locale_override({
+            locale: SOME_LOCALE
+        });
+        // Assert locale is updated.
+        assert_equals(get_current_locale(), SOME_LOCALE)
+
+        // Set another locale override.
+        await test_driver.bidi.emulation.set_locale_override({
+            locale: ANOTHER_LOCALE
+        });
+        // Assert locale is updated.
+        assert_equals(get_current_locale(), ANOTHER_LOCALE)
+
+        // Remove locale override.
+        await test_driver.bidi.emulation.set_locale_override({});
+        // Assert locale is the default one.
+        assert_equals(get_current_locale(), initial_locale)
+    }, "emulate locale and clear override");
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -70,7 +70,7 @@
      */
     window.test_driver = {
         /**
-         Represents `WebDriver BiDi <https://www.w3.org/TR/webdriver-bidi>`_ protocol.
+         Represents `WebDriver BiDi <https://w3c.github.io/webdriver-bidi>`_ protocol.
          */
         bidi: {
             /**
@@ -777,7 +777,7 @@
                  * Overrides the geolocation coordinates for the specified
                  * browsing contexts.
                  * Matches the `emulation.setGeolocationOverride
-                 * <https://www.w3.org/TR/webdriver-bidi/#command-emulation-setGeolocationOverride>`_
+                 * <https://w3c.github.io/webdriver-bidi/#command-emulation-setGeolocationOverride>`_
                  * WebDriver BiDi command.
                  *
                  * @example
@@ -796,13 +796,13 @@
                  * @param {object} params - Parameters for the command.
                  * @param {null|object} params.coordinates - The optional
                  * geolocation coordinates to set. Matches the
-                 * `emulation.GeolocationCoordinates <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
+                 * `emulation.GeolocationCoordinates <https://w3c.github.io/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
                  * value. If null or omitted and the `params.error` is set, the
                  * emulation will be removed. Mutually exclusive with
                  * `params.error`.
                  * @param {object} params.error - The optional
                  * geolocation error to emulate. Matches the
-                 * `emulation.GeolocationPositionError <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
+                 * `emulation.GeolocationPositionError <https://w3c.github.io/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
                  * value. Mutually exclusive with `params.coordinates`.
                  * @param {null|Array.<(Context)>} [params.contexts] The
                  * optional contexts parameter specifies which browsing contexts

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -70,7 +70,7 @@
      */
     window.test_driver = {
         /**
-         Represents `WebDriver BiDi <https://w3c.github.io/webdriver-bidi>`_ protocol.
+         Represents `WebDriver BiDi <https://www.w3.org/TR/webdriver-bidi>`_ protocol.
          */
         bidi: {
             /**
@@ -777,7 +777,7 @@
                  * Overrides the geolocation coordinates for the specified
                  * browsing contexts.
                  * Matches the `emulation.setGeolocationOverride
-                 * <https://w3c.github.io/webdriver-bidi/#command-emulation-setGeolocationOverride>`_
+                 * <https://www.w3.org/TR/webdriver-bidi/#command-emulation-setGeolocationOverride>`_
                  * WebDriver BiDi command.
                  *
                  * @example
@@ -796,13 +796,13 @@
                  * @param {object} params - Parameters for the command.
                  * @param {null|object} params.coordinates - The optional
                  * geolocation coordinates to set. Matches the
-                 * `emulation.GeolocationCoordinates <https://w3c.github.io/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
+                 * `emulation.GeolocationCoordinates <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
                  * value. If null or omitted and the `params.error` is set, the
                  * emulation will be removed. Mutually exclusive with
                  * `params.error`.
                  * @param {object} params.error - The optional
                  * geolocation error to emulate. Matches the
-                 * `emulation.GeolocationPositionError <https://w3c.github.io/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
+                 * `emulation.GeolocationPositionError <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetgeolocationoverride>`_
                  * value. Mutually exclusive with `params.coordinates`.
                  * @param {null|Array.<(Context)>} [params.contexts] The
                  * optional contexts parameter specifies which browsing contexts
@@ -819,6 +819,34 @@
                     return window.test_driver_internal.bidi.emulation.set_geolocation_override(
                         params);
                 },
+                /**
+                 * Overrides the locale for the specified browsing contexts.
+                 * Matches the `emulation.setLocaleOverride
+                 * <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetlocaleoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_locale_override({
+                 *     locale: 'de-DE'
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|string} params.locale - The optional
+                 * locale to set.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the locale override on. It should be either an array
+                 * of Context objects (window or browsing context id), or null.
+                 * If null or omitted, the override will be set on the current
+                 * browsing context.
+                 * @returns {Promise<void>} Resolves when the locale override
+                 * is successfully set.
+                 */
+                set_locale_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_locale_override(
+                        params);
+                }
             },
             /**
              * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
@@ -2181,6 +2209,10 @@
                 set_geolocation_override: function (params) {
                     throw new Error(
                         "bidi.emulation.set_geolocation_override is not implemented by testdriver-vendor.js");
+                },
+                set_locale_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_locale_override is not implemented by testdriver-vendor.js");
                 }
             },
             log: {

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -197,6 +197,29 @@ class BidiEmulationSetGeolocationOverrideAction:
             coordinates, error, contexts)
 
 
+class BidiEmulationSetLocaleOverrideAction:
+    name = "bidi.emulation.set_locale_override"
+
+    def __init__(self, logger, protocol):
+        do_delayed_imports()
+        self.logger = logger
+        self.protocol = protocol
+
+    async def __call__(self, payload):
+        locale = payload['locale'] if 'locale' in payload else None
+
+        if "contexts" not in payload:
+            raise ValueError("Missing required parameter: contexts")
+        contexts = []
+        for context in payload["contexts"]:
+            contexts.append(get_browsing_context_id(context))
+        if len(contexts) == 0:
+            raise ValueError("At least one context must be provided")
+
+        return await self.protocol.bidi_emulation.set_locale_override(locale,
+                                                                      contexts)
+
+
 class BidiSessionSubscribeAction:
     name = "bidi.session.subscribe"
 
@@ -245,5 +268,6 @@ async_actions = [
     BidiBluetoothSimulateDescriptorAction,
     BidiBluetoothSimulateDescriptorResponseAction,
     BidiEmulationSetGeolocationOverrideAction,
+    BidiEmulationSetLocaleOverrideAction,
     BidiPermissionsSetPermissionAction,
     BidiSessionSubscribeAction]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -372,6 +372,10 @@ class WebDriverBidiEmulationProtocolPart(BidiEmulationProtocolPart):
         return await self.webdriver.bidi_session.emulation.set_geolocation_override(
             coordinates=coordinates, error=error, contexts=contexts)
 
+    async def set_locale_override(self, locale, contexts):
+        return await self.webdriver.bidi_session.emulation.set_locale_override(
+            locale=locale, contexts=contexts)
+
 
 class WebDriverBidiPermissionsProtocolPart(BidiPermissionsProtocolPart):
     def __init__(self, parent):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -605,6 +605,11 @@ class BidiEmulationProtocolPart(ProtocolPart):
             contexts: List[str]) -> None:
         pass
 
+    @abstractmethod
+    async def set_locale_override(self, locale: Optional[str],
+            contexts: List[str]) -> None:
+        pass
+
 
 class BidiScriptProtocolPart(ProtocolPart):
     """Protocol part for executing BiDi scripts"""

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -398,6 +398,14 @@
             });
         }
 
+    window.test_driver_internal.bidi.emulation.set_locale_override = function (params) {
+        return create_action("bidi.emulation.set_locale_override", {
+            // Default to the current window.
+            contexts: [window],
+            ...params
+        });
+    };
+
     window.test_driver_internal.bidi.log.entry_added.subscribe =
         function (params) {
             return subscribe({


### PR DESCRIPTION
Add method `test_driver.bidi.emulation.set_locale_override` matching WebDriver BiDi [`emulation.setLocaleOverride`](https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetlocaleoverride)