### PR TITLE
html/popover: Add a set of focus tests for elements with slots, including details elements

### DIFF
--- a/html/semantics/popovers/popover-focus-5.html
+++ b/html/semantics/popovers/popover-focus-5.html
@@ -171,10 +171,7 @@
         );
         break;
       default:
-        assert_true(
-          false,
-          `unknown style - ${style} - expected one of imperative,commandfor,commandforelement,popovertarget,popovertargetelement`,
-        );
+        assert_unreached();
     }
     invoker.focus();
     assert_equals(document.activeElement, invoker);

--- a/html/semantics/popovers/popover-focus-5.html
+++ b/html/semantics/popovers/popover-focus-5.html
@@ -16,25 +16,27 @@
 <meta name="variant" content="?imperative" />
 
 <div data-candidate="form controls inside" data-count="2">
-  <button command="toggle-popover">Toggle popover</button>
+  <button tabindex=0 command="toggle-popover">Toggle popover</button>
   <div popover id="popover1">
-    <input type="text" data-expected="1" />
-    <input type="text" data-expected="2" />
-    <button command="hide-popover" data-expected="close">Close popover</button>
+    <input tabindex=0 type="text" data-expected="1" />
+    <input tabindex=0 type="text" data-expected="2" />
+    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
   </div>
 </div>
-<button data-expected="after">
+<button tabindex=0 data-expected="after">
   This button is where focus should land after traversing this popover
 </button>
 
 <div data-candidate="a details element inside" data-count="1">
-  <button command="toggle-popover">Toggle popover</button>
+  <button tabindex=0 command="toggle-popover">Toggle popover</button>
   <div popover id="popover2">
-    <details data-expected="1">A details element</details>
-    <button command="hide-popover" data-expected="close">Close popover</button>
+    <details data-expected="1">
+      <summary tabindex=0>A details element</summary>
+    </details>
+    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
   </div>
 </div>
-<button data-expected="after">
+<button tabindex=0 data-expected="after">
   This button is where focus should land after traversing this popover
 </button>
 
@@ -42,13 +44,13 @@
   data-candidate="a details element inside, and the after button adjacent to invoker"
   data-count="1"
 >
-  <button command="toggle-popover">Toggle popover</button>
-  <button data-expected="after">
+  <button tabindex=0 command="toggle-popover">Toggle popover</button>
+  <button tabindex=0 data-expected="after">
     This button is where focus should land after traversing this popover
   </button>
   <div popover id="popover3">
     <details data-expected="1">A details element</details>
-    <button command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
   </div>
 </div>
 
@@ -56,17 +58,17 @@
   data-candidate="a custom-element with delegatesfocus inside"
   data-count="1"
 >
-  <button command="toggle-popover">Toggle popover</button>
+  <button tabindex=0 command="toggle-popover">Toggle popover</button>
   <div popover id="popover4">
     <my-element data-expected="1">
       <template shadowrootmode="open" delegatesfocus>
-        <button></button>
+        <button tabindex=0></button>
       </template>
     </my-element>
-    <button command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
   </div>
 </div>
-<button data-expected="after">
+<button tabindex=0 data-expected="after">
   This button is where focus should land after traversing popover
 </button>
 
@@ -74,18 +76,18 @@
   data-candidate="a custom-element with a slotted button inside"
   data-count="1"
 >
-  <button command="toggle-popover">Toggle popover</button>
+  <button tabindex=0 command="toggle-popover">Toggle popover</button>
   <div popover id="popover5">
     <my-element>
       <template shadowrootmode="open">
         <slot></slot>
       </template>
-      <button data-expected="1"></button>
+      <button tabindex=0 data-expected="1"></button>
     </my-element>
-    <button command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
   </div>
 </div>
-<button data-expected="after">
+<button tabindex=0 data-expected="after">
   This button is where focus should land after traversing popover
 </button>
 
@@ -93,19 +95,23 @@
   data-candidate="custom-element with a slotted button, followed by a details element, where the after button is adjacent to the invoker"
   data-count="2"
 >
-  <button command="toggle-popover">Toggle popover</button>
-  <button data-expected="after">
+  <button tabindex=0 command="toggle-popover">Toggle popover</button>
+  <button tabindex=0 data-expected="after">
     This button is where focus should land after traversing popover
   </button>
   <div popover id="popover6">
     <my-element>
       <template shadowrootmode="open">
         <slot></slot>
-        <details data-expected="2">A details element</details>
+        <details data-expected="2">
+          <summary tabindex=0>
+            A details element
+          </summary>
+        </details>
       </template>
-      <button data-expected="1"></button>
+      <button tabindex=0 data-expected="1"></button>
     </my-element>
-    <button command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
   </div>
 </div>
 

