### PR TITLE
layout: Lay out collapsed table rows and columns, but don't paint them

### DIFF
--- a/css/css-tables/table-collapsed-row-or-column-crash.html
+++ b/css/css-tables/table-collapsed-row-or-column-crash.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/servo/servo/issues/37421">
+
+<div style="display: table; visibility: collapse">
+  <div id="scroller" style="overflow: scroll"></div>
+</div>
+
+<table>
+    <colgroup>
+        <col style="background: green; visibility: collapse">
+    </colgroup>
+    <tr>
+        <td><div id="scroller2" style="overflow: scroll"></div></td>
+    </tr>
+</table>
+
+<script>
+    scroller.scrollTo();
+    scroller2.scrollTo();
+</script>
+


### PR DESCRIPTION
It's expected that script queries be able to interact with collapsed
table rows and columns, so this change starts laying them out. They
still do not affect table dimensions, nor are they painted.

This does not fix all interaction with collapsed rows and columns. For
instance, setting scroll offsets of contained scrolling nodes does not
work properly. It does fix the panic though, which is the most important
thing.


Testing: this change includes a new WPT crash test.
Fixes: #<!-- nolink -->37421.

Reviewed in servo/servo#39027