### PR TITLE
layout: Gracefully handle script queries on nodes with uninvertible transforms

### DIFF
--- a/css/css-transforms/crashtests/uninvertible-transform-and-script-queries.html
+++ b/css/css-transforms/crashtests/uninvertible-transform-and-script-queries.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/servo/servo/issues/38848">
+
+<div style="transform: scale(0)">
+    <img style="height: 200px; width: 200px; border: solid;" id="img">
+    <div style="height: 200px; width: 200px; border: solid;" id="div"></div>
+</div>
+<script>
+    div.getBoundingClientRect();
+    div.getClientRects();
+    img.getBoundingClientRect();
+    img.getClientRects();
+    img.height;
+    img.width;
+</script>


### PR DESCRIPTION
Instead of panicking when doing a geometry script query on a node with
an uninvertible transform, return a zero-sized rectangle at the
untransformed position. This is similar to what Gecko and Blink do
(though it seems there are some differences in positioning this
zero-sized rectangle). Mostly importantly, do not panic.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->38848.

Reviewed in servo/servo#39075