### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296706

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, line:50% should be vertically centered</title>
+<title>Reference for WebVTT rendering, line:50%: top edge should be vertically centered</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
@@ -16,7 +16,6 @@ body { margin:0 }
     top: 50%;
     left: 0;
     right: 0;
-    margin-top: -4.5px;
     text-align: center
 }
 .cue > span {

--- a/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
@@ -16,8 +16,6 @@ body { margin:0 }
     top: 50%;
     left: 0;
     right: 0;
-    text-align: center
-    margin-top: -4.5px;
     text-align: center;
     font-family: Ahem, sans-serif;
     color: green;


### PR DESCRIPTION
WebKit export from bug: [WebVTT test assumes default line alignment is "center", when it should be "start"](https://bugs.webkit.org/show_bug.cgi?id=296706)