### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=276931

### DIFF
--- a/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link.html
+++ b/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="style-src 'none'; style-src-elem 'self'">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      var t = async_test("Inline style should be applied");
+      window.addEventListener('securitypolicyviolation', t.unreached_func("Should not have fired a spv event"));
+    </script>
+    <link rel="stylesheet" href="/content-security-policy/style-src/resources/allowed.css">
+</head>
+<body>
+    <script>
+      t.step(function() {
+        assert_equals(document.styleSheets.length, 1);
+        t.done();
+      });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
WebKit export from bug: [Safari ignores style-src-elem in CSP](https://bugs.webkit.org/show_bug.cgi?id=276931)