### PR TITLE
Fix navigation-api tests for WebKit's synchronous onload firing

### DIFF
--- a/navigation-api/currententrychange-event/history-back-same-doc.html
+++ b/navigation-api/currententrychange-event/history-back-same-doc.html
@@ -1,14 +1,16 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#foo");
   assert_equals(navigation.entries().length, start_length + 1);
 

--- a/navigation-api/currententrychange-event/navigation-back-forward-same-doc.html
+++ b/navigation-api/currententrychange-event/navigation-back-forward-same-doc.html
@@ -1,14 +1,16 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#foo").committed;
   assert_equals(navigation.entries().length, start_length + 1);
 

--- a/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc.html
+++ b/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let oncurrententrychange_called = false;
   let original_entry = navigation.currentEntry;

--- a/navigation-api/currententrychange-event/navigation-navigate-same-doc.html
+++ b/navigation-api/currententrychange-event/navigation-navigate-same-doc.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let oncurrententrychange_called = false;
   navigation.oncurrententrychange = t.step_func(e => {

--- a/navigation-api/navigate-event/cross-origin-traversal-redirect.html
+++ b/navigation-api/navigate-event/cross-origin-traversal-redirect.html
@@ -4,7 +4,9 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/utils.js"></script>
 <script src=/common/get-host-info.sub.js></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let i = document.createElement("iframe");
   i.src = "resources/cross-origin-redirect-on-second-visit.py?key=" + token() + "&remote_origin=" + get_host_info().HTTP_REMOTE_ORIGIN;
@@ -12,7 +14,7 @@ promise_test(async t => {
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let original_iframe_url = i.contentWindow.location.href;
 

--- a/navigation-api/navigate-event/intercept-popstate.html
+++ b/navigation-api/navigate-event/intercept-popstate.html
@@ -1,11 +1,13 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   history.replaceState({ state: "foo"}, "", "#replace");
 
   let onpopstate_fired = false;

--- a/navigation-api/navigate-event/navigate-destination-after-detach.html
+++ b/navigation-api/navigate-event/navigate-destination-after-detach.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let destination_key = i.contentWindow.navigation.currentEntry.key;
   let destination_id = i.contentWindow.navigation.currentEntry.id;

--- a/navigation-api/navigate-event/navigate-destination-dynamic-index.html
+++ b/navigation-api/navigate-event/navigate-destination-dynamic-index.html
@@ -2,13 +2,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#1").finished;
 
   let back_destination;

--- a/navigation-api/navigate-event/navigate-history-back-noop.html
+++ b/navigation-api/navigate-event/navigate-history-back-noop.html
@@ -2,7 +2,9 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
@@ -10,7 +12,7 @@ promise_test(async t => {
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   await i.contentWindow.navigation.navigate("#").finished;
   assert_equals(i.contentWindow.navigation.entries().length, 2);

--- a/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
+++ b/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let target_key = i.contentWindow.navigation.currentEntry.key;
   let target_id = i.contentWindow.navigation.currentEntry.id;

--- a/navigation-api/navigate-event/navigation-back-same-document-preventDefault.html
+++ b/navigation-api/navigate-event/navigation-back-same-document-preventDefault.html
@@ -2,14 +2,16 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   await navigation.navigate("#").finished;
   assert_equals(navigation.entries().length, start_length + 1);

--- a/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html
+++ b/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html
@@ -3,14 +3,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   // Navigate the iframe, then the top window, so that when the iframe goes back
   // to its initial entry, the top window navigates as well.

--- a/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child.html
+++ b/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child.html
@@ -3,14 +3,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i1" src="/common/blank.html"></iframe>
 <iframe id="i2" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#").finished;
   await i1.contentWindow.navigation.navigate("#").finished;
   i2.contentWindow.navigation.navigate("?");

--- a/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows.html
+++ b/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows.html
@@ -3,14 +3,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#").finished;
   await i.contentWindow.navigation.navigate("#").finished;
   assert_equals(navigation.entries().length, start_length + 1);

--- a/navigation-api/navigate-event/navigation-traverseTo-top-cancels-cross-document-child.html
+++ b/navigation-api/navigate-event/navigation-traverseTo-top-cancels-cross-document-child.html
@@ -3,14 +3,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#").finished;
   i.contentWindow.navigation.navigate("?");
   await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));

--- a/navigation-api/navigate-event/replaceState-inside-back-handler.html
+++ b/navigation-api/navigate-event/replaceState-inside-back-handler.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   await navigation.navigate("#push").finished;
   navigation.onnavigate = () => history.replaceState(null, "", "#");

--- a/navigation-api/navigate-event/same-url-replace-cross-document.html
+++ b/navigation-api/navigate-event/same-url-replace-cross-document.html
@@ -3,14 +3,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that we are definitely testing the
   // same URL as the cause of the rejections.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(navigation.entries().length, start_length);
 
   navigation.onnavigate = t.step_func(e => {

--- a/navigation-api/navigate-event/same-url-replace-same-document.html
+++ b/navigation-api/navigate-event/same-url-replace-same-document.html
@@ -3,14 +3,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
 
   // Wait for after the load event so that we are definitely testing the
   // same URL as the cause of the rejections.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(navigation.entries().length, start_length);
   await navigation.navigate("#").finished;
   assert_equals(navigation.entries().length, start_length + 1);

--- a/navigation-api/navigation-activation/activation-history-pushState.html
+++ b/navigation-api/navigation-activation/activation-history-pushState.html
@@ -1,11 +1,13 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(navigation.activation.entry, navigation.currentEntry);
   let activationEntry = navigation.activation.entry;

--- a/navigation-api/navigation-activation/activation-history-replaceState.html
+++ b/navigation-api/navigation-activation/activation-history-replaceState.html
@@ -1,11 +1,13 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(navigation.activation.entry, navigation.currentEntry);
   let activationEntry = navigation.activation.entry;

--- a/navigation-api/navigation-activation/activation-initial-about-blank.html
+++ b/navigation-api/navigation-activation/activation-initial-about-blank.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.activation, null);
 

--- a/navigation-api/navigation-activation/activation-push-cross-origin.html
+++ b/navigation-api/navigation-activation/activation-push-cross-origin.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let i = document.createElement("iframe");
   i.src = get_host_info().HTTP_ORIGIN_WITH_DIFFERENT_PORT + "/common/blank.html";

--- a/navigation-api/navigation-activation/activation-push.html
+++ b/navigation-api/navigation-activation/activation-push.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i.contentWindow.navigation.navigate("/common/blank.html?a");
   await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));

--- a/navigation-api/navigation-activation/activation-reload.html
+++ b/navigation-api/navigation-activation/activation-reload.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i.contentWindow.navigation.reload();
   await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));

--- a/navigation-api/navigation-activation/activation-replace-cross-origin.html
+++ b/navigation-api/navigation-activation/activation-replace-cross-origin.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let i = document.createElement("iframe");
   i.src = get_host_info().HTTP_ORIGIN_WITH_DIFFERENT_PORT + "/common/blank.html";

--- a/navigation-api/navigation-activation/activation-replace.html
+++ b/navigation-api/navigation-activation/activation-replace.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let before_key = i.contentWindow.navigation.currentEntry.key;
   let before_id = i.contentWindow.navigation.currentEntry.id;

--- a/navigation-api/navigation-activation/activation-same-document-then-cross-document.html
+++ b/navigation-api/navigation-activation/activation-same-document-then-cross-document.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await i.contentWindow.navigation.navigate("/common/blank.html#fragment").finished;
   assert_equals(i.contentWindow.navigation.entries().length, 2);
 

--- a/navigation-api/navigation-activation/activation-traverse-not-in-entries.html
+++ b/navigation-api/navigation-activation/activation-traverse-not-in-entries.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
 <script src="/common/get-host-info.sub.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i.contentWindow.location = get_host_info().HTTP_ORIGIN_WITH_DIFFERENT_PORT + "/common/blank.html";
   await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));

