### PR TITLE
[wdspec] tests for `emulation.setUserAgentOverride` command

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/emulation.py
+++ b/tools/webdriver/webdriver/bidi/modules/emulation.py
@@ -119,3 +119,16 @@ class Emulation(BidiModule):
             params["userContexts"] = user_contexts
 
         return params
+
+    @command
+    def set_user_agent_override(
+            self,
+            user_agent: Union[str, None],
+            contexts: Union[List[str], Undefined] = UNDEFINED,
+            user_contexts: Union[List[str], Undefined] = UNDEFINED,
+    ) -> Mapping[str, Any]:
+        return {
+            "userAgent": user_agent,
+            "contexts": contexts,
+            "userContexts": user_contexts,
+        }

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/conftest.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/conftest.py
@@ -31,7 +31,7 @@ async def assert_navigation_user_agent(bidi_session, url):
     """
 
     async def assert_navigation_user_agent(context, expected_user_agent):
-        echo_link = url("webdriver/tests/support/http_handlers/echo.py")
+        echo_link = url("webdriver/tests/support/http_handlers/headers_echo.py")
         await bidi_session.browsing_context.navigate(context=context["context"],
                                                      url=echo_link,
                                                      wait="complete")
@@ -58,7 +58,7 @@ async def assert_fetch_user_agent(bidi_session, url):
     """
 
     async def assert_navigation_user_agent(context, expected_user_agent):
