### PR TITLE
script: Implement `getModifierState` for mouse event

### DIFF
--- a/infrastructure/testdriver/actions/actionsWithKeyPressed.html
+++ b/infrastructure/testdriver/actions/actionsWithKeyPressed.html
@@ -8,7 +8,7 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <style>
-div#test1, div#test2 {
+div#test1, div#test2, div#test3 {
   position: fixed;
   top: 0;
   left: 0;
@@ -25,12 +25,26 @@ div#test2 {
   height: 100px;
   background-color: green;
 }
+
+div#test3 {
+  position: fixed;
+  top: 200px;
+  left: 0;
+  width: 100px;
+  height: 100px;
+  background-color: red;
+}
+
 </style>
 
 <div id="test1">
 </div>
 
 <div id="test2">
+  aaa
+</div>
+
+<div id="test3">
 </div>
 
 <script>


### PR DESCRIPTION
Implement missing idl function `getModifierState` for mouse event. The implementation is exactly the same as in keyboard event https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate.

https://github.com/servo/servo/blob/6651f37c05138112cecf33d59de2709b715841f1/components/script/dom/keyboardevent.rs#L267-L283

Testing: Fix `./tests/wpt/tests/infrastructure/testdriver/actions/actionsWithKeyPressed.html`

Reviewed in servo/servo#38535