### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295009

### DIFF
--- a/css/css-anchor-position/last-successful-change-fallbacks.html
+++ b/css/css-anchor-position/last-successful-change-fallbacks.html
@@ -45,13 +45,13 @@
     anchor.style.top = "150px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 250);
+    assert_equals(anchored.offsetTop, 200);
   }, "No successful position, keep flip-block");
 
   promise_test(async () => {
     anchored.style.positionTryFallbacks = "flip-block, --foo";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, -50);
+    assert_equals(anchored.offsetTop, 0);
   }, "No successful position, last successful invalidated by position-try-fallbacks change");
 </script>

--- a/css/css-anchor-position/last-successful-change-try-rule.html
+++ b/css/css-anchor-position/last-successful-change-try-rule.html
@@ -48,7 +48,7 @@
     anchor.style.top = "150px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 250);
+    assert_equals(anchored.offsetTop, 200);
   }, "No successful position, keep --try");
 
   promise_test(async () => {
@@ -56,6 +56,6 @@
     anchor_sheet.sheet.cssRules[3].style.positionArea = "bottom";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, -50);
+    assert_equals(anchored.offsetTop, 0);
   }, "No successful position, last successful invalidated by @position-try change");
 </script>

--- a/css/css-anchor-position/last-successful-iframe.html
+++ b/css/css-anchor-position/last-successful-iframe.html
@@ -55,7 +55,7 @@
       anchor.style.top = "150px";
       await waitUntilNextAnimationFrame();
       await waitUntilNextAnimationFrame();
-      assert_equals(anchored.offsetTop, 250);
+      assert_equals(anchored.offsetTop, 200);
     }, "No successful position, keep flip-block");
 
     promise_test(async () => {

--- a/css/css-anchor-position/last-successful-intermediate-ignored.html
+++ b/css/css-anchor-position/last-successful-intermediate-ignored.html
@@ -49,6 +49,6 @@
     anchor.style.top = "150px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 250);
+    assert_equals(anchored.offsetTop, 200);
   }, "No successful position (with intermediate successful), keep flip-block");
 </script>

--- a/css/css-anchor-position/last-successful-pseudo-element-basic.html
+++ b/css/css-anchor-position/last-successful-pseudo-element-basic.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<title>CSS Anchor Positioning: basic last successful position fallback</title>
+
+<title>CSS Anchor Positioning: basic last successful position fallback on pseudo-elements</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
 <link rel="help" href="https://drafts.csswg.org/css-anchor-position/#last-successful-position-fallback">
+
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/test-common.js"></script>
+
 <style>
   #container {
     position: relative;
@@ -20,38 +25,51 @@
     background: red;
     anchor-name: --a;
   }
-  #anchored {
+  #anchored::before {
     position-anchor: --a;
+    /*
+        We can't use position-area, since there's no way to access offsetTop of
+        pseudo-elements to check for position. Instead, we have to use anchor()
+        and check the computed inset values.
+    */
+    bottom: anchor(top);
+    left: anchor(left);
     position-try-fallbacks: flip-block;
     position: absolute;
     width: 100px;
     height: 200px;
-    position-area: top center;
     background: lime;
+    content: "";
   }
 </style>
+
 <div id="container">
   <div id="anchor"></div>
   <div id="anchored"></div>
 </div>
+
 <script>
   promise_test(async () => {
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 200);
+    const anchoredStyle = getComputedStyle(anchored, "::before");
+    assert_equals(anchoredStyle.top, "200px");
   }, "Starts rendering with flip-block");
 
   promise_test(async () => {
     anchor.style.top = "150px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 200);
+    const anchoredStyle = getComputedStyle(anchored, "::before");
+    assert_equals(anchoredStyle.top, "250px");
   }, "No successful position, keep flip-block");
 
   promise_test(async () => {
     anchor.style.top = "200px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 0);
+    const anchoredStyle = getComputedStyle(anchored, "::before");
+    assert_equals(anchoredStyle.top, "0px");
   }, "Base position without fallback now successful");
 </script>
+

--- a/css/css-anchor-position/last-successful-pseudo-element-fallbacks.html
+++ b/css/css-anchor-position/last-successful-pseudo-element-fallbacks.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<title>CSS Anchor Positioning: basic last successful position fallback</title>
+
+<title>CSS Anchor Positioning: changing position-try-fallbacks invalidates last successful position fallback on pseudo-elements</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
 <link rel="help" href="https://drafts.csswg.org/css-anchor-position/#last-successful-position-fallback">
