### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296455

### DIFF
--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-center-large-border-padding-ref.html"
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 100px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
@@ -3,7 +3,7 @@
 <head>
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
 <link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
-<link rel="match" href="grid-abspos-staticpos-align-self-center-large-border-padding-ref.html"
+<link rel="match" href="grid-abspos-staticpos-align-self-center-large-border-padding-ref.html">
 <meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box.">
 <style>
 .grid {

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html
@@ -3,7 +3,7 @@
 <head>
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
 <link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
-<link rel="match" href="grid-abspos-staticpos-align-self-center-ref.html"
+<link rel="match" href="grid-abspos-staticpos-align-self-center-ref.html">
 <meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box.">
 <style>
 .grid {

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-center-ref.html"
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Absolute Positioning\]\[Grid\] Expand alignment within static position rectangle to align-self center for simple content](https://bugs.webkit.org/show_bug.cgi?id=296455)