### PR TITLE
Update content-security-policy/support/checkReport.sub.js to not crash on missing report

### DIFF
--- a/content-security-policy/support/checkReport.sub.js
+++ b/content-security-policy/support/checkReport.sub.js
@@ -72,7 +72,7 @@
           assert_equals(data.length, 0,
                         "CSP report sent, but not expecting one.");
         } else {
-          let reportedBody;
+          let reportBody;
           // With the 'report-uri' directive, the report is contained in
           // `data[0]["csp-report"]`. With the 'report-to' directive, the report
           // is contained in `data[0]["body"]`.

--- a/content-security-policy/support/checkReport.sub.js
+++ b/content-security-policy/support/checkReport.sub.js
@@ -72,12 +72,11 @@
           assert_equals(data.length, 0,
                         "CSP report sent, but not expecting one.");
         } else {
+          let reportedBody;
           // With the 'report-uri' directive, the report is contained in
           // `data[0]["csp-report"]`. With the 'report-to' directive, the report
           // is contained in `data[0]["body"]`.
-          const reportBody = data[0]["body"]
-                ? data[0]["body"]
-                : data[0]["csp-report"];
+          if (data[0]) reportBody = data[0]["body"] ? data[0]["body"] : data[0]["csp-report"];
 
           assert_true(reportBody !== undefined,
                       "No CSP report sent, but expecting one.");


### PR DESCRIPTION
I'm debugging some failures and noticed that, in this helper, when a report is missing `data[0]` will not exist and so it fails with "cannot read properties of undefined" instead of "No CSP report sent".