### PR TITLE
Update css-view-transition idl test

### DIFF
--- a/css/css-view-transitions/idlharness.html
+++ b/css/css-view-transitions/idlharness.html
@@ -17,7 +17,7 @@
 'use strict';
 
 idl_test(
-  ['css-view-transitions', 'css-view-transitions-2'],
+  ['css-view-transitions'],
   ['dom', 'html', 'cssom'],
   idl_array => {
     idl_array.add_objects({


### PR DESCRIPTION
The idl file has changed names, so update the test.

This should land with https://github.com/web-platform-tests/wpt/pull/54686