### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295401

### DIFF
--- a/css/css-animations/animation-name-inline-style.html
+++ b/css/css-animations/animation-name-inline-style.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-animations-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#target { color: red }
+@keyframes green {
+    from, to { color: green }
+}
+</style>
+<div id=target style="animation-duration: 1s"></div>
+<script>
+test(t => {
+    target.style.animationName = "none";
+    assert_equals(getComputedStyle(target).color, "rgb(255, 0, 0)");
+    target.style.animationName = "green";
+    assert_equals(getComputedStyle(target).color, "rgb(0, 128, 0)");
+}, "Animation starts when the name is mutated via inline style");
+</script>


### PR DESCRIPTION
WebKit export from bug: [www.ricoh-imaging.co.jp: REGRESSION (293848@main): Images does not come into view while scrolling on product page](https://bugs.webkit.org/show_bug.cgi?id=295401)