### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297754

### DIFF
--- a/css/css-anchor-position/last-successful-fallback-to-base-style.html
+++ b/css/css-anchor-position/last-successful-fallback-to-base-style.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning: switch from using fallback style to base style</title>
+<meta name="description" content="Tests a bug in WebKit where if a fallback is initially used, then the base style is used, WebKit will remember the fallback to be the last successful position fallback instead of the base style.">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#last-successful-position-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+<style>
+  #container {
+    position: relative;
+    width: 600px;
+    height: 300px;
+    background: teal;
+  }
+  #anchor {
+    position: relative;
+    top: 100px;
+    left: 100px;
+    width: 100px;
+    height: 100px;
+    background: red;
+    anchor-name: --a;
+  }
+  #anchored {
+    position-anchor: --a;
+    position-try-fallbacks: flip-inline;
+    position: absolute;
+    width: 200px;
+    height: 100px;
+    position-area: left center;
+    background: lime;
+  }
+</style>
+<div id="container">
+  <div id="anchor"></div>
+  <div id="anchored"></div>
+</div>
+<script>
+  promise_test(async () => {
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 200);
+  }, "Starts rendering with flip-inline fallback");
+
+  promise_test(async () => {
+    anchor.style.left = "350px";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 150);
+  }, "Base position without fallback now successful");
+
+  promise_test(async () => {
+    anchor.style.left = "300px";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 100);
+  }, "Both base position and flip-inline works, keep base position since it's the last successful option");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[css-anchor-position-1\] PositionOptions::currentOption should always set lastSuccessfulPositionTryFallbackIndex](https://bugs.webkit.org/show_bug.cgi?id=297754)