### PR TITLE
script/layout: Implement `HTMLElement.scrollParent`

### DIFF
--- a/css/css-overflow/overflow-does-not-apply-to-inline-box.html
+++ b/css/css-overflow/overflow-does-not-apply-to-inline-box.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-control">
+<meta name="assert" content="Overflow does not apply to inline boxes so they do not establish scroll containers.">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="font: 100px/1 Ahem; background: red; width: 100px">
+  <span style="overflow: hidden; border-radius: 50%; color: green">X</span>
+</div>
+

--- a/css/cssom-view/scrollParent.html
+++ b/css/cssom-view/scrollParent.html
@@ -29,6 +29,7 @@
   display: none;
 }
 .contains-fixed {
+  transform: scale(1);
   contain: paint;
 }
 </style>


### PR DESCRIPTION
This new API allows getting the element which establishes an element's
scroll container. This will be used to properly implement
`scrollIntoView`. There is still work to do for this API and
`offsetParent` to properly handle ancestors which are
closed-shadow-hidden from the original query element.

In addition, fix an issue where inline boxes were establishing scrolling
containers (they shouldn't do that).

Testing: There are tests for this change.
Fixes: #<!-- nolink -->39096.

Reviewed in servo/servo#39110