### PR TITLE
Fix Safari & Safari Technology Preview GitHub Actions runs

### DIFF
--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -37,4 +37,4 @@ jobs:
       safaridriver-diagnose: false
       matrix: '{"current-chunk": [1, 2, 3, 4, 5, 6, 7, 8], "total-chunks": [8]}'
       extra-options: --no-fail-on-unexpected
-      fetch-ref: ${{ fromJSON(needs.check-workflow-run.outputs.updated-refs)['refs/heads/epochs/daily'] }}
+      fetch-ref: ${{ fromJSON(needs.check-workflow-run.outputs.updated-refs || '{}')['refs/heads/epochs/daily'] }}

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -37,4 +37,4 @@ jobs:
       safaridriver-diagnose: false
       matrix: '{"current-chunk": [1, 2, 3, 4, 5, 6, 7, 8], "total-chunks": [8]}'
       extra-options: --no-fail-on-unexpected
-      fetch-ref: ${{ fromJSON(needs.check-workflow-run.outputs.updated-refs)['refs/heads/epochs/three_hourly'] }}
+      fetch-ref: ${{ fromJSON(needs.check-workflow-run.outputs.updated-refs || '{}')['refs/heads/epochs/three_hourly'] }}

--- a/tools/ci/epochs_update.sh
+++ b/tools/ci/epochs_update.sh
@@ -43,7 +43,11 @@ main () {
     done
     # This is safe because `git push` will by default fail for a non-fast-forward
     # push, for example if the remote branch is ahead of the local branch.
-    git push --porcelain --tags ${REMOTE} ${ALL_BRANCHES_NAMES} | tee "${RUNNER_TEMP}/git-push-output.txt"
+    # We save the output so that GitHub Actions workflows can find out what got
+    # pushed, as workflows are not triggered by push events caused by another
+    # workflow. We need to pass core.abbrev as actions/checkout only allows refs to
+    # be specified as an object id if they are exactly 40 characters.
+    git -c core.abbrev=40 push --porcelain --tags ${REMOTE} ${ALL_BRANCHES_NAMES} | tee "${RUNNER_TEMP}/git-push-output.txt"
 }
 
 cd $WPT_ROOT


### PR DESCRIPTION
We make the epochs' git-push-output have 40 character commit ids, because actions/checkout allows for ref to be a commit id, but only if it is exactly a 40 character hex string (c.f. https://github.com/actions/checkout/blob/ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493/src/input-helper.ts#L74).

Then, with that fixed, the Safari & Safari Technology Preview runs should start succeeding, once again able to check code out.