### PR TITLE
Use the intended reference file for word-spacing-002.html

### DIFF
--- a/css/css-text/word-spacing/word-spacing-002-ref.html
+++ b/css/css-text/word-spacing/word-spacing-002-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Text Reference: Word Spacing</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<meta name="flags" content="ahem">
+<style>
+/* We use Ahem to avoid very minor differences between the test and the
+   reference that occur with certain font+platform combinations. */
+div     { font-family: Ahem, monospace; font-size: 20px; white-space: pre; }
+div .ws { margin: -1ch; }
+</style>
+<body>
+  <p>Test passes if the space between the words starts at zero and increases by
+  an even amount on each subsequent line.</p>
+  <div class="ws0">A&nbsp;<span class="ws">Bc</span> Def <span class="ws">Ghij</span></div>
+  <div class="ws1">A&nbsp;Bc Def Ghij</div>
+  <div class="ws2">A&nbsp; Bc  Def  Ghij</div>
+  <div class="ws3">A&nbsp;  Bc   Def   Ghij</div>
+  <div class="ws4">A&nbsp;   Bc    Def    Ghij</div>
+</body>

--- a/css/css-text/word-spacing/word-spacing-002.html
+++ b/css/css-text/word-spacing/word-spacing-002.html
@@ -4,14 +4,10 @@
 <link rel="author" title="Elika Etemad" href="http://fantasai.inkedblade.net/contact">
 <link rel="help" href="http://www.w3.org/TR/css-text-3/#word-spacing">
 <link rel="stylesheet" href="/fonts/ahem.css">
-<link rel="match" href="word-spacing-001-ref.html">
+<link rel="match" href="word-spacing-002-ref.html">
 <meta name="flags" content="ahem">
 <meta name="assert" content="Test checks various length values of word-spacing, including calc().">
 <style>
-@font-face {
-  font-family: Ahem;
-  src: url(/fonts/Ahem.ttf);
-}
 /* We use Ahem to avoid very minor differences between the test and the
    reference that occur with certain font+platform combinations. */
 div        { font-family: Ahem, monospace; font-size: 20px; }


### PR DESCRIPTION
AFAICS, this test has been broken ever since it was imported from webkit. The original webkit commit included a word-spacing-002-expected.html file (see WebKit commit 6abbfb00701a455534e7d9af010909a6dc2b66ed) clearly intended as a reference (and maybe webkit's CI used it as such), but the actual test file links to word-spacing-001-ref.html, which can never have matched (it doesn't even have the same number of test lines).

The "expected" file didn't make it into WPT at all, and the test has always been failing. This commit imports it (with the name changed to use "ref"), and updates the link in the test appropriately.