### PR TITLE
WebCryptoAPI: Test whether a task is scheduled to resolve/reject promises

### DIFF
--- a/WebCryptoAPI/digest/digest.https.any.js
+++ b/WebCryptoAPI/digest/digest.https.any.js
@@ -51,48 +51,64 @@
             var mixedCase = upCase.substr(0, 1) + downCase.substr(1);
 
             promise_test(function(test) {
-                var promise = subtle.digest({name: upCase}, sourceData[size])
+                let microtaskTriggered = false;
+                let promise = subtle.digest({name: upCase}, sourceData[size])
                 .then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
                     assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
                 }, function(err) {
                     assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
                 });
-
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
                 return promise;
             }, upCase + " with " + size + " source data");
 
             promise_test(function(test) {
-                var promise = subtle.digest({name: downCase}, sourceData[size])
+                let microtaskTriggered = false;
+                let promise = subtle.digest({name: downCase}, sourceData[size])
                 .then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
                     assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
                 }, function(err) {
                     assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
                 });
-
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
                 return promise;
             }, downCase + " with " + size + " source data");
 
             promise_test(function(test) {
-                var promise = subtle.digest({name: mixedCase}, sourceData[size])
+                let microtaskTriggered = false;
+                let promise = subtle.digest({name: mixedCase}, sourceData[size])
                 .then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
                     assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
                 }, function(err) {
                     assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
                 });
-
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
                 return promise;
             }, mixedCase + " with " + size + " source data");
 
             promise_test(function(test) {
-                var copiedBuffer = copyBuffer(sourceData[size]);
-                var promise = subtle.digest({name: upCase}, copiedBuffer)
+                let copiedBuffer = copyBuffer(sourceData[size]);
+                let microtaskTriggered = false;
+                let promise = subtle.digest({name: upCase}, copiedBuffer)
                 .then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
                     assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
                 }, function(err) {
                     assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
                 });
-
                 copiedBuffer[0] = 255 - copiedBuffer;
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
                 return promise;
             }, upCase + " with " + size + " source data and altered buffer after call");
 
