### PR TITLE
script: Fire `scroll` event whenever JS scrolled 

### DIFF
--- a/dom/events/resources/large-dimension-document.sub.html
+++ b/dom/events/resources/large-dimension-document.sub.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+    <div style="width: 10000px; height: 10000px;"></div>
+</body>

--- a/dom/events/scrolling/scroll-event-fired-to-element.html
+++ b/dom/events/scrolling/scroll-event-fired-to-element.html
@@ -3,6 +3,8 @@
 <title>Scroll event should behave correctly for Element.offsetTop and Element.offsetLeft</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="scroll_support.js"></script>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:jo.steven.novaryo@huawei.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
 <div id=log></div>
@@ -24,41 +26,20 @@ function setupTarget() {
   return target;
 }
 
-function triggerReflow(target) {
-  // These should trigger reflow
-  target.style.display = "inline-block";
-}
-
-// Create a promise, returning scrollTop whenever it receive a "scroll" event.
-function promiseForScrollTop(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollTop)),
-    { once: true },
-  );
-}
-
-// Create a promise, returning scrollLeft whenever it receive a "scroll" event.
-function promiseForScrollLeft(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollLeft)),
-    { once: true },
-  );
-}
-
 promise_test(async (t) => {
   var target = setupTarget();
 
   assert_equals(target.scrollTop, 0);
-  var updatedOffsetTop = promiseForScrollTop(target);
+  var promiseForScrollTop = waitForEvent("scroll", t, target);
   target.scrollTop = 10;
-  assert_equals(await updatedOffsetTop, 10);
+  await promiseForScrollTop;
+  assert_equals(target.scrollTop, 10);
 
   assert_equals(target.scrollLeft, 0);
-  var updatedOffsetLeft = promiseForScrollLeft(target);
+  var promiseForScrollLeft = waitForEvent("scroll", t, target);
   target.scrollLeft = 10;
-  assert_equals(await updatedOffsetLeft, 10);
+  await promiseForScrollLeft;
+  assert_equals(target.scrollLeft, 10);
 
 }, "scrollTop and scrollLeft should fire scroll event.");
 
@@ -73,7 +54,9 @@ promise_test(async (t) => {
   assert_equals(target.scrollLeft, 0);
   target.scrollLeft = 0;
 
-  triggerReflow(target); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollTop and scrollLeft being set with the same value.");
 
 promise_test(async (t) => {
@@ -84,28 +67,34 @@ promise_test(async (t) => {
   target.scrollTop = -100;
   target.scrollLeft = -100;
 
-  triggerReflow(target); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollTop and scrollLeft being set with invalid scroll offset.");
 
 promise_test(async (t) => {
   var target = setupTarget();
 
   assert_equals(target.scrollTop, 0);
-  var updatedOffsetTop = promiseForScrollTop(target);
+  var promiseForScrollTop = waitForEvent("scroll", t, target);
   target.scrollTop = 1000;
-  assert_equals(await updatedOffsetTop, 100);
+  await promiseForScrollTop;
+  assert_equals(target.scrollTop, 100);
 
   assert_equals(target.scrollLeft, 0);
-  var updatedOffsetLeft = promiseForScrollLeft(target);
+  var promiseForScrollLeft = waitForEvent("scroll", t, target);
   target.scrollLeft = 1000;
-  assert_equals(await updatedOffsetLeft, 100);
+  await promiseForScrollLeft;
+  assert_equals(target.scrollLeft, 100);
 
   target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
 
   target.scrollTop = 1000;
   target.scrollLeft = 1000;
 
-  triggerReflow(target); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollTop and scrollLeft when scrolling above maximum offset.");
 
 </script>

--- a/dom/events/scrolling/scroll-event-fired-to-element.html
+++ b/dom/events/scrolling/scroll-event-fired-to-element.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll event should behave correctly for Element.offsetTop and Element.offsetLeft</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<div id=log></div>
+<div id="container">
+</div>
+<script>
+
+function setupTarget() {
+  var container = document.getElementById("container");
+  container.innerHTML = "";
+
+  var target = document.createElement("div");
+  var overflowing_child = document.createElement("div");
+
+  target.style = "overflow:scroll; height: 100px; width: 100px; scrollbar-width: none";
+  overflowing_child.style = "height: 200px; width: 200px;";
+  target.appendChild(overflowing_child);
+  container.appendChild(target);
+  return target;
+}
+
+function triggerReflow(target) {
+  // These should trigger reflow
+  target.style.display = "inline-block";
+}
+
+// Create a promise, returning scrollTop whenever it receive a "scroll" event.
+function promiseForScrollTop(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollTop)),
+    { once: true },
+  );
+}
+
+// Create a promise, returning scrollLeft whenever it receive a "scroll" event.
+function promiseForScrollLeft(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollLeft)),
+    { once: true },
+  );
+}
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  assert_equals(target.scrollTop, 0);
+  var updatedOffsetTop = promiseForScrollTop(target);
+  target.scrollTop = 10;
+  assert_equals(await updatedOffsetTop, 10);
+
+  assert_equals(target.scrollLeft, 0);
+  var updatedOffsetLeft = promiseForScrollLeft(target);
+  target.scrollLeft = 10;
+  assert_equals(await updatedOffsetLeft, 10);
+
+}, "scrollTop and scrollLeft should fire scroll event.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  assert_equals(target.scrollTop, 0);
+  target.scrollTop = 0;
+
+  assert_equals(target.scrollLeft, 0);
+  target.scrollLeft = 0;
+
+  triggerReflow(target); // Ensure that all event is flushed.
+}, "scrollTop and scrollLeft being set with the same value.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTop = -100;
+  target.scrollLeft = -100;
+
+  triggerReflow(target); // Ensure that all event is flushed.
+}, "scrollTop and scrollLeft being set with invalid scroll offset.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  assert_equals(target.scrollTop, 0);
+  var updatedOffsetTop = promiseForScrollTop(target);
+  target.scrollTop = 1000;
+  assert_equals(await updatedOffsetTop, 100);
+
+  assert_equals(target.scrollLeft, 0);
+  var updatedOffsetLeft = promiseForScrollLeft(target);
+  target.scrollLeft = 1000;
+  assert_equals(await updatedOffsetLeft, 100);
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTop = 1000;
+  target.scrollLeft = 1000;
+
+  triggerReflow(target); // Ensure that all event is flushed.
+}, "scrollTop and scrollLeft when scrolling above maximum offset.");
+
+</script>

