### PR TITLE
Fix typos in various web platform test files

### DIFF
--- a/css/css-align/content-distribution/parse-align-content-002.html
+++ b/css/css-align/content-distribution/parse-align-content-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution" />
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-content" />
 <link rel="help" href="https://drafts.csswg.org/css-cascade/#initial-values" />
-<meta name="assert" content="Check the 'initial' value in diferent scenarios."/>
+<meta name="assert" content="Check the 'initial' value in different scenarios."/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-align/resources/alignment-parsing-utils.js"></script>

--- a/css/css-align/content-distribution/parse-justify-content-002.html
+++ b/css/css-align/content-distribution/parse-justify-content-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution" />
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-content" />
 <link rel="help" href="https://drafts.csswg.org/css-cascade/#initial-values" />
-<meta name="assert" content="Check the 'initial' value in diferent scenarios."/>
+<meta name="assert" content="Check the 'initial' value in different scenarios."/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-align/resources/alignment-parsing-utils.js"></script>

--- a/css/css-align/default-alignment/parse-align-items-002.html
+++ b/css/css-align/default-alignment/parse-align-items-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#default-alignment" />
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-items" />
 <link rel="help" href="https://drafts.csswg.org/css-cascade/#initial-values" />
-<meta name="assert" content="Check the 'initial' value in diferent scenarios."/>
+<meta name="assert" content="Check the 'initial' value in different scenarios."/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-align/resources/alignment-parsing-utils.js"></script>

--- a/css/css-align/default-alignment/parse-justify-items-002.html
+++ b/css/css-align/default-alignment/parse-justify-items-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#default-alignment" />
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-items" />
 <link rel="help" href="https://drafts.csswg.org/css-cascade/#initial-values" />
-<meta name="assert" content="Check the 'initial' value in diferent scenarios."/>
+<meta name="assert" content="Check the 'initial' value in different scenarios."/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-align/resources/alignment-parsing-utils.js"></script>

--- a/css/css-align/self-alignment/parse-align-self-002.html
+++ b/css/css-align/self-alignment/parse-align-self-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#self-alignment" />
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self" />
 <link rel="help" href="https://drafts.csswg.org/css-cascade/#initial-values" />
-<meta name="assert" content="Check the 'initial' value in diferent scenarios."/>
+<meta name="assert" content="Check the 'initial' value in different scenarios."/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-align/resources/alignment-parsing-utils.js"></script>

--- a/css/css-align/self-alignment/parse-justify-self-002.html
+++ b/css/css-align/self-alignment/parse-justify-self-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#self-alignment" />
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self" />
 <link rel="help" href="https://drafts.csswg.org/css-cascade/#initial-values" />
-<meta name="assert" content="Check the 'initial' value in diferent scenarios."/>
+<meta name="assert" content="Check the 'initial' value in different scenarios."/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-align/resources/alignment-parsing-utils.js"></script>

--- a/css/css-masking/clip/clip-negative-values-003.html
+++ b/css/css-masking/clip/clip-negative-values-003.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-vertical-stripe-ref.html">
-    <meta name="assert" content="Negative values are permited on rect function
+    <meta name="assert" content="Negative values are permitted on rect function
     for clip. Test that left edge can be negative. On pass you should see a
     vertical blue stripe.">
 </head>

--- a/css/css-masking/clip/clip-negative-values-004.html
+++ b/css/css-masking/clip/clip-negative-values-004.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clip-property">
     <link rel="match" href="reference/clip-horizontal-stripe-ref.html">
-    <meta name="assert" content="Negative values are permited on rect function
+    <meta name="assert" content="Negative values are permitted on rect function
     for clip. Test that top edge can be negative. On pass you should see a
     horizontal blue stripe.">
 </head>

