### PR TITLE
[WebVTT] Ref files should reflect that ::cue matches the block level element for all css properties that arent background

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video">

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
@@ -27,10 +27,12 @@ body { margin:0 }
     margin-top: 4.5px;
     text-align: center
 }
-.cue > span {
+.cue {
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue" id="cue1"><span>This is a test subtitle</span></span><span class="cue" id="cue2"><span>This is another test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .cueTextGoingUp {
     position: relative;

--- a/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
@@ -19,11 +19,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video">

--- a/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
@@ -19,11 +19,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: right;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: right
+    text-align: right;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/basic-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/basic-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-ref.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="cue"><span>.<br><bdo dir=ltr>&#x05D0;ab)</bdo></span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-ref.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="cue"><span><bdo dir=ltr>&#x06E9;)</bdo></span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>Here are the escaped <br>entities: &amp; &lt; &gt; &lrm; &rlm; &nbsp;</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-ref.html
@@ -14,13 +14,13 @@
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
     font-size: 50px;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>Foo</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     right: 51.2px;
     width: 64px;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>There is nothing to see here people, move on</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     right: 51.2px;
     width: 64px;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This test tests</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>f o o</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>f o o</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html
@@ -13,13 +13,13 @@ video {
     bottom: 50px;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
+    text-align: center;
     color: green;
     font-size: 50px;
+    font-family: Ahem, sans-serif;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 
 .media-container {

--- a/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-ref.html
@@ -92,10 +92,10 @@
 }
 .cue {
     width: 9px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
 }
 </style>

--- a/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-ref.html
@@ -92,10 +92,10 @@
 }
 .cue {
     width: 9px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
 }
 </style>

--- a/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-ref.html
@@ -14,12 +14,12 @@
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-ref.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    color: green;
+    font-family: sans-serif;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>'</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/evil/size_90-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/size_90-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/evil/size_99-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/size_99-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that will line break</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that will line break</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 0;
     right: 0;
     margin-top: -4.5px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-ref.html
@@ -17,11 +17,11 @@
     right: 0;
     text-align: center;
     padding-bottom: 40px;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/webvtt/rendering/cues-with-video/processing-model/media_with_controls-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/media_with_controls-ref.html
@@ -17,11 +17,11 @@
     right: 0;
     text-align: center;
     padding-bottom: 9px;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position-ref-1.html
+++ b/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position-ref-1.html
@@ -10,26 +10,17 @@
     position: relative;
     font-size: 50px;
 }
-video {
-    position: absolute;
-    width:320px;
-    height:240px;
-}
 .cue {
     position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    color: green;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
-<video>
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-</video>
 <div class="video"><span class="cue"><span>Foo</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 15%;
     right: 0;
     width: 70%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This test subtitle wraps and should be visible<br>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/basic-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/basic-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: -50%;
     right: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/scroll_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/scroll_up-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a second test subtitle<br/>This is a third test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     bottom: 0;
     left: 50%;
     right: -50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 50%;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/repaint-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/repaint-ref.html
@@ -14,11 +14,11 @@
     left: 0;
     right: 0;
     text-align: center
+    font-family: sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <p>You should see the word 'PASS' below.</p>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-ref.html
@@ -29,11 +29,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="region-cue"><span>This is a test subtitle</span></span><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: #60ff60;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: hsla(100,100%,50%,0.5);
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: rgba(128,255,128,0.5);
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-ref.html
@@ -16,14 +16,14 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-ref.html
@@ -16,14 +16,14 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-ref.html
@@ -21,11 +21,11 @@ body { margin:0 }
     direction: ltr;
     writing-mode: vertical-lr;
     -webkit-writing-mode: vertical-lr;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: #0f0 url('../../media/background.gif') repeat-x top left;
-    color: green;
 }
 .combine {
     -webkit-text-combine: horizontal;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .green {
     color: green;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: #60ff60;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: #60ff60;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: hsla(100,100%,50%,0.5);
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: hsla(100,100%,50%,0.5);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: rgba(128,255,128,0.5);
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: rgba(128,255,128,0.5);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: #00ff00;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .green {
     color: green;

--- a/webvtt/rendering/cues-with-video/processing-model/size_50-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/size_50-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 25%;
     right: 0;
     width: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that should wrap</span></span></div>


### PR DESCRIPTION
The ref files of many WebVTT tests apply styles such as font-family and font-size to the inline level element. This doesn't reflect the WebVTT spec's [expectation](https://www.w3.org/TR/webvtt1/#the-cue-pseudo-element) that styling on the ::cue pseudo-element are applied to the root/block level element (except for background properties, which are applied to the inline level element). This creates a problem because the line heights end up differing between the ref and actual file, since line height is affected by the font properties of the block element, and the block level element still has the default font when the font styling is only set on its inline child. To fix this, this patch moves any css styles that are applied onto the inline level element, except for background properties, to the block level element. 