### PR TITLE
script: Ensure autoincrement and keypath are passed in correctly from IDBTransaction

### DIFF
--- a/interfaces/IndexedDB.idl
+++ b/interfaces/IndexedDB.idl
@@ -8,7 +8,7 @@ interface IDBRequest : EventTarget {
   readonly attribute any result;
   readonly attribute DOMException? error;
   readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
-  readonly attribute IDBTransaction? transaction;
+  readonly attribute IDBTransaction transaction;
   readonly attribute IDBRequestReadyState readyState;
 
   // Event handlers:


### PR DESCRIPTION
Previously, the correct autoincremented and keypath parameters were only being passed if the object store is being created. This PR queries this info from the backend and passes it onto the constructor in IDBTransaction. Furthermore it exposes keypath and index_names from IDBObjectStore, mainly for WPT.

Testing: WPT
Fixes: None
Reviewed in servo/servo#38738