### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296439

### DIFF
--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-flex-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-flex-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: flex-end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-self-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-self-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: self-end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Absolute Positioning\]\[Grid\] align-self self-end and flex-end are equivalent to end for simple content](https://bugs.webkit.org/show_bug.cgi?id=296439)