### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297796

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>WebVTT rendering, ::cue([lang=])</title>
+<link rel="match" href="voice_color-ref.html">
+<style>
+html { overflow:hidden }
+body { margin:0 }
+::cue([lang="en"]) {
+    font-family: sans-serif;
+    color: #0000ff;
+}
+::cue([lang="de"]) {
+    font-family: sans-serif;
+    color: #00ff00;
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+    <source src="/media/white.webm" type="video/webm">
+    <source src="/media/white.mp4" type="video/mp4">
+    <track src="../../../support/test_lang_object.vtt" srclang="de" default>
+    <script>
+    document.getElementsByTagName('track')[0].track.mode = 'showing';
+    </script>
+</video>
+</html>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>WebVTT rendering, ::cue(lang), color: #0000ff</title>
+<link rel="match" href="voice_color-ref.html">
+<style>
+html { overflow:hidden }
+body { margin:0 }
+::cue(lang) {
+    font-family: sans-serif;
+    color: #0000ff;
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+    <source src="/media/white.webm" type="video/webm">
+    <source src="/media/white.mp4" type="video/mp4">
+    <track src="../../../support/test_lang_object.vtt">
+    <script>
+    document.getElementsByTagName('track')[0].track.mode = 'showing';
+    </script>
+</video>
+</html>

--- a/webvtt/rendering/cues-with-video/processing-model/support/test_lang_object.vtt
+++ b/webvtt/rendering/cues-with-video/processing-model/support/test_lang_object.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000
+Deutsch<lang en>English</lang>


### PR DESCRIPTION
Adds missing WebVTT tests for selectors ::cue([lang=xy]) and ::cue(lang)