-        echo_link = url("webdriver/tests/support/http_handlers/echo.py")
+        echo_link = url("webdriver/tests/support/http_handlers/headers_echo.py")
         await bidi_session.browsing_context.navigate(context=context["context"],
                                                      url=echo_link,
                                                      wait="complete")

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/conftest.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/conftest.py
@@ -1,0 +1,95 @@
+import json
+
+import pytest_asyncio
+
+from webdriver.bidi.modules.script import ContextTarget
+
+
+@pytest_asyncio.fixture
+async def default_user_agent(top_context, get_navigator_user_agent):
+    return await get_navigator_user_agent(top_context)
+
+
+@pytest_asyncio.fixture
+async def get_navigator_user_agent(bidi_session):
+    async def get_navigator_user_agent(context):
+        result = await bidi_session.script.evaluate(
+            expression="window.navigator.userAgent",
+            target=ContextTarget(context["context"]),
+            await_promise=False,
+        )
+
+        return result["value"]
+
+    return get_navigator_user_agent
+
+
+@pytest_asyncio.fixture
+async def assert_navigation_user_agent(bidi_session, url):
+    """
+    Helper to assert the right `user-agent` header sent in navigation request.
+    """
+
+    async def assert_navigation_user_agent(context, expected_user_agent):
+        echo_link = url("webdriver/tests/support/http_handlers/echo.py")
+        await bidi_session.browsing_context.navigate(context=context["context"],
+                                                     url=echo_link,
+                                                     wait="complete")
+
+        result = await bidi_session.script.evaluate(
+            expression="window.document.body.textContent",
+            target=ContextTarget(context["context"]),
+            await_promise=False,
+        )
+
+        headers = (json.JSONDecoder().decode(result["value"]))["headers"]
+        user_agent = headers["user-agent"][0]
+
+        assert user_agent == expected_user_agent, \
+            f"Navigation expected to send user agent '{expected_user_agent}' but sent '{user_agent}'"
+
+    return assert_navigation_user_agent
+
+
+@pytest_asyncio.fixture
+async def assert_fetch_user_agent(bidi_session, url):
+    """
+    Helper to assert the right `user-agent` header sent in fetch.
+    """
+
+    async def assert_navigation_user_agent(context, expected_user_agent):
+        echo_link = url("webdriver/tests/support/http_handlers/echo.py")
+        await bidi_session.browsing_context.navigate(context=context["context"],
+                                                     url=echo_link,
+                                                     wait="complete")
+
+        result = await bidi_session.script.evaluate(
+            expression=f"fetch('{echo_link}').then(r => r.text())",
+            target=ContextTarget(context["context"]),
+            await_promise=True,
+        )
+
+        headers = (json.JSONDecoder().decode(result["value"]))["headers"]
+        user_agent = headers["user-agent"][0]
+
+        assert user_agent == expected_user_agent, \
+            f"Fetch expected to send user agent '{expected_user_agent}' but sent '{user_agent}'"
+
+    return assert_navigation_user_agent
+
+
+@pytest_asyncio.fixture
+async def assert_user_agent(get_navigator_user_agent,
+        assert_navigation_user_agent, assert_fetch_user_agent):
+    """
+    Helper to assert the right `user-agent` returned by navigator and sent in
+    navigation and fetch.
+    """
+
+    async def assert_user_agent(context, expected_user_agent):
+        assert await get_navigator_user_agent(context) == expected_user_agent, \
+            "window.navigator.userAgent should be expected"
+        await assert_navigation_user_agent(context, expected_user_agent)
+        await assert_fetch_user_agent(context, expected_user_agent)
+
+    return assert_user_agent

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/contexts.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/contexts.py
@@ -1,0 +1,93 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+SOME_USER_AGENT = "SOME_USER_AGENT"
+
+
+async def test_contexts(bidi_session, new_tab, top_context,
+        default_user_agent, assert_user_agent):
+    # Set user-agent override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"]],
+        user_agent=SOME_USER_AGENT
+    )
+
+    # Assert user-agent override is set only in the required context.
+    await assert_user_agent(new_tab, SOME_USER_AGENT)
+    await assert_user_agent(top_context, default_user_agent)
+
+    # Reset user-agent override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"]],
+        user_agent=None
+    )
+
+    # Assert user-agent override is reset.
+    await assert_user_agent(new_tab, default_user_agent)
+    await assert_user_agent(top_context, default_user_agent)
+
+
+async def test_multiple_contexts(bidi_session, new_tab, default_user_agent,
+        assert_user_agent):
+    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+
+    # Set user-agent override
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"], new_context["context"]],
+        user_agent=SOME_USER_AGENT
+    )
+
+    # Assert user-agent override is set in all the required contexts.
+    await assert_user_agent(new_tab, SOME_USER_AGENT)
+    await assert_user_agent(new_context, SOME_USER_AGENT)
+
+    # Reset user-agent override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"], new_context["context"]],
+        user_agent=None
+    )
+
+    # Assert user-agent override is reset.
+    await assert_user_agent(new_tab, default_user_agent)
+    await assert_user_agent(new_context, default_user_agent)
+
+
+@pytest.mark.parametrize("domain", ["", "alt"],
+                         ids=["same_origin", "cross_origin"])
+async def test_iframe(bidi_session, new_tab, default_user_agent,
+        assert_user_agent, domain, inline):
+    # Set user-agent override
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"]],
+        user_agent=SOME_USER_AGENT
+    )
+
+    # Assert user-agent override is set in the required context.
+    await assert_user_agent(new_tab, SOME_USER_AGENT)
+
+    iframe_url = inline("<div id='in-iframe'>foo</div>", domain=domain)
+    page_url = inline(f"<iframe src='{iframe_url}'></iframe>")
+
+    # Load the page with iframes.
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=page_url,
+        wait="complete",
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"])
+    iframe = contexts[0]["children"][0]
+
+    # Assert user-agent override is set in the iframe context.
+    await assert_user_agent(iframe, SOME_USER_AGENT)
+
+    # Reset user-agent override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"]],
+        user_agent=None
+    )
+
+    # Assert user-agent override is reset in the iframe context.
+    await assert_user_agent(iframe, default_user_agent)

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -1,0 +1,145 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+SOME_USER_AGENT = "SOME_USER_AGENT"
+ANOTHER_USER_AGENT = "ANOTHER_USER_AGENT"
+
+
+async def test_user_agent_set_override_and_reset_globally(bidi_session,
+        top_context, create_user_context, default_user_agent,
+        assert_user_agent):
+    user_context = await create_user_context()
+    context_in_user_context = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab")
+
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=SOME_USER_AGENT
+    )
+
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+    await assert_user_agent(context_in_user_context, SOME_USER_AGENT)
+
+    another_context_in_user_context = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab")
+
+    await assert_user_agent(another_context_in_user_context, SOME_USER_AGENT)
+
+    # Reset global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=None
+    )
+
+    # Assert the override is reset for existing contexts.
+    await assert_user_agent(top_context, default_user_agent)
+    await assert_user_agent(context_in_user_context, default_user_agent)
+    await assert_user_agent(another_context_in_user_context, default_user_agent)
+    # Assert the override is reset for new context.
+    await assert_user_agent(
+        await bidi_session.browsing_context.create(user_context=user_context,
+                                                   type_hint="tab"),
+        default_user_agent)
+
+
+async def test_user_agent_set_override_and_reset_globally_and_per_context(
+        bidi_session, top_context, default_user_agent, assert_user_agent):
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[top_context["context"]],
+        user_agent=SOME_USER_AGENT
+    )
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    # Set global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=ANOTHER_USER_AGENT
+    )
+
+    # The override per context should still be active.
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    # Reset per-context override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[top_context["context"]],
+        user_agent=None
+    )
+
+    # The global override should be active.
+    await assert_user_agent(top_context, ANOTHER_USER_AGENT)
+
+    # Reset global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=ANOTHER_USER_AGENT
+    )
+
+    # The override should be disabled.
+    await assert_user_agent(top_context, default_user_agent)
+
+
+async def test_user_agent_set_override_and_reset_per_user_context_and_per_context(
+        bidi_session, top_context, default_user_agent, assert_user_agent):
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[top_context["context"]],
+        user_agent=SOME_USER_AGENT
+    )
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    # Set global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=["default"],
+        user_agent=ANOTHER_USER_AGENT
+    )
+
+    # The override per context should still be active.
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    # Reset per-context override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[top_context["context"]],
+        user_agent=None
+    )
+
+    # The global override should be active.
+    await assert_user_agent(top_context, ANOTHER_USER_AGENT)
+
+    # Reset global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=["default"],
+        user_agent=ANOTHER_USER_AGENT
+    )
+
+    # The override should be disabled.
+    await assert_user_agent(top_context, default_user_agent)
+
+
+async def test_user_agent_set_override_and_reset_globally_and_per_user_context(
+        bidi_session, top_context, default_user_agent, assert_user_agent):
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=["default"],
+        user_agent=SOME_USER_AGENT
+    )
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    # Set global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=ANOTHER_USER_AGENT
+    )
+
+    # The override per context should still be active.
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    # Reset per-context override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=["default"],
+        user_agent=None
+    )
+
+    # The global override should be active.
+    await assert_user_agent(top_context, ANOTHER_USER_AGENT)
+
+    # Reset global override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=ANOTHER_USER_AGENT
+    )
+
+    # The override should be disabled.
+    await assert_user_agent(top_context, default_user_agent)

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -98,7 +98,7 @@ async def test_user_agent_set_override_and_reset_per_user_context_and_per_contex
         user_agent=None
     )
 
