### PR TITLE
Update test for the document becomes non-fully active during DC API

### DIFF
--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -76,13 +76,12 @@
     await iframe.focus();
     const p = promise_rejects_dom(
       t,
-      "InvalidStateError",
+      "AbortError",
       DOMExceptionCtor,
       iframe.contentWindow.navigator.credentials.get(request),
       "Expect promise to reject if the document becomes non-fully active"
     );
     iframe.remove();
-    assert_equals(stolenNavigator.credentials, null, "CredentialsContainer should be null after iframe is removed");
     await p;
   }, "Promise rejects with DOMException when the document becomes non-fully active");
 </script>


### PR DESCRIPTION
This PR does the following:

1. Removes one check that was webkit specific to make the test more universal.
2. Switches the error to be "AbortError" when the iframe is destroyed while there is a request in flight.