### PR TITLE
Update the Safari docs

### DIFF
--- a/docs/running-tests/safari.md
+++ b/docs/running-tests/safari.md
@@ -1,47 +1,34 @@
 # Safari
 
-To run Safari on macOS, some manual setup is required. Some steps are different
-for Safari and Safari Technology Preview.
+To run Safari on macOS, some manual setup is required.
 
-  * Allow Safari to be controlled by SafariDriver:
-    * `safaridriver --enable` or
-    * `"/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable`
+To enable Remote Automation, run either:
 
-  * Allow pop-up windows:
-    * `defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1` or
-    * `defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1`
+  * `safaridriver --enable`, for Safari, or
+  * `"/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable`,
+    for Safari Technology Preview.
 
-  * Turn on additional experimental features Safari Technology Preview:
-    * `defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1`
-
-  * Trust the certificate:
-    * `security add-trusted-cert -k "$(security default-keychain | cut -d\" -f2)" tools/certs/cacert.pem`
-
-  * Set `no_proxy='*'` in your environment. This is a
-    workaround for a known
-    [macOS High Sierra issue](https://github.com/web-platform-tests/wpt/issues/9007).
+You must also ensure you have
+[configured the `hosts` file](from-local-system.html#hosts-file-setup).
 
 Now, run the tests using the `safari` product:
 ```
 ./wpt run safari [test_list]
 ```
 
-This will use the `safaridriver` found on the path, which will be stable Safari.
-To run Safari Technology Preview instead, use the `--channel=preview` argument:
+This will default to `--channel=preview` and run Safari Technology Preview.
+To run the system Safari instead, use the `--channel=stable` argument:
 ```
-./wpt run --channel=preview safari [test_list]
+./wpt run --channel=stable safari [test_list]
 ```
 
 ## Debugging
 
 To debug problems with `safaridriver`, add the `--webdriver-arg=--diagnose`
-argument:
+option:
 ```
 ./wpt run --channel=preview --webdriver-arg=--diagnose safari [test_list]
 ```
 
 The logs will be in `~/Library/Logs/com.apple.WebDriver/`.
-See `man safaridriver` for more information.
-
-To enable safaridriver diagnostics in Azure Pipelines, set
-`safaridriver_diagnose` to `true` in `.azure-pipelines.yml`.
+See `man 1 safaridriver` for more information.


### PR DESCRIPTION
Remove a lot of outdated content (about pop-up windows, where nowadays
the WebKit preference doesn't change Safari behaviour; about a feature
flag that hasn't existed in years; about needing to trust the
certificates; about workarounds for Python 2; about Azure Pipelines).

Correct the docs for the change of the default "channel" to point at
Safari Technology Preview rather than the system Safari, which I
believe dates back all the way to 2018(!).
