### PR TITLE
wdspec: fix navigate relative_url test to use a relative url

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigate/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/__init__.py
@@ -5,7 +5,12 @@ from webdriver.bidi.error import UnknownErrorException
 from ... import any_string
 
 
-async def navigate_and_assert(bidi_session, context, url, wait="complete", expected_error=False):
+async def navigate_and_assert(
+    bidi_session, context, url, wait="complete", expected_error=False, expected_url=None
+):
+    if expected_url is None:
+        expected_url = url
+
     if expected_error:
         with pytest.raises(UnknownErrorException):
             await bidi_session.browsing_context.navigate(
@@ -16,13 +21,13 @@ async def navigate_and_assert(bidi_session, context, url, wait="complete", expec
         result = await bidi_session.browsing_context.navigate(
             context=context['context'], url=url, wait=wait
         )
-        assert result["url"] == url
+        assert result["url"] == expected_url
         any_string(result["navigation"])
 
         contexts = await bidi_session.browsing_context.get_tree(
             root=context['context']
         )
         assert len(contexts) == 1
-        assert contexts[0]["url"] == url
+        assert contexts[0]["url"] == expected_url
 
         return contexts

--- a/webdriver/tests/bidi/browsing_context/navigate/navigate.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/navigate.py
@@ -81,14 +81,15 @@ async def test_interactive_simultaneous_navigation(bidi_session, wait_for_future
 
 
 async def test_relative_url(bidi_session, new_tab, url):
-    url_before = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html"
+    url_before = url("/webdriver/tests/bidi/browsing_context/support/empty.html")
+
+    await navigate_and_assert(bidi_session, new_tab, url_before, wait="none")
+
+    relative_url = "other.html"
+    url_after = url_before.replace("empty.html", relative_url)
+    await navigate_and_assert(
+        bidi_session, new_tab, relative_url, wait="none", expected_url=url_after
     )
-
-    await navigate_and_assert(bidi_session, new_tab, url_before, "none")
-
-    url_after = url_before.replace("empty.html", "other.html")
-    await navigate_and_assert(bidi_session, new_tab, url_after, "none")
 
 
 async def test_same_document_navigation_in_before_unload(bidi_session, new_tab, url):
@@ -96,7 +97,7 @@ async def test_same_document_navigation_in_before_unload(bidi_session, new_tab, 
         "/webdriver/tests/bidi/browsing_context/support/empty.html"
     )
 
-    await navigate_and_assert(bidi_session, new_tab, url_before, "complete")
+    await navigate_and_assert(bidi_session, new_tab, url_before, wait="complete")
 
     await bidi_session.script.evaluate(
         expression="""window.addEventListener(
@@ -108,7 +109,7 @@ async def test_same_document_navigation_in_before_unload(bidi_session, new_tab, 
         await_promise=False)
 
     url_after = url_before.replace("empty.html", "other.html")
-    await navigate_and_assert(bidi_session, new_tab, url_after, "complete")
+    await navigate_and_assert(bidi_session, new_tab, url_after, wait="complete")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When introducing the shared helper to navigate and assert we missed that this specific test was navigating to a relative URL and we can't use the same url for navigating and the final assertion.

This PR updates the helper to allow to set a custom expected_url and uses this properly in the test_relative_url test.