### PR TITLE
Map extended attr() tests to web-features

### DIFF
--- a/css/css-values/WEB_FEATURES.yml
+++ b/css/css-values/WEB_FEATURES.yml
@@ -2,6 +2,9 @@ features:
 - name: abs-sign
   files:
   - signs-abs-*
+- name: attr
+  files:
+  - attr-*
 - name: cap
   files:
   - cap-*


### PR DESCRIPTION
The 21 files attr-* files all contain the string 'attr(' and of them
only attr-notype-fallback.html contains the string 'content:' which
could be a test for the older more limited attr(). However, that test is
for attr() fallback support, which is a more recent addition, so it's
correct to map it to "attr" and not "attr-contents".