-    # The global override should be active.
+    # The override for default user context should be active.
     await assert_user_agent(top_context, ANOTHER_USER_AGENT)
 
     # Reset global override.

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -101,7 +101,7 @@ async def test_user_agent_set_override_and_reset_per_user_context_and_per_contex
     # The override for default user context should be active.
     await assert_user_agent(top_context, ANOTHER_USER_AGENT)
 
-    # Reset global override.
+    # Reset override for default user context.
     await bidi_session.emulation.set_user_agent_override(
         user_contexts=["default"],
         user_agent=ANOTHER_USER_AGENT

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -127,7 +127,7 @@ async def test_user_agent_set_override_and_reset_globally_and_per_user_context(
     # The override per user context should still be active.
     await assert_user_agent(top_context, SOME_USER_AGENT)
 
-    # Reset per-context override.
+    # Reset per user context override.
     await bidi_session.emulation.set_user_agent_override(
         user_contexts=["default"],
         user_agent=None

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -138,7 +138,7 @@ async def test_user_agent_set_override_and_reset_globally_and_per_user_context(
 
     # Reset global override.
     await bidi_session.emulation.set_user_agent_override(
-        user_agent=ANOTHER_USER_AGENT
+        user_agent=None
     )
 
     # The override should be disabled.

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -124,7 +124,7 @@ async def test_user_agent_set_override_and_reset_globally_and_per_user_context(
         user_agent=ANOTHER_USER_AGENT
     )
 
-    # The override per context should still be active.
+    # The override per user context should still be active.
     await assert_user_agent(top_context, SOME_USER_AGENT)
 
     # Reset per-context override.

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -75,42 +75,6 @@ async def test_user_agent_set_override_and_reset_globally_and_per_context(
     await assert_user_agent(top_context, default_user_agent)
 
 
-async def test_user_agent_set_override_and_reset_per_user_context_and_per_context(
-        bidi_session, top_context, default_user_agent, assert_user_agent):
-    await bidi_session.emulation.set_user_agent_override(
-        contexts=[top_context["context"]],
-        user_agent=SOME_USER_AGENT
-    )
-    await assert_user_agent(top_context, SOME_USER_AGENT)
-
-    # Set override to the default user context.
-    await bidi_session.emulation.set_user_agent_override(
-        user_contexts=["default"],
-        user_agent=ANOTHER_USER_AGENT
-    )
-
-    # The override per context should still be active.
-    await assert_user_agent(top_context, SOME_USER_AGENT)
-
-    # Reset per-context override.
-    await bidi_session.emulation.set_user_agent_override(
-        contexts=[top_context["context"]],
-        user_agent=None
-    )
-
-    # The override for default user context should be active.
-    await assert_user_agent(top_context, ANOTHER_USER_AGENT)
-
-    # Reset override for default user context.
-    await bidi_session.emulation.set_user_agent_override(
-        user_contexts=["default"],
-        user_agent=ANOTHER_USER_AGENT
-    )
-
-    # The override should be disabled.
-    await assert_user_agent(top_context, default_user_agent)
-
-
 async def test_user_agent_set_override_and_reset_globally_and_per_user_context(
         bidi_session, top_context, default_user_agent, assert_user_agent):
     await bidi_session.emulation.set_user_agent_override(

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/global.py
@@ -83,7 +83,7 @@ async def test_user_agent_set_override_and_reset_per_user_context_and_per_contex
     )
     await assert_user_agent(top_context, SOME_USER_AGENT)
 
-    # Set global override.
+    # Set override to the default user context.
     await bidi_session.emulation.set_user_agent_override(
         user_contexts=["default"],
         user_agent=ANOTHER_USER_AGENT

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/invalid.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/invalid.py
@@ -95,7 +95,7 @@ async def test_params_user_contexts_entry_invalid_value(bidi_session, value):
         )
 
 
-async def test_params_contexts_and_user_contexts(bidi_session,top_context):
+async def test_params_contexts_and_user_contexts(bidi_session, top_context):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.emulation.set_user_agent_override(
             user_agent=SOME_USER_AGENT,

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/invalid.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/invalid.py
@@ -1,0 +1,121 @@
+import pytest
+
+import webdriver.bidi.error as error
+from tests.bidi import get_invalid_cases
+from webdriver.bidi.undefined import UNDEFINED
+
+pytestmark = pytest.mark.asyncio
+
+SOME_USER_AGENT = "SOME_USER_AGENT"
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("list"))
+async def test_params_contexts_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            contexts=value
+        )
+
+
+async def test_params_contexts_empty_list(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            contexts=[])
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("string"))
+async def test_params_contexts_entry_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            contexts=[value])
+
+
+async def test_params_contexts_entry_invalid_value(bidi_session):
+    with pytest.raises(error.NoSuchFrameException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            contexts=["_invalid_"],
+        )
+
+
+async def test_params_contexts_iframe(bidi_session, new_tab, get_test_page):
+    url = get_test_page(as_frame=True)
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url, wait="complete"
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"])
+    assert len(contexts) == 1
+    frames = contexts[0]["children"]
+    assert len(frames) == 1
+
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            contexts=[frames[0]["context"]],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("list"))
+async def test_params_user_contexts_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            user_contexts=value,
+        )
+
+
+async def test_params_user_contexts_empty_list(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            user_contexts=[],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("string"))
+async def test_params_user_contexts_entry_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            user_contexts=[value],
+        )
+
+
+@pytest.mark.parametrize("value", ["", "somestring"])
+async def test_params_user_contexts_entry_invalid_value(bidi_session, value):
+    with pytest.raises(error.NoSuchUserContextException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            user_contexts=[value],
+        )
+
+
+async def test_params_contexts_and_user_contexts(bidi_session,top_context):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=SOME_USER_AGENT,
+            contexts=[top_context["context"]],
+            user_contexts=["default"],
+        )
+
+
+async def test_params_user_agent_missing(bidi_session, top_context):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=UNDEFINED,
+            contexts=[top_context["context"]],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("string", nullable=True))
+async def test_params_user_agent_invalid_type(bidi_session, top_context, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_user_agent_override(
+            user_agent=value,
+            contexts=[top_context["context"]],
+        )

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/user_agent.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/user_agent.py
@@ -1,0 +1,21 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+SOME_USER_AGENT = "SOME_USER_AGENT"
+
+
+async def test_user_agent_set_override_and_reset(bidi_session, top_context,
+        default_user_agent, assert_user_agent):
+    await assert_user_agent(top_context, default_user_agent)
+
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=SOME_USER_AGENT
+    )
+    await assert_user_agent(top_context, SOME_USER_AGENT)
+
+    await bidi_session.emulation.set_user_agent_override(
+        user_agent=None
+    )
+
+    await assert_user_agent(top_context, default_user_agent)

