### PR TITLE
Rename __HostHttp- cookie prefix to __Host-Http-

### DIFF
--- a/cookies/prefix/__Host-Http.https.html
+++ b/cookies/prefix/__Host-Http.https.html
@@ -4,60 +4,60 @@
 <script src="/cookies/resources/cookie-helper.sub.js"></script>
 <script>
   set_prefixed_cookie_via_dom_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/",
     shouldExistInDOM: false,
     shouldExistViaHTTP: false,
-    title: "__HostHttp: Does not set via DOM 'Secure; Path=/'"
+    title: "__Host-Http: Does not set via DOM 'Secure; Path=/'"
   });
 
   set_prefixed_cookie_via_dom_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/; Domain=" + document.location.hostname,
     shouldExistInDOM: false,
     shouldExistViaHTTP: false,
-    title: "__HostHttp: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=" +
+    title: "__Host-Http: Does not set via DOM with Domain attribute 'Secure; Path=/; Domain=" +
            document.location.hostname + "'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/",
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with 'Secure; Path=/'"
+    title: "__Host-Http: Does not set via HTTP with 'Secure; Path=/'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/;httponly",
     shouldExistViaHTTP: true,
     origin: self.origin,
-    title: "__HostHttp: Set via HTTP with 'Secure; Path=/; httponly'"
+    title: "__Host-Http: Set via HTTP with 'Secure; Path=/; httponly'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/cookies/;httponly",
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with 'Secure; Path=/cookies/; httponly'"
+    title: "__Host-Http: Does not set via HTTP with 'Secure; Path=/cookies/; httponly'"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Path=/",
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with 'Path=/;' (without Secure)"
+    title: "__Host-Http: Does not set via HTTP with 'Path=/;' (without Secure)"
   });
 
   set_prefixed_cookie_via_http_test({
-    prefix: "__HostHttp-",
+    prefix: "__Host-Http-",
     params: "Secure; Path=/; Domain=" + document.location.hostname,
     shouldExistViaHTTP: false,
     origin: self.origin,
-    title: "__HostHttp: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=" +
+    title: "__Host-Http: Does not set via HTTP with Domain attribute 'Secure; Path=/; Domain=" +
            document.location.hostname + "'"
   });
 </script>


### PR DESCRIPTION
This is complementary to https://github.com/httpwg/http-extensions/pull/3153 and renames the __HostHttp- prefix to __Host-Http-, to make deployment easier before the prefix is ubiquitously supported.