--- a/css/css-text/i18n/other-lang/css-text-line-break-de-cj-loose.html
+++ b/css/css-text/i18n/other-lang/css-text-line-break-de-cj-loose.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the langauge not being Chinese or Japanese makes no difference.">
+<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the language not being Chinese or Japanese makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/other-lang/css-text-line-break-de-cj-normal.html
+++ b/css/css-text/i18n/other-lang/css-text-line-break-de-cj-normal.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the langauge not being Chinese or Japanese makes no difference.">
+<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the language not being Chinese or Japanese makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/other-lang/css-text-line-break-de-cj-strict.html
+++ b/css/css-text/i18n/other-lang/css-text-line-break-de-cj-strict.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="With line-break:strict, a browser will NOT allow a conditional Japanese starter at the beginning of a line; the langauge not being Chinese or Japanese makes no difference.">
+<meta name="assert" content="With line-break:strict, a browser will NOT allow a conditional Japanese starter at the beginning of a line; the language not being Chinese or Japanese makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html
+++ b/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the langauge being unkonwn makes no difference.">
+<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the language being unknown makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html
+++ b/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the langauge being unknown makes no difference.">
+<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the language being unknown makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/unknown-lang/css-text-line-break-cj-strict.html
+++ b/css/css-text/i18n/unknown-lang/css-text-line-break-cj-strict.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="With line-break:strict, a browser will NOT allow a conditional Japanese starter at the beginning of a line; the langauge being unknown makes no difference.">
+<meta name="assert" content="With line-break:strict, a browser will NOT allow a conditional Japanese starter at the beginning of a line; the language being unknown makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/zh/css-text-line-break-zh-cj-loose.html
+++ b/css/css-text/i18n/zh/css-text-line-break-zh-cj-loose.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the langauge being chinese makes no difference.">
+<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the language being chinese makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/zh/css-text-line-break-zh-cj-normal.html
+++ b/css/css-text/i18n/zh/css-text-line-break-zh-cj-normal.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the langauge being chinese makes no difference.">
+<meta name="assert" content="The browser allows a conditional Japanese starter at the beginning of a line; the language being chinese makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/css/css-text/i18n/zh/css-text-line-break-zh-cj-strict.html
+++ b/css/css-text/i18n/zh/css-text-line-break-zh-cj-strict.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="With line-break:strict, a browser will NOT allow a conditional Japanese starter at the beginning of a line; the langauge being chinese makes no difference.">
+<meta name="assert" content="With line-break:strict, a browser will NOT allow a conditional Japanese starter at the beginning of a line; the language being chinese makes no difference.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';

