### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252589

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-default-object-height-constrained-by-max-width.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-default-object-height-constrained-by-max-width.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="assert" content="Video that has no intrinsic size should have height constrained by max-width">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-sizing-4/#aspect-ratio-size-transfers">
+<link author="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<style>
+  video {
+    background-color: green;
+    width: auto;
+    height: auto;
+    max-width: 100px;
+  }
+</style>
+</head>
+<!-- aspect-ratio should be set to: auto 100 / 100-->
+<body>
+<p>Test passes if there is a filled green square.</p>
+<video width="100" height="100" src="/css/support/60x60-green.png">
+</body>
+</html>

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-default-object-width-constrained-by-max-height.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-default-object-width-constrained-by-max-height.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="assert" content="Video that has no intrinsic size should have width constrained by max-height">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-sizing-4/#aspect-ratio-size-transfers">
+<link author="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<style>
+  video {
+    background-color: green;
+    width: auto;
+    height: auto;
+    max-height: 100px;
+  }
+</style>
+</head>
+  <!-- aspect-ratio should be set to: auto 100 / 100-->
+<body>
+<p>Test passes if there is a filled green square.</p>
+<video width="100" height="100" src="/css/support/60x60-green.png">
+</body>
+</html>

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-inline-size-containment-no-crash.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-inline-size-containment-no-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link author="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Applying inline-size containment to the video should not result in a debug assert being triggered">
+<style>
+video {
+  aspect-ratio: 1;
+  container-type: inline-size;
+  inset: 0 auto;
+  min-width: min-content;
+  position: fixed;
+}
+</style>
+</head>
+<body>
+<video></video>
+</body>
+</html>

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
@@ -26,13 +26,10 @@
              verify that width/height does not influence intrinsic ratio -->
         <video title="both width/height attributes and style"
                data-expected-width="300" data-expected-height="150"
-<<<<<<< ours
                width="100" height="100" style="width: auto; height: auto; aspect-ratio: auto"></video>
         <!-- Same, but now keeping the `aspect-ratio` presentational hint -->
         <video title="both width/height attributes and style keeping aspect-ratio"
                data-expected-width="500" data-expected-height="500"
-=======
->>>>>>> theirs
                width="100" height="100" style="width: auto; height: auto"></video>
         <script>
             Array.prototype.forEach.call(document.querySelectorAll('video'), function(video)

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
@@ -26,10 +26,13 @@
              verify that width/height does not influence intrinsic ratio -->
         <video title="both width/height attributes and style"
                data-expected-width="300" data-expected-height="150"
+<<<<<<< ours
                width="100" height="100" style="width: auto; height: auto; aspect-ratio: auto"></video>
         <!-- Same, but now keeping the `aspect-ratio` presentational hint -->
         <video title="both width/height attributes and style keeping aspect-ratio"
                data-expected-width="500" data-expected-height="500"
+=======
+>>>>>>> theirs
                width="100" height="100" style="width: auto; height: auto"></video>
         <script>
             Array.prototype.forEach.call(document.querySelectorAll('video'), function(video)


### PR DESCRIPTION
WebKit export from bug: [RenderReplaced::computeAspectRatioInformationForRenderBox does not need to call into RenderBox::computeReplacedLogicalWidth](https://bugs.webkit.org/show_bug.cgi?id=252589)