### PR TITLE
Fix digital-credentials/enabled-on-self-origin-by-permissions policy.https.sub.html

### DIFF
--- a/digital-credentials/allow-attribute-with-get.https.html
+++ b/digital-credentials/allow-attribute-with-get.https.html
@@ -104,8 +104,9 @@
                         const action = "get";
                         const options = {
                             digital: {
-                                // Results in TypeError when allowed, NotAllowedError when disallowed
-                                requests: [{ data: {}, protocol: "openid4vp" }],
+                                // Results in TypeError when allowed (since the requests list is empty), 
+                                // NotAllowedError when disallowed
+                                requests: [],
                             },
                             mediation: "required",
                         };
@@ -122,11 +123,11 @@
                         const { name, message } = data;
                         const fullMessage = `${iframe.outerHTML} - ${message}`;
                         if (expectIsAllowed) {
-                            assert_true(
-                                name == "TypeError" || name == "NotAllowedError",
-                                fullMessage
-                            );
+                            // When the call is allowed, result in a TypeError since no valid requests 
+                            // were passed to the call.
+                            assert_true(name == "TypeError", fullMessage);
                         } else {
+                            // When the call is disallowed, it MUST result in a NotAllowedError.
                             assert_equals(name, "NotAllowedError", fullMessage);
                         }
                         iframe.remove();

--- a/digital-credentials/allow-attribute-with-get.https.html
+++ b/digital-credentials/allow-attribute-with-get.https.html
@@ -104,7 +104,7 @@
                         const action = "get";
                         const options = {
                             digital: {
-                                // Results in TypeError when allowed (since the requests list is empty), 
+                                // Results in TypeError when allowed (since the requests list is empty),
                                 // NotAllowedError when disallowed
                                 requests: [],
                             },
@@ -123,7 +123,7 @@
                         const { name, message } = data;
                         const fullMessage = `${iframe.outerHTML} - ${message}`;
                         if (expectIsAllowed) {
-                            // When the call is allowed, result in a TypeError since no valid requests 
+                            // When the call is allowed, result in a TypeError since no valid requests
                             // were passed to the call.
                             assert_true(name == "TypeError", fullMessage);
                         } else {

--- a/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -9,6 +9,7 @@
 <body></body>
 <script type="module">
     import { makeGetOptions } from "./support/helper.js";
+    import { makeCreateOptions } from "./support/helper.js";
     const { HTTPS_REMOTE_ORIGIN } = get_host_info();
     const get_same_origin_src =
         "/permissions-policy/resources/digital-credentials-get.html";


### PR DESCRIPTION
The file was using `makeCreateOptions` without importing it, and hence it was producing `"ReferenceError: makeCreateOptions is not defined"`