### PR TITLE
Add TT script enforcement tests using HTMLElement.innerText and Node.…

### DIFF
--- a/trusted-types/script-enforcement-001.html
+++ b/trusted-types/script-enforcement-001.html
@@ -34,6 +34,15 @@
   }, "Script source set via TrustedScript sink HTMLScriptElement.innerText keeps trustworthiness.");
 
   promise_test(async t => {
+    let script = document.createElement("script");
+    Object.getOwnPropertyDescriptor(HTMLElement.prototype, "innerText").set.call(script, LOG_RUN_MESSAGE);
+    assert_equals(script.innerText, LOG_RUN_MESSAGE, "TrustedScript not required.");
+    await no_script_message_for(_ => {
+      container.appendChild(script);
+    });
+  }, "Script source set via HTMLElement.innerText drops trustworthiness.");
+
+  promise_test(async t => {
     await promise_rejects_js(t, TypeError, script_messages_for(_ => {
       document.createElement("script").textContent = LOG_RUN_MESSAGE;
     }), "TrustedScript required.");
@@ -44,6 +53,15 @@
     });
     assert_equals(message, "RUN");
   }, "Script source set via TrustedScript sink HTMLScriptElement.textContent keeps trustworthiness.");
+
+  promise_test(async t => {
+    let script = document.createElement("script");
+    Object.getOwnPropertyDescriptor(Node.prototype, "textContent").set.call(script, LOG_RUN_MESSAGE);
+    assert_equals(script.textContent, LOG_RUN_MESSAGE, "TrustedScript not required.");
+    await no_script_message_for(_ => {
+      container.appendChild(script);
+    });
+  }, "Script source set Node.textContent drops trustworthiness.");
 
   promise_test(async t => {
     await promise_rejects_js(t, TypeError, script_messages_for(_ => {

--- a/trusted-types/script-enforcement-002.html
+++ b/trusted-types/script-enforcement-002.html
@@ -40,12 +40,34 @@
     let messages = await script_messages_for(_ => {
       let script = document.createElement("script");
       window.log_message("SET");
+      Object.getOwnPropertyDescriptor(HTMLElement.prototype, "innerText").set.call(script, LOG_RUN_MESSAGE);
+      window.log_message("APPEND");
+      container.appendChild(script);
+    });
+    assert_array_equals(messages, ["SET", "APPEND", "CREATE_SCRIPT", "HTMLScriptElement text", "RUN_TRUSTED_SCRIPT"]);
+  }, "Default policy's calls when setting script source via HTMLElement.innerText.");
+
+  promise_test(async t => {
+    let messages = await script_messages_for(_ => {
+      let script = document.createElement("script");
+      window.log_message("SET");
       script.textContent = LOG_RUN_MESSAGE;
       window.log_message("APPEND");
       container.appendChild(script);
     });
     assert_array_equals(messages, ["SET", "CREATE_SCRIPT", "HTMLScriptElement textContent", "APPEND", "RUN_TRUSTED_SCRIPT"]);
   }, "Default policy's calls when setting script source via HTMLScriptElement.textContent.");
+
+  promise_test(async t => {
+    let messages = await script_messages_for(_ => {
+      let script = document.createElement("script");
+      window.log_message("SET");
+      Object.getOwnPropertyDescriptor(Node.prototype, "textContent").set.call(script, LOG_RUN_MESSAGE);
+      window.log_message("APPEND");
+      container.appendChild(script);
+    });
+    assert_array_equals(messages, ["SET", "APPEND", "CREATE_SCRIPT", "HTMLScriptElement text", "RUN_TRUSTED_SCRIPT"]);
+  }, "Default policy's calls when setting script source via Node.textContent.");
 
   promise_test(async t => {
     let messages = await script_messages_for(_ => {

--- a/trusted-types/script-enforcement-002.html
+++ b/trusted-types/script-enforcement-002.html
@@ -45,7 +45,7 @@
       container.appendChild(script);
     });
     assert_array_equals(messages, ["SET", "APPEND", "CREATE_SCRIPT", "HTMLScriptElement text", "RUN_TRUSTED_SCRIPT"]);
-  }, "Default policy's calls when setting script source via HTMLElement.innerText.");
+  }, "Verify when the default policy is called for script source via HTMLElement.innerText.");
 
   promise_test(async t => {
     let messages = await script_messages_for(_ => {
@@ -67,7 +67,7 @@
       container.appendChild(script);
     });
     assert_array_equals(messages, ["SET", "APPEND", "CREATE_SCRIPT", "HTMLScriptElement text", "RUN_TRUSTED_SCRIPT"]);
-  }, "Default policy's calls when setting script source via Node.textContent.");
+  }, "Verify when the default policy is called for script source set via Node.textContent.");
 
   promise_test(async t => {
     let messages = await script_messages_for(_ => {

--- a/trusted-types/script-enforcement-003.html
+++ b/trusted-types/script-enforcement-003.html
@@ -72,6 +72,15 @@
   }, "Script source set via Element.textContent drops trustworthiness.");
 
   promise_test(async t => {
+    let script = document.createElement("script");
+    Object.getOwnPropertyDescriptor(Node.prototype, "textContent").set.call(script, LOG_RUN_MESSAGE);
+    assert_equals(script.textContent, LOG_RUN_MESSAGE, "TrustedScript not required.");
+    await no_script_message_for(_ => {
+      container.appendChild(script);
+    });
+  }, "Script source set via Node.textContent drops trustworthiness.");
+
+  promise_test(async t => {
     await promise_rejects_js(t, TypeError, script_messages_for(_ => {
       document.createElementNS(NSURI_SVG, "script").innerHTML = LOG_RUN_MESSAGE;
     }), "TrustedHTML required.");

--- a/trusted-types/script-enforcement-004.html
+++ b/trusted-types/script-enforcement-004.html
@@ -88,7 +88,7 @@
       container.appendChild(script);
     });
     assert_array_equals(messages, ["SET", "APPEND", "CREATE_SCRIPT", "HTMLScriptElement text", "RUN_TRUSTED_SCRIPT"]);
-  }, "Default policy's calls when setting script source via Node.textContent.");
+  }, "Verify when the default policy is called for script set source via Node.textContent.");
 
   promise_test(async t => {
     let messages = await script_messages_for(_ => {

--- a/trusted-types/script-enforcement-004.html
+++ b/trusted-types/script-enforcement-004.html
@@ -81,6 +81,17 @@
 
   promise_test(async t => {
     let messages = await script_messages_for(_ => {
+      let script = document.createElement("script");
+      window.log_message("SET");
+      Object.getOwnPropertyDescriptor(Node.prototype, "textContent").set.call(script, LOG_RUN_MESSAGE);
+      window.log_message("APPEND");
+      container.appendChild(script);
+    });
+    assert_array_equals(messages, ["SET", "APPEND", "CREATE_SCRIPT", "HTMLScriptElement text", "RUN_TRUSTED_SCRIPT"]);
+  }, "Default policy's calls when setting script source via Node.textContent.");
+
+  promise_test(async t => {
+    let messages = await script_messages_for(_ => {
       let script = document.createElementNS(NSURI_SVG, "script");
       window.log_message("SET");
       script.innerHTML = LOG_RUN_MESSAGE;


### PR DESCRIPTION
…textContent

Setters for `HTMLElement.innerText` and `Node.textContent` can be retrieve via `HTMLElement.prototype.__lookupSetter__('innerText')` and `Node.prototype.__lookupSetter__('textContent')` respectively. New tests are added to make sure they allow to set the script source of a `<script>` element (without requiring to pass a `TrustedScript`) but that execution of such a script with modified source is blocked.