### PR TITLE
Make sticky positioned reference more accurate

### DIFF
--- a/css/css-anchor-position/anchor-scroll-to-sticky-003.html
+++ b/css/css-anchor-position/anchor-scroll-to-sticky-003.html
@@ -2,7 +2,7 @@
 <title>Tests scroll adjustments of element anchored to a sticky-position element</title>
 <link rel="author" href="mailto:wangxianzhu@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
-<link rel="match" href="reference/anchor-scroll-to-sticky-001-ref.html">
+<link rel="match" href="reference/anchor-scroll-to-sticky-003-ref.html">
 <style>
 body {
   margin: 0;

--- a/css/css-anchor-position/reference/anchor-scroll-to-sticky-003-ref.html
+++ b/css/css-anchor-position/reference/anchor-scroll-to-sticky-003-ref.html
@@ -21,7 +21,7 @@ div {
 
 #anchored {
   position: absolute;
-  top: 70px;
+  top: 20px;
   left: 0;
   background: green;
 }
@@ -30,9 +30,9 @@ div {
 
 <div id="anchored"></div>
 <div id="scroller">
-  <div style="height: 250px"></div>
+  <div style="height: 200px"></div>
   <div id="anchor"></div>
-  <div style="height: 180px"></div>
+  <div style="height: 150px"></div>
 </div>
 
 <script>


### PR DESCRIPTION
Positioning a box changes its stacking order compared to non-positioned boxes, and its position in relation to other boxes also matters. This change makes the tests and references position and order the boxes the same way so that the tests and references can properly match.