### PR TITLE
layout: Make lines non-phantom if they have inline padding/border/margin

### DIFF
--- a/css/css-inline/model/phantom-line-boxes-001.html
+++ b/css/css-inline/model/phantom-line-boxes-001.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<title>CSS Inline Layout Model: Phantom Line Boxes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#invisible-line-boxes">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9344">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Non-zero inline-axis margins, padding, or borders
+    prevent a line box from becoming a phantom line box, and therefore prevent
+    the inline formatting context from collapsing margins through.
+    This test checks non-zero padding.">
+
+<style>
+.wrapper {
+  float: left;
+  width: 50px;
+  background: red;
+}
+.wrapper.phantom {
+  background: green;
+}
+.wrapper > div {
+  line-height: 0;
+  background: green;
+}
+.wrapper.phantom > div {
+  background: red
+}
+.wrapper > div::after {
+  content: "";
+  display: flow-root;
+  margin-top: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper phantom">
+  <div><span style="padding-top: 1px"></span></div>
+</div>
+<div class="wrapper phantom">
+  <div><span style="padding-bottom: 1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="padding-left: 1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="padding-right: 1px"></span></div>
+</div>

--- a/css/css-inline/model/phantom-line-boxes-002.html
+++ b/css/css-inline/model/phantom-line-boxes-002.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<title>CSS Inline Layout Model: Phantom Line Boxes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#invisible-line-boxes">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9344">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Non-zero inline-axis margins, padding, or borders
+    prevent a line box from becoming a phantom line box, and therefore prevent
+    the inline formatting context from collapsing margins through.
+    This test checks non-zero borders.">
+
+<style>
+.wrapper {
+  float: left;
+  width: 50px;
+  background: red;
+}
+.wrapper.phantom {
+  background: green;
+}
+.wrapper > div {
+  line-height: 0;
+  background: green;
+}
+.wrapper.phantom > div {
+  background: red
+}
+.wrapper > div::after {
+  content: "";
+  display: flow-root;
+  margin-top: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper phantom">
+  <div><span style="border-top: 1px solid transparent"></span></div>
+</div>
+<div class="wrapper phantom">
+  <div><span style="border-bottom: 1px solid transparent"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="border-left: 1px solid transparent"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="border-right: 1px solid transparent"></span></div>
+</div>

--- a/css/css-inline/model/phantom-line-boxes-003.html
+++ b/css/css-inline/model/phantom-line-boxes-003.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<title>CSS Inline Layout Model: Phantom Line Boxes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#invisible-line-boxes">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9344">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Non-zero inline-axis margins, padding, or borders
+    prevent a line box from becoming a phantom line box, and therefore prevent
+    the inline formatting context from collapsing margins through.
+    This test checks positive margins.">
+
+<style>
+.wrapper {
+  float: left;
+  width: 50px;
+  background: red;
+}
+.wrapper.phantom {
+  background: green;
+}
+.wrapper > div {
+  line-height: 0;
+  background: green;
+}
+.wrapper.phantom > div {
+  background: red
+}
+.wrapper > div::after {
+  content: "";
+  display: flow-root;
+  margin-top: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper phantom">
+  <div><span style="margin-top: 1px"></span></div>
+</div>
+<div class="wrapper phantom">
+  <div><span style="margin-bottom: 1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="margin-left: 1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="margin-right: 1px"></span></div>
+</div>

--- a/css/css-inline/model/phantom-line-boxes-004.html
+++ b/css/css-inline/model/phantom-line-boxes-004.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<title>CSS Inline Layout Model: Phantom Line Boxes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#invisible-line-boxes">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9344">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Non-zero inline-axis margins, padding, or borders
+    prevent a line box from becoming a phantom line box, and therefore prevent
+    the inline formatting context from collapsing margins through.
+    This test checks negative margins.">
+
+<style>
+.wrapper {
+  float: left;
+  width: 50px;
+  background: red;
+}
+.wrapper.phantom {
+  background: green;
+}
+.wrapper > div {
+  line-height: 0;
+  background: green;
+}
+.wrapper.phantom > div {
+  background: red
+}
+.wrapper > div::after {
+  content: "";
+  display: flow-root;
+  margin-top: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper phantom">
+  <div><span style="margin-top: -1px"></span></div>
+</div>
+<div class="wrapper phantom">
+  <div><span style="margin-bottom: -1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="margin-left: -1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="margin-right: -1px"></span></div>
+</div>

--- a/css/css-inline/model/phantom-line-boxes-005.html
+++ b/css/css-inline/model/phantom-line-boxes-005.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<title>CSS Inline Layout Model: Phantom Line Boxes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#invisible-line-boxes">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9344">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Non-zero inline-axis margins, padding, or borders
+    prevent a line box from becoming a phantom line box, and therefore prevent
+    the inline formatting context from collapsing margins through.
+    This test checks non-zero margins that add up to zero in that axis.">
+
+<style>
+.wrapper {
+  float: left;
+  width: 50px;
+  background: red;
+}
+.wrapper.phantom {
+  background: green;
+}
+.wrapper > div {
+  line-height: 0;
+  background: green;
+}
+.wrapper.phantom > div {
+  background: red
+}
+.wrapper > div::after {
+  content: "";
+  display: flow-root;
+  margin-top: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper phantom">
+  <div><span style="margin-top: 1px; margin-bottom: -1px"></span></div>
+</div>
+<div class="wrapper phantom">
+  <div><span style="margin-top: -1px; margin-bottom: 1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="margin-left: 1px; margin-right: -1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="margin-left: -1px; margin-right: 1px"></span></div>
+</div>

--- a/css/css-inline/model/phantom-line-boxes-006.html
+++ b/css/css-inline/model/phantom-line-boxes-006.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<title>CSS Inline Layout Model: Phantom Line Boxes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-inline/#invisible-line-boxes">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9344">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Non-zero inline-axis margins, padding, or borders
+    prevent a line box from becoming a phantom line box, and therefore prevent
+    the inline formatting context from collapsing margins through.
+    This test checks non-zero margins and padding in the same box side, which
+    add up to zero.">
+
+<style>
+.wrapper {
+  float: left;
+  width: 50px;
+  background: red;
+}
+.wrapper.phantom {
+  background: green;
+}
+.wrapper > div {
+  line-height: 0;
+  background: green;
+}
+.wrapper.phantom > div {
+  background: red
+}
+.wrapper > div::after {
+  content: "";
+  display: flow-root;
+  margin-top: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper phantom">
+  <div><span style="padding-top: 1px; margin-top: -1px"></span></div>
+</div>
+<div class="wrapper phantom">
+  <div><span style="padding-bottom: 1px; padding-bottom: -1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="padding-left: 1px; margin-left: -1px"></span></div>
+</div>
+<div class="wrapper">
+  <div><span style="padding-right: 1px; margin-right: -1px"></span></div>
+</div>


### PR DESCRIPTION
According to https://drafts.csswg.org/css-inline/#invisible-line-boxes, if a line box contains non-zero inline-axis margins, padding or borders, then it can't be phantom.

Therefore, this patch makes adds a `has_inline_pbm` flag to the line. Note that we can't use the `has_content` flag, because that would add a soft wrap opportunity between the padding/border/margin and the first content of the line.

The patch also renames `InlineFormattingContext::had_inflow_content` to `has_line_boxes`, which is what we care about for collapsing margins through.

Testing: Adding new tests
Fixes: #<!-- nolink -->39057
Reviewed in servo/servo#39058