### PR TITLE
DOM: align cloning tests with the specification

### DIFF
--- a/custom-elements/reactions/Document.html
+++ b/custom-elements/reactions/Document.html
@@ -23,8 +23,8 @@ test_with_window(function (contentWindow, contentDocument) {
     const newDoc = contentDocument.implementation.createHTMLDocument();
     newDoc.importNode(instance);
 
-    assert_array_equals(element.takeLog().types(), []);
-}, 'importNode on Document must not construct a new custom element when importing a custom element into a window-less document');
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+}, 'importNode on Document must construct a new custom element when importing a custom element into a window-less document');
 
 test_with_window(function (contentWindow, contentDocument) {
     const element = define_custom_element_in_window(contentWindow, 'custom-element', []);

--- a/custom-elements/registries/CustomElementRegistry-upgrade.html
+++ b/custom-elements/registries/CustomElementRegistry-upgrade.html
@@ -106,8 +106,8 @@ test(() => {
     assert_equals(cdElement.elementInternals.shadowRoot.customElementRegistry, window.customElements);
     const innerAB = cdElement.elementInternals.shadowRoot.querySelector('a-b');
     assert_equals(innerAB.customElementRegistry, window.customElements);
-    assert_equals(innerAB.__proto__.constructor.name, 'HTMLElement');
-}, 'upgrade should not upgrade a candidate element not associated with the registry');
+    assert_equals(innerAB.__proto__.constructor.name, 'GlobalABElement');
+}, 'upgrade should not upgrade a candidate element not associated with a registry');
 
 </script>
 </body>

--- a/custom-elements/registries/Document-importNode.html
+++ b/custom-elements/registries/Document-importNode.html
@@ -53,8 +53,12 @@ test(() => {
 }, 'importNode should clone using the global regsitry by default');
 
 test(() => {
-    assert_true(document.importNode(document.createElement('some-element'), {customElementRegistry: scopedRegistry}) instanceof ScopedSomeElement);
-}, 'importNode should clone using the specified scoped regsitry');
+    assert_true(document.importNode(document.createElement('some-element'), {customElementRegistry: scopedRegistry}) instanceof GlobalSomeElement);
+}, 'importNode should clone using target\'s registry if non-null');
+
+test(() => {
+    assert_true(document.importNode(document.implementation.createHTMLDocument().createElement('some-element'), {customElementRegistry: scopedRegistry}) instanceof ScopedSomeElement);
+}, 'importNode should clone using the specified registry if target\'s registry is null');
 
 test(() => {
     const clone = document.importNode(host, {selfOnly: false, customElementRegistry: scopedRegistry});
@@ -83,10 +87,13 @@ test(() => {
     const element = document.createElement('div', {customElementRegistry: emptyRegistry});
     element.innerHTML = '<some-element></some-element><other-element></other-element>';
     const clone = document.importNode(element, {selfOnly: false, customElementRegistry: scopedRegistry});
-    assert_equals(clone.customElementRegistry, scopedRegistry);
-    assert_true(clone.querySelector('some-element') instanceof ScopedSomeElement);
+    assert_equals(clone.customElementRegistry, emptyRegistry);
+    assert_true(clone.querySelector('some-element') instanceof HTMLElement);
+    assert_false(clone.querySelector('some-element') instanceof GlobalSomeElement);
+    assert_false(clone.querySelector('some-element') instanceof ScopedSomeElement);
+    assert_true(clone.querySelector('other-element') instanceof HTMLElement);
     assert_false(clone.querySelector('other-element') instanceof GlobalOtherElement);
-}, 'importNode should clone an element originating from a scoped registry using another scoped registry');
+}, 'importNode should clone using target\'s registry if non-null, including when it\'s not the global registry');
 
 test(() => {
     const template = document.createElement('template');

--- a/custom-elements/upgrading/Document-importNode.html
+++ b/custom-elements/upgrading/Document-importNode.html
@@ -13,9 +13,12 @@ test_with_window((w, doc) => {
 
   let original = document.createElement('my-element');
   assert_true(original instanceof MyElement);
+  assert_equals(original.customElementRegistry, customElements);
 
   let imported = doc.importNode(original);
-  assert_true(imported instanceof MyElement2);
+  assert_true(imported instanceof MyElement);
+  assert_false(imported instanceof MyElement2);
+  assert_equals(imported.customElementRegistry, customElements);
 }, 'autonomous: document.importNode() should import custom elements successfully');
 
 test_with_window((w, doc) => {
@@ -24,9 +27,10 @@ test_with_window((w, doc) => {
 
   let original = document.createElement('my-element3');
   assert_equals(original.constructor, HTMLElement);
+  assert_equals(original.customElementRegistry, customElements);
 
   let imported = doc.importNode(original);
-  assert_true(imported instanceof MyElement3);
+  assert_equals(imported.customElementRegistry, customElements);
 }, 'autonomous: document.importNode() should import "undefined" custom elements successfully');
 </script>
 </body>


### PR DESCRIPTION
The customElementRegistry dictionary member of importNode() is only ever used as fallback and cannot cross the tree boundary.