### PR TITLE
Align tests with spec for rtt and downlink (multiples of 25)

### DIFF
--- a/netinfo/netinfo-basics.html
+++ b/netinfo/netinfo-basics.html
@@ -28,7 +28,7 @@ test(function() {
       var rtt  = navigator.connection.rtt;
       assert_greater_than_equal(rtt, 0);
       assert_less_than_equal(rtt, 3000);
-      assert_equals(rtt % 50, 0, 'rtt must be a multiple of 50 msec');
+      assert_equals(rtt % 25, 0, 'rtt must be a multiple of 25 msec');
 }, "rtt attribute");
 
 test(function() {
@@ -36,17 +36,17 @@ test(function() {
   assert_greater_than_equal(downlinkKbps, 0);
   assert_less_than_equal(downlinkKbps, 10000);
 
-  // Verify that downlinkKbps is a multiple of 50.
-  var quotient = parseInt(downlinkKbps  / 50, 10);
-  // mod is the remainder left after dividing downlinkKbps by 50 while
+  // Verify that downlinkKbps is a multiple of 25.
+  var quotient = parseInt(downlinkKbps / 25, 10);
+  // mod is the remainder left after dividing downlinkKbps by 25 while
   // restricting the quotient to an integer. For example, if downlinkKbps is
-  // 1050, then mod will be 0. If downlinkKpbps is 1030, mod will be 30.
-  var mod = downlinkKbps - 50 * quotient;
+  // 1025, then mod will be 0. If downlinkKpbps is 1030, mod will be 5.
+  var mod = downlinkKbps - 25 * quotient;
   assert_less_than_equal(0.0, mod, 'mod outside the range');
-  assert_greater_than(50.0, mod, 'mod outside the range');
+  assert_greater_than(25.0, mod, 'mod outside the range');
   // It is possible that mod is not exactly 0 because of floating point
   // computations. e.g., downlinkKbps may be 99.999999, in which case mod
-  // will be 49.999999.
-  assert_true(mod < 1e-5 || (50-mod) < 1e-5, 'downlink must be a multiple of 50 kbps');
+  // will be 24.999999.
+  assert_true(mod < 1e-5 || (25-mod) < 1e-5, 'downlink must be a multiple of 25 kbps');
 }, "downlink attribute");
 </script>


### PR DESCRIPTION
For both of these, the spec says the values should be multiples of 25: https://wicg.github.io/netinfo/#rtt-attribute
https://wicg.github.io/netinfo/#downlink-attribute

This need for the change and the change itself was initially prepared by Gemini CLI, followed by manual review and edits to clean it up.