### PR TITLE
feat(css): Add reftest for ::before as a flex containerAdd before flex reftest

### DIFF
--- a/css/css-pseudo/before-as-flex-container-ref.html
+++ b/css/css-pseudo/before-as-flex-container-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>CSS Test: ::before pseudo-element as a flex container - Reference</title>
+<link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
+
+<style>
+  div {
+    width: 200px;
+    height: 100px;
+    background: green;
+    display: flex;
+    justify-content: space-between;
+  }
+</style>
+</head>
+<body>
+<div>
+  <span>A</span>
+  <span>B</span>
+</div>
+</body>
+</html>

--- a/css/css-pseudo/before-as-flex-container.html
+++ b/css/css-pseudo/before-as-flex-container.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<title>CSS Test: ::before pseudo-element as a flex container</title>
+<link rel="author" title="Deepith N" href="mailto:deekshithdeepith@gmail.com">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#generated-content">
+<link rel="match" href="before-as-flex-container-ref.html">
+
+<style>
+  div {
+    width: 200px;
+    height: 100px;
+    background: red; /* This will show up if the test fails */
+  }
+
+  div::before {
+    content: "A B"; /* Two "words" to become flex items */
+    display: flex;
+    justify-content: space-between; /* Pushes "A" and "B" to the edges */
+    width: 200px;
+    height: 100px;
+    background: green; /* This should cover the red background */
+  }
+</style>
+
+<div></div>


### PR DESCRIPTION
This PR adds a reftest to verify that a ::before pseudo-element can act as a flex container, as per the specification.
The test applies display: flex to a ::before pseudo-element. The reference file creates an identical visual using a standard <div> with display: flex.
Spec Reference: https://www.w3.org/TR/css-pseudo-4/#generated-content