### PR TITLE
Forward CSP violations from load_whole_resource to parent event loop

### DIFF
--- a/content-security-policy/generic/test-case.sub.js
+++ b/content-security-policy/generic/test-case.sub.js
@@ -57,6 +57,12 @@ function TestCase(scenarios, sanityChecker) {
           // https://bugzilla.mozilla.org/show_bug.cgi?id=1808911
           // In Firefox sometimes violations from Worklets are delayed.
           timeout = 10;
+        } else if (scenario.subresource.startsWith('worker-') &&
+                   navigator.userAgent.includes("Servo/")) {
+          // In Servo, worker violations are also delayed, as they are
+          // sent via IPC. However, they typically arrive relatively
+          // quickly after that.
+          timeout = 1;
         }
         await new Promise(resolve => setTimeout(resolve, timeout));
 

--- a/content-security-policy/inside-worker/dedicatedworker-worker-src.html
+++ b/content-security-policy/inside-worker/dedicatedworker-worker-src.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- Test the 'worker-src' directive on nested dedicated workers -->
+<script>
+  const w = new Worker(
+      `./support/worker-src-none.sub.js?` +
+        `pipe=sub|header(Content-Security-Policy,` +
+        `worker-src 'none')`);
+  // Forward 'securitypolicyviolation' events from the document into the
+  // worker (we shouldn't actually see any, so the worker will assert that
+  // none are fired).
+  document.addEventListener('securitypolicyviolation', _ => {
+    w.postMessage("SecurityPolicyViolation from Document");
+  });
+  // Nested workers are disallowed and don't send violations to document
+  fetch_tests_from_worker(w);
+</script>

--- a/content-security-policy/inside-worker/support/worker-src-none.sub.js
+++ b/content-security-policy/inside-worker/support/worker-src-none.sub.js
@@ -1,0 +1,27 @@
+importScripts("{{location[server]}}/resources/testharness.js");
+importScripts("{{location[server]}}/content-security-policy/support/testharness-helper.js");
+
+let cspEventFiredInDocument = false;
+self.addEventListener("message", e => {
+  if (e.data == "SecurityPolicyViolation from Document") {
+    cspEventFiredInDocument = true;
+  }
+});
+
+async_test(t => {
+  const url = new URL("{{location[server]}}/content-security-policy/support/ping.js").toString();
+  const w = new Worker(url);
+  w.onmessage = t.unreached_func("Ping should not be sent.");
+  Promise.all([
+    waitUntilCSPEventForURL(t, url)
+      .then(t.step_func_done(e => {
+        assert_equals(e.blockedURI, url);
+        assert_equals(e.violatedDirective, "worker-src");
+        assert_equals(e.effectiveDirective, "worker-src");
+        assert_false(cspEventFiredInDocument, "Should not have fired event on document");
+      })),
+    waitUntilEvent(w, "error"),
+  ]);
+}, "Nested worker with worker-src is disallowed.");
+
+done();


### PR DESCRIPTION
Any CSP violations happening when loading a worker should be reported
on the global of the document that creates the worker. Since workers
run in different threads, we can't pass in this parent global into
the worker global scope. Instead, we need to send a message to the
parent event loop to report it on the correct global.

Part of https://github.com/servo/servo/issues/4577
Fixes https://github.com/servo/servo/issues/37027
Reviewed in servo/servo#38048