### PR TITLE
Make sure setting outerHTML can succeed.

### DIFF
--- a/trusted-types/trusted-types-reporting-for-Element-outerHTML.html
+++ b/trusted-types/trusted-types-reporting-for-Element-outerHTML.html
@@ -10,15 +10,19 @@
     const input = `<p>${'A'.repeat(100)}</p>`;
 
     promise_test(async t => {
-      await no_trusted_type_violation_for(_ =>
-        document.createElement("div").outerHTML = policy.createHTML(input)
-      );
+      await no_trusted_type_violation_for(_ => {
+        const div = document.createElement("div");
+        document.createElement("div").appendChild(div);
+        div.outerHTML = policy.createHTML(input)
+});
     }, "No violation reported for TrustedHTML.");
 
     promise_test(async t => {
-      let violation = await trusted_type_violation_for(TypeError, _ =>
-        document.createElement("div").outerHTML = input
-      );
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        const div = document.createElement("div");
+        document.createElement("div").appendChild(div);
+        div.outerHTML = input
+      });
       assert_equals(violation.blockedURI, "trusted-types-sink");
       assert_equals(violation.sample, `Element outerHTML|${clipSampleIfNeeded(input)}`);
     }, "Violation report for plain string.");


### PR DESCRIPTION
Setting outerHTML requires the node it's applied to to have a parent, otherwise NoModificationAllowedError is thrown, with message "Failed to set the 'outerHTML' property on 'Element': This element has no parent node."

This follows from https://html.spec.whatwg.org/#dom-element-outerhtml, steps 3+4. Here, we simply ensure there's another `<div>` around our target element.