### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=222484

### DIFF
--- a/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html
+++ b/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A Report-Only policy with a nonce does not send a report for an allowed link preload</title>
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script nonce="abc">
+var testName = "Report should not be sent for an allowed link preload";
+addEventListener("load", () => {
+    const script = document.createElement("script");
+    script.nonce = "abc";
+    script.src = `../support/checkReport.sub.js?reportExists=false&testName=${encodeURIComponent(testName)}`;
+
+    document.body.appendChild(script);
+});
+</script>
+</body>
+</html>

--- a/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html.sub.headers
+++ b/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html.sub.headers
@@ -1,0 +1,4 @@
+Set-Cookie: link-preload-report-only-nonce={{$id:uuid()}}; Path=/content-security-policy/reporting
+Content-Security-Policy: script-src 'self' 'unsafe-inline'
+Content-Security-Policy-Report-Only: script-src 'nonce-abc'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}
+Link: </content-security-policy/support/pass.js>;rel=preload;as=script;nonce=abc

--- a/content-security-policy/reporting/link-preload-report-only-nonce.sub.html
+++ b/content-security-policy/reporting/link-preload-report-only-nonce.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A Report-Only policy with a nonce does not send a report for an allowed link preload</title>
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+<link nonce="abc" rel="preload" as="script" href="../support/pass.js">
+</head>
+<body>
+<script nonce="abc">
+var testName = "Report should not be sent for an allowed link preload";
+addEventListener("load", () => {
+    const script = document.createElement("script");
+    script.nonce = "abc";
+    script.src = `../support/checkReport.sub.js?reportExists=false&testName=${encodeURIComponent(testName)}`;
+
+    document.body.appendChild(script);
+});
+</script>
+</body>
+</html>

--- a/content-security-policy/reporting/link-preload-report-only-nonce.sub.html.sub.headers
+++ b/content-security-policy/reporting/link-preload-report-only-nonce.sub.html.sub.headers
@@ -1,0 +1,3 @@
+Set-Cookie: link-preload-report-only-nonce={{$id:uuid()}}; Path=/content-security-policy/reporting
+Content-Security-Policy: script-src 'self' 'unsafe-inline'
+Content-Security-Policy-Report-Only: script-src 'nonce-abc'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/support/pass.js
+++ b/content-security-policy/support/pass.js
@@ -1,0 +1,1 @@
+// intentionally left blank.


### PR DESCRIPTION
WebKit export from bug: [CSP: Link header with rel=preload does not recognize nonces](https://bugs.webkit.org/show_bug.cgi?id=222484)