--- a/navigation-api/navigation-activation/activation-traverse-then-clobber.html
+++ b/navigation-api/navigation-activation/activation-traverse-then-clobber.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i.contentWindow.navigation.navigate("/common/blank.html?a");
   await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));

--- a/navigation-api/navigation-activation/activation-traverse.html
+++ b/navigation-api/navigation-activation/activation-traverse.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i.contentWindow.navigation.navigate("/common/blank.html?a");
   await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));

--- a/navigation-api/navigation-history-entry/after-detach.html
+++ b/navigation-api/navigation-history-entry/after-detach.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let i_navigation = i.contentWindow.navigation;
 

--- a/navigation-api/navigation-history-entry/entries-after-blank-navigation-from-cross-origin.html
+++ b/navigation-api/navigation-history-entry/entries-after-blank-navigation-from-cross-origin.html
@@ -3,9 +3,11 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let i = document.createElement("iframe");
   i.src = get_host_info().HTTP_ORIGIN_WITH_DIFFERENT_PORT + "/common/blank.html";

--- a/navigation-api/navigation-history-entry/resources/opaque-origin-page.html
+++ b/navigation-api/navigation-history-entry/resources/opaque-origin-page.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <!-- Put this page in a sandbox to give it an opaque origin -->
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.hash = "#1";
   await new Promise(resolve => window.onhashchange = resolve);