--- a/dom/events/scrolling/scroll-event-fired-to-iframe.html
+++ b/dom/events/scrolling/scroll-event-fired-to-iframe.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll event should behave correctly for Element.ScrollX and Element.ScrollLeft</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<div id=log></div>
+<div id="container">
+</div>
+<script>
+
+
+function promiseForFrameLoad(frame) {
+  return new Promise(async (resolve) => {
+    frame.addEventListener("load", () => resolve(frame), { once: true });
+  });
+}
+
+async function promiseForSetupTargetFrame() {
+  const target = document.createElement("iframe");
+  target.src = "../resources/large-dimension-document.sub.html";
+  target.width = "200";
+  target.height = "200";
+
+  var container = document.getElementById("container");
+  container.innerHTML = "";
+  container.appendChild(target);
+
+  return promiseForFrameLoad(target);
+}
+
+function triggerReflow() {
+  // These should trigger reflow
+  var container = document.getElementById("container");
+  container.style.display = "inline-block";
+  container.style.display = "block";
+}
+
+// Create a promise, returning scrollX whenever it receive a "scroll" event.
+function promiseForScrollX(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollX)),
+    { once: true },
+  );
+}
+
+// Create a promise, returning scrollY whenever it receive a "scroll" event.
+function promiseForScrollY(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollY)),
+    { once: true },
+  );
+}
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  assert_equals(target.scrollX, 0);
+  var updatedScrollX = promiseForScrollX(target);
+  target.scrollTo({left: 10});
+  assert_equals(await updatedScrollX, 10);
+
+  assert_equals(target.scrollY, 0);
+  var updatedScrollY = promiseForScrollY(target);
+  target.scrollTo({top: 10});
+  assert_equals(await updatedScrollY, 10);
+
+}, "scrollX and scrollY should fire scroll event.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  assert_equals(target.scrollX, 0);
+  target.scrollTo({left: 0});
+
+  assert_equals(target.scrollY, 0);
+  target.scrollTo({top: 0});
+
+  triggerReflow(); // Ensure that all event is flushed.
+}, "scrollX and scrollY being set with the same value.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTo({left: -100});
+  target.scrollTo({top: -100});
+
+  triggerReflow(); // Ensure that all event is flushed.
+}, "scrollX and scrollY being set with invalid scroll Scroll.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+  var frameDocEl = frame.contentDocument.documentElement;
+
+  assert_equals(target.scrollX, 0);
+  var updatedScrollX = promiseForScrollX(target);
+  target.scrollTo({left: frameDocEl.scrollWidth});
+  assert_greater_than(await updatedScrollX, 0);
+
+  assert_equals(target.scrollY, 0);
+  var updatedScrollY = promiseForScrollY(target);
+  target.scrollTo({top: frameDocEl.scrollHeight});
+  assert_greater_than(await updatedScrollY, 0);
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTo({left: updatedScrollX + 10});
+  target.scrollTo({top: updatedScrollY + 10});
+
+  triggerReflow(); // Ensure that all event is flushed.
+}, "scrollX and scrollY when scrolling above maximum Scroll.");
+
+</script>

