### PR TITLE
Fix expectation for `css/css-text/word-spacing/word-spacing-002.html`

### DIFF
--- a/css/css-text/word-spacing/word-spacing-002-ref.html
+++ b/css/css-text/word-spacing/word-spacing-002-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<meta name="flags" content="ahem">
+<style>
+@font-face {
+  font-family: Ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+div { font-family: Ahem, monospace; font-size: 20px; }
+</style>
+<body>
+  <p>Test passes if the space between the words starts at zero and increases by
+  an even amount on each subsequent line.</p>
+  <div>ABcDefGhij</div>
+  <div>A Bc Def Ghij</div>
+  <div>A &nbsp;Bc &nbsp;Def &nbsp;Ghij</div>
+  <div>A &nbsp;&nbsp;Bc &nbsp;&nbsp;Def &nbsp;&nbsp;Ghij</div>
+  <div>A &nbsp;&nbsp;&nbsp;Bc &nbsp;&nbsp;&nbsp;Def &nbsp;&nbsp;&nbsp;Ghij</div>
+</body>

--- a/css/css-text/word-spacing/word-spacing-002.html
+++ b/css/css-text/word-spacing/word-spacing-002.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Elika Etemad" href="http://fantasai.inkedblade.net/contact">
 <link rel="help" href="http://www.w3.org/TR/css-text-3/#word-spacing">
 <link rel="stylesheet" href="/fonts/ahem.css">
-<link rel="match" href="word-spacing-001-ref.html">
+<link rel="match" href="word-spacing-002-ref.html">
 <meta name="flags" content="ahem">
 <meta name="assert" content="Test checks various length values of word-spacing, including calc().">
 <style>


### PR DESCRIPTION
`css/css-text/word-spacing/word-spacing-002.html` is a reftest that expects to match `css/css-text/word-spacing/word-spacing-001-ref.html`, but the test description and the number of test cases is different.

Thats why all browsers currently fail this test: [wpt.fyi](https://wpt.fyi/results/css/css-text/word-spacing/word-spacing-002.html?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=servo&aligned&q=css%2Fcss-text%2Fword-spacing%2Fword-spacing-002.html).

This change adds a correct expectation.