### PR TITLE
Remove text-decoration-computed.html subtest that relies on currentColor default

### DIFF
--- a/css/css-text-decor/parsing/text-decoration-computed.html
+++ b/css/css-text-decor/parsing/text-decoration-computed.html
@@ -31,7 +31,6 @@ test_computed_value("text-decoration", "rgba(10, 20, 30, 0.4) dotted", "dotted r
 test_computed_value("text-decoration", "underline dashed rgb(0, 255, 0)");
 
 // Test backwards compatibility of blink.
-test_computed_value("text-decoration", "underline overline line-through blink", ["underline overline line-through", "underline overline line-through blink"]);
 test_computed_value("text-decoration", "underline overline line-through blink red", ["underline overline line-through rgb(255, 0, 0)", "underline overline line-through blink rgb(255, 0, 0)"]);
 
 // Add text-decoration-thickness in [css-text-decor-4].


### PR DESCRIPTION
This is still under discussion, let's drop it for now.