### PR TITLE
Cookie store - ensure whitespace prefix to `__Http-` and `__HostHttp-` is properly blocked

### DIFF
--- a/cookie-store/cookieStore_special_names.https.any.js
+++ b/cookie-store/cookieStore_special_names.https.any.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-['__Secure-', '__secure-', '__Host-', '__host-'].forEach(prefix => {
+['__Secure-', '__secure-', '__Host-', '__host-', '  __Secure-', '\t__Secure-', ' __Host-', '\t__Host-'].forEach(prefix => {
   promise_test(async testCase => {
     await cookieStore.set(`${prefix}cookie-name`, `secure-cookie-value`);
     assert_equals(
@@ -32,7 +32,7 @@
   }, `cookieStore.delete with ${prefix} name on secure origin`);
 });
 
-['__Host-', '__host-'].forEach(prefix => {
+['__Host-', '__host-', '  __Host-', '\t__Host-'].forEach(prefix => {
   promise_test(async testCase => {
     const currentUrl = new URL(self.location.href);
     const currentDomain = currentUrl.hostname;
@@ -54,7 +54,8 @@
   }, `cookieStore.set with ${prefix} prefix a path option`);
 });
 
-['__HostHttp-', '__hosthttp-', '__Http-', '__http-'].forEach(prefix => {
+['__HostHttp-', '__hosthttp-', '__Http-', '__http-', '  __Http-', '\t__Http-',
+ '  __HostHttp-', '\t__HostHttp-'].forEach(prefix => {
   promise_test(async testCase => {
     await promise_rejects_js(testCase, TypeError,
         cookieStore.set({ name: `${prefix}cookie-name`, value: 'cookie-value'}));
@@ -72,32 +73,20 @@ promise_test(async testCase => {
     assert_true(exceptionThrown, "No exception thrown.");
 }, 'cookieStore.set with malformed name.');
 
-promise_test(async testCase => {
-  // Nameless cookies cannot have a __Host- prefix
-  await cookieStore.delete('');
+['__Host-', '__Secure-', '__Http-', '__HostHttp-', ' __Host-', '\t__Host-', ' __Secure-',
+ '\t__Secure-', ' __Http-', '\t__Http-', ' __HostHttp-', '\t__HostHttp-'].forEach(prefix => {
+  promise_test(async testCase => {
+    // Nameless cookies cannot have special prefixes
+    await cookieStore.delete('');
 
-  const currentUrl = new URL(self.location.href);
-  const currentDomain = currentUrl.hostname;
+    const currentUrl = new URL(self.location.href);
+    const currentDomain = currentUrl.hostname;
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
-      { name: '',
-        value: '__Host-nameless-cookie',
-        domain: `.${currentDomain}` }));
-  const cookie = await cookieStore.get('');
-  assert_equals(cookie, null);
-}, 'cookieStore.set a nameless cookie cannot have __Host- prefix');
-
-promise_test(async testCase => {
-  // Nameless cookies cannot have a __Secure- prefix
-  await cookieStore.delete('');
-
-  const currentUrl = new URL(self.location.href);
-  const currentDomain = currentUrl.hostname;
-
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
-      { name: '',
-        value: '__Secure-nameless-cookie',
-        domain: `.${currentDomain}` }));
-  const cookie = await cookieStore.get('');
-  assert_equals(cookie, null);
-}, 'cookieStore.set a nameless cookie cannot have __Secure- prefix');
+    await promise_rejects_js(testCase, TypeError, cookieStore.set(
+        { name: '',
+          value: `${prefix}nameless-cookie`,
+          domain: `.${currentDomain}` }));
+    const cookie = await cookieStore.get('');
+    assert_equals(cookie, null);
+  }, `cookieStore.set a nameless cookie cannot have ${prefix} prefix`);
+});

--- a/cookie-store/cookieStore_special_names.https.any.js
+++ b/cookie-store/cookieStore_special_names.https.any.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-['__Secure-', '__secure-', '__Host-', '__host-', '  __Secure-', '\t__Secure-', ' __Host-', '\t__Host-'].forEach(prefix => {
+['__Secure-', '__secure-', '__Host-', '__host-'].forEach(prefix => {
   promise_test(async testCase => {
     await cookieStore.set(`${prefix}cookie-name`, `secure-cookie-value`);
     assert_equals(
@@ -32,7 +32,7 @@
   }, `cookieStore.delete with ${prefix} name on secure origin`);
 });
 
-['__Host-', '__host-', '  __Host-', '\t__Host-'].forEach(prefix => {
+['__Host-', '__host-'].forEach(prefix => {
   promise_test(async testCase => {
     const currentUrl = new URL(self.location.href);
     const currentDomain = currentUrl.hostname;

--- a/cookies/prefix/document-cookie.non-secure.html
+++ b/cookies/prefix/document-cookie.non-secure.html
@@ -3,12 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/cookies/resources/cookie-helper.sub.js"></script>
 <script>
+  let counter = 0;
   function create_test(prefix, params, shouldExistInDOM, shouldExistViaHTTP, title) {
     promise_test(t => {
       var name = prefix + "prefixtestcookie";
       erase_cookie_from_js(name, params);
       t.add_cleanup(() => erase_cookie_from_js(name, params));
-      var value = "" + Math.random();
+      var value = "foo" + ++counter;
       document.cookie = name + "=" + value + ";" + params;
 
       assert_dom_cookie(name, value, shouldExistInDOM);


### PR DESCRIPTION
This tests https://github.com/WICG/cookie-store/pull/269 by ensuring that whitespace-preceded prefixes are properly rejected.