### PR TITLE
webdriver: Improve "element click" by using container + Upgrade outdated test

### DIFF
--- a/webdriver/tests/classic/element_click/interactability.py
+++ b/webdriver/tests/classic/element_click/interactability.py
@@ -115,11 +115,11 @@ def test_element_intercepted(session, inline):
     assert_error(response, "element click intercepted")
 
 
-def test_element_intercepted_no_pointer_events(session, inline):
+def test_element_not_interactable_no_pointer_events(session, inline):
     session.url = inline("""<input type=button value=Roger style="pointer-events: none">""")
     element = session.find.css("input", all=False)
     response = element_click(session, element)
-    assert_error(response, "element click intercepted")
+    assert_error(response, "element not interactable")
 
 
 def test_element_not_visible_overflow_hidden(session, inline):

--- a/webdriver/tests/classic/element_click/interactability.py
+++ b/webdriver/tests/classic/element_click/interactability.py
@@ -115,7 +115,7 @@ def test_element_intercepted(session, inline):
     assert_error(response, "element click intercepted")
 
 
-def test_element_not_interactable_no_pointer_events(session, inline):
+def test_element_not_interactable_pointer_events_none(session, inline):
     session.url = inline("""<input type=button value=Roger style="pointer-events: none">""")
     element = session.find.css("input", all=False)
     response = element_click(session, element)


### PR DESCRIPTION
- According to [spec](https://w3c.github.io/webdriver/#ref-for-dfn-in-view-3), we should use container instead of element itself to determine "in-view".
- Updated `test_element_intercepted_no_pointer_events` in `element_click/interactability.py` to expect "element not interactable". This was outdated with spec as original test was written 7 years ago https://github.com/web-platform-tests/wpt/pull/11453.


Testing: new passing cases for `<option>`, `<select>`.

Reviewed in servo/servo#38436