### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296817

### DIFF
--- a/css/css-writing-modes/vertical-alignment-slr-029-ref.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-029-ref.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Hajime Shiozawa" href="mailto:hajime.shiozawa@gmail.com" />
+  <link rel="reviewer" title="G?rard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2015-09-03 -->
+  <meta name="flags" content="image" />
+  <style type="text/css"><![CDATA[
+    img#orange
+    {
+      padding-left: 30px;
+    }
+    img#blue
+    {
+      padding-left: 60px;
+    }
+    div {
+      line-height: 0;
+    }
+  ]]></style>
+
+</head>
+
+<body>
+
+<p>Test passes if the left edge of an blue square is vertically aligned with the right edge of a orange square.</p>
+
+<div>
+  <img id="orange" src="support/swatch-orange.png" width="30" height="30" alt="Image download support must be enabled" /><!--
+--><br /><img id="blue" src="support/swatch-blue.png" width="60" height="60" alt="Image download support must be enabled" />
+</div>
+
+</body>
+</html>

--- a/css/css-writing-modes/vertical-alignment-slr-029.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-029.xht
@@ -7,7 +7,7 @@
     <link rel="help" title="7.5 Line-Relative Mappings" href="http://www.w3.org/TR/css-writing-modes-4/#line-mappings" />
     <link rel="help" title="10.8.1 Leading and half-leading" href="http://www.w3.org/TR/2011/REC-CSS2-20110607/visudet.html#leading" />
     <meta name="assert" content="This test checks the position of inline non-replaced box with vertical align property. When 'writing-mode' is 'sideways-lr', 'vertical-align' is 'top', the physical left (logical top) edge of an inline non-replaced box is aligned with the physical left (logical top) edge of its line box." />
-    <link rel="match" href="vertical-alignment-008-ref.xht" />
+    <link rel="match" href="vertical-alignment-slr-029-ref.xht" />
     <meta name="flags" content="ahem" />
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css"><![CDATA[
@@ -16,7 +16,6 @@
       writing-mode: sideways-lr;
       font: 60px/3 Ahem; /* computes to 60px/180px */
       color: blue;
-      margin-top: 46px; /* 30px (height of orange square) + 16px (p's margin-bottom) */
     }
 
     span#orange
@@ -24,7 +23,6 @@
       font-size: 0.5em;
       color: orange;
       vertical-align: top;
-      margin-bottom: -2em;
     }
 
     ]]></style>
@@ -33,7 +31,7 @@
 
   <body>
 
-  <p>Test passes if the left edge of an blue square is aligned with the right edge of a orange square.</p>
+  <p>Test passes if the left edge of an blue square is vertically aligned with the right edge of a orange square.</p>
 
   <div id="slr">A<span id="orange">O</span></div>
 

--- a/css/css-writing-modes/vertical-alignment-slr-031-ref.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-031-ref.xht
@@ -1,0 +1,37 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Hajime Shiozawa" href="mailto:hajime.shiozawa@gmail.com" />
+  <link rel="reviewer" title="G?rard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2015-09-03 -->
+  <meta name="flags" content="image" />
+  <style type="text/css"><![CDATA[
+    img
+    {
+      vertical-align: top;
+    }
+
+    img
+    {
+      padding-left: 90px; /* = the position of first orange square */
+    }
+
+    img + br + img
+    {
+      padding-left: 60px; /* = the position of second orange square*/
+    }
+  ]]></style>
+
+</head>
+
+<body>
+
+<p>Test passes if the <strong>right edge</strong> of an irregular orange polygon is straight and unbroken.</p>
+
+<div>
+   <img src="support/swatch-orange.png" width="30" height="30" alt="Image download support must be enabled" /><br/><!--
+--><img src="support/swatch-orange.png" width="60" height="60" alt="Image download support must be enabled" />
+</div>
+
+</body>
+</html>

--- a/css/css-writing-modes/vertical-alignment-slr-031.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-031.xht
@@ -7,7 +7,7 @@
     <link rel="help" title="7.5 Line-Relative Mappings" href="http://www.w3.org/TR/css-writing-modes-4/#line-mappings" />
     <link rel="help" title="10.8.1 Leading and half-leading" href="http://www.w3.org/TR/2011/REC-CSS2-20110607/visudet.html#leading" />
     <meta name="assert" content="This test checks the position of an inline non-replaced box with vertical align property. When 'writing-mode' is 'sideways-lr', 'vertical-align' is 'text-top', the physical left (logical top) edge of an inline non-replaced box is aligned with the left side (logical top) of parent's content area." />
-    <link rel="match" href="vertical-alignment-006-ref.xht" />
+    <link rel="match" href="vertical-alignment-slr-031-ref.xht" />
     <meta name="flags" content="ahem" />
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css"><![CDATA[
@@ -16,12 +16,10 @@
       color: orange;
       font: 60px/3 Ahem; /* computes to 60px/180px */
       writing-mode: sideways-lr;
-      margin-top: 76px; /* 60px (height of A) + 16px (p's margin-bottom) */
     }
 
     span#orange30
     {
-      margin-bottom: -3em; /* computes to -90px */
       font-size: 0.5em; /* computes to 30px */
       vertical-align: text-top;
     }