--- a/html/semantics/popovers/popover-focus-5.html
+++ b/html/semantics/popovers/popover-focus-5.html
@@ -200,39 +200,39 @@
       assert_equals(
         document.activeElement?.getAttribute("data-expected"),
         String(i),
-        `active element ${i} should now have focus`,
+        `tab press should move to active element ${i}`,
       );
     }
     await sendTab();
     assert_equals(
       document.activeElement?.getAttribute("data-expected"),
       "close",
-      "close popover button should now have focus",
+      "tab press should move to close popover button",
     );
     await sendShiftTab();
     assert_equals(
       document.activeElement?.getAttribute("data-expected"),
       String(count),
-      "last active element should now have focus",
+      "shift+tab should move back to last active element",
     );
     await sendTab();
     assert_equals(
       document.activeElement,
       popoverClose,
-      "close popover button should now have focus",
+      "tab should move forward to re-land on close popover again",
     );
     await sendTab();
     assert_equals(
       document.activeElement?.getAttribute("data-expected"),
       "after",
-      "element after",
+      "tab should move forward to land on the button after the popover contents",
     );
     await sendShiftTab();
     popoverClose.click();
     assert_equals(
       document.activeElement,
       invoker,
-      "focus should have returned to initial invoker",
+      "popover now closed - focus should have returned to initial invoker",
     );
   }
 

--- a/html/semantics/popovers/popover-focus-5.html
+++ b/html/semantics/popovers/popover-focus-5.html
@@ -16,27 +16,31 @@
 <meta name="variant" content="?imperative" />
 
 <div data-candidate="form controls inside" data-count="2">
-  <button tabindex=0 command="toggle-popover">Toggle popover</button>
+  <button tabindex="0" command="toggle-popover">Toggle popover</button>
   <div popover id="popover1">
-    <input tabindex=0 type="text" data-expected="1" />
-    <input tabindex=0 type="text" data-expected="2" />
-    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
+    <input tabindex="0" type="text" data-expected="1" />
+    <input tabindex="0" type="text" data-expected="2" />
+    <button tabindex="0" command="hide-popover" data-expected="close">
+      Close popover
+    </button>
   </div>
 </div>
-<button tabindex=0 data-expected="after">
+<button tabindex="0" data-expected="after">
   This button is where focus should land after traversing this popover
 </button>
 
 <div data-candidate="a details element inside" data-count="1">
-  <button tabindex=0 command="toggle-popover">Toggle popover</button>
+  <button tabindex="0" command="toggle-popover">Toggle popover</button>
   <div popover id="popover2">
     <details data-expected="1">
-      <summary tabindex=0>A details element</summary>
+      <summary tabindex="0">A details element</summary>
     </details>
-    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex="0" command="hide-popover" data-expected="close">
+      Close popover
+    </button>
   </div>
 </div>
-<button tabindex=0 data-expected="after">
+<button tabindex="0" data-expected="after">
   This button is where focus should land after traversing this popover
 </button>
 
@@ -44,13 +48,15 @@
   data-candidate="a details element inside, and the after button adjacent to invoker"
   data-count="1"
 >
-  <button tabindex=0 command="toggle-popover">Toggle popover</button>
-  <button tabindex=0 data-expected="after">
+  <button tabindex="0" command="toggle-popover">Toggle popover</button>
+  <button tabindex="0" data-expected="after">
     This button is where focus should land after traversing this popover
   </button>
   <div popover id="popover3">
     <details data-expected="1">A details element</details>
-    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex="0" command="hide-popover" data-expected="close">
+      Close popover
+    </button>
   </div>
 </div>
 
@@ -58,17 +64,19 @@
   data-candidate="a custom-element with delegatesfocus inside"
   data-count="1"
 >
-  <button tabindex=0 command="toggle-popover">Toggle popover</button>
+  <button tabindex="0" command="toggle-popover">Toggle popover</button>
   <div popover id="popover4">
     <my-element data-expected="1">
       <template shadowrootmode="open" delegatesfocus>
-        <button tabindex=0></button>
+        <button tabindex="0"></button>
       </template>
     </my-element>
-    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex="0" command="hide-popover" data-expected="close">
+      Close popover
+    </button>
   </div>
 </div>
-<button tabindex=0 data-expected="after">
+<button tabindex="0" data-expected="after">
   This button is where focus should land after traversing popover
 </button>
 
@@ -76,18 +84,20 @@
   data-candidate="a custom-element with a slotted button inside"
   data-count="1"
 >
-  <button tabindex=0 command="toggle-popover">Toggle popover</button>
+  <button tabindex="0" command="toggle-popover">Toggle popover</button>
   <div popover id="popover5">
     <my-element>
       <template shadowrootmode="open">
         <slot></slot>
       </template>
-      <button tabindex=0 data-expected="1"></button>
+      <button tabindex="0" data-expected="1"></button>
     </my-element>
