### PR TITLE
[Trusted Types] Ensure moveBefore pre-conditions are met.

### DIFF
--- a/trusted-types/script-enforcement-001.html
+++ b/trusted-types/script-enforcement-001.html
@@ -248,7 +248,13 @@
   promise_test(async t => {
     await no_script_message_for(_ => {
       let script = create_html_script_with_trusted_source_text(";");
-      script.moveBefore(document.createTextNode(LOG_RUN_MESSAGE), script.firstChild);
+      let text = document.createTextNode(LOG_RUN_MESSAGE);
+      // Per https://dom.spec.whatwg.org/#move, step 1, moveBefore requires
+      // the two nodes to have the same shadow-including root.
+      let root = document.createElement("div");
+      root.appendChild(script);
+      root.appendChild(text);
+      script.moveBefore(text, script.firstChild);
       container.appendChild(script);
     });
   }, "Setting script source via Element.moveBefore() drops trustworthiness.");


### PR DESCRIPTION
The "Setting script source via Element.moveBefore() drops trustworthiness" subtest of
trusted-types/script-enforcement-001.html fails, since moveBefore requires several
preconditions that the test setup doesn't meet. Fix this so that moveBefore can
run successfully.