### PR TITLE
[wdspec] introduce `Maybe` and `Nullable` types

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/_module.py
+++ b/tools/webdriver/webdriver/bidi/modules/_module.py
@@ -104,8 +104,9 @@ def to_camelcase(name: str) -> str:
 
 def remove_undefined(obj: Any) -> Any:
     """
-    Removes entries from a dictionary where the value is UNDEFINED.
-    Recursively processes nested dictionaries.
+    Removes entries from a dictionary where the value is UNDEFINED. Also removes
+    UNDEFINED values from lists. Recursively processes nested dictionaries and
+    lists.
 
     >>> from ..undefined import UNDEFINED
     >>> remove_undefined({"a": 1, "b": UNDEFINED, "c": 3})

--- a/tools/webdriver/webdriver/bidi/modules/_module.py
+++ b/tools/webdriver/webdriver/bidi/modules/_module.py
@@ -103,4 +103,51 @@ def to_camelcase(name: str) -> str:
 
 
 def remove_undefined(obj: Mapping[str, Any]) -> Mapping[str, Any]:
-    return {key: value for key, value in obj.items() if value != UNDEFINED}
+    """
+    Removes entries from a dictionary where the value is UNDEFINED.
+    Recursively processes nested dictionaries.
+
+    >>> from ..undefined import UNDEFINED
+    >>> remove_undefined({"a": 1, "b": UNDEFINED, "c": 3})
+    {'a': 1, 'c': 3}
+
+    >>> remove_undefined({"a": 1, "b": {"x": UNDEFINED, "y": 2}, "c": UNDEFINED})
+    {'a': 1, 'b': {'y': 2}}
+
+    >>> remove_undefined({"a": 1, "b": [1, UNDEFINED, 3], "c": UNDEFINED})
+    {'a': 1, 'b': [1, 3]}
+
+    >>> remove_undefined({"a": 1, "b": [{"x": UNDEFINED, "y": 2}], "c": UNDEFINED})
+    {'a': 1, 'b': [{'y': 2}]}
+
+    >>> remove_undefined({"a": UNDEFINED, "b": {"x": UNDEFINED}})
+    {'b': {}}
+
+    >>> remove_undefined({})
+    {}
+
+    >>> remove_undefined([])
+    []
+
+    >>> remove_undefined(1)
+    1
+
+    >>> remove_undefined("foo")
+    'foo'
+
+    >>> remove_undefined(None)
+
+    """
+    if isinstance(obj, Mapping):
+        new_obj = {}
+        for key, value in obj.items():
+            if value is not UNDEFINED:
+                new_obj[key] = remove_undefined(value)
+        return new_obj
+    elif isinstance(obj, list):
+        new_list = []
+        for item in obj:
+            if item is not UNDEFINED:
+                new_list.append(remove_undefined(item))
+        return new_list
+    return obj

--- a/tools/webdriver/webdriver/bidi/modules/_module.py
+++ b/tools/webdriver/webdriver/bidi/modules/_module.py
@@ -102,7 +102,7 @@ def to_camelcase(name: str) -> str:
     return "".join(parts)
 
 
-def remove_undefined(obj: Mapping[str, Any]) -> Mapping[str, Any]:
+def remove_undefined(obj: Any) -> Any:
     """
     Removes entries from a dictionary where the value is UNDEFINED.
     Recursively processes nested dictionaries.

--- a/tools/webdriver/webdriver/bidi/modules/emulation.py
+++ b/tools/webdriver/webdriver/bidi/modules/emulation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Mapping, MutableMapping, Optional
+from typing import Any, Dict, List, Literal, Mapping, Optional
 
 from ._module import BidiModule, command
 from ..undefined import UNDEFINED, Undefinable