-    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex="0" command="hide-popover" data-expected="close">
+      Close popover
+    </button>
   </div>
 </div>
-<button tabindex=0 data-expected="after">
+<button tabindex="0" data-expected="after">
   This button is where focus should land after traversing popover
 </button>
 
@@ -95,8 +105,8 @@
   data-candidate="custom-element with a slotted button, followed by a details element, where the after button is adjacent to the invoker"
   data-count="2"
 >
-  <button tabindex=0 command="toggle-popover">Toggle popover</button>
-  <button tabindex=0 data-expected="after">
+  <button tabindex="0" command="toggle-popover">Toggle popover</button>
+  <button tabindex="0" data-expected="after">
     This button is where focus should land after traversing popover
   </button>
   <div popover id="popover6">
@@ -104,14 +114,14 @@
       <template shadowrootmode="open">
         <slot></slot>
         <details data-expected="2">
-          <summary tabindex=0>
-            A details element
-          </summary>
+          <summary tabindex="0">A details element</summary>
         </details>
       </template>
-      <button tabindex=0 data-expected="1"></button>
+      <button tabindex="0" data-expected="1"></button>
     </my-element>
-    <button tabindex=0 command="hide-popover" data-expected="close">Close popover</button>
+    <button tabindex="0" command="hide-popover" data-expected="close">
+      Close popover
+    </button>
   </div>
 </div>
 

