### PR TITLE
HTML: remove permission element from interfaces.js

### DIFF
--- a/html/semantics/interfaces.js
+++ b/html/semantics/interfaces.js
@@ -100,7 +100,6 @@ var elements = [
   ["output", "Output"],
   ["p", "Paragraph"],
   ["param", "Param"],
-  ["permission", "Permission"],
   ["picture", "Picture"],
   ["plaintext", ""],
   ["pre", "Pre"],


### PR DESCRIPTION
As long as it's non-standard it should only be tested in tentative tests.