### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296222

### DIFF
--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-008.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-008.html
@@ -7,6 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under sideways-lr."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-008.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-008.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient under sideways-lr."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-014.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-014.html
@@ -8,6 +8,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient with shape-margin under sideways-lr."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-014.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-014.html
@@ -8,7 +8,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-001-ref.html"/>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=7600-8700" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8700" />
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient with shape-margin under sideways-lr."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />


### PR DESCRIPTION
WebKit export from bug: [\[shape-outside\] Fix /css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-008/014](https://bugs.webkit.org/show_bug.cgi?id=296222)