### PR TITLE
Add test for float with display:none (CSS2)

### DIFF
--- a/css/CSS2/float-displaynone-001-ref.html
+++ b/css/CSS2/float-displaynone-001-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: no box visible</title>
+
+<style>
+  .container {
+    width: 300px;
+    height: 150px;
+    border: 2px solid black;
+  }
+</style>
+
+<div class="container"></div>

--- a/css/CSS2/float-displaynone-001.html
+++ b/css/CSS2/float-displaynone-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>float:right with display:none should clean up render tree</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=150271">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=544290">
+<link rel="author" title="Riya Kanani" href="https://github.com/riyak145">
+<link rel="match" href="float-displaynone-001-ref.html">
+
+<style>
+  .container {
+    width: 300px;
+    height: 150px;
+    border: 2px solid black;
+  }
+  .box {
+    width: 100px;
+    height: 100px;
+    float: right;
+    background: red;
+    display: none; /* here the bug case */
+  }
+</style>
+
+<div class="container">
+  <div class="box"></div>
+</div>


### PR DESCRIPTION
This pull request adds a new CSS2 test to check the behavior when a floated element also has display:none.

I’ve included two files:
float-displaynone-001.html (the test)
float-displaynone-001-ref.html (the reference)

The test was linted with ./wpt lint and should help ensure consistent handling across browsers.
Closes #5466