### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=133180

### DIFF
--- a/pointerevents/pointerevent_fractional_coordinates.html
+++ b/pointerevents/pointerevent_fractional_coordinates.html
@@ -45,8 +45,8 @@
             }
 
             function checkPointerEventCoordinates(event) {
-              if (event.clientX != Math.floor(event.clientX) ||
-                    event.clientY != Math.floor(event.clientY))
+              if ((event.clientX != Math.floor(event.clientX) || event.clientY != Math.floor(event.clientY))
+                    && (event.pageX != Math.floor(event.pageX) || event.pageY != Math.floor(event.pageY)))
                 eventsWithFractions[event.type] = true;
             }
 


### PR DESCRIPTION
WebKit export from bug: [Pointer events should allow for device-pixel accuracy](https://bugs.webkit.org/show_bug.cgi?id=133180)