### PR TITLE
layout: Use `overflow: visible` if `overflow` was propagated to viewport

### DIFF
--- a/css/css-overflow/scrollable-overflow-with-nested-elements-001.html
+++ b/css/css-overflow/scrollable-overflow-with-nested-elements-001.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: Scrollable Overflow Transform Rotate Nested Element</title>
+<link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<meta name="assert" content="Checks the scrollable overflow with overflow property and some nested element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+    .container-2 {
+        width: 100px;
+        height: 100px;
+        overflow: auto;
+        background: silver;
+        border: solid thick;
+        scrollbar-width: none;
+    }
+
+    .element {
+        width: 1000px;
+        height: 5000px;
+        background: lime;
+    }
+</style>
+
+<body onload="checkLayout('.container')">
+    <div class="container" data-expected-scroll-height="110" data-expected-height="110"
+        data-expected-client-height="110">
+        <div class="container-2" data-expected-scroll-height="5000" data-expected-scroll-width="1000"
+            data-expected-client-width="100" data-expected-client-height="100"
+            data-expected-bounding-client-rect-width="110" data-expected-bounding-client-rect-height="110"
+            data-expected-height="110" data-expected-width="110">
+            <div class="element">hello</div>
+        </div>
+    </div>
+</body>

--- a/css/css-overflow/scrollable-overflow-with-nested-elements-002.html
+++ b/css/css-overflow/scrollable-overflow-with-nested-elements-002.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: Scrollable Overflow Transform Rotate Nested Element</title>
+<link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<meta name="assert" content="Checks the scrollable overflow of parent with overflow auto and some nested element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+    .container {
+        width: 100px;
+        height: 100px;
+        background: silver;
+        scrollbar-width: none;
+    }
+
+    .list .item {
+        width: 10px;
+        height: 10px;
+        background: lime;
+        position: absolute;
+        margin: 0%;
+    }
+
+    .list {
+        position: relative;
+        background: grey;
+        scrollbar-width: none;
+    }
+</style>
+
+<body onload="checkLayout('.container')">
+    <div class="container" style="overflow-x: hidden;" data-expected-scroll-height="1010" data-expected-height="100" data-expected-width="100">
+        <div class="list" data-expected-scroll-height="1010"
+            data-expected-bounding-client-rect-height="0" data-expected-bounding-client-rect-width="100"
+            data-expected-height="0" data-expected-width="100">
+            <p class="item" style="top:0px;"></p>
+            <p class="item" style="top:1000px;"></p>
+        </div>
+    </div>
+    <div class="container" data-expected-scroll-height="1010" data-expected-height="100" data-expected-width="100">
+        <div class="list" data-expected-scroll-height="1010"
+            data-expected-bounding-client-rect-height="0" data-expected-bounding-client-rect-width="100"
+            data-expected-height="0" data-expected-width="100">
+            <p class="item" style="top:0px;"></p>
+            <p class="item" style="top:1000px;"></p>
+        </div>
+    </div>
+</body>

--- a/css/css-overflow/scrollable-overflow-with-nested-elements-003.html
+++ b/css/css-overflow/scrollable-overflow-with-nested-elements-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: Scrollable Overflow Transform Rotate Nested Element</title>
+<link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<meta name="assert" content="Checks the scrollable overflow with overflow property and some nested element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+    body {
+        overflow-x: hidden;
+    }
+
+    .list .item {
+        width: 10px;
+        height: 10px;
+        background: lime;
+        position: absolute;
+        margin: 0%;
+    }
+
+    .list {
+        position: relative;
+        background: grey;
+    }
+</style>
+
+<body onload="checkLayout('body')" data-expected-scroll-height="1010" data-expected-height="0" data-expected-client-height="0">
+    <div class="list" data-expected-scroll-height="1010" data-expected-height="0">
+        <p class="item" style="top:0px;"></p>
+        <p class="item" style="top:1000px;"></p>
+    </div>
+</body>

--- a/css/css-overflow/scrollable-overflow-with-nested-elements-004.html
+++ b/css/css-overflow/scrollable-overflow-with-nested-elements-004.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: Scrollable Overflow Transform Rotate Nested Element</title>
+<link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<meta name="assert" content="Checks the scrollable overflow with overflow property and some nested element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+    .container {
+        width: 100px;
+        height: 100px;
+        overflow-x: hidden;
+        background: silver;
+        scrollbar-width: none;
+    }
+
+    .list .item {
+        width: 10px;
+        height: 10px;
+        background: lime;
+        position: absolute;
+        margin: 0%;
+    }
+
+    .list {
+        position: relative;
+        background: grey;
+    }
+</style>
+
+<body onload="checkLayout('body')" data-expected-scroll-height="100" data-expected-height="100">
+    <div class="container" data-expected-scroll-height="1010"
+    data-expected-height="100" data-expected-width="100"
+        data-expected-client-height="100" data-expected-client-width="100">
+        <div class="list" data-expected-scroll-height="1010" data-expected-height="0">
+            <p class="item" style="top:0px;"></p>
+            <p class="item" style="top:1000px;"></p>
+        </div>
+    </div>
+</body>

--- a/css/css-overflow/scrollable-overflow-with-nested-elements-005.html
+++ b/css/css-overflow/scrollable-overflow-with-nested-elements-005.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html data-expected-scroll-height="1018" data-expected-height="8">
+
+<head>
+    <meta charset="utf-8">
+    <title>CSS Overflow: Scrollable Overflow Transform Rotate Nested Element</title>
+    <link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+    <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+    <meta name="assert" content="Checks the scrollable overflow with overflow property and some nested element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/check-layout-th.js"></script>
+    <style>
+        body {
+            overflow-x: hidden;
+        }
+
+        .list .item {
+            width: 10px;
+            height: 10px;
+            background: lime;
+            position: absolute;
+            margin: 0%;
+        }
+
+        .list {
+            position: relative;
+            background: grey;
+        }
+    </style>
+</head>
+
+<body onload="checkLayout('html')" data-expected-scroll-height="1010" data-expected-height="0" data-expected-client-height="0">
+    <div class="list" data-expected-scroll-height="1010" data-expected-height="0" data-expected-client-height="0">
+        <p class="item" style="top:0px;"></p>
+        <p class="item" style="top:1000px;"></p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
The `overflow-*` values of either the root element or the `<body>` get propagated to the viewport. However, we were missing this part:
> The element from which the value is propagated must then have a used `overflow` value of `visible`.

See https://drafts.csswg.org/css-overflow/#overflow-propagation

Testing:
 - `css/cssom-view/scrolling-quirks-vs-nonquirks.html`
 - `css/css-overflow/overflow-body-propagation-007.html`
 - `css/css-overflow/overflow-body-propagation-008.html`
 - `css/css-overflow/overflow-body-propagation-009.html`
 - `css/css-overflow/scrollable-overflow-with-nested-elements-001.html` 
 - `css/css-overflow/scrollable-overflow-with-nested-elements-002.html` 
 - `css/css-overflow/scrollable-overflow-with-nested-elements-003.html`
 - `css/css-overflow/scrollable-overflow-with-nested-elements-004.html`
 - `css/css-overflow/scrollbar-gutter-scroll-into-view.html`

Failures:
 - `css/css-overflow/overflow-body-propagation-010.html`
   Failing because of missing support for `contain: paint`.
- `css/css-overflow/scrollable-overflow-with-nested-elements-005.html`
   Failing because of wrong `data-expected-height`, but correct `data-expected-scroll-height` which is core of this PR. `data-expected-height` can be dealt separately.


Fixes: #<!-- nolink -->38248
Reviewed in servo/servo#38598