--- a/dom/events/scrolling/scroll-event-fired-to-iframe.html
+++ b/dom/events/scrolling/scroll-event-fired-to-iframe.html
@@ -3,6 +3,8 @@
 <title>Scroll event should behave correctly for Element.ScrollX and Element.ScrollLeft</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="scroll_support.js"></script>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:jo.steven.novaryo@huawei.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
 <div id=log></div>
@@ -30,44 +32,21 @@ async function promiseForSetupTargetFrame() {
   return promiseForFrameLoad(target);
 }
 
-function triggerReflow() {
-  // These should trigger reflow
-  var container = document.getElementById("container");
-  container.style.display = "inline-block";
-  container.style.display = "block";
-}
-
-// Create a promise, returning scrollX whenever it receive a "scroll" event.
-function promiseForScrollX(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollX)),
-    { once: true },
-  );
-}
-
-// Create a promise, returning scrollY whenever it receive a "scroll" event.
-function promiseForScrollY(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollY)),
-    { once: true },
-  );
-}
-
 promise_test(async (t) => {
   var frame = await promiseForSetupTargetFrame();
   var target = frame.contentWindow;
 
   assert_equals(target.scrollX, 0);
-  var updatedScrollX = promiseForScrollX(target);
+  var promiseForScrollX = waitForEvent("scroll", t, target);
   target.scrollTo({left: 10});
-  assert_equals(await updatedScrollX, 10);
+  await promiseForScrollX;
+  assert_equals(target.scrollX, 10);
 
   assert_equals(target.scrollY, 0);
-  var updatedScrollY = promiseForScrollY(target);
+  var promiseForScrollY = waitForEvent("scroll", t, target);
   target.scrollTo({top: 10});
-  assert_equals(await updatedScrollY, 10);
+  await promiseForScrollY;
+  assert_equals(target.scrollY, 10);
 
 }, "scrollX and scrollY should fire scroll event.");
 
@@ -83,7 +62,9 @@ promise_test(async (t) => {
   assert_equals(target.scrollY, 0);
   target.scrollTo({top: 0});
 
-  triggerReflow(); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollX and scrollY being set with the same value.");
 
 promise_test(async (t) => {
@@ -95,7 +76,9 @@ promise_test(async (t) => {
   target.scrollTo({left: -100});
   target.scrollTo({top: -100});
 
-  triggerReflow(); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollX and scrollY being set with invalid scroll Scroll.");
 
 promise_test(async (t) => {
@@ -104,21 +87,30 @@ promise_test(async (t) => {
   var frameDocEl = frame.contentDocument.documentElement;
 
   assert_equals(target.scrollX, 0);
-  var updatedScrollX = promiseForScrollX(target);
+  var promiseForScrollX = waitForEvent("scroll", t, target);
   target.scrollTo({left: frameDocEl.scrollWidth});
-  assert_greater_than(await updatedScrollX, 0);
+  await promiseForScrollX;
+  assert_greater_than(target.scrollX, 0);
 
   assert_equals(target.scrollY, 0);
-  var updatedScrollY = promiseForScrollY(target);
-  target.scrollTo({top: frameDocEl.scrollHeight});
-  assert_greater_than(await updatedScrollY, 0);
+  var promiseForScrollY = waitForEvent("scroll", t, target);
+  target.scrollTo({
+    top: frameDocEl.scrollHeight,
+    left: target.scrollX
+  });
+  await promiseForScrollY;
+  assert_greater_than(target.scrollY, 0);
 
   target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
 
-  target.scrollTo({left: updatedScrollX + 10});
-  target.scrollTo({top: updatedScrollY + 10});
+  target.scrollTo({
+    left: target.scrollX + 10,
+    top: target.scrollY + 10,
+  });
 
-  triggerReflow(); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollX and scrollY when scrolling above maximum Scroll.");
 
 </script>


### PR DESCRIPTION
Implement JS scroll event firing compliant to https://drafts.csswg.org/cssom-view/#scrolling-events. Basically whenever, the an element or the viewport is scrolled, we will fire a scroll event. The changes push a scroll event whenever an API causes a scroll position to change.

Testing: New WPT tests for basic APIs.
Part of: https://github.com/servo/servo/issues/31665

Reviewed in servo/servo#38321