### PR TITLE
[wptrunner] Collect per-test trace events from Chromium

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -86,6 +86,15 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
         # fail to create a session if they don't recognize this capability.
         chrome_options["quitGracefully"] = True
 
+    if trace_categories := kwargs.get("trace_categories"):
+        executor_kwargs["enable_tracing"] = True
+        capabilities["goog:loggingPrefs"] = {
+            "performance": "INFO",
+        }
+        chrome_options["perfLoggingPrefs"] = {
+            "traceCategories": trace_categories,
+        }
+
     # Here we set a few Chrome flags that are always passed.
     # ChromeDriver's "acceptInsecureCerts" capability only controls the current
     # browsing context, whereas the CLI flag works for workers, too.

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -381,6 +381,12 @@ scheme host and port.""")
         help=("Reuse a window across `testharness.js` tests where possible, "
               "which can speed up testing. Also useful for ensuring that the "
               "renderer process has a stable PID for a debugger to attach to."))
+    chrome_group.add_argument(
+        "--trace-categories",
+        metavar="CATEGORIES",
+        nargs="?",
+        const="blink,blink.bindings",
+        help="Record traces under the given categories for each test.")
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", help="Sauce Labs browser name")


### PR DESCRIPTION
When `wpt run --trace-categories` is specified, the [trace events][0] are retrieved from an internal ChromeDriver buffer and logged as an `extra` test result field. The trace will be consumed by an event listener on the Chromium side (https://crrev.com/c/6820247) and can be viewed in https://ui.perfetto.dev/.

Partially fulfills https://crbug.com/434017035

[0]: https://developer.chrome.com/docs/chromedriver/logging/performance-log