### PR TITLE
script: Strip `javascript` URL scheme using `Position::AfterScheme` rather than `Position::BeforePath`

### DIFF
--- a/url/javascript-urls.window.js
+++ b/url/javascript-urls.window.js
@@ -20,6 +20,12 @@
     "expected": undefined
   },
   {
+    "description": "javascript: URL with extra slashes at the start",
+    "input": "javascript:///globalThis.shouldNotExistC=1",
+    "property": "shouldNotExistC",
+    "expected": undefined
+  },
+  {
     "description": "javascript: URL without an opaque path",
     "input": "javascript://host/1%0a//../0/;globalThis.shouldBeOne=1;/%0aglobalThis.shouldBeOne=2;/..///",
     "property": "shouldBeOne",


### PR DESCRIPTION
This makes the initial split match step 2 of https://html.spec.whatwg.org/multipage/browsing-the-web.html#evaluate-a-javascript%3A-url.

Testing: Covered by WPT tests.
Fixes: #<!-- nolink -->38547

Reviewed in servo/servo#38599