### PR TITLE
Fix the Permission Policy DC get() Tests

### DIFF
--- a/digital-credentials/allow-attribute-with-get.https.html
+++ b/digital-credentials/allow-attribute-with-get.https.html
@@ -104,8 +104,9 @@
                         const action = "get";
                         const options = {
                             digital: {
-                                // Results in TypeError when allowed, NotAllowedError when disallowed
-                                requests: [{ data: {}, protocol: "openid4vp" }],
+                                // Results in TypeError when allowed (since the requests list is empty), 
+                                // NotAllowedError when disallowed
+                                requests: [],
                             },
                             mediation: "required",
                         };
@@ -122,11 +123,11 @@
                         const { name, message } = data;
                         const fullMessage = `${iframe.outerHTML} - ${message}`;
                         if (expectIsAllowed) {
-                            assert_true(
-                                name == "TypeError" || name == "NotAllowedError",
-                                fullMessage
-                            );
+                            // When the call is allowed, result in a TypeError since no valid requests 
+                            // were passed to the call.
+                            assert_true(name == "TypeError", fullMessage);
                         } else {
+                            // When the call is disallowed, it MUST result in a NotAllowedError.
                             assert_equals(name, "NotAllowedError", fullMessage);
                         }
                         iframe.remove();

--- a/digital-credentials/allow-attribute-with-get.https.html
+++ b/digital-credentials/allow-attribute-with-get.https.html
@@ -104,7 +104,7 @@
                         const action = "get";
                         const options = {
                             digital: {
-                                // Results in TypeError when allowed (since the requests list is empty), 
+                                // Results in TypeError when allowed (since the requests list is empty),
                                 // NotAllowedError when disallowed
                                 requests: [],
                             },
@@ -123,7 +123,7 @@
                         const { name, message } = data;
                         const fullMessage = `${iframe.outerHTML} - ${message}`;
                         if (expectIsAllowed) {
-                            // When the call is allowed, result in a TypeError since no valid requests 
+                            // When the call is allowed, result in a TypeError since no valid requests
                             // were passed to the call.
                             assert_true(name == "TypeError", fullMessage);
                         } else {


### PR DESCRIPTION
In [this PR](https://github.com/web-platform-tests/wpt/commit/180c27cfae86b260b0d1e8a61e180dd3e43af5b4), the test was mistakenly updated to send a one well-formatted request to the dc get() API.
This broke test that was expecting an `TypeError` when the API is allowed.
In fact, the test [is now failing ](https://wpt.fyi/results/digital-credentials/allow-attribute-with-get.https.html?run_id=5148654156644352&run_id=5115325210427392&run_id=5139895963353088&run_id=5089710210023424)on all browsers:

This PR is fix this and adds comment to avoid mistakenly updating the test.