### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295694

### DIFF
--- a/css/css-ruby/ruby-overhang-dynamic-ref.html
+++ b/css/css-ruby/ruby-overhang-dynamic-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  div {
+    font: 16px/5 Ahem;
+  }
+  span {
+    color: transparent;
+    font-size: 50%; /* annotation */
+  }
+</style>
+<div>X<span>XXX</span>X</div>

--- a/css/css-ruby/ruby-overhang-dynamic.html
+++ b/css/css-ruby/ruby-overhang-dynamic.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="UTF-8">
+<title>Tests for ruby-overhang: none -> auto</title>
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#ruby-overhang">
+<link rel="match" href="ruby-overhang-dynamic-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  .reftest-wait .overhangNone {
+    ruby-overhang: none;
+  }
+  div {
+    font: 16px/5 Ahem;
+  }
+  ruby, rt {
+    color: transparent;
+  }
+</style>
+<div class=overhangNone>X<ruby>X<rt>XXXX</rt></ruby>X</div>
+<script>
+  requestAnimationFrame(() => {
+    document.documentElement.classList.remove('reftest-wait');
+  });
+</script>


### PR DESCRIPTION
WebKit export from bug: [Changing ruby-overhang values does not trigger layout](https://bugs.webkit.org/show_bug.cgi?id=295694)