### PR TITLE
renderer: Apply initial viewport scale to `page_zoom`.

### DIFF
--- a/viewport/resources/viewport-page-dimensions-after-navigation-inner.html
+++ b/viewport/resources/viewport-page-dimensions-after-navigation-inner.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html data-expected-width="2048">
+    <head>
+        <title>Viewport: Verify page dimension after Navigation</title>
+        <link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+        <link rel="help" href="https://github.com/servo/servo/issues/39002">
+        <meta charset="utf-8">
+        <meta name="viewport" content="initial-scale=0.5">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="../../resources/check-layout-th.js"></script>
+    </head>
+    <body onload="checkLayout('html')">
+        <h1>Viewport: Verify page dimension after Navigation</h1>
+        <p>Test passes if page opens with width: 2048px</p>
+    </body>
+</html>

--- a/viewport/viewport-page-dimensions-after-navigation.html
+++ b/viewport/viewport-page-dimensions-after-navigation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Viewport: Verify page dimension after Navigation</title>
+    <link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+    <link rel="help" href="https://github.com/servo/servo/issues/39002">
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0">
+    <meta name="assert" content="Checks the page dimensions after navigation.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+        function runTest() {
+            const url = "resources/viewport-page-dimensions-after-navigation-inner.html";
+            window.location.replace(new URL(url, window.location));
+        }
+        onload = () => runTest();
+    </script>
+</head>
+</html>


### PR DESCRIPTION
Attached test highlights that applying viewport scale needs reflow.
Hence applying it to `page_zoom` because we reflow for `page_zoom`.

Testing: `viewport/viewport-page-dimensions-after-navigation.html`
Fixes: #<!-- nolink -->39002 

Reviewed in servo/servo#39067