### PR TITLE
Fix reporting when only the report-only CSP header is present

### DIFF
--- a/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html
+++ b/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html
@@ -7,16 +7,16 @@
 </head>
 <body>
   <script>
-    var t1 = async_test("Test that image does not load");
+    var t1 = async_test("Test that image does load");
     async_test(function(t2) {
     window.addEventListener("securitypolicyviolation", t2.step_func(function(e) {
-        assert_equals(e.blockedURI, "{{location[scheme]}}://{{location[host]}}/content-security-policy/support/fail.png");
+        assert_equals(e.blockedURI, "{{location[scheme]}}://{{location[host]}}/content-security-policy/support/pass.png");
         assert_equals(e.violatedDirective, "img-src");
         t2.done();
       }));
     }, "Event is fired");
   </script>
-  <img src='/content-security-policy/support/fail.png'
+  <img src='/content-security-policy/support/pass.png'
        onload='t1.done();'
        onerror='t1.unreached_func("The image should have loaded");'>
 


### PR DESCRIPTION
This was a bit confusing at first, but the report-only only
had an effect if it was used in conjunction with the regular
CSP header. This is incorrect, as the report-only header
can be present on its own.

Additionally, there was double-logic for parsing the CSP list
values, since we can only concatenate CSP lists if we have
an initial value, which requires a concrete policy value.

Therefore, abstract that way by looping over both headers and
handling the case where initially it is `None` and, if the
CSP header is not present, still `None` when we parse
the `report-only` header.

Additionally, update a WPT test. It was expecting the image
to load, yet was showing the fail image.

Part of #<!-- nolink -->4577

Reviewed in servo/servo#38002