### PR TITLE
Don't allow the javascript: protocol in navigation.navigate()

### DIFF
--- a/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
+++ b/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
@@ -25,6 +25,6 @@ for (const iframe of iframes) {
 
     const result = win.navigation.navigate(url, { history: "replace" });
     await assertBothRejectDOM(t, result, "NotSupportedError", win);
-  }, `navigate() to ${format_value(url)} with (auto) or { history: 'replace' }`);
+  }, `navigate() to ${format_value(url)} with { history: 'replace' }`);
 }
 </script>

--- a/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
+++ b/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
@@ -3,22 +3,28 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
+<iframe data-url="javascript:void 0"></iframe>
+<iframe data-url="javascript:'foo'"></iframe>
+
 <script type="module">
 import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
 
-promise_test(async t => {
-  // Wait for after the load event so that we are definitely testing the
-  // javascript: URL as the cause of the rejections.
-  await ensureWindowLoadEventFired(t);
+const iframes = document.querySelectorAll("iframe");
 
-  navigation.onnavigate = t.unreached_func("onnavigate should not be called");
-  navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
-  navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
+for (const iframe of iframes) {
+  const url = iframe.dataset.url;
+  promise_test(async t => {
+    // Wait for after the load event so that we are definitely testing the
+    // javascript: URL as the cause of the rejections.
+    await ensureWindowLoadEventFired(t);
 
-  let result = navigation.navigate("javascript:void 0");
-  await assertBothRejectDOM(t, result, "NotSupportedError");
+    const win = iframe.contentWindow;
+    win.navigation.onnavigate = t.unreached_func("onnavigate should not be called");
+    win.navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
+    win.navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
 
-  result = navigation.navigate("javascript:void 0", { history: "replace" });
-  await assertBothRejectDOM(t, result, "NotSupportedError");
-}, "navigate() to a javascript: URL with (auto) or { history: 'replace' }");
+    const result = win.navigation.navigate(url, { history: "replace" });
+    await assertBothRejectDOM(t, result, "NotSupportedError", win);
+  }, `navigate() to ${format_value(url)} with (auto) or { history: 'replace' }`);
+}
 </script>

--- a/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
+++ b/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
@@ -15,7 +15,10 @@ promise_test(async t => {
   navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
   navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
 
-  const result = navigation.navigate("javascript:void 0", { history: "push" });
+  let result = navigation.navigate("javascript:void 0");
   await assertBothRejectDOM(t, result, "NotSupportedError");
-}, "navigate() to a javascript: URL with { history: 'push' }");
+
+  result = navigation.navigate("javascript:void 0", { history: "replace" });
+  await assertBothRejectDOM(t, result, "NotSupportedError");
+}, "navigate() to a javascript: URL with (auto) or { history: 'replace' }");
 </script>

--- a/navigation-api/navigation-methods/return-value/navigate-push-javascript-url.html
+++ b/navigation-api/navigation-methods/return-value/navigate-push-javascript-url.html
@@ -3,19 +3,28 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/helpers.js"></script>
 
+<iframe data-url="javascript:void 0"></iframe>
+<iframe data-url="javascript:'foo'"></iframe>
+
 <script type="module">
 import { ensureWindowLoadEventFired } from "../../resources/helpers.mjs";
 
-promise_test(async t => {
-  // Wait for after the load event so that we are definitely testing the
-  // javascript: URL as the cause of the rejections.
-  await ensureWindowLoadEventFired(t);
+const iframes = document.querySelectorAll("iframe");
 
-  navigation.onnavigate = t.unreached_func("onnavigate should not be called");
-  navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
-  navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
+for (const iframe of iframes) {
+  const url = iframe.dataset.url;
+  promise_test(async t => {
+    // Wait for after the load event so that we are definitely testing the
+    // javascript: URL as the cause of the rejections.
+    await ensureWindowLoadEventFired(t);
 
-  const result = navigation.navigate("javascript:void 0", { history: "push" });
-  await assertBothRejectDOM(t, result, "NotSupportedError");
-}, "navigate() to a javascript: URL with { history: 'push' }");
+    const win = iframe.contentWindow;
+    win.navigation.onnavigate = t.unreached_func("onnavigate should not be called");
+    win.navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
+    win.navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
+
+    const result = win.navigation.navigate(url, { history: "push" });
+    await assertBothRejectDOM(t, result, "NotSupportedError", win);
+  }, `navigate() to ${format_value(url)} with { history: 'push' }`);
+}
 </script>


### PR DESCRIPTION
Test for https://github.com/whatwg/html/pull/11533

This is a replacement for https://github.com/web-platform-tests/wpt/pull/54437, which had problems with harness errors on browsers not implementing this change and an unwanted change to interop-2025.

@gsnedders @zcorpan 