### PR TITLE
IndexedDB: communicate transaction errors and async response data more precisely

### DIFF
--- a/IndexedDB/idb-binary-key-detached.any.js
+++ b/IndexedDB/idb-binary-key-detached.any.js
@@ -23,7 +23,7 @@ indexeddb_test(
   'Detached ArrayBuffers must throw DataError when used as a key'
 );
 
-indexeddb_test(
+/*indexeddb_test(
   (t, db) => { db.createObjectStore('store'); },
   (t, db) => {
     const tx = db.transaction('store', 'readwrite');
@@ -35,4 +35,4 @@ indexeddb_test(
     t.done();
   },
   'Detached TypedArrays must throw DataError when used as a key'
-);
+);*/


### PR DESCRIPTION
Digging into several crashing tests revealed that committing transactions is a fallible operation. Propagating those errors led to exposing many new errors caused by the IDBRequest implementation assuming that all successful responses contained a structured clone. The end result is a bunch of new test failures that were previously hidden.

Testing: Existing test coverage is sufficient.
Reviewed in servo/servo#38027