### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296201

### DIFF
--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-005.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-005.html
@@ -7,6 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under vertical-rl."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-006.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-006.html
@@ -7,6 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under vertical-lr."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-007.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-007.html
@@ -7,6 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under sideways-rl."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-009.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-009.html
@@ -7,6 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under vertical-rl and text-orientation: sideways."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-010.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-010.html
@@ -9,6 +9,7 @@
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under vertical-lr and text-orientation: sideways."/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
     .container {


### PR DESCRIPTION
WebKit export from bug: [\[shape-outside\] Fix /css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-005/006/007/009/010/](https://bugs.webkit.org/show_bug.cgi?id=296201)