### PR TITLE
Add --list-tests-json wptrunner command line option

### DIFF
--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -92,9 +92,9 @@ scheme host and port.""")
     mode_group.add_argument("--list-disabled", action="store_true",
                             help="List the tests that are disabled on the current platform")
     mode_group.add_argument("--list-tests", action="store_true",
-                            help="List all tests")
+                            help="List all tests included in the given test_list (whether or not they would be executed)")
     mode_group.add_argument("--list-tests-json", action="store_true",
-                            help="List all tests in JSON format")
+                            help="List details of all tests included in the given test_list in JSON format")
     stability_group = mode_group.add_mutually_exclusive_group()
     stability_group.add_argument("--verify", action="store_true",
                                  help="Run a stability check on the selected tests")

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -92,7 +92,9 @@ scheme host and port.""")
     mode_group.add_argument("--list-disabled", action="store_true",
                             help="List the tests that are disabled on the current platform")
     mode_group.add_argument("--list-tests", action="store_true",
-                            help="List all tests that will run")
+                            help="List all tests")
+    mode_group.add_argument("--list-tests-json", action="store_true",
+                            help="List all tests in JSON format")
     stability_group = mode_group.add_mutually_exclusive_group()
     stability_group.add_argument("--verify", action="store_true",
                                  help="Run a stability check on the selected tests")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -166,6 +166,25 @@ def list_tests(test_paths, product, **kwargs):
         print(test)
 
 
+def list_tests_json(test_paths, product, **kwargs):
+    env.do_delayed_imports(logger, test_paths)
+
+    _, test_loader = get_loader(test_paths, product, **kwargs)
+
+    tests = {}
+    targets = [(test_loader.tests, False),
+               (test_loader.disabled_tests, True)]
+    for subsuite in test_loader.subsuites:
+        tests[subsuite] = {}
+        for test_type in test_loader.test_types:
+            tests[subsuite][test_type] = {}
+            for target, disabled in targets:
+                for test in target[subsuite][test_type]:
+                    tests[subsuite][test_type][test.id] = {"disabled": disabled,
+                                                           "expected": test.expected()}
+    print(json.dumps(tests, indent=2))
+
+
 def get_pause_after_test(test_loader, **kwargs):
     if kwargs["pause_after_test"] is not None:
         return kwargs["pause_after_test"]
@@ -563,6 +582,8 @@ def start(**kwargs):
             list_disabled(**kwargs)
         elif kwargs["list_tests"]:
             list_tests(**kwargs)
+        elif kwargs["list_tests_json"]:
+            list_tests_json(**kwargs)
         elif kwargs["verify"] or kwargs["stability"]:
             rv = check_stability(**kwargs) or logged_critical.has_log
         else:


### PR DESCRIPTION
The current --list-tests option just prints all the test ids for tests selected on the command line. But it _doesn't_ filter down to tests that will actually be executed with the given command line arguments.

To allow for this, and to make the output easier to parse, add a `--list-tests-json` argument that emits all the selected tests grouped by subsuite and type, the expected status, and whether they are actually enabled given the metadata and current configuration.

This JSON has the form:
```
{
  <subsuite>: {
    <test type>: {
      <test id>: {
        "expected": <status>
        "disabled": <bool>
      }
    }
  }
}
```