### PR TITLE
Fix offsetParent computation for elements with fixed position

### DIFF
--- a/css/css-anchor-position/anchor-position-multicol-002.html
+++ b/css/css-anchor-position/anchor-position-multicol-002.html
@@ -90,7 +90,7 @@
              data-offset-x=26 data-offset-y=140
              data-expected-width=50 data-expected-height=90></div>
         <div class="target fixed target1-rb"
-             data-offset-x=66 data-offset-y=220></div>
+             data-offset-x=58 data-offset-y=215></div>
       </div>
 
       <!-- The containing block of querying elements is a multi-column.  -->
@@ -100,10 +100,10 @@
       <div class="target target1-rb"
            data-offset-x=294 data-offset-y=95></div>
       <div class="target fixed target1"
-           data-offset-x=152 data-offset-y=10
+           data-offset-x=144 data-offset-y=5
            data-expected-width=160 data-expected-height=100></div>
       <div class="target fixed target1-rb"
-           data-offset-x=302 data-offset-y=100></div>
+           data-offset-x=294 data-offset-y=95></div>
     </div>
 
     <!-- The containing block of querying elements is not fragmented.  -->
@@ -113,9 +113,9 @@
     <div class="target target1-rb"
          data-offset-x=294 data-offset-y=95></div>
     <div class="target fixed target1"
-         data-offset-x=152 data-offset-y=10
+         data-offset-x=144 data-offset-y=5
          data-expected-width=160 data-expected-height=100></div>
     <div class="target fixed target1-rb"
-         data-offset-x=302 data-offset-y=100></div>
-    </div>
+         data-offset-x=294 data-offset-y=95></div>
+  </div>
 </body>

--- a/css/cssom-view/offsetParent-fixed.html
+++ b/css/cssom-view/offsetParent-fixed.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:zhoupeng.1996@bytedance.com">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#fixed-cb">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12352">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#a, #b, #c, #d, #e, #f {
+  position: fixed;
+}
+#margin {
+  margin: 10px;
+}
+#transform {
+  transform: translateX(10px);
+}
+#perspective {
+  perspective: 10px;
+}
+#filter {
+  filter: opacity(25%);
+}
+#contain {
+  contain: paint;
+}
+</style>
+
+<body>
+  <div id="a"></div>
+  <div id="margin">
+    <div><div id="b"></div></div>
+  </div>
+
+  <div id="transform">
+    <div><div id="c"></div></div>
+  </div>
+  <div id="perspective">
+    <div><div id="d"></div></div>
+  </div>
+  <div id="filter">
+    <div><div id="e"></div></div>
+  </div>
+  <div id="contain">
+    <div><div id="f"></div></div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  assert_equals(a.offsetParent, null);
+  assert_equals(b.offsetParent, null);
+}, 'If the containing block for a fixed positioned element is viewport, the offsetParent should be null.');
+
+test(() => {
+  assert_equals(c.offsetParent, transform);
+  assert_equals(d.offsetParent, perspective);
+  assert_equals(e.offsetParent, filter);
+  assert_equals(f.offsetParent, contain);
+}, 'If the containing block for a fixed positioned element is the nearest ancestor box, the offsetParent should be the nearest ancestor box.');
+</script>