--- a/navigation-api/navigation-methods/back-forward-multiple-frames.html
+++ b/navigation-api/navigation-methods/back-forward-multiple-frames.html
@@ -2,13 +2,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   // Step 1
   assert_equals(navigation.entries().length, start_length, "step 1 outer entries() length");
   assert_equals(i.contentWindow.navigation.entries().length, 1, "step 1 iframe entries() length");

--- a/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple.html
+++ b/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple.html
@@ -2,13 +2,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(navigation.entries().length, start_length);
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let initial_key = navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/forward-to-pruned-entry.html
+++ b/navigation-api/navigation-methods/forward-to-pruned-entry.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#foo").finished;
   assert_equals(navigation.entries().length, start_length+1);
   await navigation.back().finished;

--- a/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document.html
+++ b/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation due to onload not having completed.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(i.contentWindow.navigation.entries().length, 1);
 
   i.contentWindow.navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");

--- a/navigation-api/navigation-methods/navigate-history-push-same-url.html
+++ b/navigation-api/navigation-methods/navigate-history-push-same-url.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation due to onload not having completed.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(navigation.entries().length, start_length);
 
 

--- a/navigation-api/navigation-methods/return-value/back-already-detached.html
+++ b/navigation-api/navigation-methods/return-value/back-already-detached.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/back-beforeunload.html
+++ b/navigation-api/navigation-methods/return-value/back-beforeunload.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/back-intercept-rejected.html
+++ b/navigation-api/navigation-methods/return-value/back-intercept-rejected.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.href = "#1";
 

--- a/navigation-api/navigation-methods/return-value/back-intercept.html
+++ b/navigation-api/navigation-methods/return-value/back-intercept.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.href = "#1";
 

--- a/navigation-api/navigation-methods/return-value/back.html
+++ b/navigation-api/navigation-methods/return-value/back.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.href = "#1";
 

--- a/navigation-api/navigation-methods/return-value/forward-already-detached.html
+++ b/navigation-api/navigation-methods/return-value/forward-already-detached.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/forward-beforeunload.html
+++ b/navigation-api/navigation-methods/return-value/forward-beforeunload.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/forward-intercept-rejected.html
+++ b/navigation-api/navigation-methods/return-value/forward-intercept-rejected.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.href = "#1";
   await navigation.back().committed;

--- a/navigation-api/navigation-methods/return-value/forward-intercept.html
+++ b/navigation-api/navigation-methods/return-value/forward-intercept.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.href = "#1";
 

--- a/navigation-api/navigation-methods/return-value/forward.html
+++ b/navigation-api/navigation-methods/return-value/forward.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   location.href = "#1";
   await navigation.back().committed;

--- a/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted.html
+++ b/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   navigation.addEventListener("navigate", e => e.intercept());
 

