### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297352

### DIFF
--- a/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.js
@@ -27,6 +27,7 @@
   }
 
   promise_test(async (t) => {
+    await SetFirstPartyCookie(altRoot, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     const frame = await SetUpResponderFrame(t, altRootResponder);
     await SetDocumentCookieFromFrame(frame, domainCookieString);
 
@@ -52,6 +53,7 @@
   }, "Cross-origin fetches from a frame with storage-access are not credentialed by default");
 
   promise_test(async (t) => {
+    await SetFirstPartyCookie(altRoot, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     const frame = await SetUpResponderFrame(t, altRootResponder);
     await SetDocumentCookieFromFrame(frame, domainCookieString);
 

--- a/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window.js
@@ -38,7 +38,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwNestedCrossOriginResponder);
 
@@ -52,7 +52,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwNestedCrossOriginResponder);
 

--- a/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.js
@@ -37,7 +37,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 
@@ -52,7 +52,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 
@@ -60,13 +60,13 @@
 
     assert_true(await FrameHasStorageAccess(frame), "frame has storage access after refresh.");
     assert_true(await HasUnpartitionedCookie(frame), "frame has access to cookies after refresh.");
-    let cookieOnLoad = await GetHTTPCookiesFromFrame(frame);
+  let cookieOnLoad = await GetHTTPCookiesFromFrame(frame);
     assert_true(cookieStringHasCookie("cookie", "unpartitioned", cookieOnLoad), "innermost frame has cookie in initial load");
   }, "Self-initiated same-origin navigations preserve storage access");
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 
@@ -83,7 +83,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 

--- a/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window.js
@@ -24,6 +24,7 @@ async function SetUpResponderFrame(t, url) {
 }
 
 promise_test(async (t) => {
+  await SetFirstPartyCookie(altRoot, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
   const frame = await SetUpResponderFrame(t, altRootResponder);
   await SetDocumentCookieFromFrame(frame, domainCookieString);
 

--- a/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js
@@ -14,7 +14,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(wwwAlt);
+    await SetFirstPartyCookie(wwwAlt);
     const responder_html = `${wwwAlt}${url_suffix}`;
     const [frame1, frame2] = await Promise.all([
       CreateFrame(responder_html),
@@ -55,6 +55,8 @@
       CreateFrame(`${www}${url_suffix}`),
       CreateFrame(`${wwwAlt}${url_suffix}`),
     ]);
+    await SetFirstPartyCookie(www, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
+    await SetFirstPartyCookie(wwwAlt, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
 
     t.add_cleanup(async () => {
       await test_driver.delete_all_cookies();

--- a/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window.js
@@ -28,7 +28,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+    await SetFirstPartyCookie(altRoot);
 
     const frame = await SetUpResponderFrame(t, altRootResponder);
     assert_true(await RequestStorageAccessInFrame(frame), "requestStorageAccess resolves without requiring a gesture.");
@@ -47,7 +47,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+    await SetFirstPartyCookie(altRoot);
 
     const frame = await SetUpResponderFrame(t, altRootResponder);
     assert_false(await FrameHasStorageAccess(frame), "frame lacks storage access before request.");

--- a/storage-access-api/requestStorageAccess-web-socket.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-web-socket.sub.https.window.js
@@ -26,7 +26,7 @@ async function SetUpResponderFrame(t, url) {
 
 promise_test(async (t) => {
   await MaybeSetStorageAccess("*", "*", "blocked");
-  await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+  await SetFirstPartyCookie(altRoot);
 
   const frame = await SetUpResponderFrame(t, altRootResponder);
 
@@ -42,7 +42,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
 
   await MaybeSetStorageAccess("*", "*", "blocked");
-  await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+  await SetFirstPartyCookie(altRoot);
   const frame = await SetUpResponderFrame(t, altRootResponder);
 
   assert_false(cookieStringHasCookie("cookie", "unpartitioned",

--- a/storage-access-api/requestStorageAccess.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess.sub.https.window.js
@@ -19,6 +19,8 @@ const canUseAutogrant = topLevelDocument ||
           testPrefix.includes('cross-origin') ||
           testPrefix.includes('ABA');
 
+const initialCookie = "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/";
+
 if (!topLevelDocument) {
   // WPT synthesizes a top-level HTML test for this JS file, and in that case we
   // don't want to, or need to, call set_test_context.
@@ -32,6 +34,7 @@ promise_test(async () => {
 
 // Most tests need to start with the feature in "prompt" state.
 async function CommonSetup() {
+  await SetFirstPartyCookie(location.origin, initialCookie);
   if (!canUseAutogrant) {
     await test_driver.set_permission({ name: 'storage-access' }, 'prompt');
   }
@@ -76,6 +79,7 @@ promise_test(
 if (!canUseAutogrant) {
   promise_test(
       async t => {
+        await SetFirstPartyCookie(location.origin, initialCookie);
         await test_driver.set_permission(
             {name: 'storage-access'}, 'denied');
 
@@ -89,6 +93,7 @@ if (!canUseAutogrant) {
 } else {
   promise_test(
       async () => {
+        await SetFirstPartyCookie(location.origin, initialCookie);
         await document.requestStorageAccess();
 
         assert_true(await CanAccessCookiesViaHTTP(), 'After obtaining storage access, subresource requests from the frame should send and set cookies.');

--- a/storage-access-api/resources/set-document-cookie.html
+++ b/storage-access-api/resources/set-document-cookie.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+  <script>
+    'use strict';
+
+    let query = window.location.search;
+    let cookieString = '';
+    if (query && query.length > 1)
+      cookieString = decodeURIComponent(query.slice(1));
+
+    document.cookie = cookieString;
+
+    window.opener.postMessage('set-document-cookie-complete', '*');
+    window.close();
+  </script>
+</body>

--- a/storage-access-api/storage-access-headers.tentative.https.sub.window.js
+++ b/storage-access-api/storage-access-headers.tentative.https.sub.window.js
@@ -122,7 +122,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -147,7 +147,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -303,7 +303,7 @@ promise_test(async t => {
 promise_test(async t => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess('*', '*', 'blocked');
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(https_origin);
+    await SetFirstPartyCookie(https_origin);
     addCommonCleanupCallback(t);
 
     const iframe_params = new URLSearchParams([['script',
@@ -337,7 +337,7 @@ promise_test(async t => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -377,7 +377,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -416,7 +416,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
     await grantStorageAccessForEmbedSite(t, cross_site);
 
@@ -456,7 +456,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
     await grantStorageAccessForEmbedSite(t, cross_site);
 


### PR DESCRIPTION
WebKit export from bug: [Storage Access API tests should set a cookie from a first-party context before setting cross-site cookies](https://bugs.webkit.org/show_bug.cgi?id=297352)