### PR TITLE
[webdriver] Fix new_session.conftest to not mutate configuration

### DIFF
--- a/webdriver/tests/classic/new_session/conftest.py
+++ b/webdriver/tests/classic/new_session/conftest.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from webdriver.transport import HTTPWireProtocol
@@ -34,7 +36,7 @@ def fixture_configuration(configuration):
   """
 
     if "acceptInsecureCerts" in configuration["capabilities"]:
-        configuration = dict(configuration)
+        configuration = deepcopy(configuration)
         del configuration["capabilities"]["acceptInsecureCerts"]
     return configuration
 


### PR DESCRIPTION
While we make a shallow copy with the dict constructor, this doesn't
actually do what we want — because we still have the same capabilities
object. Thus, we move to deepcopy.
