### PR TITLE
script: Implement document's active sandboxing flag set

### DIFF
--- a/content-security-policy/sandbox/autoplay-disabled-by-csp.html
+++ b/content-security-policy/sandbox/autoplay-disabled-by-csp.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#eligible-for-autoplay" />
+  <title>Test that autoplay is blocked by a document's active sandboxing flags</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/media.js"></script>
+  </head>
+  <body>
+    <video id="v" autoplay></video>
+    <script>
+      async_test((t) => {
+        var v = document.getElementById('v')
+
+        v.addEventListener('playing', t.unreached_func('video should not autoplay due to sandboxing flags'));
+
+        v.src = getVideoURI('/media/movie_5') + '?' + new Date() + Math.random()
+        t.step_timeout(() => t.done(), 500);
+      }, 'csp-derived sandboxing flags prevent autoplay.')
+    </script>
+  </body>
+</html>

--- a/content-security-policy/sandbox/autoplay-disabled-by-csp.html.headers
+++ b/content-security-policy/sandbox/autoplay-disabled-by-csp.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-forms

--- a/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html
+++ b/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#concept-form-submit">
+  <title>Test that form submission is blocked by a document's active sandboxing flags</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <form id="f">
+      <input type="hidden" value="test" />
+    </form>
+    <script>
+      async_test((t) => {
+        var f = document.getElementById('f')
+
+        f.addEventListener('submit', t.unreached_func('form should not be submitted due to sandboxing flags'));
+
+        f.submit();
+        t.step_timeout(() => t.done(), 500);
+      }, 'csp-derived sandboxing flags prevent form submission.')
+    </script>
+  </body>
+</html>

--- a/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html.headers
+++ b/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts


### PR DESCRIPTION
Implements document's active sandboxing flags. These are currently populated only from CSP-derived sandboxing flags for a new document, when defined in the CSP.

Testing: 1 new pass, and some new wpt's are added to test points in the spec where these flags influence behaviour. 
Reviewed in servo/servo#39079