### PR TITLE
Disable scripting when sandbox flag is set

### DIFF
--- a/content-security-policy/sandbox/autoplay-disabled-by-csp.html
+++ b/content-security-policy/sandbox/autoplay-disabled-by-csp.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#eligible-for-autoplay" />
+  <title>Test that autoplay is blocked by a document's active sandboxing flags</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src='../support/logTest.sub.js?logs=["Loaded iframe"]'></script>
+  <script src="/common/media.js"></script>
+  </head>
+  <body>
+    <iframe id="iframe" src="support/autoplay.html"></iframe>
+    <script>
+      async_test((t) => {
+        iframe.addEventListener('load', () => {
+          log('Loaded iframe');
+          var v = iframe.contentWindow.document.getElementById('v');
+
+          v.addEventListener('playing', t.unreached_func(
+            'video should not autoplay due to sandboxing flags'
+          ));
+
+          v.src = getVideoURI('/media/movie_5') + '?' + new Date() + Math.random()
+          t.step_timeout(() => t.done(), 500);
+        });
+      }, 'csp-derived sandboxing flags prevent autoplay.')
+    </script>
+  </body>
+</html>

--- a/content-security-policy/sandbox/sandbox-empty.sub.html
+++ b/content-security-policy/sandbox/sandbox-empty.sub.html
@@ -18,7 +18,7 @@
        }
     </script>
 
-    <iframe src="support/sandboxed-post-message-to-parent.sub.html?sandbox="
+    <iframe src="support/sandboxed-post-message-to-parent.html"
             onload="log('PASS2')"></iframe>
 </body>
 

--- a/content-security-policy/sandbox/sandbox-last-directive-csp.html
+++ b/content-security-policy/sandbox/sandbox-last-directive-csp.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+    <!-- Programmatically converted from a WebKit Reftest, please forgive resulting idiosyncracies.-->
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'self'; connect-src 'self';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS (1/2): Script can execute","PASS (2/2): Eval works"]'></script>
+    <script src='../support/alertAssert.sub.js?alerts=[]'></script>
+</head>
+<body>
+  <script>
+    window.onmessage = function(e) {
+      log(e.data);
+    }
+  </script>
+  <iframe src="support/sandboxed-last-directive-csp.html"></iframe>
+</body>
+</html>

--- a/content-security-policy/sandbox/support/autoplay.html
+++ b/content-security-policy/sandbox/support/autoplay.html
@@ -1,0 +1,1 @@
+<video id="v" autoplay></video>

--- a/content-security-policy/sandbox/support/autoplay.html.headers
+++ b/content-security-policy/sandbox/support/autoplay.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox

--- a/content-security-policy/sandbox/support/sandboxed-last-directive-csp.headers
+++ b/content-security-policy/sandbox/support/sandboxed-last-directive-csp.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox; sandbox allow-scripts

--- a/content-security-policy/sandbox/support/sandboxed-last-directive-csp.html
+++ b/content-security-policy/sandbox/support/sandboxed-last-directive-csp.html
@@ -1,0 +1,4 @@
+<script>
+  window.parent.postMessage('PASS (1/2): Script can execute', '*');
+  eval("window.parent.postMessage('PASS (2/2): Eval works', '*')");
+</script>

--- a/content-security-policy/sandbox/support/sandboxed-post-message-to-parent.headers
+++ b/content-security-policy/sandbox/support/sandboxed-post-message-to-parent.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox


### PR DESCRIPTION
While I adding spec comments to the CSP crate, I discovered two issues:
1. We should only use the last sandbox value (WPT test added)
2. We weren't checking for the scripting sandbox flag in document

Also, the autoplay test should have allowed scripts to run, otherwise the test doesn't run. Since we weren't checking the flag before, the test ran fine for Servo. However, it wouldn't run for other browsers.

Also realized that an existing test was pointing to a non-existent file (since it doesn't have `.sub`). Updated that and confirmed that in other browsers it now properly works (it no longer shows a 404). However, Servo now fails that test as we don't fire an load event.

Part of #<!-- nolink -->913
Reviewed in servo/servo#39163