### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295641

### DIFF
--- a/css/css-backgrounds/background-clip/clip-text-text-emphasis-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-text-emphasis-ref.html
@@ -2,7 +2,7 @@
 <style>
 .clip {
   font-size: 80px;
-  text-emphasis: filled currentColor;
+  text-emphasis: filled dot currentColor;
   color: green;
 }
 </style>

--- a/css/css-backgrounds/background-clip/clip-text-text-emphasis.html
+++ b/css/css-backgrounds/background-clip/clip-text-text-emphasis.html
@@ -6,7 +6,7 @@
 <style>
 .clip {
   font-size: 80px;
-  text-emphasis: filled transparent;
+  text-emphasis: filled dot transparent;
   color: transparent;
   background-color: green;
   background-clip: text;

--- a/css/css-text-decor/parsing/text-emphasis-style-computed-vertical-lr.html
+++ b/css/css-text-decor/parsing/text-emphasis-style-computed-vertical-lr.html
@@ -3,15 +3,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<div id="target"></div>
+<style>
+    #target {
+        writing-mode: vertical-lr;
+    }
+</style>
+<div id="target" ></div>
 <script>
 // Computed value: the keyword none, a pair of keywords representing the shape
 // and fill, or a string
 test_computed_value('text-emphasis-style', 'none');
 test_computed_value('text-emphasis-style', 'dot', 'dot');
 test_computed_value('text-emphasis-style', 'filled circle', 'circle');
-test_computed_value('text-emphasis-style', 'filled', 'circle');
-test_computed_value('text-emphasis-style', 'open', 'open circle');
+test_computed_value('text-emphasis-style', 'filled', 'sesame');
+test_computed_value('text-emphasis-style', 'open', 'open sesame');
 test_computed_value('text-emphasis-style', 'double-circle', 'double-circle');
 test_computed_value('text-emphasis-style', 'triangle', 'triangle');
 test_computed_value('text-emphasis-style', 'open sesame');


### PR DESCRIPTION
WebKit export from bug: [Default computed value for `text-emphasis-style: filled|open` should be `filled|open circle` not `filled|open dot` in horizontal typographic modes](https://bugs.webkit.org/show_bug.cgi?id=295641)