### PR TITLE
Safari infrastructure/ tests shouldn't pass --no-fail-on-unexpected

### DIFF
--- a/.github/workflows/pull_request_test_jobs.yml
+++ b/.github/workflows/pull_request_test_jobs.yml
@@ -30,7 +30,7 @@ jobs:
       safari-technology-preview: true
       safaridriver-diagnose: false
       fetch-depth: 2
-      extra-options: --affected ${{ github.sha }}^1
+      extra-options: --affected ${{ github.sha }}^1 --no-fail-on-unexpected
 
   affected_without_changes_safari_preview:
     name: "affected tests without changes: Safari Technology Preview"
@@ -44,7 +44,7 @@ jobs:
       safaridriver-diagnose: false
       fetch-depth: 2
       test-rev: HEAD^1
-      extra-options: --affected ${{ github.sha }}
+      extra-options: --affected ${{ github.sha }} --no-fail-on-unexpected
 
   infrastructure_mac:
     name: "infrastructure/ tests: macOS"

--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -102,7 +102,6 @@ jobs:
           ./wpt run \
             --no-manifest-update \
             --no-restart-on-unexpected \
-            --no-fail-on-unexpected \
             --no-pause \
             --this-chunk "$CURRENT_CHUNK" \
             --total-chunks "$TOTAL_CHUNKS" \

--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -36,3 +36,4 @@ jobs:
       safari-technology-preview: false
       safaridriver-diagnose: false
       matrix: '{"current-chunk": [1, 2, 3, 4, 5, 6, 7, 8], "total-chunks": [8]}'
+      extra-options: --no-fail-on-unexpected

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -36,3 +36,4 @@ jobs:
       safari-technology-preview: true
       safaridriver-diagnose: false
       matrix: '{"current-chunk": [1, 2, 3, 4, 5, 6, 7, 8], "total-chunks": [8]}'
+      extra-options: --no-fail-on-unexpected

--- a/infrastructure/metadata/infrastructure/assumptions/canvas-background.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/canvas-background.html.ini
@@ -1,3 +1,3 @@
 [canvas-background.html]
   expected:
-    if product == "safari": [ERROR, CRASH]
+    if product == "safari": [ERROR, PASS]

--- a/infrastructure/metadata/infrastructure/server/http2-websocket.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-websocket.sub.h2.any.js.ini
@@ -1,16 +1,12 @@
 [http2-websocket.sub.h2.any.html]
-  expected:
-    if product == "safari": TIMEOUT
   [WSS over h2]
     expected:
       if product == "epiphany" or product == "webkit": FAIL
-      if product == "safari": TIMEOUT
+      if product == "safari": FAIL
 
 
 [http2-websocket.sub.h2.any.worker.html]
-  expected:
-    if product == "safari": TIMEOUT
   [WSS over h2]
     expected:
       if product == "epiphany" or product == "webkit": FAIL
-      if product == "safari": TIMEOUT
+      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
@@ -5,4 +5,3 @@
     expected:
       if (product == "epiphany") or (product == "webkit"): FAIL
       if product == "firefox_android": FAIL
-      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/window/minimize-1.html.ini
+++ b/infrastructure/metadata/infrastructure/window/minimize-1.html.ini
@@ -2,3 +2,4 @@
   [Minimize a window]
     expected:
       if os == "android": FAIL
+      if product == "safari": [PASS, FAIL]


### PR DESCRIPTION
This matches how Taskcluster works by explicitly passing
--no-fail-on-unexpected in all the places we actually want it.