--- a/html/semantics/popovers/popover-focus-5.html
+++ b/html/semantics/popovers/popover-focus-5.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Popover focus behaviors in slot elements</title>
+<meta name="timeout" content="long" />
+<link rel="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/popover-utils.js"></script>
+
+<meta name="variant" content="?commandforelement" />
+<meta name="variant" content="?popovertargetelement" />
+<meta name="variant" content="?commandfor" />
+<meta name="variant" content="?imperative" />
+
+<div data-candidate="form controls inside" data-count="2">
+  <button command="toggle-popover">Toggle popover</button>
+  <div popover id="popover1">
+    <input type="text" data-expected="1" />
+    <input type="text" data-expected="2" />
+    <button command="hide-popover" data-expected="close">Close popover</button>
+  </div>
+</div>
+<button data-expected="after">
+  This button is where focus should land after traversing this popover
+</button>
+
+<div data-candidate="a details element inside" data-count="1">
+  <button command="toggle-popover">Toggle popover</button>
+  <div popover id="popover2">
+    <details data-expected="1">A details element</details>
+    <button command="hide-popover" data-expected="close">Close popover</button>
+  </div>
+</div>
+<button data-expected="after">
+  This button is where focus should land after traversing this popover
+</button>
+
+<div
+  data-candidate="a details element inside, and the after button adjacent to invoker"
+  data-count="1"
+>
+  <button command="toggle-popover">Toggle popover</button>
+  <button data-expected="after">
+    This button is where focus should land after traversing this popover
+  </button>
+  <div popover id="popover3">
+    <details data-expected="1">A details element</details>
+    <button command="hide-popover" data-expected="close">Close popover</button>
+  </div>
+</div>
+
+<div
+  data-candidate="a custom-element with delegatesfocus inside"
+  data-count="1"
+>
+  <button command="toggle-popover">Toggle popover</button>
+  <div popover id="popover4">
+    <my-element data-expected="1">
+      <template shadowrootmode="open" delegatesfocus>
+        <button></button>
+      </template>
+    </my-element>
+    <button command="hide-popover" data-expected="close">Close popover</button>
+  </div>
+</div>
+<button data-expected="after">
+  This button is where focus should land after traversing popover
+</button>
+
+<div
+  data-candidate="a custom-element with a slotted button inside"
+  data-count="1"
+>
+  <button command="toggle-popover">Toggle popover</button>
+  <div popover id="popover5">
+    <my-element>
+      <template shadowrootmode="open">
+        <slot></slot>
+      </template>
+      <button data-expected="1"></button>
+    </my-element>
+    <button command="hide-popover" data-expected="close">Close popover</button>
+  </div>
+</div>
+<button data-expected="after">
+  This button is where focus should land after traversing popover
+</button>
+
+<div
+  data-candidate="custom-element with a slotted button, followed by a details element, where the after button is adjacent to the invoker"
+  data-count="2"
+>
+  <button command="toggle-popover">Toggle popover</button>
+  <button data-expected="after">
+    This button is where focus should land after traversing popover
+  </button>
+  <div popover id="popover6">
+    <my-element>
+      <template shadowrootmode="open">
+        <slot></slot>
+        <details data-expected="2">A details element</details>
+      </template>
+      <button data-expected="1"></button>
+    </my-element>
+    <button command="hide-popover" data-expected="close">Close popover</button>
+  </div>
+</div>
+
+<script>
+  async function testCandidate(el, style, signal) {
+    const count = parseInt(el.getAttribute("data-count"));
+    const invoker = el.querySelector("button:first-child");
+    const popover = el.querySelector("[popover]");
+    const popoverClose = el.querySelector('[data-expected="close"]');
+    assert_greater_than_equal(count, 0, "test candidate had an invalid count");
+    assert_not_equals(
+      invoker,
+      null,
+      "could not find invoker in test candidate",
+    );
+    assert_not_equals(
+      popover,
+      null,
+      "could not find popover in test candidate",
+    );
+    assert_not_equals(
+      popoverClose,
+      null,
+      "could not find popover close button in test candidate",
+    );
+    switch (style) {
+      case "popovertarget":
+        invoker.setAttribute("popovertarget", popover.id);
+        popoverClose.setAttribute("popovertarget", popover.id);
+        break;
+      case "popovertargetelement":
+        invoker.popoverTargetElement = popover;
+        popoverClose.popoverTargetElement = popover;
+        break;
+      case "commandfor":
+        invoker.setAttribute("commandfor", popover.id);
+        popoverClose.setAttribute("commandfor", popover.id);
+        break;
+      case "commandforelement":
+        invoker.commandForElement = popover;
+        popoverClose.commandForElement = popover;
+        break;
+      case "imperative":
+        invoker.addEventListener(
+          "click",
+          () => {
+            popover.togglePopover({ source: invoker });
+          },
+          { signal },
+        );
+        popoverClose.addEventListener(
+          "click",
+          () => {
+            popover.hidePopover({ source: invoker });
+          },
+          { signal },
+        );
+        break;
+      default:
+        assert_true(
+          false,
+          `unknown style - ${style} - expected one of imperative,commandfor,commandforelement,popovertarget,popovertargetelement`,
+        );
+    }
+    invoker.focus();
+    assert_equals(document.activeElement, invoker);
+    invoker.click();
+    assert_true(
+      popover.matches(":popover-open"),
+      "popover should be invoked by invoker",
+    );
+    assert_equals(
+      document.activeElement,
+      invoker,
+      "invoker should still be focused",
+    );
+    for (let i = 1; i <= count; i += 1) {
+      await sendTab();
+      assert_equals(
+        document.activeElement?.getAttribute("data-expected"),
+        String(i),
+        `active element ${i} should now have focus`,
+      );
+    }
+    await sendTab();
+    assert_equals(
+      document.activeElement?.getAttribute("data-expected"),
+      "close",
+      "close popover button should now have focus",
+    );
+    await sendShiftTab();
+    assert_equals(
+      document.activeElement?.getAttribute("data-expected"),
+      String(count),
+      "last active element should now have focus",
+    );
+    await sendTab();
+    assert_equals(
+      document.activeElement,
+      popoverClose,
+      "close popover button should now have focus",
+    );
+    await sendTab();
+    assert_equals(
+      document.activeElement?.getAttribute("data-expected"),
+      "after",
+      "element after",
+    );
+    await sendShiftTab();
+    popoverClose.click();
+    assert_equals(
+      document.activeElement,
+      invoker,
+      "focus should have returned to initial invoker",
+    );
+  }
+
+  const style = window.location.search.substring(1) || "popovertarget";
+  for (const candidate of document.querySelectorAll("[data-candidate]")) {
+    promise_test(
+      async (t) => {
+        const controller = new AbortController();
+        t.add_cleanup(() => {
+          controller.abort();
+          for (const el of document.querySelectorAll(
+            ":is([popovertarget],[commandfor],[disabled],[tabindex])",
+          )) {
+            el.removeAttribute("popovertarget");
+            el.removeAttribute("commandfor");
+            el.removeAttribute("disabled");
+            el.removeAttribute("tabindex");
+          }
+          for (const el of document.querySelectorAll(":popover-open")) {
+            el.hidePopover();
+          }
+        });
+        await testCandidate(candidate, style);
+      },
+      `Focusing elements inside a popover with ${candidate.getAttribute("data-candidate")}, using ${style}`,
+    );
+  }
+</script>


### PR DESCRIPTION
/cc @nt1m @mfreed7 @lukewarlow 

Popovers have myriad focusing issues, especially when it comes to elements with `<slot>`s inside, such as `<details>` or a custom element.

This new set of tests excercises the functionality of focus over the entry/exit range of a popover. Each block of HTML has an:

 - invoker
 - set of elements focus is expected to land on
 - a close button which should be inside the popover, and focussed last
 - an "after" button which is the next focussed item after the popover is exited

These tests currently fail in Firefox and Chrome, due to focus issues. It would be great to get careful review from y'all to ensure they're valid per human expectations, so we can work to address these issues in our respective browsers.