### PR TITLE
Remove reliance on :open pseudo selector in unrelated tests

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html
@@ -17,7 +17,7 @@
   function openDialog(openMethod) {
     dialog.close();
     if (!dialog.open) {
-      assert_false(dialog.matches(':open'),'Should be closed to start');
+      assert_false(dialog.matches('[open]'),'Should be closed to start');
       switch (openMethod) {
         case 'modeless' :
           dialog.show();
@@ -33,7 +33,7 @@
       }
     }
     assert_true(dialog.open,'Should be open now');
-    assert_true(dialog.matches(':open'),'Should be open now (pseudo)');
+    assert_true(dialog.matches('[open]'),'Should be open now (selector)');
   }
 
   function awaitClose(el, signal) {
@@ -131,7 +131,7 @@
   function runTest(openMethod, changeMethod) {
     function setup(t) {
       assert_false(dialog.open,'setup');
-      assert_false(dialog.matches(':open'), 'Dialog should start the test closed');
+      assert_false(dialog.matches('[open]'), 'Dialog should start the test closed');
       assert_equals(dialog.closedBy, "any", 'Dialog should be closedby=any');
 
       const signal = t.get_signal();
@@ -155,7 +155,7 @@
       await step;
 
       const respondsToEsc = !dialog.open;
-      assert_equals(!dialog.matches(':open'),respondsToEsc,':open should match dialog.open');
+      assert_equals(!dialog.matches('[open]'),respondsToEsc,'[open] should match dialog.open');
 
       const shouldRespond = changeMethod.respondsTo?.(openMethod) ?? true;
 
@@ -171,7 +171,7 @@
       await step;
 
       const respondsToLightDismiss = !dialog.open;
-      assert_equals(!dialog.matches(':open'),respondsToLightDismiss,':open should match dialog.open');
+      assert_equals(!dialog.matches('[open]'),respondsToLightDismiss,'[open] should match dialog.open');
 
       const shouldRespond = changeMethod.respondsTo?.(openMethod) ?? true;
 

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
@@ -16,16 +16,16 @@ const ESC = '\uE00C';
 promise_test(async (t) => {
   const dialog = document.querySelector('dialog#test1');
   assert_true(dialog.open);
-  assert_true(dialog.matches(':open'));
+  assert_true(dialog.matches('[open]'));
   await new test_driver.send_keys(document.documentElement,ESC);
   assert_false(dialog.open);
-  assert_false(dialog.matches(':open'));
+  assert_false(dialog.matches('[open]'));
   dialog.showModal();
   assert_true(dialog.open);
-  assert_true(dialog.matches(':open'));
+  assert_true(dialog.matches('[open]'));
   await new test_driver.send_keys(document.documentElement,ESC);
   assert_false(dialog.open);
-  assert_false(dialog.matches(':open'));
+  assert_false(dialog.matches('[open]'));
 }, `Dialogs that start open and have closedby should still function`);
 </script>
 
@@ -65,11 +65,11 @@ promise_test(async (t) => {
     });
   });
   assert_true(dialog.open);
-  assert_true(dialog.matches(':open'));
+  assert_true(dialog.matches('[open]'));
   // Stop re-running showModal(), so we can check that the dialog closes with ESC:
   controller.abort();
   await test_driver.send_keys(document.documentElement,ESC);
   assert_false(dialog.open,'ESC should still work');
-  assert_false(dialog.matches(':open'));
+  assert_false(dialog.matches('[open]'));
 }, `Opening and closing a dialog during the dialog focus fixup should still leave closedby functional`);
 </script>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-closedby.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-closedby.html
