### PR TITLE
Fix incorrect pseudo-element selector

### DIFF
--- a/css/css-view-transitions/get-computed-style-crash.html
+++ b/css/css-view-transitions/get-computed-style-crash.html
@@ -10,7 +10,7 @@ async function start() {
  var el = document.createElement(undefined);
  document.body.appendChild(el);
 
- var style = self.getComputedStyle(el, ':view-transition');
+ var style = self.getComputedStyle(el, '::view-transition');
  style.getPropertyValue("--child");
 }
 </script>


### PR DESCRIPTION
::view-transition cannot be selected with a single colon. This test did not make any sense.