### PR TITLE
Fix missing assertion in `css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006.html`

### DIFF
--- a/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006.html
+++ b/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006.html
@@ -51,7 +51,7 @@
          https://www.w3.org/TR/css-align-3/#propdef-align-self -->
     <!-- auto | normal | stretch -->
     <div class="container"><div style="align-self: auto" data-offset-x="6" data-offset-y="1"></div></div>
-    <div class="container"><div style="align-self: normal" data-offset-x="10" data-offset-y=""></div></div>
+    <div class="container"><div style="align-self: normal" data-offset-x="10" data-offset-y="1"></div></div>
     <div class="container"><div style="align-self: stretch" data-offset-x="10" data-offset-y="1"></div></div>
     <br>
     <!-- <baseline-position> -->


### PR DESCRIPTION
Pretty sure this is just a typo. All the other tests have `1` for the assertion. And believe an empty `data-offset-y` attribute is invalid.