@@ -31,7 +31,7 @@
 <script>
   function openDialog(dialog,openMethod) {
     assert_false(dialog.open,'Should be closed to start');
-    assert_equals(dialog.matches(':open'),dialog.open,':open should match .open');
+    assert_equals(dialog.matches('[open]'),dialog.open,'[open] should match .open');
     switch (openMethod) {
       case 'modeless' :
         dialog.show();
@@ -46,7 +46,7 @@
         assert_unreached('Invalid open method');
     }
     assert_true(dialog.open,'Should be open now');
-    assert_equals(dialog.matches(':open'),dialog.open,':open should match .open');
+    assert_equals(dialog.matches('[open]'),dialog.open,'[open] should match .open');
   }
 
   function getDefaultExpectations(behavior, openMethod) {
@@ -96,7 +96,7 @@
   function runTest(dialog, openMethod) {
     promise_test(async (t) => {
       assert_false(dialog.open,'setup');
-      assert_false(dialog.matches(':open'));
+      assert_false(dialog.matches('[open]'));
       t.add_cleanup(() => dialog.close());
       let expectations = getDefaultExpectations(dialog.dataset.behavior, openMethod);
 
@@ -117,7 +117,7 @@
         await waitForRender();
       }
       const respondsToEsc = !dialog.open;
-      assert_equals(!dialog.matches(':open'),respondsToEsc,':open should match dialog.open');
+      assert_equals(!dialog.matches('[open]'),respondsToEsc,'[open] should match dialog.open');
       dialog.close();
 
       // Try clicking outside
@@ -125,7 +125,7 @@
       assert_equals(dialog.matches(':modal'),openMethod === 'modal',':modal incorrect');
       await clickOn(outside);
       const respondsToLightDismiss = !dialog.open;
-      assert_equals(!dialog.matches(':open'),respondsToLightDismiss,':open should match dialog.open');
+      assert_equals(!dialog.matches('[open]'),respondsToLightDismiss,'[open] should match dialog.open');
       dialog.close();
 
       // See if expectations match

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html
@@ -17,7 +17,7 @@ function waitForRender() {
 const dialog = document.querySelector('dialog');
 function openDialog(openMethod) {
   assert_false(dialog.open);
-  assert_false(dialog.matches(':open'));
+  assert_false(dialog.matches('[open]'));
   switch (openMethod) {
     case 'modeless':
       dialog.show();
@@ -32,7 +32,7 @@ function openDialog(openMethod) {
       assert_unreached('Unknown open method');
   }
   assert_true(dialog.open);
-  assert_true(dialog.matches(':open'));
+  assert_true(dialog.matches('[open]'));
   assert_equals(dialog.matches(':modal'),openMethod === 'modal');
 }
 
@@ -57,7 +57,7 @@ function setup(t,closedby) {
       openDialog(openMethod);
       dialog.requestClose();
       assert_false(dialog.open);
-      assert_false(dialog.matches(':open'));
+      assert_false(dialog.matches('[open]'));
     },`requestClose basic behavior ${testDescription}`);
 
     promise_test(async (t) => {
@@ -73,7 +73,7 @@ function setup(t,closedby) {
       assert_array_equals(events,[]);
       dialog.requestClose();
       assert_false(dialog.open);
-      assert_false(dialog.matches(':open'));
+      assert_false(dialog.matches('[open]'));
       assert_array_equals(events,['cancel'],'close is scheduled');
       await untilFullyClosed;
       assert_array_equals(events,['cancel','close']);
@@ -95,7 +95,7 @@ function setup(t,closedby) {
       assert_array_equals(events,[]);
       dialog.requestClose();
       assert_false(dialog.open,'Adding closedby after dialog is open');
-      assert_false(dialog.matches(':open'));
+      assert_false(dialog.matches('[open]'));
       assert_array_equals(events,['cancel']);
       await untilFullyClosed;
       events=[];
@@ -121,11 +121,11 @@ function setup(t,closedby) {
         openDialog(openMethod);
         dialog.requestClose();
         assert_true(dialog.open,'cancel event was cancelled - dialog shouldn\'t close');
-        assert_true(dialog.matches(':open'));
+        assert_true(dialog.matches('[open]'));
         shouldPreventDefault = false;
         dialog.requestClose();
         assert_false(dialog.open,'cancel event was not cancelled - dialog should now close');
-        assert_false(dialog.matches(':open'));
+        assert_false(dialog.matches('[open]'));
       },`requestClose can be cancelled ${testDescription}`);
 
       promise_test(async (t) => {
@@ -137,7 +137,7 @@ function setup(t,closedby) {
         dialog.requestClose();
         dialog.requestClose();
         assert_true(dialog.open,'cancel event was cancelled - dialog shouldn\'t close');
-        assert_true(dialog.matches(':open'));
+        assert_true(dialog.matches('[open]'));
       },`requestClose avoids abuse prevention logic ${testDescription}`);
 
       promise_test(async (t) => {
@@ -147,7 +147,7 @@ function setup(t,closedby) {
         const returnValue = 'The return value';
         dialog.requestClose(returnValue);
         assert_false(dialog.open);
-        assert_false(dialog.matches(':open'));
+        assert_false(dialog.matches('[open]'));
         assert_equals(dialog.returnValue,returnValue,'Return value should be set');
         dialog.show();
         dialog.close();
@@ -165,7 +165,7 @@ function setup(t,closedby) {
         assert_equals(dialog.returnValue,'foo');
         dialog.requestClose('This should not get saved');
         assert_true(dialog.open,'cancelled');
-        assert_true(dialog.matches(':open'));
+        assert_true(dialog.matches('[open]'));
         assert_equals(dialog.returnValue,'foo','Return value should not be changed');
       },`requestClose(returnValue) doesn't change returnvalue when cancelled ${testDescription}`);
     }

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source.html
@@ -76,7 +76,7 @@ createToggleEventSourceTest({
   closeFunc: async () => {
     dialog.addEventListener('cancel', event => event.preventDefault(), {once: true});
     requestclosebutton.click();
-    assert_true(dialog.matches(':open'),
+    assert_true(dialog.matches('[open]'),
       'cancel preventDefault should have prevented dialog from closing.');
     await (new test_driver.Actions()
       .pointerMove(0, 0, {origin: lightdismiss})


### PR DESCRIPTION
WebKit doesn't yet support this pseudo class, so match against [open] instead.