--- a/webdriver/tests/bidi/emulation/set_user_agent_override/user_contexts.py
+++ b/webdriver/tests/bidi/emulation/set_user_agent_override/user_contexts.py
@@ -1,0 +1,157 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+SOME_USER_AGENT = "SOME_USER_AGENT"
+
+
+async def test_contexts(bidi_session, new_tab, top_context, default_user_agent,
+        assert_user_agent):
+    # Set user-agent override
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"]],
+        user_agent=SOME_USER_AGENT
+    )
+
+    # Assert user-agent override is set only in the required context.
+    await assert_user_agent(new_tab, SOME_USER_AGENT)
+    await assert_user_agent(top_context, default_user_agent)
+
+    # Reset user-agent override.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[new_tab["context"]],
+        user_agent=None
+    )
+
+    # Assert user-agent override is reset.
+    await assert_user_agent(new_tab, default_user_agent)
+    await assert_user_agent(top_context, default_user_agent)
+
+
+async def test_user_contexts(bidi_session, create_user_context, new_tab,
+        assert_user_agent, default_user_agent):
+    user_context = await create_user_context()
+    context_in_user_context = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab")
+
+    await assert_user_agent(new_tab, default_user_agent)
+
+    # Set user-agent override
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=[user_context],
+        user_agent=SOME_USER_AGENT)
+
+    # Assert user-agent override is set in user context.
+    await assert_user_agent(context_in_user_context, SOME_USER_AGENT)
+
+    # Assert the default user context is not affected.
+    await assert_user_agent(new_tab, default_user_agent)
+
+    # Create a new context in the user context.
+    another_context_in_user_context = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab")
+    # Assert user-agent override is set in a new browsing context of the user context.
+    await assert_user_agent(
+        another_context_in_user_context, SOME_USER_AGENT)
+
+
+async def test_set_to_default_user_context(bidi_session, new_tab,
+        create_user_context, assert_user_agent, default_user_agent, ):
+    user_context = await create_user_context()
+    context_in_user_context = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab"
+    )
+
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=["default"],
+        user_agent=SOME_USER_AGENT,
+    )
+
+    # Make sure that the user-agent override applied only to the context
+    # associated with default user context.
+    await assert_user_agent(context_in_user_context, default_user_agent)
+    await assert_user_agent(new_tab, SOME_USER_AGENT)
+
+    # Create a new context in the default context.
+    context_in_default_context = await bidi_session.browsing_context.create(
+        type_hint="tab"
+    )
+
+    await assert_user_agent(context_in_default_context, SOME_USER_AGENT)
+
+    # Reset user-agent override.
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=["default"],
+        user_agent=None
+    )
+
+
+async def test_set_to_multiple_user_contexts(bidi_session, create_user_context,
+        assert_user_agent, default_user_agent):
+    # Create the first user context.
+    user_context_1 = await create_user_context()
+    # Create a browsing context within the first user context.
+    context_in_user_context_1 = await bidi_session.browsing_context.create(
+        user_context=user_context_1, type_hint="tab"
+    )
+    # Create the second user context.
+    user_context_2 = await create_user_context()
+    # Create a browsing context within the second user context.
+    context_in_user_context_2 = await bidi_session.browsing_context.create(
+        user_context=user_context_2, type_hint="tab"
+    )
+    # Set user-agent override for both user contexts.
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=[user_context_1, user_context_2],
+        user_agent=SOME_USER_AGENT
+    )
+
+    # Assert user-agent override is set in the browsing context of the first
+    # user context.
+    await assert_user_agent(context_in_user_context_1, SOME_USER_AGENT)
+    # Assert user-agent override is set in the browsing context of the second
+    # user context.
+    await assert_user_agent(context_in_user_context_2, SOME_USER_AGENT)
+
+
+async def test_set_to_user_context_and_then_to_context(bidi_session,
+        create_user_context, new_tab, assert_user_agent, default_user_agent, ):
+    user_context = await create_user_context()
+    context_in_user_context_1 = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab"
+    )
+
+    # Apply user-agent override to the user context.
+    await bidi_session.emulation.set_user_agent_override(
+        user_contexts=[user_context],
+        user_agent=SOME_USER_AGENT
+    )
+
+    # Apply user-agent override now only to the context.
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[context_in_user_context_1["context"]],
+        user_agent=None
+    )
+    await assert_user_agent(context_in_user_context_1, default_user_agent)
+
+    await bidi_session.browsing_context.reload(
+        context=context_in_user_context_1["context"], wait="complete"
+    )
+
+    # Make sure that after reload the user-agent override is still applied.
+    await assert_user_agent(context_in_user_context_1, default_user_agent)
+
+    # Create a new context in the user context.
+    context_in_user_context_2 = await bidi_session.browsing_context.create(
+        user_context=user_context, type_hint="tab"
+    )
+    # Make sure that the user-agent override for the user context is applied.
+    await assert_user_agent(context_in_user_context_2, SOME_USER_AGENT)
+
+    await bidi_session.emulation.set_user_agent_override(
+        contexts=[context_in_user_context_1["context"]],
+        user_agent=None,
+    )
+
+    # Make sure that the user-agent override was reset.
+    await assert_user_agent(context_in_user_context_1, default_user_agent)

