### PR TITLE
Ensure %0A and %0D in Trusted Type header tests are followed by whitespace.

### DIFF
--- a/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html
+++ b/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html
@@ -104,10 +104,10 @@ header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',Tr
   // per the spec's ABNF:
   // https://www.w3.org/TR/trusted-types/#require-trusted-types-for-csp-directive
   // https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace
-  // U+00A LF breaks the header field value into two lines so make sure that
-  // "the continuation line begins with a space or horizontal tab" in accordance
-  // with https://www.rfc-editor.org/rfc/rfc2616
-  ["%09", "%0A%20", "%0C", "%0D", "%20"].forEach(whitespace => {
+  // U+00A and U+00D LF break the header field value into two lines so make sure
+  // that "the continuation line begins with a space or horizontal tab" in
+  // accordance with https://www.rfc-editor.org/rfc/rfc2616
+  ["%09", "%0A%20", "%0C", "%0D%20", "%20"].forEach(whitespace => {
     let directive = `require-trusted-types-for 'invalid'${whitespace}'script'`;
     promise_test(async t => {
       let results = await trySendingPlainStringToTrustedTypeSink(

--- a/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html
+++ b/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html
@@ -91,13 +91,13 @@
   // ABNF:
   // https://w3c.github.io/trusted-types/dist/spec/#serialized-tt-configuration
   // https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace
-  // U+00A LF breaks the header field value into two lines so make sure that
-  // "the continuation line begins with a space or horizontal tab" in accordance
-  // with https://www.rfc-editor.org/rfc/rfc2616
+  // U+00A / U+00D LF breaks the header field value into two lines so make sure
+  // that "the continuation line begins with a space or horizontal tab" in
+  // accordance with https://www.rfc-editor.org/rfc/rfc2616
   promise_test(async t => {
     let results = await tryCreatingTrustedTypePoliciesWithCSP(
       ["_TTP1_", "_TTP2_", "_TTP3_", "_TTP4_", "_TTP5_", "_TTP6_"],
-      "header(Content-Security-Policy,trusted-types _TTP1_%09_TTP2_%0A%20_TTP3_%0C_TTP4_%0D_TTP5_%20_TTP6_,True)"
+      "header(Content-Security-Policy,trusted-types _TTP1_%09_TTP2_%0A%20_TTP3_%0C_TTP4_%0D%20_TTP5_%20_TTP6_,True)"
     );
     assert_equals(results.length, 6);
     results.forEach((result, index) => {


### PR DESCRIPTION
Make sure that both 0x0a and 0x0d in the headers are followed by a whitespace character in the Trusted Types test.

Per RFC 2616, header lines can be continued iff the first character of the next line is a whitespace. The test already contains treatment for this for the 0x0A character. However, the same needs to also be done for 0x0D.

Spec justification is RFC2616, 4.2 Message Headers, which refers to section 3.1 of RFC 822. RFC 822, 3.1.2 says, "The field-body may be composed of any ASCII characters, except CR or LF." CR and LF correspond to 0x0A and 0x0D.