### PR TITLE
Rename __HostHttp- to __Host-Http- for improved backward compat

### DIFF
--- a/cookies/prefix/__Host-Http.https.html
+++ b/cookies/prefix/__Host-Http.https.html
@@ -4,60 +4,60 @@
 <script src="/cookies/resources/cookie-helper.sub.js"></script>
 <script>
   set_prefixed_cookie_via_dom_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/",
     shouldExistInDOM: false,
     shouldExistViaHTTP: false,
-    title: "__HostHttp: Does not set via DOM 'Secure; Path=/'"
+    title: "__Host-Http: Does not set via DOM 'Secure; Path=/'"
   });
 
   set_prefixed_cookie_via_dom_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/; Domain=" + document.location.hostname,
     shouldExistInDOM: false,
     shouldExistViaHTTP: false,
-    title: "__HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=" +
+    title: "__Host-Http: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=" +
            document.location.hostname + "'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/",
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with 'Secure; Path=/'"
+    title: "__Host-Http: Does not set via HTTP with 'Secure; Path=/'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/;httponly",
     shouldExistViaHTTP: true,
     origin: self.origin,
-    title: "__HostHttp: Set via HTTP with 'Secure; Path=/; httponly'"
+    title: "__Host-Http: Set via HTTP with 'Secure; Path=/; httponly'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/cookies/;httponly",
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly'"
+    title: "__Host-Http: Does not set via HTTP with 'Secure; Path=/cookies/; httponly'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Path=/",
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with 'Path=/;' (without Secure)"
+    title: "__Host-Http: Does not set via HTTP with 'Path=/;' (without Secure)"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/; Domain=" + document.location.hostname,
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=" +
+    title: "__Host-Http: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=" +
            document.location.hostname + "'"
   });
 </script>

--- a/cookiestore/cookieStore_special_names.https.any.js
+++ b/cookiestore/cookieStore_special_names.https.any.js
@@ -56,8 +56,8 @@
   }, `cookieStore.set with ${prefix} prefix a path option`);
 });
 
-['__HostHttp-', '__hosthttp-', '__Http-', '__http-', '  __Http-', '\t__Http-',
- '  __HostHttp-', '\t__HostHttp-'].forEach(prefix => {
+['__Host-Http-', '__host-http-', '__Http-', '__http-', '  __Http-', '\t__Http-',
+ '  __Host-Http-', '\t__Host-Http-'].forEach(prefix => {
   promise_test(async testCase => {
     await promise_rejects_js(testCase, TypeError,
         cookieStore.set({ name: `${prefix}cookie-name`, value: 'cookie-value'}));
@@ -75,8 +75,8 @@ promise_test(async testCase => {
     assert_true(exceptionThrown, "No exception thrown.");
 }, 'cookieStore.set with malformed name.');
 
-['__Host-', '__Secure-', '__Http-', '__HostHttp-', ' __Host-', '\t__Host-', ' __Secure-',
- '\t__Secure-', ' __Http-', '\t__Http-', ' __HostHttp-', '\t__HostHttp-'].forEach(prefix => {
+['__Host-', '__Secure-', '__Http-', '__Host-Http-', ' __Host-', '\t__Host-', ' __Secure-',
+ '\t__Secure-', ' __Http-', '\t__Http-', ' __Host-Http-', '\t__Host-Http-'].forEach(prefix => {
   promise_test(async testCase => {
     // Nameless cookies cannot have special prefixes
     await cookieStore.delete('');


### PR DESCRIPTION
Test changes to go along with https://github.com/httpwg/http-extensions/pull/3153

This makes it easier to deploy this to non-supporting browsers while not losing the characteristics that __Host- provides.