### PR TITLE
fix subscription scope in `testdriver.js`

### DIFF
--- a/infrastructure/webdriver/bidi/subscription.html
+++ b/infrastructure/webdriver/bidi/subscription.html
@@ -6,21 +6,132 @@
 <script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
-    promise_test(async () => {
-        const some_message = "SOME MESSAGE";
-        // Subscribe to `log.entryAdded` BiDi events. This will not add a listener to the page.
-        await test_driver.bidi.log.entry_added.subscribe();
-        // Add a listener for the log.entryAdded event. This will not subscribe to the event, so the subscription is
-        // required before. The cleanup is done automatically after the test is finished.
-        const log_entry_promise = test_driver.bidi.log.entry_added.once();
-        // Emit a console.log message.
-        // Note: Lint rule is disabled in `lint.ignore` file.
-        console.log(some_message);
-        // Wait for the log.entryAdded event to be received.
-        const event = await log_entry_promise;
-        // Assert the log.entryAdded event has the expected message.
+    const MAIN_WINDOW_MESSAGE = "1. MAIN WINDOW MESSAGE";
+    const POPUP_MESSAGE = "2. POPUP MESSAGE";
+
+    /** Assert the event is `console.log` with the given message. */
+    function assertLogEvent(event, expected_message) {
+        assert_equals(event.type, "console");
+        assert_equals(event.method, "log");
         assert_equals(event.args.length, 1);
         const event_message = event.args[0];
-        assert_equals(event_message.value, some_message);
-    }, "Assert testdriver can subscribe and receive events");
+        assert_equals(event_message.type, "string");
+        assert_equals(event_message.value, expected_message);
+    }
+
+    /** Wait for a given number of log messages. */
+    function waitForLogMessages(count) {
+        return new Promise(resolve => {
+            const events = []
+            test_driver.bidi.log.entry_added.on(event => {
+                events.push(event);
+                if (events.length === count) {
+                    // The order of the events from different browsing contexts
+                    // are not guaranteed, so sort them by the message for
+                    // test consistency.
+                    events.sort((a, b) => a?.args[0]?.value?.localeCompare(
+                        b?.args[0]?.value));
+                    resolve(events);
+                }
+            });
+        });
+    }
+
+    promise_test(async (t) => {
+        // Open a new window.
+        const popup = window.open();
+        t.add_cleanup(() => popup.close());
+
+        const unsubscribe_handle = await test_driver.bidi.log.entry_added.subscribe();
+        t.add_cleanup(async () => await unsubscribe_handle());
+
+        // Add a listener for the log.entryAdded event.
+        const messages_promise = waitForLogMessages(1)
+
+        // The order of the calls matter, as if the subscription does not
+        // isolate events properly, the first invoked event is likely (but not
+        // guaranteed to) be emitted and received first.
+
+        popup.console.log(POPUP_MESSAGE);
+        console.log(MAIN_WINDOW_MESSAGE);
+
+        const events = await messages_promise;
+        assert_equals(events.length, 1);
+        assertLogEvent(events[0], MAIN_WINDOW_MESSAGE)
+    }, "Assert testdriver can subscribe without arguments");
+
+    promise_test(async (t) => {
+        // Open a new window.
+        const popup = window.open();
+        t.add_cleanup(() => popup.close());
+
+        const unsubscribe_handle = await test_driver.bidi.log.entry_added.subscribe(
+            {contexts: [window]});
+        t.add_cleanup(async () => await unsubscribe_handle());
+
+        // Add a listener for the log.entryAdded event.
+        const messages_promise = waitForLogMessages(1)
+
+        // The order of the calls matter, as if the subscription does not
+        // isolate events properly, the first invoked event is likely (but not
+        // guaranteed to) be emitted and received first.
+
+        popup.console.log(POPUP_MESSAGE);
+        console.log(MAIN_WINDOW_MESSAGE);
+
+        const events = await messages_promise;
+        assert_equals(events.length, 1);
+        assertLogEvent(events[0], MAIN_WINDOW_MESSAGE)
+    }, "Assert testdriver can subscribe for current window");
+
+    promise_test(async (t) => {
+        // Open a new window.
+        const popup = window.open();
+        t.add_cleanup(() => popup.close());
+
+        const unsubscribe_handle = await test_driver.bidi.log.entry_added.subscribe(
+            {contexts: [popup]});
+        t.add_cleanup(async () => await unsubscribe_handle());
+
+        // Add a listener for the log.entryAdded event.
+        const messages_promise = waitForLogMessages(1)
+
+        // The order of the calls matter, as if the subscription does not
+        // isolate events properly, the first invoked event is likely (but not
+        // guaranteed to) be emitted and received first.
+
+        console.log(MAIN_WINDOW_MESSAGE);
+        popup.console.log(POPUP_MESSAGE);
+
+        const events = await messages_promise;
+        assert_equals(events.length, 1);
+        // Expect the popup log message.
+        assertLogEvent(events[0], POPUP_MESSAGE)
+    }, "Assert testdriver can subscribe for another window");
+
+    promise_test(async (t) => {
+        // Open a new window.
+        const popup = window.open();
+        t.add_cleanup(() => popup.close());
+
+        const unsubscribe_handle = await test_driver.bidi.log.entry_added.subscribe(
+            {contexts: null});
+        t.add_cleanup(async () => await unsubscribe_handle());
+
+        // Add a listener for the log.entryAdded event.
+        const messages_promise = waitForLogMessages(2)
+
+        // The order of the calls does not matter, as the events will be
+        // sorted by the `waitForLogMessages` helper.
+
+        console.log(MAIN_WINDOW_MESSAGE);
+        popup.console.log(POPUP_MESSAGE);
+
+        // The order of the events is guaranteed by the `waitForLogMessages`
+        // helper.
+        const events = await messages_promise;
+        assert_equals(events.length, 2);
+        assertLogEvent(events[0], MAIN_WINDOW_MESSAGE)
+        assertLogEvent(events[1], POPUP_MESSAGE)
+    }, "Assert testdriver can subscribe globally");
 </script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -526,8 +526,8 @@
                      * event will be subscribed to globally. If omitted, the
                      * event will be subscribed to on the current browsing
                      * context.
