### PR TITLE
Remove focus outline from dialog-in-rtl-iframe-child.html

### DIFF
--- a/css/css-view-transitions/support/dialog-in-rtl-iframe-child.html
+++ b/css/css-view-transitions/support/dialog-in-rtl-iframe-child.html
@@ -23,6 +23,7 @@
         box-sizing: border-box;
         background-color: limegreen;
         border: 1px solid black;
+        outline: none;
       }
 
     </style>


### PR DESCRIPTION
It's causing fuzziness and it's not necessary for the purposes of the test.