+
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/test-common.js"></script>
+
 <style>
   #container {
     position: relative;
@@ -20,16 +25,26 @@
     background: red;
     anchor-name: --a;
   }
-  #anchored {
+  #anchored::before {
     position-anchor: --a;
+    bottom: anchor(top);
+    left: anchor(left);
     position-try-fallbacks: flip-block;
     position: absolute;
     width: 100px;
     height: 200px;
-    position-area: top center;
     background: lime;
+    content: "";
+  }
+  /*
+    Hack to change position-try-fallbacks of the pseudo-element,
+    since there's no easy way to change it in JavaScript.
+  */
+  #anchored.new-fallback::before {
+    position-try-fallbacks: flip-block, --foo;
   }
 </style>
+
 <div id="container">
   <div id="anchor"></div>
   <div id="anchored"></div>
@@ -38,20 +53,24 @@
   promise_test(async () => {
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 200);
+    const anchoredStyle = getComputedStyle(anchored, "::before");
+    assert_equals(anchoredStyle.top, "200px");
   }, "Starts rendering with flip-block");
 
   promise_test(async () => {
     anchor.style.top = "150px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 200);
+    const anchoredStyle = getComputedStyle(anchored, "::before");
+    assert_equals(anchoredStyle.top, "250px");
   }, "No successful position, keep flip-block");
 
   promise_test(async () => {
-    anchor.style.top = "200px";
+    anchored.classList.add("new-fallback");
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 0);
-  }, "Base position without fallback now successful");
+    const anchoredStyle = getComputedStyle(anchored, "::before");
+    assert_equals(anchoredStyle.top, "-50px");
+  }, "No successful position, last successful invalidated by position-try-fallbacks change");
 </script>
+

--- a/css/css-anchor-position/position-try-transition-basic.html
+++ b/css/css-anchor-position/position-try-transition-basic.html
@@ -20,6 +20,8 @@
     width: 50px;
     height: 50px;
     background: skyblue;
+  }
+  #target.fallback {
     position-try-fallbacks: --200;
   }
   #target.anim {
@@ -44,7 +46,7 @@
     t.add_cleanup(cleanup);
     assert_equals(target.offsetLeft, 300);
     cb.classList.add('shrink');
-    target.classList.add('anim');
+    target.classList.add('fallback', 'anim');
     // Now we take the --200 fallback:
     assert_equals(target.offsetLeft, 250);
   }, 'Transition when @position-try is applied');
@@ -52,8 +54,10 @@
   test((t) => {
     t.add_cleanup(cleanup);
     cb.classList.add('shrink');
+    target.classList.add('fallback');
     assert_equals(target.offsetLeft, 200);
     cb.classList.remove('shrink');
+    target.classList.remove('fallback');
     target.classList.add('anim');
     assert_equals(target.offsetLeft, 250);
   }, 'Transition when @position-try is unapplied');

--- a/css/css-anchor-position/position-try-transition-flip.html
+++ b/css/css-anchor-position/position-try-transition-flip.html
@@ -32,6 +32,8 @@
     width: 50px;
     height: 50px;
     background: skyblue;
+  }
+  #target.fallback {
     position-try-fallbacks: flip-start;
   }
   #target.anim {
@@ -54,15 +56,17 @@
     t.add_cleanup(cleanup);
     assert_equals(target.offsetLeft, 300);
     cb.classList.add('shrink');
-    target.classList.add('anim');
+    target.classList.add('fallback', 'anim');
     assert_equals(target.offsetLeft, 275);
   }, 'Transition to a flipped state');
 
   test((t) => {
     t.add_cleanup(cleanup);
     cb.classList.add('shrink');
+    target.classList.add('fallback');
     assert_equals(target.offsetLeft, 250);
     cb.classList.remove('shrink');
+    target.classList.remove('fallback');
     target.classList.add('anim');
     assert_equals(target.offsetLeft, 275);
   }, 'Transition to an unflipped state');


### PR DESCRIPTION
WebKit export from bug: [\[css-anchor-position-1\] Fallback options are not "sticky"](https://bugs.webkit.org/show_bug.cgi?id=295009)