### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296903

### DIFF
--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+  align-items: center;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-center-large-border-padding-ref.html">
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box when statically positioned and align-items: center in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+  align-items: center;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: center;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-center-ref.html">
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box when statically positioned and align-items: center in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: center;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: end in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: end in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-flex-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: flex-end in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-flex-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: flex-end in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-self-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: self-end in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-ref.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html
+++ b/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-self-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: self-end in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Absolute Positioning\]\[Grid\] align-self auto should resolve against the parent's align items when statically positioned.](https://bugs.webkit.org/show_bug.cgi?id=296903)