### PR TITLE
Fix css of WebVTT ref files to match real vtt cue settings

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
@@ -14,8 +14,8 @@ body { margin:0 }
 .cue {
     position: absolute;
     top: 0;
-    right: 51.2px;
-    width: 64px;
+    left: 80%;
+    width: 20%;
     text-align: left;
     font-family: Ahem, sans-serif;
     color: green;

--- a/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
@@ -14,8 +14,8 @@ body { margin:0 }
 .cue {
     position: absolute;
     top: 0;
-    right: 51.2px;
-    width: 64px;
+    left: 80%;
+    width: 20%;
     text-align: left;
     font-family: Ahem, sans-serif;
     color: green;


### PR DESCRIPTION
dom_override_cue_align_position_line_size_while_paused.html and dom_override_cue_align_position_line_size.html give the vtt cue the following settings:

        c.align = 'start';
        c.position = 80;
        c.line = 0;
        c.size = 20;

Align = "start" and position = 80 mean that the left edge of the cue is positioned 80% of the video width (320px) to the right of the left edge of the video. Currently the ref files set right: 51.2px on the fake cue (16%). This should be changed to left: 80% to match the real vtt cue. Additionally this patch changes width: 64px to width: 20% on the ref cue for readability.