### PR TITLE
Ensure functions inside :heading() are parse errors

### DIFF
--- a/css/selectors/parsing/parse-heading.html
+++ b/css/selectors/parsing/parse-heading.html
@@ -31,4 +31,8 @@
   test_invalid_selector(':heading(2, 3n)');
   test_invalid_selector(':heading(2 of .foo)');
   test_invalid_selector(':heading(2n of .foo)');
+  test_invalid_selector(':heading(calc(1))');
+  test_invalid_selector(':heading(max(1, 2))');
+  test_invalid_selector(':heading(min(1, 2)');
+  test_invalid_selector(':heading(var(--level))');
 </script>


### PR DESCRIPTION
For more see the conversation here: https://github.com/w3c/csswg-drafts/pull/12634#discussion_r2291451416

/cc @AtkinsSJ @annevk 