### PR TITLE
Add animation tests for math-* properties

### DIFF
--- a/mathml/relations/css-styling/parsing/math-depth-computed.html
+++ b/mathml/relations/css-styling/parsing/math-depth-computed.html
@@ -12,6 +12,9 @@
 <body>
 <math id="target"></math>
 <script>
+  test_computed_value("math-depth", "auto-add", "0");
+  test_computed_value("math-depth", "add(0)", "0");
+  test_computed_value("math-depth", "add(1)", "1");
   test_computed_value("math-depth", "0");
   test_computed_value("math-depth", "1");
 </script>

--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -905,6 +905,26 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'circle', 'square' ] ] }
     ]
   },
+  "math-depth": {
+    // https://w3c.github.io/mathml-core/#propdef-math-depth
+    types: [
+      "integer",
+      { type: "discrete", options: [ [ "auto-add", "1", "0", "1" ],
+                                     [ "add(1)", "2", "1", "2" ] ] },
+    ],
+  },
+  "math-shift": {
+    // https://w3c.github.io/mathml-core/#propdef-math-shift
+    types: [
+      { type: "discrete", options: [ [ "normal", "compact" ] ] },
+    ],
+  },
+  "math-style": {
+    // https://w3c.github.io/mathml-core/#propdef-math-style
+    types: [
+      { type: "discrete", options: [ [ "normal", "compact" ] ] },
+    ],
+  },
   'margin-block-end': {
     // https://drafts.csswg.org/css-logical-props/#propdef-margin-block-end
     types: [


### PR DESCRIPTION
Adds animation tests for `math-*` properties defined in the [`zaqhttps://w3c.github.io/mathml-core/#css-extensions-for-math-layoutMathML Core Spec](https://w3c.github.io/mathml-core/#css-extensions-for-math-layout). The properties will animate by computed value as discussed on w3c/mathml-core#293, which resolves to:

- `math-shift`: Discrete.
- `math-style`: Discrete.
- `math-depth`: Like an integer.

I also included a few cases that I missed when adding the parsing tests for `math-depth` that are relevant to verify the values when testing the animation from `auto-add` and `add()`.