### PR TITLE
Update docker README file with clearer instructions

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -3,15 +3,13 @@ other tasks on Taskcluster. When any of the files in this directory change, the
 images must be updated as well. Doing this requires you to have write
 permissions to the repository.
 
-The tag for a new docker image is of the form
-`ghcr.io/web-platform-tests/wpt:${PREV_VERSION++}`.
-
 To update the docker image:
 
 * Run the workflow
   https://github.com/web-platform-tests/wpt/actions/workflows/docker.yml via the
-  GitHub UI.
+  GitHub UI. Use a number for the "Tag for the container image", the previous
+  version plus 1.
 
-* Update the following Taskcluster configurations to use the new image:
- - `.taskcluster.yml` (the decision task)
- - `tools/ci/tc/tasks/test.yml` (all the other tasks)
+* Update the following Taskcluster configurations to use the new image (refer to the image with `ghcr.io/web-platform-tests/wpt:${tag}`):
+    * `.taskcluster.yml` (the decision task)
+    * `tools/ci/tc/tasks/test.yml` (all the other tasks)


### PR DESCRIPTION
I didn't quite understand the instructions and originally put "ghcr.io/web-platform-tests/wpt:3" as the tag name, which lead to the awkwardly named docker images you can now see here: https://github.com/web-platform-tests/wpt/pkgs/container/wpt

Hopefully this makes it clearer for the next person :)