### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296112

### DIFF
--- a/css/css-text-decor/parsing/text-decoration-computed.html
+++ b/css/css-text-decor/parsing/text-decoration-computed.html
@@ -30,6 +30,10 @@ test_computed_value("text-decoration", "rgba(10, 20, 30, 0.4) dotted", "dotted r
 
 test_computed_value("text-decoration", "underline dashed rgb(0, 255, 0)");
 
+// Test backwards compatibility of blink.
+test_computed_value("text-decoration", "underline overline line-through blink", ["underline overline line-through", "underline overline line-through blink"]);
+test_computed_value("text-decoration", "underline overline line-through blink red", ["underline overline line-through rgb(255, 0, 0)", "underline overline line-through blink rgb(255, 0, 0)"]);
+
 // Add text-decoration-thickness in [css-text-decor-4].
 test_computed_value("text-decoration", "auto", currentColor);
 test_computed_value("text-decoration", "from-font", "from-font " + currentColor);

--- a/css/css-text-decor/parsing/text-decoration-valid.html
+++ b/css/css-text-decor/parsing/text-decoration-valid.html
@@ -18,6 +18,8 @@ test_valid_value("text-decoration", "10px");
 
 test_valid_value("text-decoration", "double overline underline", "underline overline double");
 test_valid_value("text-decoration", "underline overline line-through red");
+test_valid_value("text-decoration", "underline overline line-through blink", ["underline overline line-through", "underline overline line-through blink"]);
+test_valid_value("text-decoration", "underline overline line-through blink red", ["underline overline line-through rgb(255, 0, 0)", "underline overline line-through blink rgb(255, 0, 0)"]);
 test_valid_value("text-decoration", "rgba(10, 20, 30, 0.4) dotted", "dotted rgba(10, 20, 30, 0.4)");
 test_valid_value("text-decoration", "overline green from-font", "overline from-font green");
 test_valid_value("text-decoration", "underline dashed green");


### PR DESCRIPTION
WebKit export from bug: [Remove outdated getComputedStyle tests for text-decoration](https://bugs.webkit.org/show_bug.cgi?id=296112)