### PR TITLE
`XMLHttpRequest` `Send`: fix Content-Type failures

### DIFF
--- a/xhr/setrequestheader-content-type.htm
+++ b/xhr/setrequestheader-content-type.htm
@@ -206,15 +206,6 @@
         "application/x-www-form-urlencoded;charset=UTF-8",
         'URLSearchParams request has correct default Content-Type of "application/x-www-form-urlencoded;charset=UTF-8"'
       )
-      request(
-        function _URLSearchParams() { return new URLSearchParams("q=testQ&topic=testTopic") },
-        {"Content-Type": "application/xml;charset=ASCII"},
-        "application/xml;charset=UTF-8",
-        "URLSearchParams request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
-        // the default Content-Type for URLSearchParams has a charset specified (utf-8) in
-        // https://fetch.spec.whatwg.org/#bodyinit, so the user's must be changed to match it
-        // as per https://xhr.spec.whatwg.org/#the-send%28%29-method step 4.
-      )
     </script>
   </body>
 </html>


### PR DESCRIPTION
Replaced usage of `typed_insert` since it ended converting `UTF-8` to lowercase.
Removed one of the test cases since it wasn't following spec since [xhr/205](https://github.com/whatwg/xhr/pull/205).

Testing: Changes covered by wpt
Fixes: #<!-- nolink -->20436

Reviewed in servo/servo#38993