--- a/webdriver/tests/support/http_handlers/echo.py
+++ b/webdriver/tests/support/http_handlers/echo.py
@@ -1,0 +1,26 @@
+import json
+
+
+def main(request, response):
+    """Simple handler that returns a response with Cache-Control max-age=3600.
+    """
+
+    response.headers.set(b"Content-Type", b"application/json")
+
+    headers_dict = {}
+    for key, value in request.headers.items():
+        # Decode the key once
+        decoded_key = key.decode("utf-8")
+
+        # The value can be a single byte string or a list of byte strings
+        # if the same header is present multiple times.
+        if isinstance(value, list):
+            # If it's a list, decode each item in it.
+            headers_dict[decoded_key] = [v.decode("utf-8") for v in value]
+        else:
+            # Otherwise, just decode the single value.
+            headers_dict[decoded_key] = value.decode("utf-8")
+
+    response.content = json.dumps({
+        "headers": headers_dict
+    })

--- a/webdriver/tests/support/http_handlers/headers_echo.py
+++ b/webdriver/tests/support/http_handlers/headers_echo.py
@@ -24,3 +24,4 @@ def main(request, response):
     response.content = json.dumps({
         "headers": headers_dict
     })
+


### PR DESCRIPTION
Additionally to the usual tests, I added tests for setting simultaneous emulation per context, user agent and globally.

Also `webdriver/tests/support/http_handlers/echo.py` was introduced to accurately represent the actual headers was sent. Required to avoid dependency on `Network` module.