### PR TITLE
Add well-known route for Device Bound Session Credentials

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -801,6 +801,7 @@ class RoutesBuilder:
             ("*", "/.well-known/private-aggregation/*", handlers.PythonScriptHandler),
             ("GET", "/.well-known/shared-storage/trusted-origins", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
+            ("*", "/.well-known/device-bound-sessions", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)
         ]


### PR DESCRIPTION
This supports the Web Platform Tests for session registration from a subdomain being added in https://crrev.com/c/6847053.