### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297525

### DIFF
--- a/storage-access-api/requestStorageAccess-sandboxed-iframe-allow-storage-access.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-sandboxed-iframe-allow-storage-access.sub.https.window.js
@@ -7,6 +7,6 @@ const frameSourceUrl =
     'https://{{hosts[alt][www]}}:{{ports[https][0]}}/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html';
 
 const sandboxAttribute =
-    'allow-scripts allow-same-origin allow-storage-access-by-user-activation';
+    'allow-scripts allow-same-origin allow-storage-access-by-user-activation allow-popups';
 
 RunTestsInIFrame(frameSourceUrl, sandboxAttribute);

--- a/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html
+++ b/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html
@@ -29,6 +29,7 @@
     t.add_cleanup(async () => {
       await test_driver.set_permission({name: 'storage-access'}, 'prompt');
     });
+    await SetFirstPartyCookie(location.origin, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
     await document.requestStorageAccess();
@@ -45,6 +46,7 @@
     t.add_cleanup(async () => {
       await test_driver.set_permission({name: 'storage-access'}, 'prompt');
     });
+    await SetFirstPartyCookie(location.origin, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
 


### PR DESCRIPTION
WebKit export from bug: [Set a first-party cookie before setting cross-site cookies in `sandboxed-iframe-allow-storage-access.html`](https://bugs.webkit.org/show_bug.cgi?id=297525)