### PR TITLE
Do not use `pipe=trickle` on empty page

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigate/error.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/error.py
@@ -145,7 +145,7 @@ async def test_with_new_navigation(
     wait_for_future_safe,
 ):
     slow_page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
     await subscribe_events(events=[NAVIGATION_STARTED_EVENT])
 
@@ -212,7 +212,7 @@ async def test_close_context(
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
     slow_page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
 
     on_navigation_started = wait_for_event(NAVIGATION_STARTED_EVENT)
@@ -250,7 +250,7 @@ async def test_close_iframe(
     iframe_context = contexts[0]["children"][0]["context"]
 
     slow_page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
     await subscribe_events(events=[NAVIGATION_STARTED_EVENT])
 

--- a/webdriver/tests/bidi/browsing_context/navigate/wait.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/wait.py
@@ -67,7 +67,7 @@ async def test_slow_image_blocks_load(bidi_session, inline, new_tab, wait, expec
 )
 async def test_slow_page(bidi_session, new_tab, url, wait, expect_timeout):
     page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
 
     await wait_for_navigation(bidi_session, new_tab["context"], page_url, wait, expect_timeout)

--- a/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py
+++ b/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py
@@ -230,7 +230,7 @@ async def test_with_new_navigation(
     wait_for_future_safe,
 ):
     slow_page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
     # Depending on implementation, the `trickle(d10)` page can or can not yet
     # create a new document. Depending on this, `aborted` or `failed` event
@@ -346,7 +346,7 @@ async def test_close_context(
 ):
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
     slow_page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
     # Depending on implementation, the `trickle(d10)` page can or can not yet
     # create a new document. Depending on this, `aborted` or `failed` event
@@ -412,7 +412,7 @@ async def test_close_iframe(
     iframe_context = contexts[0]["children"][0]["context"]
 
     slow_page_url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d10)"
     )
     # Navigate in the iframe.
     result = await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/browsing_context/reload/wait.py
+++ b/webdriver/tests/bidi/browsing_context/reload/wait.py
@@ -97,7 +97,7 @@ async def test_slow_page(
     wait_for_future_safe,
 ):
     url = url(
-        "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d3)"
+        "/webdriver/tests/support/html/default.html?pipe=trickle(d3)"
     )
 
     await bidi_session.browsing_context.navigate(


### PR DESCRIPTION
Somehow `pipe=trickle(...)` does not take effect on empty pages in Chromium. Replace it with non-empty page to take the effects.