### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296186

### DIFF
--- a/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSS Reference File</title>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-    <style type="text/css">
+    <style>
         body {
           overflow: hidden;
         }

--- a/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="/fonts/ahem.css">
     <style>
         body {
-          overflow: hidden;
+            overflow: hidden;
         }
         div {
             width: 50px;

--- a/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>CSS Reference File</title>
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <link rel="stylesheet" href="/fonts/ahem.css">
     <style>
         body {
           overflow: hidden;

--- a/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/reference/shape-outside-linear-gradient-horizontal-rtl-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Reference File</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <style type="text/css">
+        body {
+          overflow: hidden;
+        }
+        div {
+            width: 50px;
+            height: 200px;
+            position: relative;
+        }
+        .non-gradient-box {
+            background-color: green;
+        }
+        .gradient-box {
+            width: 100px;
+            background: linear-gradient(to right, green 50%, transparent 50%);
+        }
+    </style>
+</head>
+<body>
+    <p>
+        The test passes if you see a green square. There should be no red.
+    </p>
+    <div class="gradient-box"></div>
+    <div class="non-gradient-box" style="left: 50px; top: -200px"></div>
+    <div class="non-gradient-box" style="top: -200px"></div>
+    <div class="gradient-box" style="top: -400px; left: 50px;"></div>
+</body>
+</html>

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test: Test shape-outside with linear gradient when rtl direction is applied.</title>
+    <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
+    <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
+    <link rel="match" href="reference/shape-outside-linear-gradient-rtl-ref.html"/>
+    <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient when rtl direction is applied."/>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <style type="text/css">
+    .container {
+      inline-size: 100px;
+      block-size: 200px;
+      background-color: red;
+      font-family: Ahem;
+      font-size: 50px;
+      line-height: 1;
+      direction: rtl;
+      color: green;
+    }
+    #float-left {
+      float: left;
+      inline-size: 100px;
+      block-size: 200px;
+      background: linear-gradient(to right, green 50%, transparent 50%);
+      shape-outside: linear-gradient(to right, green 50%, transparent 50%);
+    }
+    #float-right {
+      float: right;
+      inline-size: 100px;
+      block-size: 200px;
+      background: linear-gradient(to left, green 50%, transparent 50%);
+      shape-outside: linear-gradient(to left, green 50%, transparent 50%);
+    }
+    </style>
+  </head>
+  <body>
+    <p>
+      The test passes if you see a green square. There should be no red.
+    </p>
+    <div class="container">
+      <div id="float-left"></div>
+      x x x x
+    </div>
+    <div class="container">
+      <div id="float-right"></div>
+      x x x x
+    </div>
+  </body>
+</html>

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
@@ -4,7 +4,7 @@
     <title>CSS Test: Test shape-outside with linear gradient when rtl direction is applied.</title>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
-    <link rel="match" href="reference/shape-outside-linear-gradient-rtl-ref.html"/>
+    <link rel="match" href="reference/shape-outside-linear-gradient-horizontal-rtl-ref.html"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient when rtl direction is applied."/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
@@ -6,8 +6,8 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="match" href="reference/shape-outside-linear-gradient-horizontal-rtl-ref.html"/>
     <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient when rtl direction is applied."/>
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-    <style type="text/css">
+    <link rel="stylesheet" href="/fonts/ahem.css" />
+    <style>
     .container {
       inline-size: 100px;
       block-size: 200px;

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-horizontal-rtl.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <title>CSS Test: Test shape-outside with linear gradient when rtl direction is applied.</title>
-    <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
-    <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
-    <link rel="match" href="reference/shape-outside-linear-gradient-horizontal-rtl-ref.html"/>
-    <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient when rtl direction is applied."/>
-    <link rel="stylesheet" href="/fonts/ahem.css" />
+    <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image">
+    <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
+    <link rel="match" href="reference/shape-outside-linear-gradient-horizontal-rtl-ref.html">
+    <meta name="assert" content="This test verifies that shape-outside respects a simple linear gradient when rtl direction is applied.">
+    <link rel="stylesheet" href="/fonts/ahem.css">
     <style>
     .container {
       inline-size: 100px;


### PR DESCRIPTION
WebKit export from bug: [\[shape-outside\] Gradient based shape-outside floating fails when rtl is applied](https://bugs.webkit.org/show_bug.cgi?id=296186)