### PR TITLE
Replace edgedriver URL to fix Edge runs

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1787,7 +1787,7 @@ class Edge(Browser):
 
         try:
             # MojoJS version url must match the browser binary version exactly.
-            url = ("https://msedgedriver.azureedge.net/wpt-mojom/"
+            url = ("https://msedgedriver.microsoft.com/wpt-mojom/"
                    f"{edge_version}/linux64/mojojs.zip")
             # Check the status without downloading the content (this is a
             # streaming request).
@@ -1888,7 +1888,7 @@ class Edge(Browser):
         elif self.platform == "win":
             bits = "win64" if uname[4] == "x86_64" else "win32"
 
-        url = f"https://msedgedriver.azureedge.net/{version}/edgedriver_{bits}.zip"
+        url = f"https://msedgedriver.microsoft.com/{version}/edgedriver_{bits}.zip"
         self.logger.info(f"Downloading MSEdgeDriver from {url}")
         unzip(get(url).raw, dest)
         edgedriver_path = which("msedgedriver", path=dest)


### PR DESCRIPTION
Fixes: #53908

Currently, they are failing with this error:

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='msedgedriver.azureedge.net', port=443): Max retries exceeded with url: /140.0.3430.1/edgedriver_win32.zip (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x00000176949CBC50>: Failed to resolve 'msedgedriver.azureedge.net' ([Errno 11001] getaddrinfo failed)"))
```

Looks like https://msedgedriver.azureedge.net was deprecated.

See:
- https://github.com/webdriverio-community/node-edgedriver/pull/501
- https://github.com/seleniumhq/selenium/issues/16073