--- a/editing/edit-context/edit-context-property.tentative.html
+++ b/editing/edit-context/edit-context-property.tentative.html
@@ -79,7 +79,7 @@ test(function () {
   assert_equals(element2.editContext, null, "element2 association should not have changed");
 
   element1.editContext = editContext2;
-  assert_equals(element1.editContext, editContext2, "Association can be switched directly to second EditConext");
+  assert_equals(element1.editContext, editContext2, "Association can be switched directly to second EditContext");
 
   element1.editContext = editContext2;
   assert_equals(element1.editContext, editContext2, "Assigning to the same EditContext again is a no-op");

--- a/fetch/api/response/response-clone.any.js
+++ b/fetch/api/response/response-clone.any.js
@@ -38,7 +38,7 @@ test(function() {
 
 promise_test(function(test) {
   return validateStreamFromString(response.body.getReader(), body);
-}, "Check orginal response's body after cloning");
+}, "Check original response's body after cloning");
 
 promise_test(function(test) {
   return validateStreamFromString(clonedResponse.body.getReader(), body);
@@ -104,7 +104,7 @@ function testReadableStreamClone(initialBuffer, bufferType)
         }).then(function(data) {
             assert_false(data.done);
             if (initialBuffer instanceof ArrayBuffer) {
-              assert_true(data.value instanceof ArrayBuffer, "Cloned buffer is ArrayBufer");
+              assert_true(data.value instanceof ArrayBuffer, "Cloned buffer is ArrayBuffer");
               assert_equals(initialBuffer.byteLength, data.value.byteLength, "Length equal");
               assert_array_equals(new Uint8Array(data.value), new Uint8Array(initialBuffer), "Cloned buffer chunks have the same content");
             } else if (initialBuffer instanceof DataView) {

--- a/html/semantics/text-level-semantics/the-a-element/a-click-handler-with-null-browsing-context-crash.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-click-handler-with-null-browsing-context-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>HTMLAnchorElement.onclick with null browsing conext</title>
+<title>HTMLAnchorElement.onclick with null browsing context</title>
 <link rel="author" title="Nate Chapin" href="mailto:japhet@chromium.org">
 <link rel="help" href="https://html.spec.whatwg.org/C/#the-a-element">
 <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1083721">

--- a/service-workers/service-worker/windowclient-navigate.https.html
+++ b/service-workers/service-worker/windowclient-navigate.https.html
@@ -48,7 +48,7 @@ navigateTest({
 });
 
 navigateTest({
-  description: 'cross orgin url',
+  description: 'cross origin url',
   destUrl: CROSS_ORIGIN_URL,
   expected: null
 });

--- a/shadow-dom/focus-navigation/focus-navigation-slot-fallback-default-tabindex.html
+++ b/shadow-dom/focus-navigation/focus-navigation-slot-fallback-default-tabindex.html
@@ -37,7 +37,7 @@ It should traverse focusable elements in the increasing numerical order and then
 
     <slot name='slot5' id='x5' tabindex=2>
       x. The tabindex is 2. The slot node should be ignored. The host child is assigned to this slot node.
-      <div id='-' tabindex=1>-. The host child is assigned to the parent slot node. This text shouldn't apeare.</div>
+      <div id='-' tabindex=1>-. The host child is assigned to the parent slot node. This text shouldn't appear.</div>
     </slot>
 
     <slot name='slot6' id='x6' tabindex=5>

--- a/wai-aria/manual/slider_readonly_false-manual.html
+++ b/wai-aria/manual/slider_readonly_false-manual.html
@@ -73,7 +73,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ],
                [
                   "property",

--- a/wai-aria/manual/slider_readonly_true-manual.html
+++ b/wai-aria/manual/slider_readonly_true-manual.html
@@ -73,7 +73,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ],
                [
                   "property",

--- a/wai-aria/manual/slider_readonly_unspecified-manual.html
+++ b/wai-aria/manual/slider_readonly_unspecified-manual.html
@@ -73,7 +73,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ],
                [
                   "property",

--- a/wai-aria/manual/spinbutton_readonly_false-manual.html
+++ b/wai-aria/manual/spinbutton_readonly_false-manual.html
@@ -73,7 +73,8 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
+
                ],
                [
                   "property",

--- a/wai-aria/manual/spinbutton_readonly_false-manual.html
+++ b/wai-aria/manual/spinbutton_readonly_false-manual.html
@@ -74,7 +74,6 @@
                   "interfaces",
                   "contains",
                   "IAccessibleValue"
-
                ],
                [
                   "property",

--- a/wai-aria/manual/spinbutton_readonly_true-manual.html
+++ b/wai-aria/manual/spinbutton_readonly_true-manual.html
@@ -73,7 +73,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ],
                [
                   "property",

--- a/wai-aria/manual/spinbutton_readonly_unspecified-manual.html
+++ b/wai-aria/manual/spinbutton_readonly_unspecified-manual.html
@@ -73,7 +73,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ],
                [
                   "property",

--- a/wasm/webapi/esm-integration/script-src-allows-source-phase-wasm.tentative.html
+++ b/wasm/webapi/esm-integration/script-src-allows-source-phase-wasm.tentative.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Source phase imports alowed by CSP</title>
+<title>Source phase imports allowed by CSP</title>
 <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
This PR fixes several typos in the test files as reported in issue #53584:

- "IAcesssibleValue" → "IAccessibleValue"
- "orgin" → "origin"
- "orginal" → "original"
- "diferent" → "different"
- "langauge" → "language"
- "unkonwn" → "unknown"
- "apeare" → "appear"
- "conext" → "context"
- "EditConext" → "EditContext"
- "alowed" → "allowed"
- "permited" → "permitted"
- "htlml" → "html"

All corrections are minor and non-functional, limited to spelling improvements in test files. This helps improve clarity and consistency across the test suite.

Closes #53584
