### PR TITLE
Consistently refer to HTTP/2 as HTTP/2 (and not HTTP/2.0)

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -399,10 +399,10 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
 
     def handle_one_request(self):
         """
-        This is the main HTTP/2.0 Handler.
+        This is the main HTTP/2 Handler.
 
         When a browser opens a connection to the server
-        on the HTTP/2.0 port, the server enters this which will initiate the h2 connection
+        on the HTTP/2 port, the server enters this which will initiate the h2 connection
         and keep running throughout the duration of the interaction, and will read/write directly
         from the socket.
 

--- a/tools/wptserve/wptserve/utils.py
+++ b/tools/wptserve/wptserve/utils.py
@@ -169,7 +169,7 @@ def get_port(host: str = '') -> int:
     return port
 
 def http2_compatible() -> bool:
-    # The HTTP/2.0 server requires OpenSSL 1.0.2+.
+    # The HTTP/2 server requires OpenSSL 1.0.2+.
     #
     # For systems using other SSL libraries (e.g. LibreSSL), we assume they
     # have the necessary support.
@@ -177,7 +177,7 @@ def http2_compatible() -> bool:
     if not ssl.OPENSSL_VERSION.startswith("OpenSSL"):
         logger = get_logger()
         logger.warning(
-            'Skipping HTTP/2.0 compatibility check as system is not using '
+            'Skipping HTTP/2 compatibility check as system is not using '
             'OpenSSL (found: %s)' % ssl.OPENSSL_VERSION)
         return True
 


### PR DESCRIPTION
The spec was renamed away from HTTP/2.0 many years ago, and we should
thus consistently call it HTTP/2.

This leaves a single instance of HTTP/2.0: what we set as
Request.protocol_version, as this is exposed to clients of wptserve.
