### PR TITLE
CSS2: reftest for float:right → display:none render-tree cleanup

### DIFF
--- a/css/CSS2/float-displaynone-001.html
+++ b/css/CSS2/float-displaynone-001.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>float:right becomes display:none -> render tree cleanup</title>
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#floats">
+<link rel="author" title="Riya Kanani" href="https://github.com/riyak145">
+<link rel="match" href="reference/float-displaynone-001-ref.html">
+<style>
+  .container { width: 300px; border: 2px solid black; }
+  .floaty   { float: right; width: 100px; height: 100px; }
+  .block    { height: 100px; background: lightgray; }
+</style>
+<div class="container" id="c">
+  <div id="f" class="floaty"></div>
+  <div class="block"></div>
+</div>
+<script>
+  // Remove the float at runtime; then flush; then allow snapshot.
+  requestAnimationFrame(() => {
+    const f = document.getElementById('f');
+    f.style.display = 'none';
+    getComputedStyle(document.getElementById('c')).width; // flush
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove('reftest-wait');
+    });
+  });
+</script>
+</html>

--- a/css/CSS2/reference/float-displaynone-001-ref.html
+++ b/css/CSS2/reference/float-displaynone-001-ref.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Reference: layout with no float present</title>
+<style>
+  .container { width: 300px; border: 2px solid black; }
+  .block     { height: 100px; background: lightgray; }
+</style>
+<div class="container">
+  <div class="block"></div>
+</div>


### PR DESCRIPTION
Adds a reftest to verify that when a floated element is hidden via display:none,
its float effects are cleaned up in layout.

- Test dynamically toggles display:none at runtime and forces a style/layout flush.
- Reference page represents the expected layout with no float present.

(General coverage improvement for CSS2 floats.)
