### PR TITLE
[Gecko Bug 1975531] Adjust web-platform-tests for & being replaced by :where(:scope) in @scope.

### DIFF
--- a/css/css-cascade/scope-invalidation.html
+++ b/css/css-cascade/scope-invalidation.html
@@ -861,12 +861,9 @@ test_scope_invalidation(document.currentScript, () => {
   assert_green(c);
   let scope_rule = main.querySelector('style').sheet.cssRules[1];
   assert_true(scope_rule instanceof CSSScopeRule);
-  // Note: relative selectors imply a :where(:scope) selector to the left,
-  // which is observably different from an implicit '&' selector through
-  // specificity.
   scope_rule.cssRules[0].selectorText = '> .b'; /* Still (0, 1, 0) */
-  scope_rule.cssRules[1].selectorText = '& > .c'; /* (0, 3, 0) */
+  scope_rule.cssRules[1].selectorText = '& > .c'; /* Still (0, 1, 0) */
   assert_green(b);
-  assert_red(c);
-}, 'Relative selectors set with selectorText are relative to :scope, not &');
+  assert_green(c);
+}, 'Relative selectors set with selectorText are relative to :scope and &');
 </script>

--- a/css/css-cascade/scope-nesting.html
+++ b/css/css-cascade/scope-nesting.html
@@ -2,6 +2,7 @@
 <title>@scope - nesting (&)</title>
 <link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">
 <link rel="help" href="https://drafts.csswg.org/css-nesting-1/#nest-selector">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9740">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <main id=main></main>
@@ -9,12 +10,18 @@
 <template id=test_nest_scope_end>
   <div>
     <style>
