### PR TITLE
[testdriver] extend testdriver with screen orientation emulation

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -340,4 +340,5 @@ Emulation of browser APIs via [WebDriver BiDi Emulation](https://www.w3.org/TR/w
 ```eval_rst
 .. js:autofunction:: test_driver.bidi.emulation.set_geolocation_override
 .. js:autofunction:: test_driver.bidi.emulation.set_locale_override
+.. js:autofunction:: test_driver.bidi.emulation.set_screen_orientation_override
 ```

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_screen_orientation_override.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_screen_orientation_override.https.html.ini
@@ -1,0 +1,3 @@
+[set_screen_orientation_override.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/testdriver/bidi/emulation/set_screen_orientation_override.https.html
+++ b/infrastructure/testdriver/bidi/emulation/set_screen_orientation_override.https.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<title>TestDriver bidi.emulation.set_screen_orientation_override method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+    // WebDriver BiDi screen orientation is not equal to one provided by Web
+    // API. The mapping is specified in
+    // https://www.w3.org/TR/screen-orientation/#dfn-screen-orientation-values-lists.
+    SOME_BIDI_SCREEN_ORIENTATION = {
+        "natural": "landscape",
+        "type": "portrait-secondary"
+    }
+    // Matches `SOME_BIDI_SCREEN_ORIENTATION`.
+    SOME_WEB_SCREEN_ORIENTATION = {"angle": 270, "type": "portrait-secondary"}
+
+    ANOTHER_BIDI_SCREEN_ORIENTATION = {
+        "natural": "portrait",
+        "type": "landscape-primary"
+    }
+    // Matches `ANOTHER_BIDI_SCREEN_ORIENTATION`.
+    ANOTHER_WEB_SCREEN_ORIENTATION = {"angle": 90, "type": "landscape-primary"}
+
+    /** Get the current screen orientation */
+    function get_current_screen_orientation() {
+        return {
+            angle: screen.orientation.angle,
+            type: screen.orientation.type
+        }
+    }
+
+    function assert_screen_orientation_equal(s1, s2) {
+        assert_equals(s1.angle, s2.angle)
+        assert_equals(s1.type, s2.type)
+    }
+
+    promise_test(async () => {
+        // Get the initial screen orientation.
+        const initial_screen_orientation = get_current_screen_orientation();
+
+        // Set the screen orientation override
+        await test_driver.bidi.emulation.set_screen_orientation_override({
+            screenOrientation: SOME_BIDI_SCREEN_ORIENTATION
+        });
+        // Assert the screen orientation matches the override.
+        assert_screen_orientation_equal(get_current_screen_orientation(),
+            SOME_WEB_SCREEN_ORIENTATION);
+
+        // Set another screen orientation override
+        await test_driver.bidi.emulation.set_screen_orientation_override({
+            screenOrientation: ANOTHER_BIDI_SCREEN_ORIENTATION
+        });
+
+        // Assert the screen orientation matches the override.
+        assert_screen_orientation_equal(get_current_screen_orientation(),
+            ANOTHER_WEB_SCREEN_ORIENTATION);
+
+        // Clear the screen orientation override.
+        await test_driver.bidi.emulation.set_screen_orientation_override({});
+        // Assert screen orientation is set to the original value.
+        assert_screen_orientation_equal(get_current_screen_orientation(),
+            initial_screen_orientation);
+    }, "emulate screen orientation and clear override");
+
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -846,7 +846,42 @@
                     assertBidiIsEnabled();
                     return window.test_driver_internal.bidi.emulation.set_locale_override(
                         params);
-                }
+                },
+                /**
+                 * Overrides the screen orientation for the specified browsing
+                 * contexts.
+                 * Matches the `emulation.setScreenOrientationOverride
+                 * <https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetscreenorientationoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_screen_orientation_override({
+                 *     screenOrientation: {
+                 *         natural: 'portrait',
+                 *         type: 'landscape-secondary'
+                 *     }
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|object} params.screenOrientation - The optional
+                 * screen orientation. Matches the
+                 * `emulation.ScreenOrientation <https://www.w3.org/TR/webdriver-bidi/#cddl-type-emulationscreenorientation>`_
+                 * type. If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the screen orientation override on. It should be
+                 * either an array of Context objects (window or browsing
+                 * context id), or null. If null or omitted, the override will
+                 * be set on the current browsing context.
+                 * @returns {Promise<void>} Resolves when the screen orientation
+                 * override is successfully set.
+                 */
+                set_screen_orientation_override: function (params) {
+                    // Ensure the bidi feature is enabled before calling the internal method
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_screen_orientation_override(
+                        params);
+                },
             },
             /**
              * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
@@ -2213,6 +2248,10 @@
                 set_locale_override: function (params) {
                     throw new Error(
                         "bidi.emulation.set_locale_override is not implemented by testdriver-vendor.js");
+                },
+                set_screen_orientation_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_screen_orientation_override is not implemented by testdriver-vendor.js");
                 }
             },
             log: {

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -220,6 +220,31 @@ class BidiEmulationSetLocaleOverrideAction:
                                                                       contexts)
 
 
+class BidiEmulationSetScreenOrientationOverrideAction:
+    name = "bidi.emulation.set_screen_orientation_override"
+
+    def __init__(self, logger, protocol):
+        do_delayed_imports()
+        self.logger = logger
+        self.protocol = protocol
+
+    async def __call__(self, payload):
+        screen_orientation = payload['screenOrientation'] \
+            if 'screenOrientation' in payload \
+            else None
+
+        if "contexts" not in payload:
+            raise ValueError("Missing required parameter: contexts")
+        contexts = []
+        for context in payload["contexts"]:
+            contexts.append(get_browsing_context_id(context))
+        if len(contexts) == 0:
+            raise ValueError("At least one context must be provided")
+
+        return await self.protocol.bidi_emulation.set_screen_orientation_override(
+            screen_orientation, contexts)
+
+
 class BidiSessionSubscribeAction:
     name = "bidi.session.subscribe"
 
@@ -269,5 +294,6 @@ async_actions = [
     BidiBluetoothSimulateDescriptorResponseAction,
     BidiEmulationSetGeolocationOverrideAction,
     BidiEmulationSetLocaleOverrideAction,
+    BidiEmulationSetScreenOrientationOverrideAction,
     BidiPermissionsSetPermissionAction,
     BidiSessionSubscribeAction]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -376,6 +376,11 @@ class WebDriverBidiEmulationProtocolPart(BidiEmulationProtocolPart):
         return await self.webdriver.bidi_session.emulation.set_locale_override(
             locale=locale, contexts=contexts)
 
+    async def set_screen_orientation_override(self, screen_orientation,
+            contexts):
+        return await self.webdriver.bidi_session.emulation.set_screen_orientation_override(
+            screen_orientation=screen_orientation, contexts=contexts)
+
 
 class WebDriverBidiPermissionsProtocolPart(BidiPermissionsProtocolPart):
     def __init__(self, parent):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -610,6 +610,12 @@ class BidiEmulationProtocolPart(ProtocolPart):
             contexts: List[str]) -> None:
         pass
 
+    @abstractmethod
+    async def set_screen_orientation_override(self,
+            screen_orientation: Optional[Mapping[str, Any]],
+            contexts: List[str]) -> None:
+        pass
+
 
 class BidiScriptProtocolPart(ProtocolPart):
     """Protocol part for executing BiDi scripts"""

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -402,9 +402,19 @@
         return create_action("bidi.emulation.set_locale_override", {
             // Default to the current window.
             contexts: [window],
-            ...params
+            ...(params ?? {})
         });
     };
+
+    window.test_driver_internal.bidi.emulation.set_screen_orientation_override =
+        function (params) {
+            return create_action(
+                "bidi.emulation.set_screen_orientation_override", {
+                    // Default to the current window.
+                    contexts: [window],
+                    ...(params ?? {})
+                });
+        }
 
     window.test_driver_internal.bidi.log.entry_added.subscribe =
         function (params) {


### PR DESCRIPTION
Add method `test_driver.bidi.emulation.set_screen_orientation_override` matching WebDriver BiDi [`emulation.setScreenOrientationOverride`](https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetscreenorientationoverride)