### PR TITLE
Fix canvas writingmode tests

### DIFF
--- a/html/canvas/element/text/2d.text.writingmode-expected.html
+++ b/html/canvas/element/text/2d.text.writingmode-expected.html
@@ -4,7 +4,7 @@
 <title>Canvas test: 2d.text.writingmode</title>
 <h1>2d.text.writingmode</h1>
 <p class="desc">writing-mode in css should not change how text is rendered</p>
-<canvas id="canvas" width="100" height="50">
+<canvas id="canvas" width="300" height="300">
   <p class="fallback">FAIL (fallback content)</p>
 </canvas>
 <script>
@@ -14,5 +14,5 @@
   ctx.font = "bold 64px Arial";
   ctx.textBaseline = "top";
 
-  ctx.fillText("Happy", 0, 100);
+  ctx.fillText("Happy", 100, 0);
 </script>

--- a/html/canvas/element/text/2d.text.writingmode.html
+++ b/html/canvas/element/text/2d.text.writingmode.html
@@ -5,18 +5,19 @@
 <title>Canvas test: 2d.text.writingmode</title>
 <h1>2d.text.writingmode</h1>
 <p class="desc">writing-mode in css should not change how text is rendered</p>
-<canvas id="canvas" width="100" height="50">
+<canvas id="canvas" width="300" height="300">
   <p class="fallback">FAIL (fallback content)</p>
 </canvas>
 <script>
   const canvas = document.getElementById("canvas");
   const ctx = canvas.getContext('2d');
 
+  canvas.style.textOrientation = "upright";
   canvas.style.writingMode = "vertical-rl";
   canvas.style.fontFamily = "Arial";
 
   ctx.font = "bold 64px Arial";
   ctx.textBaseline = "top";
 
-  ctx.fillText("Happy", 0, 100);
+  ctx.fillText("Happy", 100, 0);
 </script>

--- a/html/canvas/tools/yaml/text.yaml
+++ b/html/canvas/tools/yaml/text.yaml
@@ -3265,18 +3265,20 @@
 - name: 2d.text.writingmode
   desc: writing-mode in css should not change how text is rendered
   canvas_types: ['HtmlCanvas']
+  size: [300, 300]
   code: |
+    canvas.style.textOrientation = "upright";
     canvas.style.writingMode = "vertical-rl";
     canvas.style.fontFamily = "Arial";
 
     ctx.font = "bold 64px Arial";
     ctx.textBaseline = "top";
 
-    ctx.fillText("Happy", 0, 100);
+    ctx.fillText("Happy", 100, 0);
   reference: |
     ctx.font = "bold 64px Arial";
     ctx.textBaseline = "top";
 
-    ctx.fillText("Happy", 0, 100);
+    ctx.fillText("Happy", 100, 0);
 
 # TODO: shadows, alpha, composite, clip


### PR DESCRIPTION
The tests were wrongfully passing everywhere, because not rendering anything at all. Also they were missing the necessary `textOrientation` rule so that Chrome and Safari also render vertically.

See https://issues.chromium.org/issues/40064950#comment6 and https://github.com/whatwg/html/issues/11449