### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296345

### DIFF
--- a/css/css-grid/abspos/grid-abspos-static-pos-align-self-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-static-pos-align-self-end-large-border-padding-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>
+
+

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Absolute Positioning\] Add simple end self alignment support for abspos child of a grid](https://bugs.webkit.org/show_bug.cgi?id=296345)