### PR TITLE
layout: Fix `scrollParent` to skip ancestors with `display: contents`

### DIFF
--- a/css/cssom-view/scrollParent.html
+++ b/css/cssom-view/scrollParent.html
@@ -57,6 +57,10 @@
           <div id="hidden" class="hidden">
             <div id="childOfHidden"></div>
           </div>
+          <!-- No box with `display: contents` -->
+          <div style="display: contents">
+            <div id="childOfDisplayContents"></div>
+          </div>
         </div>
       </div>
     </div>
@@ -82,6 +86,9 @@ test(() => { assert_equals(fixedContainedByRoot.scrollParent, document.scrolling
     "scrollParent of fixed element contained within root is document scrolling element.");
 test(() => { assert_equals(document.body.scrollParent, null); },
     "scrollParent of body is null.");
-
+test(() => { assert_equals(document.documentElement.scrollParent, null); },
+    "scrollParent of root is null.");
+test(() => { assert_equals(childOfDisplayContents.scrollParent, scroller1); },
+    "scrollParent skips ancestors with `display: contents`.");
 </script>
 </html>


### PR DESCRIPTION
When encountering such an ancestor, we were returning null instead of skipping it.

Testing: Adding new subtest for this. And while I'm at it, another one for the root element, unrelated to this fix.

Reviewed in servo/servo#39153