### PR TITLE
add caretRangeFromPoint tests

### DIFF
--- a/css/cssom/caretRangeFromPoint-replace-document.tentative.html
+++ b/css/cssom/caretRangeFromPoint-replace-document.tentative.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>document.caretRangeFromPoint()</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/12362" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    const textarea = document.createElement("textarea");
+    document.replaceChild(textarea, document.documentElement);
+    let range = document.caretRangeFromPoint(0, 0);
+    assert_true(range instanceof Range);
+    assert_equals(range.startOffset, 1);
+    assert_equals(range.endOffset, 1);
+    assert_equals(range.startContainer, textarea);
+    assert_equals(range.endContainer, textarea);
+  }, "document.caretRangeFromPoint(0, 0)");
+</script>

--- a/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html
+++ b/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html
@@ -10,7 +10,7 @@
     translate: -50%;
   }
 </style>
-<textarea id="textarea" style="translate: -50% -50%">
+<textarea id="textarea">
 AAAAAAAAAAAAAAAAAAAAA</textarea
 >
 <script>

--- a/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html
+++ b/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>document.caretRangeFromPoint()</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/12362" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  textarea {
+    display: block;
+    translate: -50%;
+  }
+</style>
+<textarea id="textarea" style="translate: -50% -50%">
+AAAAAAAAAAAAAAAAAAAAA</textarea
+>
+<script>
+  test(() => {
+    let range = document.caretRangeFromPoint(0, 0);
+    assert_true(range instanceof Range);
+    assert_equals(range.startOffset, 0);
+    assert_equals(range.endOffset, 0);
+    assert_equals(range.startContainer, textarea);
+    assert_equals(range.endContainer, textarea);
+  }, "document.caretRangeFromPoint(0, 0)");
+  test(() => {
+    let range = document.caretRangeFromPoint(10, 10);
+    assert_true(range instanceof Range);
+    assert_equals(range.startOffset, 0);
+    assert_equals(range.endOffset, 0);
+    assert_equals(range.startContainer, textarea);
+    assert_equals(range.endContainer, textarea);
+  }, "document.caretRangeFromPoint(10, 10)");
+</script>

--- a/css/cssom/caretRangeFromPoint.tentative.html
+++ b/css/cssom/caretRangeFromPoint.tentative.html
@@ -98,13 +98,14 @@
     const x = rect.left + characterWidth * characterIndex;
     const y = rect.top + rect.height / 2;
     const range = document.caretRangeFromPoint(x, y);
+    const point = document.caretPositionFromPoint(x, y);
     assert_true(range instanceof Range);
-    assert_equals(range.startContainer, document.body);
-    assert_equals(range.endContainer, document.body);
+    assert_equals(range.startContainer, point.offsetNode);
+    assert_equals(range.endContainer, point.offsetNode);
     assert_equals(range.startOffset, characterIndex);
     assert_equals(range.endOffset, characterIndex);
     assert_true(range.collapsed);
