### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297306

### DIFF
--- a/css/cssom/caretPositionFromPoint-audioVideo.html
+++ b/css/cssom/caretPositionFromPoint-audioVideo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>document.caretPositionFromPoint()</title>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="container"></div>
+<script>
+  test(() => {
+    container.setHTMLUnsafe(`<audio controls></audio>`);
+    const audio = document.querySelector("audio");
+    const caretPosition = document.caretPositionFromPoint(audio.offsetLeft + audio.offsetWidth / 2, audio.offsetTop + audio.offsetHeight / 2);
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 0);
+  }, "document.caretPositionFromPoint() should return a CaretPosition over audio elements");
+
+  test(() => {
+    container.setHTMLUnsafe(`<video controls></video>`);
+    const video = document.querySelector("video");
+    const caretPosition = document.caretPositionFromPoint(video.offsetLeft + video.offsetWidth / 2, video.offsetTop + video.offsetHeight / 2);
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 0);
+  }, "document.caretPositionFromPoint() should return a CaretPosition over video elements");
+</script>

--- a/css/cssom/caretPositionFromPoint.html
+++ b/css/cssom/caretPositionFromPoint.html
@@ -70,22 +70,6 @@
   }, "document.caretPositionFromPoint() should return a CaretPosition over elements with `user-select: none`");
 
   test(() => {
-    container.setHTMLUnsafe(`<video controls></video>`);
-    const video = document.querySelector("video");
-    const caretPosition = document.caretPositionFromPoint(video.offsetLeft + video.offsetWidth / 2, video.offsetTop + video.offsetHeight / 2);
-    assert_equals(caretPosition.offsetNode, container);
-    assert_equals(caretPosition.offset, 0);
-  }, "document.caretPositionFromPoint() should return a CaretPosition over video elements");
-
-  test(() => {
-    container.setHTMLUnsafe(`<audio controls></audio>`);
-    const audio = document.querySelector("audio");
-    const caretPosition = document.caretPositionFromPoint(audio.offsetLeft + audio.offsetWidth / 2, audio.offsetTop + audio.offsetHeight / 2);
-    assert_equals(caretPosition.offsetNode, container);
-    assert_equals(caretPosition.offset, 0);
-  }, "document.caretPositionFromPoint() should return a CaretPosition over audio elements");
-
-  test(() => {
     container.setHTMLUnsafe(`<svg width=100 height=100><circle cx=50 cy=50 r=50 /></svg>`);
     const circle = document.querySelector("circle");
     const caretPosition = document.caretPositionFromPoint(50, 50);


### PR DESCRIPTION
WebKit export from bug: [Split out media element subtests for `document.caretPositionFromPoint`](https://bugs.webkit.org/show_bug.cgi?id=297306)