### PR TITLE
script: Add remaining unique element event listeners

### DIFF
--- a/trusted-types/support/event-handler-attributes.mjs
+++ b/trusted-types/support/event-handler-attributes.mjs
@@ -35,13 +35,17 @@ export async function getEventHandlerAttributeWithInterfaceNames() {
     addOnAttributes(htmlIDL, interfaceName);
   });
 
-  const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
-  // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
-  addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
+  if ("HTMLMediaElement" in self) {
+    const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
+    // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
+    addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
+  }
 
-  const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
-  // SVGAnimationElement has extra event handlers.
-  addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
+  if ("SVGAnimationElement" in self) {
+    const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
+    // SVGAnimationElement has extra event handlers.
+    addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
+  }
 
   return attributeNamesWithInterfaceName;
 }


### PR DESCRIPTION
This adds the remaining window as well as specific svg and animation listeners. The test suite was erroring before, as we don't implement `SVGAnimationElement` yet. Now, the test gracefully checks if the interface exists before doing a lookup.

Part of #<!-- nolink -->36258
Reviewed in servo/servo#38888