### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296230

### DIFF
--- a/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-026.html
+++ b/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-026.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-inset-026-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=1" />
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the inset(10px round 60px 0/ 40px 0) border-box value under sideways-lr writing-mode.">
   <meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-4">
   <style>

--- a/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-027.html
+++ b/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-027.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-inset-027-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=1" />
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the inset(10px round 60px 0/ 40px 0) border-box value under sideways-lr writing-mode.">
   <meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-2">
   <style>


### PR DESCRIPTION
WebKit export from bug: [\[shape-outside\] Fix css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-026/027.html](https://bugs.webkit.org/show_bug.cgi?id=296230)