### PR TITLE
Also handle moveBefore in script-enforcement-002, -003, and -004.

### DIFF
--- a/trusted-types/script-enforcement-002.html
+++ b/trusted-types/script-enforcement-002.html
@@ -296,7 +296,13 @@
     let messages = await script_messages_for(_ => {
       let script = create_html_script_with_trusted_source_text(";");
       window.log_message("SET");
-      script.moveBefore(document.createTextNode(LOG_RUN_MESSAGE), script.firstChild);
+      // Per https://dom.spec.whatwg.org/#move, step 1, moveBefore requires
+      // the two nodes to have the same shadow-including root.
+      let text = document.createTextNode(LOG_RUN_MESSAGE);
+      let root = document.createElement("div");
+      root.appendChild(text);
+      root.appendChild(script);
+      script.moveBefore(text, script.firstChild);
       window.log_message("APPEND");
       container.appendChild(script);
     });

--- a/trusted-types/script-enforcement-003.html
+++ b/trusted-types/script-enforcement-003.html
@@ -275,10 +275,16 @@
   promise_test(async t => {
     await no_script_message_for(_ => {
       let script = create_svg_script_with_trusted_source_text(";");
-      script.moveBefore(document.createTextNode(LOG_RUN_MESSAGE), script.firstChild);
+      // Per https://dom.spec.whatwg.org/#move, step 1, moveBefore requires
+      // the two nodes to have the same shadow-including root.
+      let text = document.createTextNode(LOG_RUN_MESSAGE);
+      let root = document.createElement("div");
+      root.appendChild(text);
+      root.appendChild(script);
+      script.moveBefore(text, script.firstChild);
       container.appendChild(script);
     });
-  }, "Setting script source via ElementmoveBefore() drops trustworthiness.");
+  }, "Setting script source via Element.moveBefore() drops trustworthiness.");
 
   promise_test(async t => {
     await promise_rejects_js(t, TypeError, script_messages_for(_ => {

--- a/trusted-types/script-enforcement-004.html
+++ b/trusted-types/script-enforcement-004.html
@@ -330,7 +330,13 @@
     let messages = await script_messages_for(_ => {
       let script = create_svg_script_with_trusted_source_text(";");
       window.log_message("SET");
-      script.moveBefore(document.createTextNode(LOG_RUN_MESSAGE), script.firstChild);
+      // Per https://dom.spec.whatwg.org/#move, step 1, moveBefore requires
+      // the two nodes to have the same shadow-including root.
+      let text = document.createTextNode(LOG_RUN_MESSAGE);
+      let root = document.createElement("div");
+      root.appendChild(text);
+      root.appendChild(script);
+      script.moveBefore(text, script.firstChild);
       window.log_message("APPEND");
       container.appendChild(script);
     });


### PR DESCRIPTION
Ensure the pre-conditions for `Element.moveBefore()` are met before calling them. Otherwise the code will throw an exception that's unrelated to the intent of the test.

This is exactly analogous to https://github.com/web-platform-tests/wpt/pull/54050, and applies to additional tests in the same directory.