### PR TITLE
Ensure we delete a session when closing the last window

### DIFF
--- a/webdriver/tests/classic/close_window/close.py
+++ b/webdriver/tests/classic/close_window/close.py
@@ -73,8 +73,15 @@ def test_close_last_browsing_context(session):
 
     assert_success(response, [])
 
-    # With no more open top-level browsing contexts, the session is closed.
-    session.session_id = None
+    try:
+        # The session should've been deleted by closing the last context.
+        with pytest.raises(error.InvalidSessionIdException):
+            session.handles
+
+    finally:
+        # Need an explicit call to session.end() to notify the test harness
+        # that a new session needs to be created for subsequent tests.
+        session.end()
 
 
 def test_element_usage_after_closing_browsing_context(session, inline):


### PR DESCRIPTION
Previously, we just set `session.session_id` to `None`; this is valid
if the browser has (correctly) deleted the session, but is very
problematic if it has not, as it means we no longer have the
`session_id` of the currently active session, and thus we can neither
use that session nor delete the session.

This copies what we do in the delete session tests, and both checks
that the session has been deleted, and then cleanly ends the session.

This should get the majority of WebDriver tests passing again on STP,
where everything after this test fails with:

webdriver.error.SessionNotCreatedException: session not created (500):
Could not create a session: The Safari instance is already paired with
another WebDriver session.