@@ -6,69 +6,52 @@ from ..undefined import UNDEFINED, Undefinable
 
 class CoordinatesOptions(Dict[str, Any]):
     def __init__(
-        self,
-        latitude: float,
-        longitude: float,
-        accuracy: Undefinable[float] = UNDEFINED,
-        altitude: Undefinable[float] = UNDEFINED,
-        altitude_accuracy: Undefinable[float] = UNDEFINED,
-        heading: Undefinable[float] = UNDEFINED,
-        speed: Undefinable[float] = UNDEFINED,
+            self,
+            latitude: float,
+            longitude: float,
+            accuracy: Undefinable[float] = UNDEFINED,
+            altitude: Undefinable[Optional[float]] = UNDEFINED,
+            altitude_accuracy: Undefinable[Optional[float]] = UNDEFINED,
+            heading: Undefinable[Optional[float]] = UNDEFINED,
+            speed: Undefinable[Optional[float]] = UNDEFINED,
     ):
         self["latitude"] = latitude
         self["longitude"] = longitude
-
-        if accuracy is not UNDEFINED:
-            self["accuracy"] = accuracy
-        if altitude is not UNDEFINED:
-            self["altitude"] = altitude
-        if altitude_accuracy is not UNDEFINED:
-            self["altitudeAccuracy"] = altitude_accuracy
-        if heading is not UNDEFINED:
-            self["heading"] = heading
-        if speed is not UNDEFINED:
-            self["speed"] = speed
+        self["accuracy"] = accuracy
+        self["altitude"] = altitude
+        self["altitudeAccuracy"] = altitude_accuracy
+        self["heading"] = heading
+        self["speed"] = speed
 
 
 class Emulation(BidiModule):
     @command
     def set_geolocation_override(
-        self,
-        coordinates: Undefinable[CoordinatesOptions] = UNDEFINED,
-        error: Undefinable[Dict[str, Any]] = UNDEFINED,
-        contexts: Undefinable[List[str]] = UNDEFINED,
-        user_contexts: Undefinable[List[str]] = UNDEFINED,
+            self,
+            coordinates: Undefinable[Optional[CoordinatesOptions]] = UNDEFINED,
+            error: Undefinable[Dict[str, Any]] = UNDEFINED,
+            contexts: Undefinable[List[str]] = UNDEFINED,
+            user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
-        params: MutableMapping[str, Any] = {}
-
-        if coordinates is not UNDEFINED:
-            params["coordinates"] = coordinates
-        if error is not UNDEFINED:
-            params["error"] = error
-        if contexts is not UNDEFINED:
-            params["contexts"] = contexts
-        if user_contexts is not UNDEFINED:
-            params["userContexts"] = user_contexts
-
-        return params
+        return {
+            "coordinates": coordinates,
+            "error": error,
+            "contexts": contexts,
+            "userContexts": user_contexts
+        }
 
     @command
     def set_locale_override(
-        self,
-        locale: Optional[str],
-        contexts: Undefinable[List[str]] = UNDEFINED,
-        user_contexts: Undefinable[List[str]] = UNDEFINED,
+            self,
+            locale: Optional[str],
+            contexts: Undefinable[List[str]] = UNDEFINED,
+            user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
-        params: MutableMapping[str, Any] = {
-            "locale": locale
+        return {
+            "locale": locale,
+            "contexts": contexts,
+            "userContexts": user_contexts
         }
-
-        if contexts is not UNDEFINED:
-            params["contexts"] = contexts
-        if user_contexts is not UNDEFINED:
-            params["userContexts"] = user_contexts
-
-        return params
 
     @command
     def set_scripting_enabled(
@@ -85,21 +68,16 @@ class Emulation(BidiModule):
 
     @command
     def set_screen_orientation_override(
-        self,
-        screen_orientation:Dict[str, Any],
-        contexts: Undefinable[List[str]] = UNDEFINED,
-        user_contexts: Undefinable[List[str]] = UNDEFINED,
+            self,
+            screen_orientation: Optional[Dict[str, Any]],
+            contexts: Undefinable[List[str]] = UNDEFINED,
+            user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
-        params: MutableMapping[str, Any] = {
-            "screenOrientation": screen_orientation
+        return {
+            "screenOrientation": screen_orientation,
+            "contexts": contexts,
+            "userContexts": user_contexts
         }
-
-        if contexts is not UNDEFINED:
-            params["contexts"] = contexts
-        if user_contexts is not UNDEFINED:
-            params["userContexts"] = user_contexts
-
-        return params
 
     @command
     def set_timezone_override(
@@ -108,16 +86,11 @@ class Emulation(BidiModule):
             contexts: Undefinable[List[str]] = UNDEFINED,
             user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
-        params: MutableMapping[str, Any] = {
-            "timezone": timezone
+        return {
+            "timezone": timezone,
+            "contexts": contexts,
+            "userContexts": user_contexts
         }
-
-        if contexts is not UNDEFINED:
-            params["contexts"] = contexts
-        if user_contexts is not UNDEFINED:
-            params["userContexts"] = user_contexts
-
-        return params
 
     @command
     def set_user_agent_override(

--- a/tools/webdriver/webdriver/bidi/modules/emulation.py
+++ b/tools/webdriver/webdriver/bidi/modules/emulation.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, List, Literal, Mapping, Optional
+from typing import Any, Dict, List, Literal, Mapping
 
 from ._module import BidiModule, command
-from ..undefined import UNDEFINED, Maybe
+from ..undefined import UNDEFINED, Maybe, Nullable
 
 
 class CoordinatesOptions(Dict[str, Any]):
@@ -10,10 +10,10 @@ class CoordinatesOptions(Dict[str, Any]):
             latitude: float,
             longitude: float,
             accuracy: Maybe[float] = UNDEFINED,
-            altitude: Maybe[Optional[float]] = UNDEFINED,
-            altitude_accuracy: Maybe[Optional[float]] = UNDEFINED,
-            heading: Maybe[Optional[float]] = UNDEFINED,
-            speed: Maybe[Optional[float]] = UNDEFINED,
+            altitude: Maybe[Nullable[float]] = UNDEFINED,
+            altitude_accuracy: Maybe[Nullable[float]] = UNDEFINED,
+            heading: Maybe[Nullable[float]] = UNDEFINED,
+            speed: Maybe[Nullable[float]] = UNDEFINED,
     ):
         self["latitude"] = latitude
         self["longitude"] = longitude
@@ -28,7 +28,7 @@ class Emulation(BidiModule):
     @command
     def set_geolocation_override(
             self,
-            coordinates: Maybe[Optional[CoordinatesOptions]] = UNDEFINED,
+            coordinates: Maybe[Nullable[CoordinatesOptions]] = UNDEFINED,
             error: Maybe[Dict[str, Any]] = UNDEFINED,
             contexts: Maybe[List[str]] = UNDEFINED,
             user_contexts: Maybe[List[str]] = UNDEFINED,
@@ -43,7 +43,7 @@ class Emulation(BidiModule):
     @command
     def set_locale_override(
             self,
-            locale: Optional[str],
+            locale: Nullable[str],
             contexts: Maybe[List[str]] = UNDEFINED,
             user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
@@ -56,7 +56,7 @@ class Emulation(BidiModule):
     @command
     def set_scripting_enabled(
             self,
-            enabled: Literal[False, None],
+            enabled: Nullable[Literal[False]],
             contexts: Maybe[List[str]] = UNDEFINED,
             user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
@@ -69,7 +69,7 @@ class Emulation(BidiModule):
     @command
     def set_screen_orientation_override(
             self,
-            screen_orientation: Optional[Dict[str, Any]],
+            screen_orientation: Nullable[Dict[str, Any]],
             contexts: Maybe[List[str]] = UNDEFINED,
             user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
@@ -82,7 +82,7 @@ class Emulation(BidiModule):
     @command
     def set_timezone_override(
             self,
-            timezone: Optional[str],
+            timezone: Nullable[str],
             contexts: Maybe[List[str]] = UNDEFINED,
             user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
@@ -95,9 +95,9 @@ class Emulation(BidiModule):
     @command
     def set_user_agent_override(
             self,
-            user_agent: Union[str, None],
-            contexts: Union[List[str], Undefined] = UNDEFINED,
-            user_contexts: Union[List[str], Undefined] = UNDEFINED,
+            user_agent: Nullable[str],
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "userAgent": user_agent,

--- a/tools/webdriver/webdriver/bidi/modules/emulation.py
+++ b/tools/webdriver/webdriver/bidi/modules/emulation.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, List, Literal, Mapping, MutableMapping, Optional, \
-    Union
+from typing import Any, Dict, List, Literal, Mapping, MutableMapping, Optional
 
 from ._module import BidiModule, command
-from ..undefined import UNDEFINED, Undefined
+from ..undefined import UNDEFINED, Undefinable
 
 
 class CoordinatesOptions(Dict[str, Any]):
@@ -10,24 +9,24 @@ class CoordinatesOptions(Dict[str, Any]):
         self,
         latitude: float,
         longitude: float,
-        accuracy: Optional[float] = None,
-        altitude: Optional[float] = None,
-        altitude_accuracy: Optional[float] = None,
-        heading: Optional[float] = None,
-        speed: Optional[float] = None,
+        accuracy: Undefinable[float] = UNDEFINED,
+        altitude: Undefinable[float] = UNDEFINED,
+        altitude_accuracy: Undefinable[float] = UNDEFINED,
+        heading: Undefinable[float] = UNDEFINED,
+        speed: Undefinable[float] = UNDEFINED,
     ):
         self["latitude"] = latitude
         self["longitude"] = longitude
 
-        if accuracy is not None:
+        if accuracy is not UNDEFINED:
             self["accuracy"] = accuracy
-        if altitude is not None:
+        if altitude is not UNDEFINED:
             self["altitude"] = altitude
-        if altitude_accuracy is not None:
+        if altitude_accuracy is not UNDEFINED:
             self["altitudeAccuracy"] = altitude_accuracy
-        if heading is not None:
+        if heading is not UNDEFINED:
             self["heading"] = heading
-        if speed is not None:
+        if speed is not UNDEFINED:
             self["speed"] = speed
 
 
@@ -35,20 +34,20 @@ class Emulation(BidiModule):
     @command
     def set_geolocation_override(
         self,
-        coordinates: Union[CoordinatesOptions, Undefined] = UNDEFINED,
-        error: Optional[Dict[str, Any]] = None,
-        contexts: Optional[List[str]] = None,
-        user_contexts: Optional[List[str]] = None,
+        coordinates: Undefinable[CoordinatesOptions] = UNDEFINED,
+        error: Undefinable[Dict[str, Any]] = UNDEFINED,
+        contexts: Undefinable[List[str]] = UNDEFINED,
+        user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {}
 
         if coordinates is not UNDEFINED:
             params["coordinates"] = coordinates
-        if error is not None:
+        if error is not UNDEFINED:
             params["error"] = error
-        if contexts is not None:
+        if contexts is not UNDEFINED:
             params["contexts"] = contexts
-        if user_contexts is not None:
+        if user_contexts is not UNDEFINED:
             params["userContexts"] = user_contexts
 
         return params
@@ -56,17 +55,17 @@ class Emulation(BidiModule):
     @command
     def set_locale_override(
         self,
-        locale: Union[str, None],
-        contexts: Optional[List[str]] = None,
-        user_contexts: Optional[List[str]] = None,
+        locale: Optional[str],
+        contexts: Undefinable[List[str]] = UNDEFINED,
+        user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {
             "locale": locale
         }
 
-        if contexts is not None:
+        if contexts is not UNDEFINED:
             params["contexts"] = contexts
-        if user_contexts is not None:
+        if user_contexts is not UNDEFINED:
             params["userContexts"] = user_contexts
 
         return params
@@ -75,8 +74,8 @@ class Emulation(BidiModule):
     def set_scripting_enabled(
             self,
             enabled: Literal[False, None],
-            contexts: Union[List[str], Undefined] = UNDEFINED,
-            user_contexts: Union[List[str], Undefined] = UNDEFINED,
+            contexts: Undefinable[List[str]] = UNDEFINED,
+            user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "enabled": enabled,
@@ -88,16 +87,16 @@ class Emulation(BidiModule):
     def set_screen_orientation_override(
         self,
         screen_orientation:Dict[str, Any],
-        contexts: Optional[List[str]] = None,
-        user_contexts: Optional[List[str]] = None,
+        contexts: Undefinable[List[str]] = UNDEFINED,
+        user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {
             "screenOrientation": screen_orientation
         }
 
-        if contexts is not None:
+        if contexts is not UNDEFINED:
             params["contexts"] = contexts
-        if user_contexts is not None:
+        if user_contexts is not UNDEFINED:
             params["userContexts"] = user_contexts
 
         return params
@@ -105,17 +104,17 @@ class Emulation(BidiModule):
     @command
     def set_timezone_override(
             self,
-            timezone: Union[str, None],
-            contexts: Optional[List[str]] = None,
-            user_contexts: Optional[List[str]] = None,
+            timezone: Optional[str],
+            contexts: Undefinable[List[str]] = UNDEFINED,
+            user_contexts: Undefinable[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {
             "timezone": timezone
         }
 
-        if contexts is not None:
+        if contexts is not UNDEFINED:
             params["contexts"] = contexts
-        if user_contexts is not None:
+        if user_contexts is not UNDEFINED:
             params["userContexts"] = user_contexts
 
         return params

--- a/tools/webdriver/webdriver/bidi/modules/emulation.py
+++ b/tools/webdriver/webdriver/bidi/modules/emulation.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Literal, Mapping, Optional
 
 from ._module import BidiModule, command
-from ..undefined import UNDEFINED, Undefinable
+from ..undefined import UNDEFINED, Maybe
 
 
 class CoordinatesOptions(Dict[str, Any]):
@@ -9,11 +9,11 @@ class CoordinatesOptions(Dict[str, Any]):
             self,
             latitude: float,
             longitude: float,
-            accuracy: Undefinable[float] = UNDEFINED,
-            altitude: Undefinable[Optional[float]] = UNDEFINED,
-            altitude_accuracy: Undefinable[Optional[float]] = UNDEFINED,
-            heading: Undefinable[Optional[float]] = UNDEFINED,
-            speed: Undefinable[Optional[float]] = UNDEFINED,
+            accuracy: Maybe[float] = UNDEFINED,
+            altitude: Maybe[Optional[float]] = UNDEFINED,
+            altitude_accuracy: Maybe[Optional[float]] = UNDEFINED,
+            heading: Maybe[Optional[float]] = UNDEFINED,
+            speed: Maybe[Optional[float]] = UNDEFINED,
     ):
         self["latitude"] = latitude
         self["longitude"] = longitude
@@ -28,10 +28,10 @@ class Emulation(BidiModule):
     @command
     def set_geolocation_override(
             self,
-            coordinates: Undefinable[Optional[CoordinatesOptions]] = UNDEFINED,
-            error: Undefinable[Dict[str, Any]] = UNDEFINED,
-            contexts: Undefinable[List[str]] = UNDEFINED,
-            user_contexts: Undefinable[List[str]] = UNDEFINED,
+            coordinates: Maybe[Optional[CoordinatesOptions]] = UNDEFINED,
+            error: Maybe[Dict[str, Any]] = UNDEFINED,
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "coordinates": coordinates,
@@ -44,8 +44,8 @@ class Emulation(BidiModule):
     def set_locale_override(
             self,
             locale: Optional[str],
-            contexts: Undefinable[List[str]] = UNDEFINED,
-            user_contexts: Undefinable[List[str]] = UNDEFINED,
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "locale": locale,
@@ -57,8 +57,8 @@ class Emulation(BidiModule):
     def set_scripting_enabled(
             self,
             enabled: Literal[False, None],
-            contexts: Undefinable[List[str]] = UNDEFINED,
-            user_contexts: Undefinable[List[str]] = UNDEFINED,
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "enabled": enabled,
@@ -70,8 +70,8 @@ class Emulation(BidiModule):
     def set_screen_orientation_override(
             self,
             screen_orientation: Optional[Dict[str, Any]],
-            contexts: Undefinable[List[str]] = UNDEFINED,
-            user_contexts: Undefinable[List[str]] = UNDEFINED,
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "screenOrientation": screen_orientation,
@@ -83,8 +83,8 @@ class Emulation(BidiModule):
     def set_timezone_override(
             self,
             timezone: Optional[str],
-            contexts: Undefinable[List[str]] = UNDEFINED,
-            user_contexts: Undefinable[List[str]] = UNDEFINED,
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
     ) -> Mapping[str, Any]:
         return {
             "timezone": timezone,

--- a/tools/webdriver/webdriver/bidi/undefined.py
+++ b/tools/webdriver/webdriver/bidi/undefined.py
@@ -17,5 +17,5 @@ UNDEFINED = Undefined.UNDEFINED
 T = TypeVar("T")
 
 #: A type hint for a value that can be of a specific type or UNDEFINED.
-#: For example, ``Undefinable[str]`` is equivalent to ``Union[str, Undefined]``.
-Undefinable = Union[T, Undefined]
+#: For example, ``Maybe[str]`` is equivalent to ``Union[str, Undefined]``.
+Maybe = Union[T, Undefined]

--- a/tools/webdriver/webdriver/bidi/undefined.py
+++ b/tools/webdriver/webdriver/bidi/undefined.py
@@ -1,6 +1,21 @@
-class Undefined:
-    def __init__(self) -> None:
-        raise RuntimeError('Import UNDEFINED instead.')
+import enum
+from enum import Enum
+from typing import TypeVar, Union
 
 
-UNDEFINED = Undefined.__new__(Undefined)
+class Undefined(Enum):
+    """
+    Class representin special value that indicates that a property is notset.
+    """
+
+    UNDEFINED = enum.auto()
+
+
+UNDEFINED = Undefined.UNDEFINED
+"""A special value that indicates that a property is not set."""
+
+T = TypeVar("T")
+
+#: A type hint for a value that can be of a specific type or UNDEFINED.
+#: For example, ``Undefinable[str]`` is equivalent to ``Union[str, Undefined]``.
+Undefinable = Union[T, Undefined]

--- a/tools/webdriver/webdriver/bidi/undefined.py
+++ b/tools/webdriver/webdriver/bidi/undefined.py
@@ -5,7 +5,7 @@ from typing import TypeVar, Union
 
 class Undefined(Enum):
     """
-    Class representin special value that indicates that a property is notset.
+    Class representing special value that indicates that a property is notset.
     """
 
     UNDEFINED = enum.auto()
@@ -19,3 +19,7 @@ T = TypeVar("T")
 #: A type hint for a value that can be of a specific type or UNDEFINED.
 #: For example, ``Maybe[str]`` is equivalent to ``Union[str, Undefined]``.
 Maybe = Union[T, Undefined]
+
+#: A type hint which can have protocol values `null`. Intended to be used
+# instead of `Optional` to avoid confusion.
+Nullable = Union[T, None]

--- a/tools/webdriver/webdriver/bidi/undefined.py
+++ b/tools/webdriver/webdriver/bidi/undefined.py
@@ -5,7 +5,7 @@ from typing import TypeVar, Union
 
 class Undefined(Enum):
     """
-    Class representing special value that indicates that a property is notset.
+    Class representing special value that indicates that a property is not set.
     """
 
     UNDEFINED = enum.auto()

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -176,14 +176,14 @@ class BidiEmulationSetGeolocationOverrideAction:
             raise ValueError(
                 "Params `error` and `coordinates` are mutually exclusive")
 
-        # If `error` is present, set it. Otherwise, do not pass it (error: None).
-        # Note, unlike `coordinates`, `error` cannot be `UNDEFINED`. It's either
-        # `None` and it's not passed, or some dict value which is passed.
-        error = payload['error'] if 'error' in payload else None
-        # If `error` is present, do not pass `coordinates` (coordinates: UNDEFINED).
-        # Otherwise, remove emulation (coordinates: None).
-        coordinates = payload['coordinates'] if 'coordinates' in payload else (
-            None if error is None else webdriver.bidi.undefined.UNDEFINED)
+        # If `error` is present, set it. Otherwise, use `UNDEFINED`.
+        error = payload['error'] if 'error' in payload else webdriver.bidi.undefined.UNDEFINED
+        coordinates = webdriver.bidi.undefined.UNDEFINED
+        if 'coordinates' in payload:
+            coordinates = payload['coordinates']
+        elif error is webdriver.bidi.undefined.UNDEFINED:
+            # If `error` is not present, pass `coordinates` of null.
+            coordinates = None
 
         if "contexts" not in payload:
             raise ValueError("Missing required parameter: contexts")


### PR DESCRIPTION
* In order to avoid confusion, add `Maybe` and `Nullable` types for WebDriver BiDi parameters.
* And do not use `None` for missing parameter in `Emulation` module.

Out of scope: updating of the other modules.

Context: https://github.com/w3c/webdriver-bidi/issues/642