### PR TITLE
URL: add path setter tests for parent directory

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -2214,6 +2214,14 @@
                 "href": "http://example.net/%00",
                 "pathname": "/%00"
             }
+        },
+        {
+            "href": "foo://path/to",
+            "new_value": "/..",
+            "expected": {
+                "href": "foo://path/",
+                "pathname": "/"
+            }
         }
     ],
     "search": [


### PR DESCRIPTION
I found out a gap between WHATWG's URL and Node.js as the below and add the test to capture it.
```js
const NodeURL = require("url").URL;
const WhatwgURL = require("../whatwg-url/").URL;
const newPath = '/..';

const url = new NodeURL("foo://path/to");  
url.pathname = newPath;
console.log(url.href); // => foo://path

const url2 = new WhatwgURL("foo://path/to");
url2.pathname = newPath;
console.log(url2.href); // => foo://path/
```