### PR TITLE
script: check if the canvas is paintable before measuring text

### DIFF
--- a/html/canvas/text-metrics-for-unpaintable-crash.html
+++ b/html/canvas/text-metrics-for-unpaintable-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<!-- https://github.com/servo/servo/issues/36845 -->
+<canvas id="canvas" height="0"></canvas>
+<script>
+  canvas.getContext("2d").measureText("1");
+</script>


### PR DESCRIPTION
The `Canvas2dMsg::MeasureText` is dropped inside `send_canvas_2d_msg` if the canvas is not paintable,
leading to a panic on the receiving end. Checking the paint-ability before sending the message prevents this panic, and if the canvas is not pain-table, a default text metrics is used.

Testing: Manual testing of the minimal test case in the associated issue, and crash test added.
Fixes: https://github.com/servo/servo/issues/36845

Reviewed in servo/servo#38664