### PR TITLE
Revert "Add accept-encoding:identity for range requests"

### DIFF
--- a/fetch/range/general.any.js
+++ b/fetch/range/general.any.js
@@ -88,10 +88,7 @@ promise_test(async () => {
     });
 
     const response = await fetch(stashTakeURL);
-
-    assert_regexp_match(await response.json(),
-                        /.*\bidentity\b.*/,
-                        `Expect identity accept-encoding if range header is ${JSON.stringify(rangeHeader)}`);
+    assert_equals(await response.json(), 'identity', `Expect identity accept-encoding if range header is ${JSON.stringify(rangeHeader)}`);
   }
 }, `Fetch with range header will be sent with Accept-Encoding: identity`);
 


### PR DESCRIPTION
This reverts commit d190b1e9ab78945bbacc9d1baeda252319c69932.

This commit, introduced in https://github.com/web-platform-tests/wpt/pull/35804, was really suspicious. It makes it so that the `Accept-Encoding` header need only contain the string `identity` in it *somewhere*. This means that, for instance, `"gzip, deflate, br, zstd, identity"` passes since it contains `identity`.

It was *supposedly* reviewed in Firefox as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1782835, but passed by entirely without comment. 

https://github.com/whatwg/fetch/pull/751 seems to suggest that if a `range` header is present, then `identity` must be the *entire contents* of the `Accept-Encoding` header. Surely, it was not intended to allow other encodings if `identity` is also present somewhere. As far as I can tell, https://github.com/web-platform-tests/wpt/pull/35804 serves only to allow Firefox to bypass this requirement.

https://bugzilla.mozilla.org/show_bug.cgi?id=1782835 seems to have not undergone review from any third party. It contains a putative code change to Firefox's HTTP client code, but per https://bugzilla.mozilla.org/show_bug.cgi?id=1983387, that code change doesn't appear to actually do anything. The only other change in that changeset is this update to WPT, which only serves to obscure the fact that the other code changes don't work!

/cc @jakearchibald (correct me if I'm wrong about any of this)