### PR TITLE
layout: Fix `depends_on_block_constraints` logic

### DIFF
--- a/css/css-flexbox/stretched-child-in-nested-flexbox-003.html
+++ b/css/css-flexbox/stretched-child-in-nested-flexbox-003.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>css-flexbox: stretching of flex item in nested flexbox</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/38023">
+<link rel="match" href="/css/reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Due to min-height, the outer flex container is 200px tall.
+  It's single-line, so its flex item stretched to that size, and is considered definite.
+  Therefore, the percentage in the nested flex container resolves as 200px.
+  And thus its flex item is also stretched to be 200px tall.
+">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: flex; min-height: 200px">
+  <div>
+    <div style="display: flex; height: 100%; background-color: red">
+      <div style="width: 200px; background-color: green;"></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
The logic was wrong, sometimes we weren't setting it to true on flex containers that needed it, and then as a workaround we were setting it to to true on flex items that didn't need it.

For example, this testcase had 5 cache misses when stretching the items, now we will avoid laying them out again:
```html
<div style="display: flex">
  <div></div>  <div></div>  <div></div>  <div></div>  <div></div>
</div>
```

Also, the workaround wasn't always working, e.g. it failed to stretch the green element here:
```html
<div style="display: flex; min-height: 200px">
  <div>
    <div style="display: flex; height: 100%; background-color: red">
      <div style="width: 200px; background-color: green;"></div>
    </div>
  </div>
</div>
```

Testing: Adding new test
Fixes: #<!-- nolink -->38023

Reviewed in servo/servo#38318