### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296229

### DIFF
--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-052.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-052.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-052-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=3" />
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by circle(50% at right 40px bottom 40px) value under sideways-lr writing-mode.">
   <style>
   .container {

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-053.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-053.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-053-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=1-3" />
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at right 40px top 40px) value under sideways-lr writing-mode.">
   <style>
   .container {

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-050.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-050.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-050-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=2" />
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the basic shape ellipse(closest-side farthest-side at left 40px top 60px) border-box">
   <style>
   .container {

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-051.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-051.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-051-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=1-2" />
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(closest-side farthest-side at left 40px top 60px) border-box">
   <style>
   .container {


### PR DESCRIPTION
WebKit export from bug: [\[shape-outside\] Fix various shape test cases inside sideways-lr containers](https://bugs.webkit.org/show_bug.cgi?id=296229)