### PR TITLE
Use 'pixelated' as fallback of 'crisp-edges' in object-position tests

### DIFF
--- a/css/css-images/object-fit-contain-png-001-ref.html
+++ b/css/css-images/object-fit-contain-png-001-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-16x8.png");
         background-size: contain;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-contain-png-001c.html
+++ b/css/css-images/object-fit-contain-png-001c.html
@@ -12,12 +12,12 @@
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-fit">
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-position">
     <link rel="match" href="object-fit-contain-png-001-ref.html">
-    <meta name=fuzzy content="maxDifference=0-20;totalPixels=0-2000">
     <style type="text/css">
       canvas {
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-001e.html
+++ b/css/css-images/object-fit-contain-png-001e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-001i.html
+++ b/css/css-images/object-fit-contain-png-001i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-001o.html
+++ b/css/css-images/object-fit-contain-png-001o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-001p.html
+++ b/css/css-images/object-fit-contain-png-001p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-002-ref.html
+++ b/css/css-images/object-fit-contain-png-002-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-8x16.png");
         background-size: contain;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-contain-png-002c.html
+++ b/css/css-images/object-fit-contain-png-002c.html
@@ -12,12 +12,12 @@
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-fit">
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-position">
     <link rel="match" href="object-fit-contain-png-002-ref.html">
-    <meta name=fuzzy content="maxDifference=0-20;totalPixels=0-2000">
     <style type="text/css">
       canvas {
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-002e.html
+++ b/css/css-images/object-fit-contain-png-002e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-002i.html
+++ b/css/css-images/object-fit-contain-png-002i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-002o.html
+++ b/css/css-images/object-fit-contain-png-002o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-contain-png-002p.html
+++ b/css/css-images/object-fit-contain-png-002p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-001-ref.html
+++ b/css/css-images/object-fit-cover-png-001-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-16x8.png");
         background-size: cover;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-cover-png-001c.html
+++ b/css/css-images/object-fit-cover-png-001c.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-001e.html
+++ b/css/css-images/object-fit-cover-png-001e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-001i.html
+++ b/css/css-images/object-fit-cover-png-001i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-001o.html
+++ b/css/css-images/object-fit-cover-png-001o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-001p.html
+++ b/css/css-images/object-fit-cover-png-001p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-002-ref.html
+++ b/css/css-images/object-fit-cover-png-002-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-8x16.png");
         background-size: cover;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-cover-png-002c.html
+++ b/css/css-images/object-fit-cover-png-002c.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-002e.html
+++ b/css/css-images/object-fit-cover-png-002e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-002i.html
+++ b/css/css-images/object-fit-cover-png-002i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-002o.html
+++ b/css/css-images/object-fit-cover-png-002o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-cover-png-002p.html
+++ b/css/css-images/object-fit-cover-png-002p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: cover;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-001-ref.html
+++ b/css/css-images/object-fit-fill-png-001-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-16x8.png");
         background-size: 100% 100%;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-fill-png-001c.html
+++ b/css/css-images/object-fit-fill-png-001c.html
@@ -12,12 +12,12 @@
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-fit">
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-position">
     <link rel="match" href="object-fit-fill-png-001-ref.html">
-    <meta name=fuzzy content="maxDifference=0-20;totalPixels=0-3200">
     <style type="text/css">
       canvas {
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-001e.html
+++ b/css/css-images/object-fit-fill-png-001e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-001i.html
+++ b/css/css-images/object-fit-fill-png-001i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-001o.html
+++ b/css/css-images/object-fit-fill-png-001o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-001p.html
+++ b/css/css-images/object-fit-fill-png-001p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-002-ref.html
+++ b/css/css-images/object-fit-fill-png-002-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-8x16.png");
         background-size: 100% 100%;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-fill-png-002c.html
+++ b/css/css-images/object-fit-fill-png-002c.html
@@ -12,12 +12,12 @@
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-fit">
     <link rel="help" href="http://www.w3.org/TR/css3-images/#the-object-position">
     <link rel="match" href="object-fit-fill-png-002-ref.html">
-    <meta name=fuzzy content="maxDifference=0-20;totalPixels=0-3200">
     <style type="text/css">
       canvas {
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-002e.html
+++ b/css/css-images/object-fit-fill-png-002e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-002i.html
+++ b/css/css-images/object-fit-fill-png-002i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-002o.html
+++ b/css/css-images/object-fit-fill-png-002o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-fill-png-002p.html
+++ b/css/css-images/object-fit-fill-png-002p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: fill;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-001-ref.html
+++ b/css/css-images/object-fit-none-png-001-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-16x8.png");
         background-size: auto auto;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-none-png-001c.html
+++ b/css/css-images/object-fit-none-png-001c.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-001e.html
+++ b/css/css-images/object-fit-none-png-001e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-001i.html
+++ b/css/css-images/object-fit-none-png-001i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-001o.html
+++ b/css/css-images/object-fit-none-png-001o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-001p.html
+++ b/css/css-images/object-fit-none-png-001p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-002-ref.html
+++ b/css/css-images/object-fit-none-png-002-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-8x16.png");
         background-size: auto auto;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .bigWide {

--- a/css/css-images/object-fit-none-png-002c.html
+++ b/css/css-images/object-fit-none-png-002c.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-002e.html
+++ b/css/css-images/object-fit-none-png-002e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-002i.html
+++ b/css/css-images/object-fit-none-png-002i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-002o.html
+++ b/css/css-images/object-fit-none-png-002o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-none-png-002p.html
+++ b/css/css-images/object-fit-none-png-002p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: none;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-001-ref.html
+++ b/css/css-images/object-fit-scale-down-png-001-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-16x8.png");
         background-size: auto auto;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .objectOuter > .small { background-size: contain; }

--- a/css/css-images/object-fit-scale-down-png-001c.html
+++ b/css/css-images/object-fit-scale-down-png-001c.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-001e.html
+++ b/css/css-images/object-fit-scale-down-png-001e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-001i.html
+++ b/css/css-images/object-fit-scale-down-png-001i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-001o.html
+++ b/css/css-images/object-fit-scale-down-png-001o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-001p.html
+++ b/css/css-images/object-fit-scale-down-png-001p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-002-ref.html
+++ b/css/css-images/object-fit-scale-down-png-002-ref.html
@@ -18,6 +18,7 @@
         background-image: url("support/colors-8x16.png");
         background-size: auto auto;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       .objectOuter > .small { background-size: contain; }

--- a/css/css-images/object-fit-scale-down-png-002c.html
+++ b/css/css-images/object-fit-scale-down-png-002c.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-002e.html
+++ b/css/css-images/object-fit-scale-down-png-002e.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-002i.html
+++ b/css/css-images/object-fit-scale-down-png-002i.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-002o.html
+++ b/css/css-images/object-fit-scale-down-png-002o.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-fit-scale-down-png-002p.html
+++ b/css/css-images/object-fit-scale-down-png-002p.html
@@ -17,6 +17,7 @@
         border: 1px dashed gray;
         padding: 1px;
         object-fit: scale-down;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
         float: left;
       }

--- a/css/css-images/object-position-png-001-ref.html
+++ b/css/css-images/object-position-png-001-ref.html
@@ -15,6 +15,8 @@
         background-image: url("support/colors-16x8.png");
         background-size: contain;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-001c.html
+++ b/css/css-images/object-position-png-001c.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-001e.html
+++ b/css/css-images/object-position-png-001e.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-001i.html
+++ b/css/css-images/object-position-png-001i.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-001o.html
+++ b/css/css-images/object-position-png-001o.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-001p.html
+++ b/css/css-images/object-position-png-001p.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-002-ref.html
+++ b/css/css-images/object-position-png-002-ref.html
@@ -15,6 +15,8 @@
         background-image: url("support/colors-8x16.png");
         background-size: contain;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-002c.html
+++ b/css/css-images/object-position-png-002c.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-002e.html
+++ b/css/css-images/object-position-png-002e.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-002i.html
+++ b/css/css-images/object-position-png-002i.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-002o.html
+++ b/css/css-images/object-position-png-002o.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/object-position-png-002p.html
+++ b/css/css-images/object-position-png-002p.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/tools/template-object-fit-ref.html
+++ b/css/css-images/tools/template-object-fit-ref.html
@@ -18,6 +18,7 @@
         background-image: url("REPLACEME_IMAGE_FILENAME");
         background-size: REPLACEME_BACKGROUND_SIZE_VAL;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
         image-rendering: crisp-edges;
       }
       REPLACEME_SCALE_DOWN_EXTRA_RULE

--- a/css/css-images/tools/template-object-position-ref.html
+++ b/css/css-images/tools/template-object-position-ref.html
@@ -15,6 +15,8 @@
         background-image: url("REPLACEME_IMAGE_FILENAME");
         background-size: contain;
         background-repeat: no-repeat;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;

--- a/css/css-images/tools/template-object-position-test.html
+++ b/css/css-images/tools/template-object-position-test.html
@@ -17,6 +17,8 @@
         background: lightgray;
         margin-right: 2px;
         object-fit: contain;
+        image-rendering: pixelated; /* for UAs that don't support crisp-edges */
+        image-rendering: crisp-edges;
         float: left;
         width: 20px;
         height: 20px;


### PR DESCRIPTION
The tests fail in Chrome due to small pixel differences between the background-image used in the ref files and the different elements used to test the object-position, like canvas, img or video.

The use of 'image-rendering: crisp-edges' helps to reduce the impact of the different scaling algorithms implemented in the engine's rendering pipelines. However, some web engines don't implement the 'crisp-edges' features; this is the case of the Chrome browser. 

It seems using 'pixelated' as fallback solves most of the PNG related test cases. 

Change-Id: Ie8bf2a14f5d22d692b45e85a1d3eb2bd0c34725f