### PR TITLE
script: abort planned form navigations

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>The planned navigation of a form should be cancelled by a window stop 
+<title>The planned navigation of a form should be cancelled by a window stop
   in the same task as the form submission</title>
 <link rel="help" href="https://github.com/whatwg/html/issues/3730">
 <script src="/resources/testharness.js"></script>

--- a/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The planned navigation of a form should be cancelled by a window stop 
+  in the same task as the form submission</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/3730">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<body>
+<script>
+"use strict";
+async_test(t => {
+  let unloaded = false;
+  window.onload = t.step_func(() => {
+    form.submit();
+    window.stop();
+  });
+  window.onunload = () => {
+    unloaded = true;
+  };
+  t.step_timeout(() => {
+    // The document should not have unloaded.
+    assert_equals(unloaded, false);
+    t.done();
+  }, 100);
+});
+</script>
+<form id="form">


### PR DESCRIPTION
Servo shows a behavior unlike FF and Safari(I don't have Chrome), where stopping a window does not cancel planned form navigation, resulting in an infinite navigation loop. The current behavior of Servo does seem to follow the wording of the spec, so I will open a [companion issue at the spec](https://github.com/whatwg/html/issues/11562), and I have also written a WPT tests for the non-standard but widely followed behavior. This PR also adds a beginning of an implementation of the "ongoing navigation" concept, which is used by the spec to cancel navigations, and which is used in this PR only to cancel planned form navigations. The generation id concept, which corresponds to the planned navigation concept in the spec, is turned into a simple struct private cell, and is documented per the spec.

Testing: A new WPT test is added
Fixes: Only one part of https://github.com/servo/servo/issues/36747

Reviewed in servo/servo#38676