### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=298163

### DIFF
--- a/css/css-color/parsing/color-computed-color-function.html
+++ b/css/css-color/parsing/color-computed-color-function.html
@@ -18,7 +18,7 @@
   }
 </style>
 <script>
-for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
+for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3", "display-p3-linear" ]) {
     test_computed_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} 10% 10% 10%)`, `color(${colorSpace} 0.1 0.1 0.1)`);
     test_computed_value("color", `color(${colorSpace} .2 .2 25%)`, `color(${colorSpace} 0.2 0.2 0.25)`);
@@ -148,6 +148,26 @@ test_computed_value("color", "color(display-p3 none none none / none)", "color(d
 test_computed_value("color", "color(display-p3 1.00 none 0.2 / none)", "color(display-p3 1 none 0.2 / none)", "[Display P3 with alpha, number and none]");
 test_computed_value("color", "color(display-p3 100% none 20% / 30%)", "color(display-p3 1 none 0.2 / 0.3)", "[Display P3 with alpha, percent and none]");
 test_computed_value("color", "color(display-p3 100% none 0.2 / 23.7%)", "color(display-p3 1 none 0.2 / 0.237)", "[Display P3 with alpha, number, percent and none]");
+
+// Opaque Display P3 Linear in color()
+test_computed_value("color", "color(display-p3-linear 1.00 0.50 0.200)", "color(display-p3-linear 1 0.5 0.2)", "[Display P3 Linear all numbers]");
+test_computed_value("color", "color(display-p3-linear 100% 50% 20%)", "color(display-p3-linear 1 0.5 0.2)", "[Display P3 Linear all percent]");
+test_computed_value("color", "color(display-p3-linear 100% 0.5 20%)", "color(display-p3-linear 1 0.5 0.2)", "[Display P3 Linear mixed number and percent]");
+test_computed_value("color", "color(display-p3-linear 1.00 50% 0.2)", "color(display-p3-linear 1 0.5 0.2)", "[Display P3 Linear mixed number and percent 2]");
+test_computed_value("color", "color(display-p3-linear none none none)", "color(display-p3-linear none none none)", "[Display P3 Linear all none]");
+test_computed_value("color", "color(display-p3-linear 1.00 none 0.2)", "color(display-p3-linear 1 none 0.2)", "[Display P3 Linear number and none]");
+test_computed_value("color", "color(display-p3-linear 100% none 20%)", "color(display-p3-linear 1 none 0.2)", "[Display P3 Linear percent and none]");
+test_computed_value("color", "color(display-p3-linear 100% none 0.2)", "color(display-p3-linear 1 none 0.2)", "[Display P3 Linear number, percent and none]");
+
+// non-unity alpha, Display P3 Linear in  color()
+test_computed_value("color", "color(display-p3-linear 1.00 0.50 0.200 / 0.6)", "color(display-p3-linear 1 0.5 0.2 / 0.6)", "[Display P3 Linear with alpha, all numbers]");
+test_computed_value("color", "color(display-p3-linear 100% 50% 20% / 60%)", "color(display-p3-linear 1 0.5 0.2 / 0.6)", "[Display P3 Linear with alpha, all percent]");
+test_computed_value("color", "color(display-p3-linear 100% 0.5 20% / 0.6)", "color(display-p3-linear 1 0.5 0.2 / 0.6)", "[Display P3 Linear with alpha, mixed number and percent]");
+test_computed_value("color", "color(display-p3-linear 1.00 50% 0.2 / 60%)", "color(display-p3-linear 1 0.5 0.2 / 0.6)", "[Display P3 Linear with alpha, mixed number and percent 2]");
+test_computed_value("color", "color(display-p3-linear none none none / none)", "color(display-p3-linear none none none / none)", "[Display P3 Linear with alpha, all none]");
+test_computed_value("color", "color(display-p3-linear 1.00 none 0.2 / none)", "color(display-p3-linear 1 none 0.2 / none)", "[Display P3 Linear with alpha, number and none]");
+test_computed_value("color", "color(display-p3-linear 100% none 20% / 30%)", "color(display-p3-linear 1 none 0.2 / 0.3)", "[Display P3 Linear with alpha, percent and none]");
+test_computed_value("color", "color(display-p3-linear 100% none 0.2 / 23.7%)", "color(display-p3-linear 1 none 0.2 / 0.237)", "[Display P3 Linear with alpha, number, percent and none]");
 
 // Opaque A98 RGB in color()
 test_computed_value("color", "color(a98-rgb 1.00 0.50 0.200)", "color(a98-rgb 1 0.5 0.2)", "[A98 RGB all numbers]");

--- a/css/css-color/parsing/color-computed-color-mix-function.html
+++ b/css/css-color/parsing/color-computed-color-mix-function.html
@@ -489,7 +489,7 @@
     fuzzy_test_computed_color(`color-mix(in oklab, oklab(0.1 0.2 0.3 / 25%) 0%, oklab(none none none / 0.5))`, `oklab(0.1 0.2 0.3 / 0.5)`);
     fuzzy_test_computed_color(`color-mix(in oklab, oklab(0.1 0.2 0.3 / 25%) 0%, oklab(0.5 none none / 0.5))`, `oklab(0.5 0.2 0.3 / 0.5)`);
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "display-p3-linear", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
         const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
 
         fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.3 0.4 0.5)`);