--- a/shadow-dom/offsetParent-across-shadow-boundaries.html
+++ b/shadow-dom/offsetParent-across-shadow-boundaries.html
@@ -81,6 +81,72 @@ function testOffsetParentOnElementAssignedToSlotInsideOffsetParent(mode) {
 testOffsetParentOnElementAssignedToSlotInsideOffsetParent('open');
 testOffsetParentOnElementAssignedToSlotInsideOffsetParent('closed');
 
+function testOffsetParentOnElementAssignedToSlotInsideFixedPositionWithContainingBlock(mode) {
+    test(function () {
+        const host = document.createElement('div');
+        host.innerHTML = '<div id="target"></div>';
+        container.appendChild(host);
+        this.add_cleanup(() => host.remove());
+        const shadowRoot = host.attachShadow({mode});
+        shadowRoot.innerHTML = [
+            '<div style="transform: translate(10px, 10px);" id="wrapper">',
+            '<div style="position: fixed; padding-left: 85px; padding-top: 45px;">',
+                '<slot></slot>',
+            '</div></div>'].join('');
+        const target = host.querySelector('#target');
+        assert_equals(target.offsetParent, container);
+        assert_equals(target.offsetLeft, 85);
+        assert_equals(target.offsetTop, 45);
+    }, `offsetParent must return the fixed position containing block of an element when the context object is assigned to a slot within a fixed containing block in shadow tree of ${mode} mode`);
+}
+
+testOffsetParentOnElementAssignedToSlotInsideFixedPositionWithContainingBlock('open');
+testOffsetParentOnElementAssignedToSlotInsideFixedPositionWithContainingBlock('closed');
+
+function testOffsetParentOnFixedElementAssignedToSlotInsideFixedPositionWithContainingBlock(mode) {
+    test(function () {
+        const host = document.createElement('div');
+        host.innerHTML = '<div id="target" style="position: fixed;"></div>';
+        container.appendChild(host);
+        this.add_cleanup(() => host.remove());
+        const shadowRoot = host.attachShadow({mode});
+        shadowRoot.innerHTML = [
+            '<div style="transform: translate(10px, 10px);" id="wrapper">',
+            '<div style="position: fixed; padding-left: 85px; padding-top: 45px;">',
+                '<slot></slot>',
+            '</div></div>'].join('');
+        const target = host.querySelector('#target');
+        assert_equals(target.offsetParent, container);
+        assert_equals(target.offsetLeft, 85);
+        assert_equals(target.offsetTop, 45);
+    }, `offsetParent must return the fixed position containing block of a fixed element when the context object is assigned to a slot within a fixed containing block in shadow tree of ${mode} mode`);
+}
+
+testOffsetParentOnFixedElementAssignedToSlotInsideFixedPositionWithContainingBlock('open');
+testOffsetParentOnFixedElementAssignedToSlotInsideFixedPositionWithContainingBlock('closed');
+
+function testOffsetParentOnElementAssignedToSlotInsideFixedPosition(mode) {
+    test(function () {
+        const host = document.createElement('div');
+        host.innerHTML = '<div id="target"></div>';
+        container.appendChild(host);
+        this.add_cleanup(() => host.remove());
+        const shadowRoot = host.attachShadow({mode});
+        shadowRoot.innerHTML = [
+            '<div id="fixed" style="position: fixed; padding-left: 85px; padding-top: 45px;">',
+                '<slot></slot>',
+            '</div>'].join('');
+        const target = host.querySelector('#target');
+        const fixed = shadowRoot.querySelector('#fixed');
+        assert_equals(target.offsetParent, null);
+        assert_equals(target.offsetLeft, 85 + fixed.offsetLeft);
+        assert_equals(target.offsetTop, 45 + fixed.offsetTop);
+    }, `offsetParent must return null when the context object is assigned to a slot without a fixed containing block in shadow tree of ${mode} mode`);
+}
+
+testOffsetParentOnElementAssignedToSlotInsideFixedPosition('open');
+testOffsetParentOnElementAssignedToSlotInsideFixedPosition('closed');
+
 function testOffsetParentOnElementAssignedToSlotInsideNestedOffsetParents(mode) {
     test(function () {
         const host = document.createElement('div');


### PR DESCRIPTION
Consider this test case: <div style="transform: translate(50px, 50px);" id="transform">
  <div style="position: fixed;" id="fixed"></div>
</div>

Observed behavior: `div#fixed` has `offsetParent = null`, but its `offsetLeft` and `offsetTop` are relative to `div#transform` (both values = 0).

Specification conflict, current CSSOM spec states:
> The element’s computed value of the position property is fixed.
This contradicts the observed behavior since transform establishes a containing block for fixed-position descendants. Other properties like will-change and contain can trigger this too.

Proposed Specification Update of `offsetParent`:
> If any of the following holds true return null and terminate this algorithm:
- The element’s computed value of the position property is fixed and no ancestor establishes a fixed position containing block.

> Let ancestor be the parent of the element in the flat tree and repeat these substeps:
- If ancestor is closed-shadow-hidden from the element, the element has a computed `position` value of `fixed`, and no ancestor establishes a fixed position containing block, terminate this algorithm and return null.

Implement it in Chromium first, then update the spec. See https://github.com/w3c/csswg-drafts/issues/12352 for more details.

Bug: 40694036
Change-Id: I4bf32a9a5ab73c44051d13fd9c79eac7515c973e
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6774502
Reviewed-by: Ian Kilpatrick <ikilpatrick@chromium.org>
Commit-Queue: Peng Zhou <zhoupeng.1996@bytedance.com>
Cr-Commit-Position: refs/heads/main@{#1492432}