### PR TITLE
Implement parsing of Link HTTP headers

### DIFF
--- a/preload/preload-referrer-policy.html
+++ b/preload/preload-referrer-policy.html
@@ -23,7 +23,7 @@ const loaders = {
         if (preloadPolicy === '')
             params.set('preload-policy', '');
         else
-            params.set('preload-policy', `referrerpolicy=${preloadPolicy}`);
+            params.set('preload-policy', `referrerpolicy=${preloadPolicy};`);
         params.set('resource-name', 'link-header-referrer-policy.html');
         iframe.src = `resources/link-header-referrer-policy.py?${params.toString()}`;
         t.add_cleanup(() => iframe.remove());

--- a/preload/resources/link-header-referrer-policy.py
+++ b/preload/resources/link-header-referrer-policy.py
@@ -1,5 +1,5 @@
 def main(request, response):
-    response_headers = [(b"Link", b"<%s>;rel=\"preload\";%s;as=\"script\"" %
+    response_headers = [(b"Link", b"<%s>;rel=\"preload\";%sas=\"script\"" %
                         (request.GET.first(b"href", b""),
                          request.GET.first(b"preload-policy", b"")))]
     body = ""


### PR DESCRIPTION
The Link HTTP header can do the same as link elements,
in that they can preload/prefetch/etc... This implements
the basics of header parsing and hooks it up for preload.

Note that we use a new nom-rfc8288 crate that implements
the parsing behavior. However, that crate is too strict
in that empty attributes (`;;` as part of the header) are
discarded and resulting in a parsing failure. I temporarily
edited the WPT infrastructure to make our tests run, but
that needs to be reverted before merging when the crate
is updated to handle these cases correctly.

Part of #<!-- nolink -->35035
Reviewed in servo/servo#38175