-      @scope (.a) to (& > &) {
-        * { z-index:1; }
+      /* (& > .b) behaves like (:where(:scope) > .b), due to & mapping to :where(:scope).*/
+      @scope (.a) to (& > .b) {
+        :scope { z-index:1; }
+      }
+
+      /* Should not match, since <scope-end> refers to the scope itself. */
+      @scope (.a) to (.b&) {
+        :scope { z-index:42; }
       }
     </style>
-    <div class=a> <!-- This scope is limited by the element below. -->
-      <div class=a> <!-- This scope is limited by its own root. -->
+    <div class="a b">
+      <div class=b>
         <div id=below></div>
       </div>
     </div>
@@ -25,7 +32,10 @@
 test((t) => {
   t.add_cleanup(() => main.replaceChildren());
   main.append(test_nest_scope_end.content.cloneNode(true));
-
+  let a = document.querySelector('.a');
+  let b = document.querySelector('.a > .b');
+  assert_equals(getComputedStyle(a).zIndex, '1');
+  assert_equals(getComputedStyle(b).zIndex, 'auto');
   assert_equals(getComputedStyle(below).zIndex, 'auto');
   assert_equals(getComputedStyle(outside).zIndex, 'auto');
 }, 'Nesting-selector in <scope-end>');
@@ -97,16 +107,16 @@ test((t) => {
 <template id=test_inner_nest>
   <div>
     <style>
-      @scope (.a) {
-        & + & {
-          z-index:1;
+      @scope (#div) {
+        & {
+          z-index: 1;
+          & {
+            z-index: 2;
+          }
         }
       }
     </style>
-    <div class=a>
-      <div id=inner1 class=a></div>
-      <div id=inner2 class=a></div>
-    </div>
+    <div id=div></div>
   </div>
 </template>
 <script>
@@ -114,9 +124,8 @@ test((t) => {
   t.add_cleanup(() => main.replaceChildren());
   main.append(test_inner_nest.content.cloneNode(true));
 
-  assert_equals(getComputedStyle(inner1).zIndex, 'auto');
-  assert_equals(getComputedStyle(inner2).zIndex, '1');
-}, 'Nesting-selector in the scope\'s <stylesheet>');
+  assert_equals(getComputedStyle(div).zIndex, '2');
+}, 'Nested nesting-selectors within scope\'s <stylesheet> select inclusive descendants of the scope root');
 </script>
 
 <template id=test_parent_in_pseudo_scope>
@@ -227,38 +236,6 @@ test((t) => {
 }, 'Parent pseudo class within scope-start');
 </script>
 
-<template id=test_parent_pseudo_in_nested_scope_end>
-  <div>
-    <style>
-      .a {
-        /* Note that & in <scope-end> refers to <scope-start>,
-           not the outer style rule. */
-        @scope (&.b) to (&.c) {
-           :scope, * { z-index: 1; }
-        }
-      }
-    </style>
-    <div class="a b">
-      <div class="a c">
-        <div class="a b c">
-        </div>
-      </div>
-    </div>
-  </div>
-</template>
-<script>
-test((t) => {
-  t.add_cleanup(() => main.replaceChildren());
-  main.append(test_parent_pseudo_in_nested_scope_end.content.cloneNode(true));
-
-  let ab = document.querySelector('.a.b:not(.c)');
-  let ac = document.querySelector('.a.c:not(.b)');
-  let abc = document.querySelector('.a.b.c');
-  assert_equals(getComputedStyle(ab).zIndex, '1');
-  assert_equals(getComputedStyle(ac).zIndex, '1');
-  assert_equals(getComputedStyle(abc).zIndex, 'auto', 'limit element is not in scope');
-}, 'Parent pseudo class within scope-end');
-</script>
 
 <template id=test_parent_pseudo_in_nested_scope_body>
   <div>
@@ -621,7 +598,12 @@ test((t) => {
   main.append(test_insert_ampersand_rule_within_scope.content.cloneNode(true));
   assert_equals(getComputedStyle(child).color, 'rgb(255, 0, 0)');
   let scope_rule = main.querySelector('style').sheet.cssRules[0].cssRules[0];
-  scope_rule.insertRule('& #child { color: green; }');
+  // & does not add specificity - inserting it up front does nothing...
+  scope_rule.insertRule('& #child { color: green; }', 0);
+  assert_equals(getComputedStyle(child).color, 'rgb(255, 0, 0)');
+  scope_rule.deleteRule(0);
+  // ... But inserting it at the end makes it win by order of appearance.
+  scope_rule.insertRule('& #child { color: green; }', scope_rule.cssRules.length);
   assert_equals(getComputedStyle(child).color, 'rgb(0, 128, 0)');
 }, 'Insert a nested style rule within @scope, &');
 </script>

--- a/css/css-cascade/scope-specificity.html
+++ b/css/css-cascade/scope-specificity.html
@@ -79,15 +79,14 @@ test_scope_specificity(['@scope (#main) to (.b)', '.a'], '.a');
 test_scope_specificity(['@scope (#main, .foo, .bar)', '#a'], '#a');
 test_scope_specificity(['@scope (#main)', 'div.b'], 'div.b');
 test_scope_specificity(['@scope (#main)', ':scope .b'], '.a .b');
-// Inherit the specificity of the scope-start selector.
-test_scope_specificity(['@scope (#main)', '& .b'], '#main .b');
+// & behaves like :where(:scope) - No specificity is added.
+// See https://github.com/w3c/csswg-drafts/issues/9740
+test_scope_specificity(['@scope (#main)', '& .b'], ':where(#main) .b');
 test_scope_specificity(['@scope (#main)', 'div .b'], 'div .b');
 test_scope_specificity(['@scope (#main)', '@scope (.a)', '.b'], '.b');
 // Explicit `:scope` adds specficity.
 test_scope_specificity(['@scope (#main)', ':scope .b'], ':scope .b');
-// Using & in scoped style with implicit scope root matches the same elements
-// as `:scope`, but does not add any specificity.
-// https://github.com/w3c/csswg-drafts/issues/10196
+// & behaves like :where(:scope), even for implicit scope roots.
 test_scope_specificity(['@scope', '& .b'], ':where(:scope) .b', styleImplicit);
 // Using relative selector syntax does not add specificity
 test_scope_specificity(['@scope (#main)', '> .a'], ':where(#main) > .a');


### PR DESCRIPTION
**Note:** This is a continuation of web-platform-tests/wpt#53831, addressing comments from @mdubet. I do not have push permissions to that branch on that repo. If this should be handled differently, please let me know. 

This is as per the CSSWG resolution [1].

* scope-invalidation.html: Adjust for `&` no longer inheriting scope start selector's specificity.
* scope-specificity.html: Now equate `@scope(#main) { & .b {} }` with `:where(#main) .b` in terms of specificity.
* scope-nesting.html:
  * `test_nest_scope_end`: Now behaves identically to `test_nest_scope_end_implicit_scope`
  * `test_inner_nest`: Now behaves identically to `test_parent_in_pseudo_scope`
  * `test_parent_pseudo_in_nested_scope_end`: Removed; there's no equivalence with implicit `:scope`
  * `test_insert_ampersand_rule_within_scope`: Insert the selector using & before and after the selector using implicit scope selector, since order of apperance matters.

[1] https://github.com/w3c/csswg-drafts/issues/9740

Differential Revision: https://phabricator.services.mozilla.com/D257704

bugzilla-url: https://bugzilla.mozilla.org/show_bug.cgi?id=1975531
gecko-commit: b7593b87da93868f2b9302b5de723110eb96428d
gecko-reviewers: firefox-style-system-reviewers, emilio