--- a/css/css-color/parsing/color-computed-relative-color.html
+++ b/css/css-color/parsing/color-computed-relative-color.html
@@ -641,7 +641,7 @@
   fuzzy_test_computed_color(`color-mix(in oklch, oklch(from oklch(0.7 0.45 30) l c none), oklch(0.7 0.45 30))`, `oklch(0.7 0.45 30)`);
   fuzzy_test_computed_color(`oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)`, `oklch(0.7 0.45 30)`);
 
-  for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
+  for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3", "display-p3-linear" ]) {
       // Testing no modifications.
       fuzzy_test_computed_color(`color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 0.7 0.5 0.3)`);
       fuzzy_test_computed_color(`color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 0.7 0.5 0.3)`);

--- a/css/css-color/parsing/color-invalid-color-mix-function.html
+++ b/css/css-color/parsing/color-invalid-color-mix-function.html
@@ -74,7 +74,7 @@
         test_invalid_value(`color`, `color-mix(${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70))`); // Missing interpolation method.
     }
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "display-p3-linear", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
         test_invalid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3) -10%, color(${colorSpace} .5 .6 .7))`); // Percentages less than 0 are not valid.
         test_invalid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3) 150%, color(${colorSpace} .5 .6 .7))`); // Percentages greater than 100 are not valid.
         test_invalid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3) 0%, color(${colorSpace} .5 .6 .7) 0%)`); // Sum of percengates cannot be 0%.

--- a/css/css-color/parsing/color-invalid-relative-color.html
+++ b/css/css-color/parsing/color-invalid-relative-color.html
@@ -109,7 +109,7 @@
         test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) l c calc(h + 1deg))`);
     }
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3", "display-p3-linear" ]) {
         // Testing invalid values.
         test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 10deg g b)`);
         test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 10deg b)`);

--- a/css/css-color/parsing/color-valid-color-function.html
+++ b/css/css-color/parsing/color-valid-color-function.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <script>
-for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3", "xyz", "xyz-d50", "xyz-d65" ]) {
+for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3", "display-p3-linear", "xyz", "xyz-d50", "xyz-d65" ]) {
     const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
 
     test_valid_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${resultColorSpace} 0 0 0)`);

--- a/css/css-color/parsing/color-valid-color-mix-function.html
+++ b/css/css-color/parsing/color-valid-color-mix-function.html
@@ -389,7 +389,7 @@
     fuzzy_test_valid_color(`color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / 0.5))`, `color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / 0.5))`);
     fuzzy_test_valid_color(`color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / none))`, `color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / none))`);
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "display-p3-linear", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
       const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
 
       fuzzy_test_valid_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} .5 .6 .7))`, `color-mix(in ${resultColorSpace}, color(${resultColorSpace} 0.1 0.2 0.3), color(${resultColorSpace} 0.5 0.6 0.7))`);

--- a/css/css-color/parsing/color-valid-relative-color.html
+++ b/css/css-color/parsing/color-valid-relative-color.html
@@ -582,7 +582,7 @@
     // color-mix
     fuzzy_test_valid_color(`oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)`);
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3", "display-p3-linear" ]) {
         // Testing no modifications.
         fuzzy_test_valid_color(`color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b)`);
         fuzzy_test_valid_color(`color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / alpha)`);


### PR DESCRIPTION
WebKit export from bug: [\[Color\] Add support for display-p3-linear colors in CSS](https://bugs.webkit.org/show_bug.cgi?id=298163)