### PR TITLE
Additional test cases for ::first-letter and ::first-line with MathML

### DIFF
--- a/mathml/relations/css-styling/first-line-first-letter-pseudo-elements-003-ref.html
+++ b/mathml/relations/css-styling/first-line-first-letter-pseudo-elements-003-ref.html
@@ -5,7 +5,10 @@
 <ol>
   <li>
     <div class="firstline">
-      <math style="display: inline math"><mtext>Hello<br>World!</mtext></math>
+      <math>
+        <mtext style="display: inline math">Hello<br>World!</mtext>
+      </math>
+    </div>
   </li>
   <li>
     <div class="firstletter">
@@ -26,6 +29,46 @@
       <math>
         <mtext style="display: block math">Hello<br>World!</mtext>
       </math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math style="display: inline math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math style="display: inline math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math style="display: block math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math style="display: block math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math display="inline"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math display="inline"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math display="block"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math display="block"><mtext>Hello<br>World!</mtext></math>
     </div>
   </li>
 </ol>

--- a/mathml/relations/css-styling/first-line-first-letter-pseudo-elements-003.html
+++ b/mathml/relations/css-styling/first-line-first-letter-pseudo-elements-003.html
@@ -12,7 +12,10 @@
 <ol>
   <li>
     <div class="firstline">
-      <math style="display: inline math"><mtext>Hello<br>World!</mtext></math>
+      <math>
+        <mtext style="display: inline math">Hello<br>World!</mtext>
+      </math>
+    </div>
   </li>
   <li>
     <div class="firstletter">
@@ -33,6 +36,46 @@
       <math>
         <mtext style="display: block math">Hello<br>World!</mtext>
       </math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math style="display: inline math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math style="display: inline math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math style="display: block math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math style="display: block math"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math display="inline"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math display="inline"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstline">
+      <math display="block"><mtext>Hello<br>World!</mtext></math>
+    </div>
+  </li>
+  <li>
+    <div class="firstletter">
+      <math display="block"><mtext>Hello<br>World!</mtext></math>
     </div>
   </li>
 </ol>


### PR DESCRIPTION
Completes the tests for `::first-letter` and `::first-line` introduced in #43334 according to [Fred's comment](https://github.com/web-platform-tests/wpt/pull/43334#discussion_r1555351872). Related to w3c/mathml-core#236.

Adds cases for three different ways of specifying `display`:
- In the `mtext` element.
- In the `math` element with `style`.
- In the `math` element with `display`.

The behaviour is currently different across engines, so it seems relevant to test all three. From left to right, Firefox, Chromium and WebKit:

![Rendering in different engines](https://github.com/user-attachments/assets/0357abd4-b44d-4d3c-8750-82194339440a)