--- a/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate.html
+++ b/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let result2;
   navigation.onnavigate = t.step_func(e => {

--- a/navigation-api/navigation-methods/return-value/navigate-interrupted.html
+++ b/navigation-api/navigation-methods/return-value/navigate-interrupted.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const result1 = navigation.navigate("#1");
   const result2 = navigation.navigate("#2");

--- a/navigation-api/navigation-methods/return-value/navigate-push-initial-about-blank.html
+++ b/navigation-api/navigation-methods/return-value/navigate-push-initial-about-blank.html
@@ -5,11 +5,13 @@
 
 <body>
 <iframe id="i"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that we are definitely testing the initial
   // about:blank-ness as the cause of the rejections.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i.contentWindow.navigation.onnavigate = t.unreached_func("onnavigate should not be called");
   i.contentWindow.navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");

--- a/navigation-api/navigation-methods/return-value/navigate-push-javascript-url.html
+++ b/navigation-api/navigation-methods/return-value/navigate-push-javascript-url.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that we are definitely testing the
   // javascript: URL as the cause of the rejections.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   navigation.onnavigate = t.unreached_func("onnavigate should not be called");
   navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");

--- a/navigation-api/navigation-methods/return-value/resources/back-forward-opaque-origin-page.html
+++ b/navigation-api/navigation-methods/return-value/resources/back-forward-opaque-origin-page.html
@@ -3,11 +3,13 @@
 <script src="helpers.js"></script>
 <!-- Put this page in a sandbox to give it an opaque origin -->
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   navigation.onnavigate = t.unreached_func("onnavigate should not be called");
   navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");

--- a/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-cross-document-preventDefault.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-before-navigate-event.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document-before-navigate-event.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-detach-cross-document.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document.html
@@ -5,11 +5,13 @@
 
 <iframe id="i" src="/common/blank.html"></iframe>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   let key = i.contentWindow.navigation.currentEntry.key;

--- a/navigation-api/navigation-methods/return-value/traverseTo-intercept-rejected.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-intercept-rejected.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const key0 = navigation.currentEntry.key;
 

--- a/navigation-api/navigation-methods/return-value/traverseTo-intercept.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-intercept.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const key0 = navigation.currentEntry.key;
 

--- a/navigation-api/navigation-methods/return-value/traverseTo-repeated.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo-repeated.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const key = navigation.currentEntry.key;
   const entry = navigation.currentEntry;

--- a/navigation-api/navigation-methods/return-value/traverseTo.html
+++ b/navigation-api/navigation-methods/return-value/traverseTo.html
@@ -3,13 +3,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const key0 = navigation.currentEntry.key;
 

--- a/navigation-api/navigation-methods/traverseTo-multiple-steps.html
+++ b/navigation-api/navigation-methods/traverseTo-multiple-steps.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(navigation.entries().length, start_length);
   let key0 = navigation.currentEntry.key;
   await navigation.navigate("#1").committed;

--- a/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes.html
+++ b/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes.html
@@ -4,12 +4,14 @@
 <body>
 <iframe id="i1" src="/common/blank.html"></iframe>
 <iframe id="i2" src="resources/slow-no-store.py"></iframe>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   i1.src = "/common/blank.html?navigated";
   await new Promise(resolve => i1.onload = resolve);

--- a/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
@@ -6,11 +6,13 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/anchor-download-intercept.html
+++ b/navigation-api/ordering-and-transition/anchor-download-intercept.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#1").finished;
 
   const from = navigation.currentEntry;

--- a/navigation-api/ordering-and-transition/back-same-document-intercept.html
+++ b/navigation-api/ordering-and-transition/back-same-document-intercept.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#1").finished;
 
   const from = navigation.currentEntry;

--- a/navigation-api/ordering-and-transition/back-same-document.html
+++ b/navigation-api/ordering-and-transition/back-same-document.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#1").finished;
 
   const recorder = new Recorder({

--- a/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept.html
+++ b/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept.html
@@ -1,12 +1,14 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   let start_length = navigation.entries().length;
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#foo").committed;
   assert_equals(navigation.entries().length, start_length + 1);
 

--- a/navigation-api/ordering-and-transition/intercept-async.html
+++ b/navigation-api/ordering-and-transition/intercept-async.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/location-href-canceled.html
+++ b/navigation-api/ordering-and-transition/location-href-canceled.html
@@ -4,11 +4,12 @@
 
 <script type="module">
 import { Recorder } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const recorder = new Recorder({
     finalExpectedEvent: "promise microtask"

--- a/navigation-api/ordering-and-transition/location-href-double-intercept.html
+++ b/navigation-api/ordering-and-transition/location-href-double-intercept.html
@@ -6,10 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const fromStart = navigation.currentEntry;
   let fromHash1;

--- a/navigation-api/ordering-and-transition/location-href-intercept-reentrant.html
+++ b/navigation-api/ordering-and-transition/location-href-intercept-reentrant.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
   let firstNavigate = true;

--- a/navigation-api/ordering-and-transition/location-href-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/location-href-intercept-reject.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/location-href-intercept.html
+++ b/navigation-api/ordering-and-transition/location-href-intercept.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-canceled.html
+++ b/navigation-api/ordering-and-transition/navigate-canceled.html
@@ -4,11 +4,12 @@
 
 <script type="module">
 import { Recorder } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const recorder = new Recorder({
     finalExpectedEvent: "finished rejected"

--- a/navigation-api/ordering-and-transition/navigate-double-intercept.html
+++ b/navigation-api/ordering-and-transition/navigate-double-intercept.html
@@ -6,10 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const fromStart = navigation.currentEntry;
   let fromHash1;

--- a/navigation-api/ordering-and-transition/navigate-in-transition-finished.html
+++ b/navigation-api/ordering-and-transition/navigate-in-transition-finished.html
@@ -6,10 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const fromStart = navigation.currentEntry;
   let fromHash1;

--- a/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-redirect.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler-reject.tentative.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept-precommitHandler.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-intercept-stop.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept-stop.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-intercept.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-same-document-intercept-reentrant.html
+++ b/navigation-api/ordering-and-transition/navigate-same-document-intercept-reentrant.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
   let firstNavigate = true;

--- a/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/navigate-same-document.html
+++ b/navigation-api/ordering-and-transition/navigate-same-document.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const recorder = new Recorder({
     skipCurrentChange: !hasVariant("currententrychange"),

--- a/navigation-api/ordering-and-transition/reload-canceled.html
+++ b/navigation-api/ordering-and-transition/reload-canceled.html
@@ -4,11 +4,12 @@
 
 <script type="module">
 import { Recorder } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const recorder = new Recorder({
     finalExpectedEvent: "finished rejected"

--- a/navigation-api/ordering-and-transition/reload-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/reload-intercept-reject.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/reload-intercept.html
+++ b/navigation-api/ordering-and-transition/reload-intercept.html
@@ -6,11 +6,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/reload-no-popstate.html
+++ b/navigation-api/ordering-and-transition/reload-no-popstate.html
@@ -4,11 +4,12 @@
 
 <script type="module">
 import { Recorder, hasVariant } from "./resources/helpers.mjs";
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/precommit-handler/precommitHandler-redirect-options.html
+++ b/navigation-api/precommit-handler/precommitHandler-redirect-options.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let start_length = navigation.entries().length;
   let start_hash = location.hash;

--- a/navigation-api/precommit-handler/precommitHandler-redirect-push-changed-to-replace.html
+++ b/navigation-api/precommit-handler/precommitHandler-redirect-push-changed-to-replace.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let start_length = navigation.entries().length;
   let start_hash = location.hash;

--- a/navigation-api/precommit-handler/precommitHandler-redirect-push.html
+++ b/navigation-api/precommit-handler/precommitHandler-redirect-push.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let start_length = navigation.entries().length;
   let start_hash = location.hash;

--- a/navigation-api/precommit-handler/precommitHandler-redirect-replace-changed-to-push.html
+++ b/navigation-api/precommit-handler/precommitHandler-redirect-replace-changed-to-push.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let start_length = navigation.entries().length;
   let start_hash = location.hash;

--- a/navigation-api/precommit-handler/precommitHandler-redirect-replace.html
+++ b/navigation-api/precommit-handler/precommitHandler-redirect-replace.html
@@ -2,11 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let start_length = navigation.entries().length;
   let start_hash = location.hash;

--- a/navigation-api/precommit-handler/precommitHandler-redirect-throws.html
+++ b/navigation-api/precommit-handler/precommitHandler-redirect-throws.html
@@ -2,7 +2,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
 
 promise_test(async t => {
   let precommit_controller;
@@ -86,7 +87,7 @@ promise_test(async t => {
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   await navigation.navigate("#forward").finished;
 

--- a/navigation-api/precommit-handler/precommitHandler-traversal-commit-new-navigation-before-commit.html
+++ b/navigation-api/precommit-handler/precommitHandler-traversal-commit-new-navigation-before-commit.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   await navigation.navigate("#1").finished;
 

--- a/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit.html
+++ b/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event because window.stop() hangs the test harness
   // if called before the load event.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   let start_length = navigation.entries().length;
   let start_index = navigation.currentEntry.index;

--- a/navigation-api/precommit-handler/precommitHandler-uncancelable.html
+++ b/navigation-api/precommit-handler/precommitHandler-uncancelable.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <iframe id="i" src="/common/blank.html"></iframe>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   await i.contentWindow.navigation.navigate("#1").finished;
 

--- a/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit.html
+++ b/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <body>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event because window.stop() hangs the test harness
   // if called before the load event.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   navigation.onnavigate = e => {
     e.intercept({ precommitHandler: async () => {} });

--- a/navigation-api/resources/helpers.mjs
+++ b/navigation-api/resources/helpers.mjs
@@ -1,0 +1,10 @@
+export async function ensureWindowLoadEventFired(t) {
+  return new Promise(resolve => {
+    const callback = () => t.step_timeout(resolve, 0);
+    if (document.readyState === 'complete') {
+      callback();
+    } else {
+      window.onload = callback;
+    }
+  });
+}

--- a/navigation-api/scroll-behavior/after-transition-basic.html
+++ b/navigation-api/scroll-behavior/after-transition-basic.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html
+++ b/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
 
   history.scrollRestoration = "manual";

--- a/navigation-api/scroll-behavior/after-transition-explicit-scroll.html
+++ b/navigation-api/scroll-behavior/after-transition-explicit-scroll.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
+++ b/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
@@ -3,11 +3,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <div id="main" style="height: 1000px; width: 1000px;"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   window.scrollTo(0, 100);
   assert_equals(window.scrollY, 100);

--- a/navigation-api/scroll-behavior/after-transition-push.html
+++ b/navigation-api/scroll-behavior/after-transition-push.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
 
   let intercept_resolve;

--- a/navigation-api/scroll-behavior/after-transition-reject.html
+++ b/navigation-api/scroll-behavior/after-transition-reject.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/after-transition-reload.html
+++ b/navigation-api/scroll-behavior/after-transition-reload.html
@@ -5,11 +5,13 @@
 <div id="buffer" style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
 <div style="height: 1000px; width: 1000px;"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   // Scroll down 10px from #frag

--- a/navigation-api/scroll-behavior/after-transition-replace.html
+++ b/navigation-api/scroll-behavior/after-transition-replace.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
 
   let intercept_resolve;

--- a/navigation-api/scroll-behavior/after-transition-timing.html
+++ b/navigation-api/scroll-behavior/after-transition-timing.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/after-transition-with-history-scroll-restoration-manual.html
+++ b/navigation-api/scroll-behavior/after-transition-with-history-scroll-restoration-manual.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
 
   history.scrollRestoration = "manual";

--- a/navigation-api/scroll-behavior/manual-basic.html
+++ b/navigation-api/scroll-behavior/manual-basic.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/manual-immediate-scroll.html
+++ b/navigation-api/scroll-behavior/manual-immediate-scroll.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/manual-scroll-after-dispatch.html
+++ b/navigation-api/scroll-behavior/manual-scroll-after-dispatch.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/manual-scroll-after-resolve.html
+++ b/navigation-api/scroll-behavior/manual-scroll-after-resolve.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist.html
+++ b/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);
 

--- a/navigation-api/scroll-behavior/manual-scroll-in-precommit-handler.html
+++ b/navigation-api/scroll-behavior/manual-scroll-in-precommit-handler.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/manual-scroll-push.html
+++ b/navigation-api/scroll-behavior/manual-scroll-push.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
 
   let intercept_resolve;

--- a/navigation-api/scroll-behavior/manual-scroll-reload.html
+++ b/navigation-api/scroll-behavior/manual-scroll-reload.html
@@ -5,11 +5,13 @@
 <div id="buffer" style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
 <div style="height: 1000px; width: 1000px;"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   // Scroll down 10px from #frag

--- a/navigation-api/scroll-behavior/manual-scroll-repeated.html
+++ b/navigation-api/scroll-behavior/manual-scroll-repeated.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/manual-scroll-replace.html
+++ b/navigation-api/scroll-behavior/manual-scroll-replace.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   assert_equals(window.scrollY, 0);
 
   let intercept_resolve;

--- a/navigation-api/scroll-behavior/manual-scroll-resets-when-no-fragment.html
+++ b/navigation-api/scroll-behavior/manual-scroll-resets-when-no-fragment.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
   let start_url = location.href;
   await navigation.navigate("#frag").finished;
   assert_not_equals(window.scrollY, 0);

--- a/navigation-api/scroll-behavior/scroll-after-preventDefault.html
+++ b/navigation-api/scroll-behavior/scroll-after-preventDefault.html
@@ -5,11 +5,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   navigation.addEventListener("navigate", t.step_func(e => {
     e.intercept();

--- a/navigation-api/scroll-behavior/scroll-without-intercept.html
+++ b/navigation-api/scroll-behavior/scroll-without-intercept.html
@@ -4,11 +4,13 @@
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
-<script>
+<script type="module">
+import { ensureWindowLoadEventFired } from "../resources/helpers.mjs";
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await ensureWindowLoadEventFired(t);
 
   navigation.addEventListener("navigate", t.step_func(e => {
     assert_throws_dom("InvalidStateError", () => e.scroll());


### PR DESCRIPTION
WebKit fires window.onload synchronously which prevents navigation-api tests from running properly. This change replaces direct window.onload usage with a new ensureWindowLoadEventFired helper that checks document.readyState and handles the synchronous case correctly.

- Add ensureWindowLoadEventFired helper in resources/helpers.mjs
- Replace window.onload patterns across all affected navigation-api tests
- Convert scripts to module type to enable helper import