### PR TITLE
layout: Remove workaround for `body` while building overflow frame for `StackingContextTree` construction.

### DIFF
--- a/css/css-overflow/overflow-body-propagation-012-ref.html
+++ b/css/css-overflow/overflow-body-propagation-012-ref.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>CSS Reference: BODY with overflow:hidden</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+  div {
+    width: 400px;
+    height: 400px;
+    background: green;
+  }
+</style></head>
+<body><div></div></body>
+</html>

--- a/css/css-overflow/overflow-body-propagation-012.html
+++ b/css/css-overflow/overflow-body-propagation-012.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>CSS Test: BODY with overflow:hidden</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/38799">
+<meta name="assert" content="The overflow value that gets propagated to
+  the viewport is the one of the <html>, not the <body>.
+  Therefore, the <body> is able to hide its overflowing contents.">
+<link rel="match" href="overflow-body-propagation-012-ref.html">
+<style>
+  html {
+    overflow: hidden;
+    height: 500px;
+  }
+  body {
+    overflow: hidden;
+    width: 0px;
+    height: 0px;
+    border: solid 200px green;
+  }
+
+  div {
+    background: red;
+    height: 200px;
+    width: 200px;
+  }
+</style></head>
+<body><div></div></body>
+</html>


### PR DESCRIPTION
While building the stacking context tree we were assuming that `<body>` would have propagated its `overflow` value to the viewport, and thus its used `overflow` would be `visible`.

However, the element that propagates `overflow` can be the root element instead. Since #<!-- nolink -->38598 we are correctly taking this into account in `effective_overflow()`, so we no longer need to do anything special in the stacking context logic.

Testing: `css/css-overflow/overflow-body-propagation-012.html`

Fixes: #<!-- nolink -->38799


Reviewed in servo/servo#38825