### PR TITLE
WebCryptoAPI: Test bare algorithm identifiers for {X,Ed}{25519,448}

### DIFF
--- a/WebCryptoAPI/util/helpers.js
+++ b/WebCryptoAPI/util/helpers.js
@@ -93,6 +93,10 @@ function objectToString(obj) {
 // Is key a CryptoKey object with correct algorithm, extractable, and usages?
 // Is it a secret, private, or public kind of key?
 function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
+    if (typeof algorithm === "string") {
+        algorithm = { name: algorithm };
+    }
+
     var correctUsages = [];
 
     var registeredAlgorithmName;
@@ -203,6 +207,7 @@ function allAlgorithmSpecifiersFor(algorithmName) {
             results.push({name: algorithmName, namedCurve: curveName});
         });
     } else if (algorithmName.toUpperCase().substring(0, 1) === "X" || algorithmName.toUpperCase().substring(0, 2) === "ED") {
+        results.push(algorithmName);
         results.push({ name: algorithmName });
     }
 


### PR DESCRIPTION
For X25519, X448, Ed25519 and Ed448, it's possible to pass a bare string as an algorithm identifier, instead of a `{name}` object. Check that this works properly.

Cc @Frosne and @davidben as this will cause new test failures for X448 and Ed448 in existing implementations.