### PR TITLE
Allow shorthand to be serialized if property has same mapping logic

### DIFF
--- a/css/cssom/cssstyledeclaration-csstext.html
+++ b/css/cssom/cssstyledeclaration-csstext.html
@@ -100,8 +100,8 @@
         test(function(){
             var style = newElm().style;
             style.cssText = "margin: 10px; margin-inline: 10px; margin-block: 10px; margin-inline-end: 10px; margin-bottom: 10px;";
-            assert_equals(style.cssText, "margin-top: 10px; margin-right: 10px; margin-left: 10px; margin-inline-start: 10px; margin-block: 10px; margin-inline-end: 10px; margin-bottom: 10px;");
-        }, 'Shorthands aren\'t serialized if there are other properties with different logical groups in between');
+            assert_equals(style.cssText, "margin-top: 10px; margin-right: 10px; margin-left: 10px; margin-inline: 10px; margin-block: 10px; margin-bottom: 10px;");
+        }, 'Shorthands aren\'t serialized if there are other properties with same logical property group but different mapping logic in between');
 
         test(function(){
             var style = newElm().style;


### PR DESCRIPTION
The [spec](https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block) states that:
>6. If there is any declaration in declaration block in between the first and the last longhand in current longhands which belongs to the same logical property group, but has a different mapping logic as any of the longhands in current longhands, and is not in current longhands, continue with the steps labeled shorthand loop."

When trying to serialize the "margin-inline-start" declaration as the "margin-inline" shorthand we end up with the following state at the above step:

```
shorthand = margin-inline
declarations = [margin-top, margin-right, margin-left, margin-inline-start, margin-block-start, margin-block-end, margin-inline-end, margin-bottom]
current longhands = [margin-inline-start, margin-inline-end]
```

While we have declarations that meet three of the criteria (in between first and last longhand in current longhands, belong to the same logical property group, not in current longhands) in margin-block-start and margin-block-end, we do not have any declarations that meet all criteria as "margin-block-start" and "margin-block-end" have the same mapping logic (flow-relative) as "margin-inline-start" and "margin-inline-end", thus we should continue serializing the margin-inline shorthand.