### PR TITLE
wpt: Ensure that faulty JSON testharness output does not crash the Python test harness

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -173,7 +173,10 @@ class ServoTestharnessExecutor(ServoExecutor):
         prefix = "ALERT: RESULT: "
         decoded_line = line.decode("utf8", "replace")
         if decoded_line.startswith(prefix):
-            self.result_data = json.loads(decoded_line[len(prefix):])
+            try:
+                self.result_data = json.loads(decoded_line[len(prefix):])
+            except json.JSONDecodeError as error:
+                self.logger.error(f"Could not process test output JSON: {error}")
             self.result_flag.set()
         else:
             ServoExecutor.on_output(self, line)


### PR DESCRIPTION
When a testharness test also prints debugging output, sometimes the
output can be mixed with the JSON output printed via an alert. This
causes a JSON decoding error in the output. Instead of crashing the
harness and printing many lines of Python stack trace output, print a
nice error. This makes the test output easier to read.

Testing: This is a change to the test harness itself, so no tests necessary.

Reviewed in servo/servo#38420