-  }, "document.caretRangeFromPoint() on a shadow should return a Range pointing at document.body");
+  }, "document.caretRangeFromPoint() on a shadow should return a Range pointing at the same node as caretPositionFromPoint");
 
   test(() => {
     const rect = canvas.getBoundingClientRect();

--- a/css/cssom/caretRangeFromPoint.tentative.html
+++ b/css/cssom/caretRangeFromPoint.tentative.html
@@ -87,7 +87,7 @@
     assert_approx_equals(rangeRect.x, x, 1);
     assert_approx_equals(rangeRect.y, rect.height / 2, 3);
     assert_approx_equals(rangeRect.height, rect.height, 1);
-    assert_equals(rangeRect.width, 0, "Caret range should be collapsed");
+    assert_approx_equals(rangeRect.width, 0, 0.02, "Caret range should be collapsed");
   }, "document.caretRangeFromPoint() should return a client rect close to the given coords");
 
   test(() => {

--- a/css/cssom/caretRangeFromPoint.tentative.html
+++ b/css/cssom/caretRangeFromPoint.tentative.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>document.caretRangeFromPoint()</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/12362" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div {
+    display: inline-block;
+  }
+  canvas {
+    display: block;
+    background: green;
+  };
+</style>
+<div id="div">abc</div>
+<div id="shadow">
+  <template shadowrootmode="open">
+    <div>def</div>
+  </template>
+</div>
+
+<canvas id="canvas" width="500" height="500"></canvas>
+
+<script>
+  test(() => {
+    let range = document.caretRangeFromPoint();
+    assert_true(range instanceof Range);
+    assert_equals(range.startOffset, 0);
+    assert_equals(range.endOffset, 0);
+  }, "document.caretRangeFromPoint() (no supplied coordinates) returns Range with 0 0 values");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("");
+    let range = doc.caretRangeFromPoint(0, 0);
+    assert_equals(range, null);
+  }, "document.caretRangeFromPoint() should return null for a document with no viewport");
+
+  test(() => {
+    assert_equals(document.caretRangeFromPoint(-5, 5), null);
+    assert_equals(document.caretRangeFromPoint(5, -5), null);
+    assert_equals(
+      document.caretRangeFromPoint(document.documentElement.clientWidth * 2, 5),
+      null,
+    );
+    assert_equals(
+      document.caretRangeFromPoint(
+        5,
+        document.documentElement.clientHeight * 2,
+      ),
+      null,
+    );
+  }, "document.caretRangeFromPoint() should return null if given coordinates outside of the viewport");
+
+  test(() => {
+    const rect = div.getBoundingClientRect();
+    const characterWidth = rect.width / div.textContent.length;
+    const characterIndex = 2;
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const range = document.caretRangeFromPoint(x, y);
+    assert_true(range instanceof Range);
+    assert_equals(range.startContainer, div.childNodes[0]);
+    assert_equals(range.endContainer, div.childNodes[0]);
+    assert_equals(range.startOffset, characterIndex);
+    assert_equals(range.endOffset, characterIndex);
+    assert_true(range.collapsed);
+    range.setEnd(div.childNodes[0], characterIndex + 1);
+    assert_false(range.collapsed);
+    assert_equals(range.toString(), "c");
+    range.setStart(div.childNodes[0], characterIndex - 1);
+    assert_false(range.collapsed);
+    assert_equals(range.toString(), "bc");
+    range.setStart(div.childNodes[0], 0);
+    assert_false(range.collapsed);
+    assert_equals(range.toString(), "abc");
+  }, "document.caretRangeFromPoint() should return a Range at the specified location");
+
+  test(() => {
+    const rect = div.getBoundingClientRect();
+    const characterWidth = rect.width / div.textContent.length;
+    const characterIndex = 2;
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const range = document.caretRangeFromPoint(x, y);
+    let rangeRect = range.getBoundingClientRect();
+    assert_approx_equals(rangeRect.x, x, 1);
+    assert_approx_equals(rangeRect.y, rect.height / 2, 3);
+    assert_approx_equals(rangeRect.height, rect.height, 1);
+    assert_equals(rangeRect.width, 0, "Caret range should be collapsed");
+  }, "document.caretRangeFromPoint() should return a client rect close to the given coords");
+
+  test(() => {
+    const shadowDiv = shadow.shadowRoot.querySelector("div");
+    const rect = shadow.getBoundingClientRect();
+    const characterWidth = rect.width / shadow.textContent.length;
+    const characterIndex = 2;
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const range = document.caretRangeFromPoint(x, y);
+    assert_true(range instanceof Range);
+    assert_equals(range.startContainer, document.body);
+    assert_equals(range.endContainer, document.body);
+    assert_equals(range.startOffset, characterIndex);
+    assert_equals(range.endOffset, characterIndex);
+    assert_true(range.collapsed);
+  }, "document.caretRangeFromPoint() on a shadow should return a Range pointing at document.body");
+
+  test(() => {
+    const rect = canvas.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const range = document.caretRangeFromPoint(x, y);
+    assert_true(range instanceof Range);
+    assert_equals(range.startContainer, canvas);
+    assert_equals(range.endContainer, canvas);
+    assert_equals(range.startOffset, 0);
+    assert_equals(range.endOffset, 0);
+    assert_true(range.collapsed);
+  }, "document.caretRangeFromPoint() on a textarea should return a Range pointing at canvas");
+</script>


### PR DESCRIPTION
This attempts to write some tests for https://github.com/w3c/csswg-drafts/pull/12362

/cc @mfreed7 can I get a reviewer from the Chrome side please? Some of these tests will fail and impl may need adjusting as I think all browsers are inconsistent (`caretRangeFromPoint.tentative.html` passes but others don't - reporting the wrong node).

/cc @annevk	likewise - if I can get a suitable WebKit reviewer, as some of these will fail in WebKit.

/cc @gregorypappas