### PR TITLE
feat(html): Add test for multiple title elements

### DIFF
--- a/html/semantics/document-metadata/the-title-element/title-multiple-elements.html
+++ b/html/semantics/document-metadata/the-title-element/title-multiple-elements.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Title One</title>
+  <title>Title Two</title>
+  <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+
+  <script>
+    test(function() {
+      assert_equals(document.title, "Title One", "The document's title should be the content of the first <title> element.");
+    }, "Browsers must ignore <title> elements after the first one.");
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a new test to verify browser behavior when a document contains more than one `<title>` element.

According to the HTML specification, if multiple `<title>` elements are present, all but the first one must be ignored by the browser. This test confirms that `document.title` correctly reflects the content of the first `<title>` tag in such a scenario.

**Spec Reference:**
https://html.spec.whatwg.org/multipage/semantics.html#the-title-element

**Test Methodology:**
An iframe is created and populated with HTML containing two distinct `<title>` elements. The test then asserts that `iframe.contentDocument.title` matches the text of the first element.