### PR TITLE
Test effect of block-ellipsis on unwrappable line

### DIFF
--- a/css/css-overflow/line-clamp/block-ellipsis-023.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-023.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: no-ellipsis when there's not enough room</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
+<link rel="match" href="reference/block-ellipsis-023-ref.html">
+<meta name="assert" content="block-ellipsis: no-ellipsis must not displace content to make room for the (non-existant) ellipsis">
+<style>
+.clamp {
+  line-clamp: 4 no-ellipsis
+  width: 32ch;
+  font-family: monospace;
+}
+</style>
+<div class="clamp">
+  Test passes if there are 4 lines
+  and the last two are identical
+  supercalifragilisticexpialidocious
+  supercalifragilisticexpialidocious
+  Test fails: this should not be visible
+</div>

--- a/css/css-overflow/line-clamp/block-ellipsis-024.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-024.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: empty string and no-ellipsis</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
+<link rel="match" href="reference/block-ellipsis-023-ref.html">
+<meta name="assert" content="block-ellipsis: '' as the same effect as no-ellipsis, and must not displace content to make room for the (non-existant) ellipsis">
+<style>
+.clamp {
+  line-clamp: 4 "";
+  width: 32ch;
+  font-family: monospace;
+}
+</style>
+<div class="clamp">
+  Test passes if there are 4 lines
+  and the last two are identical
+  supercalifragilisticexpialidocious
+  supercalifragilisticexpialidocious
+  Test fails: this should not be visible
+</div>

--- a/css/css-overflow/line-clamp/block-ellipsis-025.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-025.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: no-ellipsis when there's not enough room</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
+<link rel="match" href="reference/block-ellipsis-025-ref.html">
+<meta name="assert" content="the block overflow ellipsis displaces text, taking soft wrap opportunities into account. This may result in the entire line being displaced, and just the ellipsis being left.">
+<style>
+.clamp {
+  line-clamp: 4;
+  width: 32.5ch;
+  font-family: monospace;
+}
+</style>
+<div class="clamp">
+  Test passes if there are 4 lines
+  and the last one only contains …
+  supercalifragilisticexpialidocious
+  supercalifragilisticexpialidocious
+  Test fails: this should not be visible
+</div>

--- a/css/css-overflow/line-clamp/reference/block-ellipsis-023-ref.html
+++ b/css/css-overflow/line-clamp/reference/block-ellipsis-023-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<style>
+.clamp {
+  width: 32ch;
+  font-family: monospace;
+}
+</style>
+<div class="clamp">
+Test passes if there are 4 lines
+and the last two are identical
+supercalifragilisticexpialidocious
+supercalifragilisticexpialidocious
+</div>

--- a/css/css-overflow/line-clamp/reference/block-ellipsis-025-ref.html
+++ b/css/css-overflow/line-clamp/reference/block-ellipsis-025-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<style>
+.clamp {
+  line-clamp: 4;
+  width: 32.5ch;
+  font-family: monospace;
+}
+</style>
+<div class="clamp">
+  Test passes if there are 4 lines
+  and the last one only contains …
+  supercalifragilisticexpialidocious
+  …
+</div>


### PR DESCRIPTION
auto should remove the content to make room for “…”, while neither no-ellipsis nor the empty string should do that.

See https://github.com/w3c/csswg-drafts/issues/12416