### PR TITLE
Allow browsers/executors to pass firstMatch capabilities

### DIFF
--- a/webdriver/tests/classic/back/conftest.py
+++ b/webdriver/tests/classic/back/conftest.py
@@ -4,7 +4,7 @@ from webdriver.error import NoSuchWindowException
 
 
 @pytest.fixture(name="session")
-def fixture_session(capabilities, session):
+def fixture_session(session):
     """Prevent re-using existent history by running the test in a new window."""
     original_handle = session.window_handle
     session.window_handle = session.new_window()

--- a/webdriver/tests/classic/forward/conftest.py
+++ b/webdriver/tests/classic/forward/conftest.py
@@ -4,7 +4,7 @@ from webdriver.error import NoSuchWindowException
 
 
 @pytest.fixture(name="session")
-def fixture_session(capabilities, session):
+def fixture_session(session):
     """Prevent re-using existent history by running the test in a new window."""
     original_handle = session.window_handle
     session.window_handle = session.new_window()

--- a/webdriver/tests/classic/perform_actions/conftest.py
+++ b/webdriver/tests/classic/perform_actions/conftest.py
@@ -5,7 +5,7 @@ from webdriver.error import NoSuchWindowException
 
 
 @pytest.fixture
-def session_new_window(capabilities, session):
+def session_new_window(session):
     # Prevent unreleased dragged elements by running the test in a new window.
     original_handle = session.window_handle
     session.window_handle = session.new_window()

--- a/webdriver/tests/classic/send_alert_text/conftest.py
+++ b/webdriver/tests/classic/send_alert_text/conftest.py
@@ -4,7 +4,7 @@ from webdriver.error import NoSuchAlertException, NoSuchWindowException
 
 
 @pytest.fixture(name="session")
-def fixture_session(capabilities, session):
+def fixture_session(session):
     """Prevent dialog rate limits by running the test in a new window."""
     original_handle = session.window_handle
     session.window_handle = session.new_window()


### PR DESCRIPTION
This adds the ability for browsers and executors to provide `firstMatch` capabilities.

On its own, this is perhaps not massively useful.

However, this provides a way to then feature-detect support (e.g., all WebDriver browsers can have `supports_pac=True` and then we send the relevant proxy config as a `firstMatch` capability and find out if it was applied or not). That further requires us to have an ability to pass back from the executor that something is unsupported, which is work beyond the scope of this PR.