### PR TITLE
Fix codepoint markup in JavaScript

### DIFF
--- a/mathml/presentation-markup/mrow/dynamic-mrow-like-001.html
+++ b/mathml/presentation-markup/mrow/dynamic-mrow-like-001.html
@@ -30,7 +30,7 @@
               mn.textContent = "X";
               e.appendChild(mn);
               mn = FragmentHelper.createElement("mn");
-              mn.textContent = "&#x00C9;";
+              mn.textContent = "\u00C9";
               e.appendChild(mn);
               mn = FragmentHelper.createElement("mn");
               mn.textContent = "p";


### PR DESCRIPTION
Fixes an oversight with #53476, the codepoint for "É" in JavaScript was written with HTML formatting, so it was registering as multiple characters, making the test fail.