-                     * @returns {Promise<void>} Resolves when the subscription
-                     * is successfully done.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
                      */
                     subscribe: async function(params = {}) {
                         assertBidiIsEnabled();
@@ -593,8 +593,8 @@
                      * event will be subscribed to globally. If omitted, the
                      * event will be subscribed to on the current browsing
                      * context.
-                     * @returns {Promise<void>} Resolves when the subscription
-                     * is successfully done.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
                      */
                     subscribe: async function(params = {}) {
                         assertBidiIsEnabled();
@@ -660,8 +660,8 @@
                      * event will be subscribed to globally. If omitted, the
                      * event will be subscribed to on the current browsing
                      * context.
-                     * @returns {Promise<void>} Resolves when the subscription
-                     * is successfully done.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
                      */
                     subscribe: async function(params = {}) {
                         assertBidiIsEnabled();
@@ -727,8 +727,8 @@
                      * event will be subscribed to globally. If omitted, the
                      * event will be subscribed to on the current browsing
                      * context.
-                     * @returns {Promise<void>} Resolves when the subscription
-                     * is successfully done.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
                      */
                     subscribe: async function(params = {}) {
                         assertBidiIsEnabled();
@@ -907,8 +907,8 @@
                      * event will be subscribed to globally. If omitted, the
                      * event will be subscribed to on the current browsing
                      * context.
-                     * @returns {Promise<void>} Resolves when the subscription
-                     * is successfully done.
+                     * @returns {Promise<(function(): Promise<void>)>} Callback
+                     * for unsubscribing from the created subscription.
                      */
                     subscribe: async function (params = {}) {
                         assertBidiIsEnabled();

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -263,6 +263,23 @@ class BidiSessionSubscribeAction:
         return await self.protocol.bidi_events.subscribe(events, contexts)
 
 
+class BidiSessionUnsubscribeAction:
+    name = "bidi.session.unsubscribe"
+
+    def __init__(self, logger, protocol):
+        do_delayed_imports()
+        self.logger = logger
+        self.protocol = protocol
+
+    async def __call__(self, payload):
+        subscriptions = payload["subscriptions"]
+        if len(subscriptions) == 0:
+            raise ValueError("At least one subscription ID should be provided")
+
+        return await self.protocol.bidi_events.unsubscribe(
+            subscriptions=subscriptions)
+
+
 class BidiPermissionsSetPermissionAction:
     name = "bidi.permissions.set_permission"
 
@@ -296,4 +313,5 @@ async_actions = [
     BidiEmulationSetLocaleOverrideAction,
     BidiEmulationSetScreenOrientationOverrideAction,
     BidiPermissionsSetPermissionAction,
-    BidiSessionSubscribeAction]
+    BidiSessionSubscribeAction,
+    BidiSessionUnsubscribeAction]

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -565,6 +565,14 @@ class BidiEventsProtocolPart(ProtocolPart):
         pass
 
     @abstractmethod
+    async def unsubscribe(self, subscriptions: List[str]) -> Mapping[str, Any]:
+        """
+        Unsubscribes from the subscriptions with the given IDs.
+        :param subscriptions: The list of subscription ids to unsubscribe from.
+        """
+        pass
+
+    @abstractmethod
     async def unsubscribe_all(self):
         """Cleans up the subscription state. Removes all the previously added subscriptions."""
         pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -207,12 +207,25 @@
         return create_action(name, context_params);
     };
 
-    const subscribe = function (params) {
-        return create_action("bidi.session.subscribe", {
+    /**
+     * @returns {Promise<(function(): Promise<void>)>}: callback for
+     * unsubscribing from the created subscription.
+     */
+    const subscribe = async function (params) {
+        const action_result = await create_action("bidi.session.subscribe", {
             // Default to subscribing to the window's events.
             contexts: [window],
             ...params
         });
+        const subscription_id = action_result["subscription"];
+
+        return async ()=>{
+            console.log("!!@@## unsubscribing")
+            await create_action("bidi.session.unsubscribe", {
+                // Default to subscribing to the window's events.
+                subscriptions: [subscription_id]
+            });
+        }
     };
 
     window.test_driver_internal.in_automation = true;
@@ -319,7 +332,7 @@
     window.test_driver_internal.bidi.bluetooth.request_device_prompt_updated.subscribe =
         function(params) {
         return subscribe(
-            {params, events: ['bluetooth.requestDevicePromptUpdated']})
+            {...params, events: ['bluetooth.requestDevicePromptUpdated']})
     };
 
     window.test_driver_internal.bidi.bluetooth.request_device_prompt_updated.on =
@@ -336,7 +349,7 @@
     window.test_driver_internal.bidi.bluetooth.gatt_connection_attempted.subscribe =
         function(params) {
         return subscribe(
-            {params, events: ['bluetooth.gattConnectionAttempted']})
+            {...params, events: ['bluetooth.gattConnectionAttempted']})
     };
 
     window.test_driver_internal.bidi.bluetooth.gatt_connection_attempted.on =
@@ -353,7 +366,7 @@
     window.test_driver_internal.bidi.bluetooth.characteristic_event_generated.subscribe =
         function(params) {
         return subscribe(
-            {params, events: ['bluetooth.characteristicEventGenerated']})
+            {...params, events: ['bluetooth.characteristicEventGenerated']})
     };
 
     window.test_driver_internal.bidi.bluetooth.characteristic_event_generated.on =
@@ -370,7 +383,7 @@
     window.test_driver_internal.bidi.bluetooth.descriptor_event_generated.subscribe =
         function(params) {
         return subscribe(
-            {params, events: ['bluetooth.descriptorEventGenerated']});
+            {...params, events: ['bluetooth.descriptorEventGenerated']});
     };
 
     window.test_driver_internal.bidi.bluetooth.descriptor_event_generated.on =
@@ -419,7 +432,7 @@
     window.test_driver_internal.bidi.log.entry_added.subscribe =
         function (params) {
             return subscribe({
-                params,
+                ...params,
                 events: ["log.entryAdded"]
             })
         };


### PR DESCRIPTION
The subscription didn't respect the params, as they were incorrectly passed. Adding infra tests for it required introducing "unsubscribe" functionality.

No RFC is required, as the `unsubscribe` method matches the WebDriver BiDi command.