--- a/css/css-writing-modes/vertical-alignment-slr-033-ref.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-033-ref.xht
@@ -1,0 +1,33 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Hajime Shiozawa" href="mailto:hajime.shiozawa@gmail.com" />
+  <link rel="reviewer" title="G?rard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2015-09-01 -->
+  <meta name="flags" content="image" />
+  <style type="text/css"><![CDATA[
+    img
+    {
+      vertical-align: top;
+    }
+
+    img
+    {
+      padding-left: 60px; /* =  position of orange squares */
+    }
+
+  ]]></style>
+
+</head>
+
+<body>
+
+<p>Test passes if the <strong>left edge</strong> of an irregular orange polygon is straight and unbroken.</p>
+
+<div>
+   <img src="support/swatch-orange.png" width="30" height="30" alt="Image download support must be enabled" /><br/><!--
+--><img src="support/swatch-orange.png" width="60" height="60" alt="Image download support must be enabled" />
+</div>
+
+</body>
+</html>

--- a/css/css-writing-modes/vertical-alignment-slr-033.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-033.xht
@@ -7,7 +7,7 @@
     <link rel="help" title="7.5 Line-Relative Mappings" href="http://www.w3.org/TR/css-writing-modes-4/#line-mappings" />
     <link rel="help" title="10.8.1 Leading and half-leading" href="http://www.w3.org/TR/2011/REC-CSS2-20110607/visudet.html#leading" />
     <meta name="assert" content="This test checks the position of an inline non-replaced box with vertical align property. When 'writing-mode' is 'sideways-lr', 'vertical-align' is 'text-bottom', the physical right (logical bottom) edge of an inline non-replaced box is aligned with the right side (logical bottom) of parent's content area." />
-    <link rel="match" href="vertical-alignment-004-ref.xht" />
+    <link rel="match" href="vertical-alignment-slr-033-ref.xht" />
     <meta name="flags" content="ahem" />
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css"><![CDATA[
@@ -16,12 +16,10 @@
       color: orange;
       font: 60px/3 Ahem; /* computes to 60px/180px */
       writing-mode: sideways-lr;
-      margin-top: 76px; /* 60px (height of A) + 16px (p's margin-bottom) */
     }
 
     span#orange30
     {
-      margin-bottom: -3em; /* computes to -90px */
       font-size: 0.5em; /* computes to 30px */
       vertical-align: text-bottom;
     }

--- a/css/css-writing-modes/vertical-alignment-slr-035-ref.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-035-ref.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Hajime Shiozawa" href="mailto:hajime.shiozawa@gmail.com" />
+  <link rel="reviewer" title="G?rard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2015-09-03 -->
+  <meta name="flags" content="image" />
+  <style type="text/css"><![CDATA[
+    img#orange
+    {
+      padding-left: 120px;
+    }
+    img#blue
+    {
+      padding-left: 60px;
+    }
+    div {
+      line-height: 0;
+    }
+  ]]></style>
+
+</head>
+
+<body>
+
+<p>Test passes if the right edge of an blue square is vertically aligned with the left edge of a orange square.</p>
+
+<div>
+  <img id="orange" src="support/swatch-orange.png" width="30" height="30" alt="Image download support must be enabled" /><!--
+--><br /><img id="blue" src="support/swatch-blue.png" width="60" height="60" alt="Image download support must be enabled" />
+</div>
+
+</body>
+</html>

--- a/css/css-writing-modes/vertical-alignment-slr-035.xht
+++ b/css/css-writing-modes/vertical-alignment-slr-035.xht
@@ -7,7 +7,7 @@
     <link rel="help" title="7.5 Line-Relative Mappings" href="http://www.w3.org/TR/css-writing-modes-4/#line-mappings" />
     <link rel="help" title="10.8.1 Leading and half-leading" href="http://www.w3.org/TR/2011/REC-CSS2-20110607/visudet.html#leading" />
     <meta name="assert" content="This test checks the position of inline non-replaced box with vertical align property. When 'writing-mode' is 'sideways-lr', 'vertical-align' is 'bottom', the physical right (logical bottom) edge of an inline non-replaced box is aligned with the physical right (logical bottom) edge of its line box." />
-    <link rel="match" href="vertical-alignment-002-ref.xht" />
+    <link rel="match" href="vertical-alignment-slr-035-ref.xht" />
     <meta name="flags" content="ahem" />
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css"><![CDATA[
@@ -16,7 +16,6 @@
       writing-mode: sideways-lr;
       font: 60px/3 Ahem; /* computes to 60px/180px */
       color: blue;
-      margin-top: 46px; /* 30px (height of orange square) + 16px (p's margin-bottom) */
     }
 
     span#orange
@@ -24,7 +23,6 @@
       font-size: 0.5em;
       color: orange;
       vertical-align: bottom;
-      margin-bottom: -2em; /* computes to -60px */
     }
     ]]></style>
 
@@ -32,7 +30,7 @@
 
   <body>
 
-  <p>Test passes if the right edge of an blue square is aligned with the left edge of a orange square.</p>
+  <p>Test passes if the right edge of an blue square is vertically aligned with the left edge of a orange square.</p>
 
   <div id="slr">A<span id="orange">O</span></div>
 


### PR DESCRIPTION
WebKit export from bug: [css/css-writing-modes/vertical-alignment-slr-029.xht (031, 033, 035) fail due to difference in content measuring](https://bugs.webkit.org/show_bug.cgi?id=296817)