### PR TITLE
Ensure WebDriver sessions end up in a valid state

### DIFF
--- a/tools/webdriver/webdriver/bidi/client.py
+++ b/tools/webdriver/webdriver/bidi/client.py
@@ -154,11 +154,17 @@ class BidiSession:
                     loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
         """Connect to the WebDriver BiDi remote via WebSockets"""
 
-        await self.start_transport(loop)
+        try:
+            await self.start_transport(loop)
 
-        if self.session_id is None:
-            self.session_id, self.capabilities = await self.session.new(  # type: ignore
-                capabilities=self.requested_capabilities)
+            if self.session_id is None:
+                self.session_id, self.capabilities = await self.session.new(  # type: ignore
+                    capabilities=self.requested_capabilities)
+
+        except Exception:
+            # Make sure we end up back in a consistent state.
+            await self.end()
+            raise
 
     async def send_command(
         self,

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -446,40 +446,44 @@ class Session:
         if self.requested_capabilities is not None:
             body["capabilities"] = self.requested_capabilities
 
-        value = self.send_command("POST", "session", body=body)
-        assert isinstance(value["sessionId"], str)
-        assert isinstance(value["capabilities"], Dict)
+        try:
+            value = self.send_command("POST", "session", body=body)
+            assert isinstance(value["sessionId"], str)
+            assert isinstance(value["capabilities"], Dict)
 
-        self.session_id = value["sessionId"]
-        self.capabilities = value["capabilities"]
+            self.session_id = value["sessionId"]
+            self.capabilities = value["capabilities"]
 
-        if "webSocketUrl" in self.capabilities:
-            self.bidi_session = BidiSession.from_http(self.session_id,
-                                                      self.capabilities)
-        elif self.enable_bidi:
+            if "webSocketUrl" in self.capabilities:
+                self.bidi_session = BidiSession.from_http(self.session_id,
+                                                          self.capabilities)
+            elif self.enable_bidi:
+                self.end()
+                raise error.SessionNotCreatedException(
+                    "Requested bidi session, but webSocketUrl capability not found")
+
+            if self.extension_cls:
+                self.extension = self.extension_cls(self)
+
+            return value
+
+        except Exception:
+            # Make sure we end up back in a consistent state.
             self.end()
-            raise error.SessionNotCreatedException(
-                "Requested bidi session, but webSocketUrl capability not found")
-
-        if self.extension_cls:
-            self.extension = self.extension_cls(self)
-
-        return value
+            raise
 
     def end(self):
         """Try to close the active session."""
-        if self.session_id is None:
-            return
-
-        if not isinstance(self.session_id, str):
-            raise TypeError("Session.session_id must be a str or None")
-
         try:
-            self.send_command("DELETE", "session/%s" % self.session_id)
+            if self.session_id is not None:
+                self.send_command("DELETE", "session/%s" % self.session_id)
         except (OSError, error.InvalidSessionIdException):
             pass
         finally:
             self.session_id = None
+            self.capabilities = None
+            self.bidi_session = None
+            self.extension = None
             self.transport.close()
 
     def send_command(self, method, url, body=None, timeout=None):


### PR DESCRIPTION
At both fixture and client levels, handle exceptions by ensuring we've
ended the session we were just creating.

This has only been seen on the BiDi side, where we'd believe we had an
existing transport, having created it successfully, even if we didn't
manage to actually create the session itself.

But for the sake of resilience, make Classic match this too.
