### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282754

### DIFF
--- a/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-022.html
+++ b/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-022.html
@@ -10,7 +10,11 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-inset-022-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the inset(10px round 60px 0/ 40px 0) border-box value under vertical-rl writing-mode.">
+<<<<<<< ours
   <meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-4">
+=======
+  <meta name="fuzzy" content="maxDifference=2; totalPixels=1" />
+>>>>>>> theirs
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-025.html
+++ b/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-025.html
@@ -10,7 +10,11 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-inset-025-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the inset(10px round 60px 0/ 40px 0) border-box value under vertical-lr writing-mode.">
+<<<<<<< ours
   <meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-4">
+=======
+  <meta name="fuzzy" content="maxDifference=2; totalPixels=1" />
+>>>>>>> theirs
   <style>
   .container {
     writing-mode: vertical-lr;


### PR DESCRIPTION
WebKit export from bug: [\[macOS wk2 x86_64 \] 2 tests in imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes are a constant failure](https://bugs.webkit.org/show_bug.cgi?id=282754)