### PR TITLE
Remove "Content Visibility" from hidden=until-found test titles

### DIFF
--- a/html/editing/the-hidden-attribute/hidden-until-found-002.html
+++ b/html/editing/the-hidden-attribute/hidden-until-found-002.html
@@ -1,6 +1,6 @@
 <!doctype HTML>
 <meta charset="utf8">
-<title>Content Visibility: tab order navigation ignores hidden=until-found subtrees</title>
+<title>Tab order navigation ignores hidden=until-found subtrees</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 <meta name="assert" content="tab order navigation ignores hidden=until-found subtrees.">

--- a/html/editing/the-hidden-attribute/hidden-until-found-005-ref.html
+++ b/html/editing/the-hidden-attribute/hidden-until-found-005-ref.html
@@ -1,7 +1,7 @@
 <!doctype HTML>
 <html>
 <meta charset="utf8">
-<title>Content Visibility: hidden-matchable and size contained (reference)</title>
+<title>hidden=until-found and size contained (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 

--- a/html/editing/the-hidden-attribute/resources/container-ref.html
+++ b/html/editing/the-hidden-attribute/resources/container-ref.html
@@ -1,9 +1,8 @@
 <!doctype HTML>
 <html>
 <meta charset="utf8">
-<title>CSS Content Visibility: container (reference)</title>
+<title>Container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 #container {

--- a/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html
+++ b/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html
@@ -1,7 +1,7 @@
 <!doctype HTML>
 <html>
 <meta charset="utf8">
-<title>Content Visibility: spacer and a container (reference)</title>
+<title>Spacer and a container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 

--- a/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html
+++ b/html/editing/the-hidden-attribute/resources/spacer-and-container-ref.html
@@ -3,7 +3,6 @@
 <meta charset="utf8">
 <title>Spacer and a container (reference)</title>
 <link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
-<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found">
 
 <style>
 .spacer {


### PR DESCRIPTION
I think this is a leftover of when this feature was `content-visibility: hidden-matchable`