### PR TITLE
Elements with required acc parent role with presentational role and global WAI-ARIA attribute (Presentational Roles Conflict Resolution)

### DIFF
--- a/wai-aria/role/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role/role_none_conflict_resolution.tentative.html
@@ -11,6 +11,8 @@
   </head>
   <body>
 
+    <!-- current spec: https://w3c.github.io/aria/#conflict_resolution_presentation_none --> 
+    <!-- PR with proposed clarification, pending user agent tests: https://github.com/w3c/aria/pull/2237 --> 
     <h1>Presentational role inherited with global</h1>
 
     <!-- li is inheriting presentational role from ul; it has a global aria attr but it doesn't impact the presentational conflict resolution -->

--- a/wai-aria/role/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role/role_none_conflict_resolution.tentative.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Name Comp: inherited presentational role with global attr (Tentative)</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+
+    <h1>Presentational role inherited with global</h1>
+
+    <!-- li is inheriting presentational role from ul; it has a global aria attr but it doesn't impact the presentational conflict resolution -->
+    <ul role="none">
+      <li aria-describedby="test" data-testname="presentational roles conflict - ul[role=none] > li[aria-describedby]" class="ex-generic">a</li>
+      <li aria-describedby="test">b</li>
+      <li aria-describedby="test">c</li>
+    </ul>
+
+    <!-- td is inheriting presentational role from table; it has a global aria attr but it doesn't impact the presentational conflict resolution -->
+    <table role="none">
+      <tbody>
+          <tr>
+            <td aria-describedby="test" data-testname="presentational roles conflict - table[role=none] td[aria-describedby]" class="ex-generic">a</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <!-- td is inheriting presentational role from table; it has a global aria attr but it doesn't impact the presentational conflict resolution -->
+    <table role="none">
+      <tbody>
+          <tr>
+            <td aria-describedby="test" data-testname="presentational roles conflict - table[role=none] td[aria-describedby]" class="ex-generic">a</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <!-- td is inheriting presentational role from table; it has a global aria attr but it doesn't impact the presentational conflict resolution -->
+    <style>
+      table.with-style, table.with-style th, table.with-style td {
+        border: 1px solid black;
+        border-collapse: collapse;
+      }
+    </style>
+    <table role="none" class="with-style">
+      <tbody>
+          <tr>
+            <th>col 1</th>
+            <th>col 2</th>
+          </tr>
+          <tr>
+            <td aria-describedby="test" data-testname="presentational roles conflict - table.with-style[role=none] td[aria-describedby]" class="ex-generic">cell 1</td>
+            <td>cell 2</td>
+          </tr>
+          <tr>
+            <td>cell 3</td>
+            <td>cell 4</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <script>
+      AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+    </script>
+  
+  </body>
+</html>

--- a/wai-aria/role/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role/role_none_conflict_resolution.tentative.html
@@ -65,6 +65,6 @@
     <script>
       AriaUtils.verifyGenericRolesBySelector(".ex-generic");
     </script>
-  
+
   </body>
 </html>

--- a/wai-aria/role/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role/role_none_conflict_resolution.tentative.html
@@ -11,8 +11,8 @@
   </head>
   <body>
 
-    <!-- current spec: https://w3c.github.io/aria/#conflict_resolution_presentation_none --> 
-    <!-- PR with proposed clarification, pending user agent tests: https://github.com/w3c/aria/pull/2237 --> 
+    <!-- current spec: https://w3c.github.io/aria/#conflict_resolution_presentation_none -->
+    <!-- PR with proposed clarification, pending user agent tests: https://github.com/w3c/aria/pull/2237 -->
     <h1>Presentational role inherited with global</h1>
 
     <!-- li is inheriting presentational role from ul; it has a global aria attr but it doesn't impact the presentational conflict resolution -->

--- a/wai-aria/role/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role/role_none_conflict_resolution.tentative.html
@@ -32,15 +32,6 @@
     </table>
 
     <!-- td is inheriting presentational role from table; it has a global aria attr but it doesn't impact the presentational conflict resolution -->
-    <table role="none">
-      <tbody>
-          <tr>
-            <td aria-describedby="test" data-testname="presentational roles conflict - table[role=none] td[aria-describedby]" class="ex-generic">a</td>
-          </tr>
-      </tbody>
-    </table>
-
-    <!-- td is inheriting presentational role from table; it has a global aria attr but it doesn't impact the presentational conflict resolution -->
     <style>
       table.with-style, table.with-style th, table.with-style td {
         border: 1px solid black;


### PR DESCRIPTION
TENTATIVE

Closes: https://github.com/web-platform-tests/interop-accessibility/issues/195

Relates and match: https://github.com/w3c/aria/pull/2237

Ambiguity: https://w3c.github.io/aria/#conflict_resolution_presentation_none

This PR adds tests for:
Elements with global ARIA attributes when they inherit a presentation role. Specifically, in cases where the element requires a specific [accessibility parent role](https://w3c.github.io/aria/#scope) and that parent has a presentation role.

[please add necessary WAI-ARIA labels]