### PR TITLE
`css/css-anchor-position/position-try-fallbacks-004.html`: wait one frame after scrolling before taking screenshot

### DIFF
--- a/css/css-anchor-position/position-try-fallbacks-004.html
+++ b/css/css-anchor-position/position-try-fallbacks-004.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<head>
 <title>Retrying fallbacks after failing with a non-existing fallback</title>
 <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
 <link rel="help" href="https://issues.chromium.org/issues/427134601">
@@ -19,6 +23,11 @@
     position-area: right;
   }
 </style>
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+</head>
+
+<body>
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div style="position:relative; height:200px;">
   <div id="container" style="overflow:hidden; width:100px; height:100px; background:red;">
@@ -34,9 +43,15 @@
   </div>
 </div>
 <script>
-  requestAnimationFrame(()=> {
-    requestAnimationFrame(()=> {
+  waitForAtLeastOneFrame().then(() => {
+    waitForAtLeastOneFrame().then(() => {
       container.scrollTop = 50;
+      waitForAtLeastOneFrame().then(() => {
+        takeScreenshot();
+      });
     });
   });
 </script>
+</body>
+
+</html>


### PR DESCRIPTION
`css/css-anchor-position/position-try-fallbacks-004.html` is flaky on Safari because it doesn't wait for one frame after scrolling before taking screenshots.