### PR TITLE
Remove sloppy-mode duplicate function

### DIFF
--- a/IndexedDB/resources/support-get-all.js
+++ b/IndexedDB/resources/support-get-all.js
@@ -414,30 +414,6 @@ function assert_large_array_equals(actual, expected, description) {
   assert_equals(array_string, expected_string, description);
 }
 
-// Verifies a record from the results of `getAllRecords()`.
-function assert_record_equals(actual_record, expected_record) {
-  assert_class_string(
-      actual_record, 'IDBRecord', 'The record must be an IDBRecord');
-  assert_idl_attribute(
-      actual_record, 'key', 'The record must have a key attribute');
-  assert_idl_attribute(
-      actual_record, 'primaryKey',
-      'The record must have a primaryKey attribute');
-  assert_idl_attribute(
-      actual_record, 'value', 'The record must have a value attribute');
-
-  // Verify the key properties.
-  assert_equals(
-      actual_record.primaryKey, expected_record.primaryKey,
-      'The record must have the expected primaryKey');
-  assert_equals(
-      actual_record.key, expected_record.key,
-      'The record must have the expected key');
-
-  // Verify the value.
-  assert_idb_value_equals(actual_record.value, expected_record.value);
-}
-
 // Verifies two IDB values are equal.  The expected value may be a primitive, an
 // object, or an array.
 function assert_idb_value_equals(actual_value, expected_value) {


### PR DESCRIPTION
This helper file for the IndexedDB tests contains an unnecessary duplicate function, `assert_record_equal`. Since the script runs in sloppy mode, only the second declaration actually matters, so we can remove the first.