### PR TITLE
feat(css): Add reftest for margin-inline-start on an inline element

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *       -text
+*.html text eol=lf

--- a/css/css-logical/margin-inline-start-ltr-001-ref.html
+++ b/css/css-logical/margin-inline-start-ltr-001-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Reference for margin-inline-start on an inline element</title>
+  <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
+  <style>
+    .ref {
+      margin-left: 100px; /* Use the physical property */
+      background: green;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <p>
+    <span>Red</span><span class="ref">Green</span>
+  </p>
+</body>
+</html>

--- a/css/css-logical/margin-inline-start-ltr-001-ref.html
+++ b/css/css-logical/margin-inline-start-ltr-001-ref.html
@@ -7,15 +7,16 @@
   <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
   <style>
     .ref {
-      margin-left: 100px; /* Use the physical property */
+      margin-left: 100px;
       background: green;
-      color: green;
+      color: white;
     }
   </style>
 </head>
 <body>
+  <p>Test passes if there is a green box with 100px margin on the left.</p>
   <p>
-    <span>Red</span><span class="ref">Green</span>
+    <span class="ref">Green</span>
   </p>
 </body>
 </html>

--- a/css/css-logical/margin-inline-start-ltr-001.html
+++ b/css/css-logical/margin-inline-start-ltr-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CSS Test: margin-inline-start on an inline element</title>
+  <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
+  <link rel="help" href="https://www.w3.org/TR/css-logical-1/#margin-properties">
+  <link rel="match" href="margin-inline-start-inline-001-ref.html">
+  <style>
+    .test {
+      margin-inline-start: 100px;
+      background: green;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <p>Test passes if there is no red.</p>
+  <p>
+    <span>Red</span><span class="test">Green</span>
+  </p>
+</body>
+</html>

--- a/css/css-logical/margin-inline-start-ltr-001.html
+++ b/css/css-logical/margin-inline-start-ltr-001.html
@@ -6,7 +6,7 @@
   <title>CSS Test: margin-inline-start on an inline element</title>
   <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
   <link rel="help" href="https://www.w3.org/TR/css-logical-1/#margin-properties">
-  <link rel="match" href="margin-inline-start-inline-001-ref.html">
+<link rel="match" href="margin-inline-start-ltr-001-ref.html">
   <style>
     .test {
       margin-inline-start: 100px;

--- a/css/css-logical/margin-inline-start-ltr-001.html
+++ b/css/css-logical/margin-inline-start-ltr-001.html
@@ -6,19 +6,19 @@
   <title>CSS Test: margin-inline-start on an inline element</title>
   <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
   <link rel="help" href="https://www.w3.org/TR/css-logical-1/#margin-properties">
-<link rel="match" href="margin-inline-start-ltr-001-ref.html">
+  <link rel="match" href="margin-inline-start-ltr-001-ref.html">
   <style>
     .test {
       margin-inline-start: 100px;
       background: green;
-      color: green;
+      color: white;
     }
   </style>
 </head>
 <body>
-  <p>Test passes if there is no red.</p>
+  <p>Test passes if there is a green box with 100px margin on the left.</p>
   <p>
-    <span>Red</span><span class="test">Green</span>
+    <span class="test">Green</span>
   </p>
 </body>
 </html>


### PR DESCRIPTION

This PR adds a reftest to verify that `margin-inline-start` is applied correctly to inline elements in a left-to-right context.

According to the CSS Logical Properties specification, `margin-inline-start` should behave like `margin-left` in this case. The test confirms this behavior.

**Spec Reference:**
https://www.w3.org/TR/css-logical-1/#margin-properties