### PR TITLE
layout: Set color and text decoration on `<select>` elements by default

### DIFF
--- a/html/rendering/replaced-elements/the-select-element/select-text-decoration-ref.html
+++ b/html/rendering/replaced-elements/the-select-element/select-text-decoration-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+<select>
+    <option>Foobar</option>
+</select>
+</body>
+</html>

--- a/html/rendering/replaced-elements/the-select-element/select-text-decoration.html
+++ b/html/rendering/replaced-elements/the-select-element/select-text-decoration.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Text decoration should not propagate into select elements by default</title>
+  <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+  <link rel="match" href="select-text-decoration-ref.html">
+  <link rel="help" href="https://github.com/servo/servo/issues/37895">
+
+  <style>
+    body {
+        color: red;
+        text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+<select>
+    <option>Foobar</option>
+</select>
+</body>
+</html>


### PR DESCRIPTION
This makes the default style for `<select>` elements match that of gecko (https://searchfox.org/mozilla-central/rev/a1f4cb9fc03d81be41ca2ba81294592df784364d/layout/style/res/forms.css#217-243), with some small modifications because servo does not have fancy things like `color: -moz-ComboboxText;`.

Testing: Includes a new web platform test
Fixes: https://github.com/servo/servo/issues/37895

Reviewed in servo/servo#38570