### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297596

### DIFF
--- a/css/css-animations/animation-duration-infinite-ref.html
+++ b/css/css-animations/animation-duration-infinite-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+}
+
+</style>
+<div></div>

--- a/css/css-animations/animation-duration-infinite.html
+++ b/css/css-animations/animation-duration-infinite.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Setting 'animation-duration' to an infinite value should not hang</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=297596">
+<link rel="match" href="animation-duration-infinite-ref.html">
+<meta name="assert" content="Setting 'animation-duration' to an infinite value should not hang">
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+
+  animation-name: slide;
+  animation-duration: calc(infinity * 1s);
+}
+
+@keyframes slide {
+  to { margin-left: 100px }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [“Infinite” CSS animation durations render page unresponsive](https://bugs.webkit.org/show_bug.cgi?id=297596)