### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295936

### DIFF
--- a/css/css-anchor-position/position-area-anchor-001-ref.html
+++ b/css/css-anchor-position/position-area-anchor-001-ref.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <title>anchor() resolution in position-area</title>
 
+<<<<<<< ours
+=======
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="author" name="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+>>>>>>> theirs
 <style>
   .container {
     width: 100px; height: 100px;


### PR DESCRIPTION
WebKit export from bug: [\[css-anchor-position-1\] anchor() fails to account for position-area](https://bugs.webkit.org/show_bug.cgi?id=295936)