### PR TITLE
popovers: Ensure verifyFocusOrder does not tab away from document controls into browser chrome

### DIFF
--- a/html/semantics/popovers/resources/popover-utils.js
+++ b/html/semantics/popovers/resources/popover-utils.js
@@ -143,13 +143,21 @@ function assertNotAPopover(nonPopover) {
 async function verifyFocusOrder(order,description) {
   order[0].focus();
   for(let i=0;i<order.length;++i) {
+    // Press tab between each check, excluding first (because it should already be focused)
+    // and the last (because tabbing after the last element may send focus into browser chrome).
+    if (i != 0) {
+      await sendTab();
+    }
     const control = order[i];
     assert_equals(document.activeElement,control,`${description}: Step ${i+1}`);
-    await sendTab();
   }
   for(let i=order.length-1;i>=0;--i) {
     const control = order[i];
-    await sendShiftTab();
     assert_equals(document.activeElement,control,`${description}: Step ${i+1} (backwards)`);
+    // Press shift+tab between each check, excluding last (because it should already be focused)
+    // and the first (because shift+tabbing after the last element may send focus into browser chrome).
+    if (i != 0) {
+      await sendShiftTab();
+    }
   }
 }


### PR DESCRIPTION
Firefox is currently failing a set of tests around popover focus. I tried to break down to find out what was happening. When I use the test suite as a playbook and actually press the tab key on my keyboard, I can manually verify that the focus order is correct and popovers are opening as expected, but we can't shake the failures in WPT:

```
/html/semantics/popovers/popover-focus-2.html?test2
  FAIL Popover focus navigation with command/commandfor invocation - assert_true: popover2 should be invoked by nested invoker expected true got false
testPopoverFocusNavigation@http://web-platform.test:8000/html/semantics/popovers/popover-focus-2.html?test2:82:14
/html/semantics/popovers/popover-focus-2.html?test1
  FAIL Popover focus navigation with popovertarget invocation - assert_true: popover2 should be invoked by nested invoker expected true got false
testPopoverFocusNavigation@http://web-platform.test:8000/html/semantics/popovers/popover-focus-2.html?test1:82:14
/html/semantics/popovers/popover-focus-2.html?test3
  FAIL Popover focus navigation with imperative invocation - assert_true: popover2 should be invoked by nested invoker expected true got false
testPopoverFocusNavigation@http://web-platform.test:8000/html/semantics/popovers/popover-focus-2.html?test3:82:14
```

We fail on line 82, where `popover2.matches(':popover-open')`. When I manually verify I can focus `invoker2`, and press enter, and the popover opens! So why are we failing?!

I decided to go for a brute force approach. I added a 10s sleep on line 81 so I could run the test non-headless and stare intently at the browser until it gave up its secrets. That's when something became evident:

<img width="1287" height="1048" alt="image" src="https://github.com/user-attachments/assets/001d7cea-b7a9-42a6-bfac-8c90ad52443a" />

The recent browsing button was active...

`invoker2.focus()` is never properly executed because focus has left the document and is into the browser chrome.

Nothing looks untoward in the test file... so maybe something else is going on. Then I spotted `verifyFocusOrder`. I stepped into the file, and I saw the loop and something raised my spidey sense... a for loop, `order.length`, `++i`.... I bet there's an off-by-one error here.

I added the same sleeps and BAM, there it was, calling `sendTab()` after each `assert_equals` shifts the focus to the next item, however it does so 1 more time than necessary, which causes focus to shift out of the document.

So this change re-orders the `sendTab` & `sendShiftTab` functions to only be executed...

1. ... for n-1 the number of elements, ensuring we only cycle focus among the set of given elements and not more, which runs the risk of moving focus out of the document.
2. ... at a time more appropriate for each assertion, so that the `sendTab()` is run before each assertion (except the first) - ensuring that we don't write code which might otherwise have to treat numbers delicately and risk potential other off-by-ones.

I've verified that Chrome still passes the two tests reliant on this: `popover-focus-2.html` (and variants) and `popover-focus-3.html` and Firefox _now_ passes these too. I've also red-greened this to ensure the tests are still correctly verifying a focus order and I haven't somehow inadvertently broken the tests, an example of a red-green test I tried:

```diff
diff --git html/semantics/popovers/resources/popover-utils.js html/semantics/popovers/resources/popover-utils.js
index 2790e7e039..ee1204bfcb 100644
--- html/semantics/popovers/resources/popover-utils.js
+++ html/semantics/popovers/resources/popover-utils.js
@@ -148,11 +148,11 @@ async function verifyFocusOrder(order,description) {
     if (i != 0) {
       await sendTab();
     }
-    const control = order[i];
+    const control = order[i == order.length -1 ? 0 : i];
     assert_equals(document.activeElement,control,`${description}: Step ${i+1}`);
   }
   for(let i=order.length-1;i>=0;--i) {
-    const control = order[i];
+    const control = order[i == order.length -1 ? 0 : i];
     assert_equals(document.activeElement,control,`${description}: Step ${i+1} (backwards)`);
     // Press shift+tab between each check, excluding last (because it should already be focused)
     // and the first (because shift+tabbing after the last element may send focus into browser chrome).

```

This causes assertion failures as we might expect, so I believe this is working correctly as we expect.

---

One question I have... which I haven't really got time to verify but maybe @mfreed7 can answer: how were these tests passing in Chrome prior? Does the contentshell not move have any browser chrome, so focus wraps into the document? Or is it doing something different here, by allowing `.focus()`? Or something else? More curious than anything else.

Refs https://bugzilla.mozilla.org/show_bug.cgi?id=1972533. 