### PR TITLE
Fix missing containing block in `css/css-anchor-position/anchor-center-fallback-transition-behavior.html`

### DIFF
--- a/css/css-anchor-position/anchor-center-fallback-transition-behavior.html
+++ b/css/css-anchor-position/anchor-center-fallback-transition-behavior.html
@@ -6,10 +6,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <style>
   body { margin: 0; }
+  #cb {
+    position: relative;
+    width: 400px;
+    height: 100px;
+    border: 1px solid black;
+  }
   #a1 {
     anchor-name: --a1;
     width: 100px;
     height: 100px;
+    background: green;
   }
   #t1 {
     position-anchor: --a1;
@@ -20,13 +27,16 @@
     position-try-fallbacks: --right;
     width: 200px;
     height: 100px;
+    background: cyan;
   }
   @position-try --right {
     position-area: right;
   }
 </style>
-<div id="a1"></div>
-<div id="t1"></div>
+<div id="cb">
+  <div id="a1"></div>
+  <div id="t1"></div>
+</div>
 <script>
   test(() => {
     assert_equals(t1.offsetLeft, 100, "Positioned using --right fallback");


### PR DESCRIPTION
In `css/css-anchor-position/anchor-center-fallback-transition-behavior.html`, there's no explicit containing block for anchor `#a1` and anchor-positioned `#t1`, therefore the containing block of `#a1` is the viewport and the fallback isn't used (because `#t1` will be positioned within the containing block). Add an explicit containing block as parent of `#a1` and `#t1` to force the fallback behavior.

Tested on latest Safari Technology Preview. From the [crbug](https://issues.chromium.org/issues/342428030) that added the test, it is for a bug in Chrome 127 that was fixed in Chrome 132. I tried and the new test fails in Chromium 127.0.6533.0 (Developer Build) (arm64) and passes in Chromium 139.0.7258.0 (Developer Build) (arm64)