### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=298271

### DIFF
--- a/navigation-api/navigate-event/navigate-svg-anchor-download-userInitiated.html
+++ b/navigation-api/navigate-event/navigate-svg-anchor-download-userInitiated.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<body>
+<svg><a id="a" href="?1"><text x="0" y="5">Click me</text></a></svg>
+<script>
+async_test(t => {
+  a.download = "";
+  navigation.onnavigate = t.step_func(e => {
+    assert_equals(e.navigationType, "push");
+    assert_true(e.cancelable);
+    assert_true(e.canIntercept);
+    assert_true(e.userInitiated);
+    assert_false(e.hashChange);
+    assert_equals(e.downloadRequest, "");
+    assert_equals(e.formData, null);
+    assert_equals(new URL(e.destination.url).search, "?1");
+    assert_false(e.destination.sameDocument);
+    assert_equals(e.destination.key, "");
+    assert_equals(e.destination.id, "");
+    assert_equals(e.destination.index, -1);
+    assert_equals(e.sourceElement, document.getElementById("a"));
+    e.preventDefault();
+    t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
+  });
+  test_driver.click(a);
+}, `SVG <a download> click fires navigate event`);
+</script>
+</body>

--- a/navigation-api/navigate-event/navigate-svg-anchor-download.html
+++ b/navigation-api/navigate-event/navigate-svg-anchor-download.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<svg><a id="a" href="foo.html"></a></svg>
+<script>
+for (const download_attr of ["", "filename"]) {
+  async_test(t => {
+    a.download = download_attr;
+    navigation.onnavigate = t.step_func_done(e => {
+      assert_equals(e.navigationType, "push");
+      assert_true(e.cancelable);
+      assert_true(e.canIntercept);
+      assert_false(e.userInitiated);
+      assert_false(e.hashChange);
+      assert_equals(e.downloadRequest, download_attr);
+      assert_equals(e.formData, null);
+      assert_equals(new URL(e.destination.url).pathname,
+                    "/navigation-api/navigate-event/foo.html");
+      assert_false(e.destination.sameDocument);
+      assert_equals(e.destination.key, "");
+      assert_equals(e.destination.id, "");
+      assert_equals(e.destination.index, -1);
+      assert_equals(e.sourceElement, a);
+      e.preventDefault();
+    });
+    a.dispatchEvent(new MouseEvent('click')); // SVG <a> doesn't support .click()
+  }, `SVG <a> fires navigate and populates downloadRequest with '${download_attr}'`);
+}
+</script>
+</body>


### PR DESCRIPTION
Adds navigate event tests for `<a download>` in SVG.