### PR TITLE
Add test for exportparts across multiple shadow boundaries

### DIFF
--- a/css/css-shadow-parts/exportparts-layered.html
+++ b/css/css-shadow-parts/exportparts-layered.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" title="Keith Cirkel">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-parts/">
+<link rel="match" href="exportparts-layered.ref.html">
+<style>
+my-parent::part(base) { font-size: 1px; }
+my-parent::part(child-base) { font-size: 2rem; }
+</style>
+<my-parent>
+  <template shadowrootmode="open">
+    <style>
+      ::host::part(base) { background: red; }
+      ::host::part(child-base) { background: green; }
+    </style>
+    <my-child exportparts="base:child-base">
+      <template shadowrootmode="open">
+        <style>
+        :host::part(base) {
+          background: red;
+        }
+        </style>
+        <span part="base">Should be large and green</span>
+      </template>
+    </my-child>
+  </template>
+</my-parent>

--- a/css/css-shadow-parts/exportparts-layered.html
+++ b/css/css-shadow-parts/exportparts-layered.html
@@ -4,21 +4,19 @@
 <link rel="help" href="https://drafts.csswg.org/css-shadow-parts/">
 <link rel="match" href="exportparts-layered.ref.html">
 <style>
-my-parent::part(base) { font-size: 1px; }
+my-parent::part(base) { font-size: 1px !important; }
 my-parent::part(child-base) { font-size: 2rem; }
 </style>
 <my-parent>
   <template shadowrootmode="open">
     <style>
-      ::host::part(base) { background: red; }
-      ::host::part(child-base) { background: green; }
+      :host::part(base) { background: red !important; }
+      :host::part(child-base) { background: green; }
     </style>
     <my-child exportparts="base:child-base">
       <template shadowrootmode="open">
         <style>
-        :host::part(base) {
-          background: red;
-        }
+        :host::part(base) { background: red; }
         </style>
         <span part="base">Should be large and green</span>
       </template>

--- a/css/css-shadow-parts/exportparts-layered.html
+++ b/css/css-shadow-parts/exportparts-layered.html
@@ -5,18 +5,21 @@
 <link rel="match" href="exportparts-layered.ref.html">
 <style>
 my-parent::part(base) { font-size: 1px !important; }
+my-child::part(base) { font-size: 1px !important; }
 my-parent::part(child-base) { font-size: 2rem; }
 </style>
 <my-parent>
   <template shadowrootmode="open">
     <style>
       :host::part(base) { background: red !important; }
+      my-child::part(child-base) { background: red !important; }
       :host::part(child-base) { background: green; }
     </style>
     <my-child exportparts="base:child-base">
       <template shadowrootmode="open">
         <style>
         :host::part(base) { background: red; }
+        :host::part(child-base) { background: red !important; }
         </style>
         <span part="base">Should be large and green</span>
       </template>

--- a/css/css-shadow-parts/exportparts-layered.ref.html
+++ b/css/css-shadow-parts/exportparts-layered.ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<span style="background: green;font-size: 2rem;">Should be large and green</span>
+


### PR DESCRIPTION
I was summoned in https://bsky.app/profile/lukewarlow.dev/post/3lv5zxwyklc2w, where @konnorrogers and @jonathantneal were pointing out issues with exportparts. They had some codepen demos which pointed out some inconsistencies. I have ported them to WPT.

Adding @emilio, @nt1m, @mfreed7 to confirm if they beleive these tests are valid. They are failing in all 3 browsers.