### PR TITLE
Event Timing: fix flaky timing in tests

### DIFF
--- a/event-timing/click-timing.html
+++ b/event-timing/click-timing.html
@@ -58,8 +58,10 @@
     })
 
     timeBeforeFirstClick = performance.now();
+    mainThreadBusy(2);
     await clickAndBlockMain('button');
     timeAfterFirstClick = performance.now();
+    mainThreadBusy(2);
     await clickAndBlockMain('button');
     timeAfterSecondClick = performance.now();
 

--- a/event-timing/crossiframe.html
+++ b/event-timing/crossiframe.html
@@ -53,6 +53,7 @@
     });
 
     clickTimeMin = performance.now();
+    mainThreadBusy(2);
 
     let observedPointerDown = false;
     const observerPromise = new Promise(resolve => {

--- a/event-timing/timingconditions.html
+++ b/event-timing/timingconditions.html
@@ -16,6 +16,7 @@
   let trustedClickStart;
   function trustedClickAndBlockMain(id) {
     trustedClickStart = performance.now();
+    mainThreadBusy(2);
     return clickAndBlockMain(id);
   }
 


### PR DESCRIPTION
Add some busy loops to guarantee some time passes after a timestamp is taken, which is required for some asserts that enforce ordering. Without the busy loop, the reduced resolution of `performance.now()` sometimes causes tests to fail.

## Examples of failures:

(on https://ews-build.s3-us-west-2.amazonaws.com/macOS-Sonoma-Release-WK2-Tests-EWS/3c4e4c71-26388-stress-mode/results.html)

### click-timing.html :
```
Generate a 'click' event

FAIL Event Timing: compare click timings. assert_between_exclusive: First click's processingStart
expected a number greater than 5 and less than 126 but got 5
```

### crossiframe.html :
```
Generate a 'click' event

FAIL Event Timing: entries should only be observable by its own frame. assert_greater_than: The
entry's start time should be later than clickTimeMin. expected a number greater than 11 but got 11
```

### timingconditions.html :
```
Generate a 'click' event

FAIL Event Timing only times certain types of trusted event. assert_greater_than: The startTime
should be after trustedClickStart expected a number greater than 126 but got 126
```