### PR TITLE
[Navigation API] autofocus test wrongly expects disabling to synchronously unfocus

### DIFF
--- a/navigation-api/focus-reset/autofocus.html
+++ b/navigation-api/focus-reset/autofocus.html
@@ -120,7 +120,6 @@ promise_test(async t => {
   assert_equals(document.activeElement, decoy, "Focus stays on the initially-focused button during the transition");
 
   decoy.disabled = true;
-  assert_equals(document.activeElement, document.body, "Disabling the initially-focused button temporarily resets focus to the body");
 
   await finished;
   assert_equals(document.activeElement, autofocusTarget, "Focus moves to the second autofocused button after the transition");


### PR DESCRIPTION
This test has a check that assumes that if an element becomes disabled, and it was the active/focused element, that document.activeElement should immediately change.

The HTML spec does not enforce that if an element becomes disabled (and thus, unfocusable), that the focused element must change immediately. So this check is faulty. Chrome does appear to do this synchronoulsy, but Safari and Mozilla do not, and so the test fails for them.

This check isn't actually checking the behavior of the Navigation API, but rather the behavior of focus. Since the check is faulty, unrelated to the Navigation API, and is causing the test to fail on 2/3 browsers, we remove it.

One alternative considered was to wait for the next rendering update since that should cause a new element to be focused in, but this races with await finished and the issue is that often the navigation will finish even before the assert, which means that that the active element gets changed to the autoFocusTarget and then fails that way. Hence, it's best to just remove this assert.