### PR TITLE
Fix Digital Credentials `.get()` tests that test the absence of `requests`

### DIFF
--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -107,8 +107,12 @@
   }, "Calling navigator.credentials.get() without a digital member same origin.");
 
   promise_test(async (t) => {
-    for (const request of [undefined, []]) {
-      const options = makeGetOptions(request);
+    for (const r of [undefined, []]) {
+      const options = {
+        digital: {
+          requests: r
+        },
+      };
       await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
@@ -121,8 +125,12 @@
   promise_test(async (t) => {
     iframeSameOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
-    for (const request of [undefined, []]) {
-      const options = makeGetOptions(request);
+    for (const r of [undefined, []]) {
+      const options = {
+        digital: {
+          requests: r
+        },
+      };
       await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
@@ -134,8 +142,12 @@
 
   promise_test(async (t) => {
     iframeCrossOrigin.focus();
-    for (const request of [undefined, []]) {
-      const options = makeGetOptions(request);
+    for (const r of [undefined, []]) {
+      const options = {
+        digital: {
+          requests: r
+        },
+      };
       const result = await sendMessage(iframeCrossOrigin, {
         action: "get",
         options,


### PR DESCRIPTION
There were two tests that are using the helper `makeGetOptions()` to test how the API behaves in the absence of requests
```
    for (const request of [undefined, []]) {
      const options = makeGetOptions(request);
      await promise_rejects_js(
        t,
        TypeError,
        navigator.credentials.get(options)
      );
    }
```

However, `makeGetOptions()` is configured to ignore `undefined` param and switches it to `"default"`, which produces a valid requests and falsifies the purpose of the test.

This PR avoid using the helper method to properly test both cases.