### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296250

### DIFF
--- a/css/css-values/random-in-keyframe.html
+++ b/css/css-values/random-in-keyframe.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: random() in @keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#random">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @keyframes --anim {
+    from {
+        translate: 0px;
+        translate: random(2px, 200px);
+    }
+    to {
+        translate: 0px;
+    }
+  }
+  #target {
+    animation: --anim 1000s step-end;
+  }
+</style>
+<div id="target"></div>
+<script>
+  test(() => {
+    assert_not_equals(getComputedStyle(target).translate, "0px");
+  }, "random() is not ignored in keyframe");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[CSS random()\] Allow in `@keyframes`](https://bugs.webkit.org/show_bug.cgi?id=296250)