### PR TITLE
preload: add test for reusing as=fetch preload when fetch() sets Accept

### DIFF
--- a/preload/preload-fetch-headers.https.html
+++ b/preload/preload-fetch-headers.https.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Preload reuse for as=fetch when fetch() specifies headers</title>
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/semantics.html#link-type-preload"
+/>
+<link rel="help" href="https://fetch.spec.whatwg.org/" />
+<meta
+  name="assert"
+  content="A resource preloaded with as=fetch is reused even when the subsequent fetch() specifies request headers like Accept."
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/preload/resources/preload_helper.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+  "use strict";
+
+  const { HTTPS_REMOTE_ORIGIN } = get_host_info();
+
+  function createEchoURL(body, type) {
+    return `/preload/resources/echo-with-cors.py?type=${encodeURIComponent(
+      type
+    )}&content=${encodeURIComponent(body)}&uid=${token()}`;
+  }
+
+  promise_test(async (t) => {
+    // Use cross-origin CORS with anonymous credentials so that preload uses
+    // the fetch algorithm path relevant to the reported issue.
+    const href =
+      new URL(
+        createEchoURL('{"ok":true}', "application/json"),
+        HTTPS_REMOTE_ORIGIN
+      ).href + `&${token()}`;
+
+    // Preload the resource as fetch with CORS (anonymous).
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.as = "fetch";
+    link.crossOrigin = "anonymous";
+    link.href = href;
+    document.head.appendChild(link);
+    t.add_cleanup(() => link.remove());
+    await new Promise((resolve) => link.addEventListener("load", resolve));
+
+    // Now fetch the same resource but specify a simple header (Accept).
+    // This must still consume the preloaded response rather than fetching again.
+    const response = await fetch(href, {
+      mode: "cors",
+      credentials: "omit",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    const text = await response.text();
+    assert_equals(text, '{"ok":true}');
+
+    // Expect no double-download: even if UA creates multiple RT entries
+    // for preload and fetch, at most one should have transferSize > 0.
+    if (numberOfResourceTimingEntries(href) < 1) {
+      await new Promise((resolve) => t.step_timeout(resolve, 300));
+    }
+    verifyLoadedAndNoDoubleDownload(href);
+  }, "Cross-origin as=fetch preload is reused even when fetch() specifies Accept header");
+</script>


### PR DESCRIPTION
This adds a new test to verify that a resource preloaded with rel="preload" as="fetch" crossorigin="anonymous" is reused even when the subsequent fetch() specifies request headers like Accept: application/json.
Test path: preload/preload-fetch-headers.https.html
Cross-origin (CORS, anonymous) to ensure the fetch algorithm path relevant to the bug
Uses Resource Timing to assert no double network download:
Allows multiple RT entries (preload + fetch)
Requires that at most one entry has transferSize > 0

Firefox wasn’t consuming the preload if fetch() specified certain headers (e.g., Accept), though spec doesn’t require header matching; Chrome previously removed preloaded resources by headers.

References:
WPT issue #51217 (https://github.com/web-platform-tests/wpt/issues/51217)
Chromium issue 40685467 (https://issues.chromium.org/issues/40685467#comment21)
Firefox bug 1854292 (https://bugzilla.mozilla.org/show_bug.cgi?id=1854292)