### PR TITLE
Inherit CSP for blob workers

### DIFF
--- a/workers/dedicated-worker-from-blob-url.window.js
+++ b/workers/dedicated-worker-from-blob-url.window.js
@@ -27,3 +27,21 @@ promise_test(async t => {
   const reply = await message_from_port(worker);
   assert_equals(reply, run_result);
 }, 'Creating a dedicated worker from a blob URL works immediately before revoking.');
+
+promise_test(async t => {
+  const run_result = false;
+  const blob_contents = `
+let constructedRequest = false;
+try {
+  new Request("./file.js");
+  constructedRequest = true;
+} catch (e) {}
+self.postMessage(constructedRequest);
+`;
+  const blob = new Blob([blob_contents]);
+  const url = URL.createObjectURL(blob);
+
+  const worker = new Worker(url);
+  const reply = await message_from_port(worker);
+  assert_equals(reply, run_result, "Should not be able to resolve request with relative file path in blob");
+}, 'Blob URLs should not resolve relative to document base URL.');

--- a/workers/shared-worker-from-blob-url.window.js
+++ b/workers/shared-worker-from-blob-url.window.js
@@ -51,3 +51,21 @@ promise_test(async t => {
   const reply2 = await message_from_port(worker2.port);
   assert_equals(reply2, run_result + '2');
 }, 'Connecting to a shared worker on a revoked blob URL works.');
+
+promise_test(async t => {
+  const run_result = false;
+  const blob_contents = `
+let constructedRequest = false;
+try {
+  new Request("./file.js");
+  constructedRequest = true;
+} catch (e) {}
+self.postMessage(constructedRequest);
+`;
+  const blob = new Blob([blob_contents]);
+  const url = URL.createObjectURL(blob);
+
+  const worker = new SharedWorker(url);
+  const reply = await message_from_port(worker);
+  assert_equals(reply, run_result, "Should not be able to resolve request with relative file path in blob");
+}, 'Blob URLs should not resolve relative to document base URL.');


### PR DESCRIPTION
Workers created from Blobs inherit their CSP. Now we inherit the CSP and set the correct base API url. The base API url should be used when determining the
report-uri endpoint. Otherwise, the blob URL would be used as a base, which is invalid and the report wouldn't be sent.

Also create a helper method to concatenate two optionals of CSPList, which was used in several places.

Part of #<!-- nolink -->4577 
Reviewed in servo/servo#38033