@@ -105,13 +121,17 @@
         badNames.forEach(function(badName) {
 
             promise_test(function(test) {
-                var promise = subtle.digest({name: badName}, sourceData[size])
+                let microtaskTriggered = false;
+                let promise = subtle.digest({name: badName}, sourceData[size])
                 .then(function(result) {
                     assert_unreached("digest() should not have worked for " + badName + ":" + size);
                 }, function(err) {
+                    assert_false(microtaskTriggered, "promise rejected too late");
                     assert_equals(err.name, "NotSupportedError", "Bad algorithm name should cause NotSupportedError")
                 });
-
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
                 return promise;
             }, badName + " with " + size);
 
@@ -121,13 +141,17 @@
     // Call digest() with empty algorithm object
     Object.keys(sourceData).forEach(function(size) {
         promise_test(function(test) {
-            var promise = subtle.digest({}, sourceData[size])
+            let microtaskTriggered = false;
+            let promise = subtle.digest({}, sourceData[size])
             .then(function(result) {
                 assert_unreached("digest() with missing algorithm name should have thrown a TypeError");
             }, function(err) {
+                assert_false(microtaskTriggered, "promise rejected too late");
                 assert_equals(err.name, "TypeError", "Missing algorithm name should cause TypeError")
             });
-
+            Promise.resolve().then(() => {
+                microtaskTriggered = true;
+            });
             return promise;
         }, "empty algorithm object with " + size);
     });

--- a/WebCryptoAPI/encrypt_decrypt/aes.js
+++ b/WebCryptoAPI/encrypt_decrypt/aes.js
@@ -17,12 +17,18 @@ function run_test() {
         var promise = importVectorKey(vector, ["encrypt", "decrypt"])
         .then(function(vector) {
             promise_test(function(test) {
-                return subtle.encrypt(vector.algorithm, vector.key, vector.plaintext)
+                let microtaskTriggered = false;
+                let promise = subtle.encrypt(vector.algorithm, vector.key, vector.plaintext)
                 .then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
                     assert_true(equalBuffers(result, vector.result), "Should return expected result");
                 }, function(err) {
                     assert_unreached("encrypt error for test " + vector.name + ": " + err.message);
                 });
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
+                return promise;
             }, vector.name);
         }, function(err) {
             // We need a failed test if the importVectorKey operation fails, so
@@ -66,12 +72,18 @@ function run_test() {
         var promise = importVectorKey(vector, ["encrypt", "decrypt"])
         .then(function(vector) {
             promise_test(function(test) {
-                return subtle.decrypt(vector.algorithm, vector.key, vector.result)
+                let microtaskTriggered = false;
+                let promise = subtle.decrypt(vector.algorithm, vector.key, vector.result)
                 .then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
                     assert_true(equalBuffers(result, vector.plaintext), "Should return expected result");
                 }, function(err) {
                     assert_unreached("decrypt error for test " + vector.name + ": " + err.message);
                 });
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
+                return promise;
             }, vector.name + " decryption");
         }, function(err) {
             // We need a failed test if the importVectorKey operation fails, so

--- a/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
@@ -67,16 +67,22 @@
     // extrable is true, export the key and verify that it matches the input.
     function testFormat(format, algorithm, keyData, keySize, usages, extractable) {
         promise_test(function(test) {
-            return subtle.importKey(format, keyData, algorithm, extractable, usages).
+            let microtaskTriggered = false;
+            let promise = subtle.importKey(format, keyData, algorithm, extractable, usages).
             then(function(key) {
+                assert_true(microtaskTriggered, "promise resolved too early");
+
                 assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
                 assert_goodCryptoKey(key, hasLength(key.algorithm) ? { length: keySize, ...algorithm } : algorithm, extractable, usages, 'secret');
                 if (!extractable) {
                     return;
                 }
 
-                return subtle.exportKey(format, key).
+                microtaskTriggered = false;
+                let promise = subtle.exportKey(format, key).
                 then(function(result) {
+                    assert_true(microtaskTriggered, "promise resolved too early");
+
                     if (format !== "jwk") {
                         assert_true(equalBuffers(keyData, result), "Round trip works");
                     } else {
@@ -85,9 +91,17 @@
                 }, function(err) {
                     assert_unreached("Threw an unexpected error: " + err.toString());
                 });
+                Promise.resolve().then(() => {
+                    microtaskTriggered = true;
+                });
+                return promise;
             }, function(err) {
                 assert_unreached("Threw an unexpected error: " + err.toString());
             });
+            Promise.resolve().then(() => {
+                microtaskTriggered = true;
+            });
+            return promise;
         }, "Good parameters: " + keySize.toString() + " bits " + parameterString(format, keyData, algorithm, extractable, usages));
     }
 
@@ -96,12 +110,18 @@
     function testEmptyUsages(format, algorithm, keyData, keySize, extractable) {
         const usages = [];
         promise_test(function(test) {
-            return subtle.importKey(format, keyData, algorithm, extractable, usages).
+            let microtaskTriggered = false;
+            let promise = subtle.importKey(format, keyData, algorithm, extractable, usages).
             then(function(key) {
                 assert_unreached("importKey succeeded but should have failed with SyntaxError");
             }, function(err) {
+                assert_true(microtaskTriggered, "promise rejected too early");
                 assert_equals(err.name, "SyntaxError", "Should throw correct error, not " + err.name + ": " + err.message);
             });
+            Promise.resolve().then(() => {
+                microtaskTriggered = true;
+            });
+            return promise;
         }, "Empty Usages: " + keySize.toString() + " bits " + parameterString(format, keyData, algorithm, extractable, usages));
     }
 


### PR DESCRIPTION
Add tests to check whether or not a task is scheduled to resolve/reject the promise returned by (a subset of) `SubtleCrypto`'s methods, according to the Web Crypto spec.

This is being debated in https://github.com/w3c/webcrypto/issues/389.