### PR TITLE
Update the tested Storage Access Testdriver invariant to match other tests, allowing default partitioning

### DIFF
--- a/storage-access-api/helpers.js
+++ b/storage-access-api/helpers.js
@@ -133,31 +133,6 @@ async function DeleteCookieInFrame(frame, name, params) {
   assert_false(cookieStringHasCookie(name, '0', await GetJSCookiesFromFrame(frame)), `Verify that cookie '${name}' has been deleted.`);
 }
 
-// Tests whether the frame can write cookies via document.cookie. Note that this
-// overwrites, then optionally deletes, cookies named "cookie" and "foo".
-//
-// This function requires the caller to have included
-// /cookies/resources/cookie-helper.sub.js.
-async function CanFrameWriteCookies(frame, keep_after_writing = false) {
-  const cookie_suffix = "Secure;SameSite=None;Path=/";
-  await DeleteCookieInFrame(frame, "cookie", cookie_suffix);
-  await DeleteCookieInFrame(frame, "foo", cookie_suffix);
-
-  await SetDocumentCookieFromFrame(frame, `cookie=monster;${cookie_suffix}`);
-  await SetDocumentCookieFromFrame(frame, `foo=bar;${cookie_suffix}`);
-
-  const cookies = await GetJSCookiesFromFrame(frame);
-  const can_write = cookieStringHasCookie("cookie", "monster", cookies) &&
-      cookieStringHasCookie("foo", "bar", cookies);
-
-  if (!keep_after_writing) {
-    await DeleteCookieInFrame(frame, "cookie", cookie_suffix);
-    await DeleteCookieInFrame(frame, "foo", cookie_suffix);
-  }
-
-  return can_write;
-}
-
 // Sets a cookie in an unpartitioned context by opening a window that
 // writes a cookie using document.cookie.
 async function SetFirstPartyCookie(origin, cookie="cookie=unpartitioned;Secure;SameSite=None;Path=/") {

--- a/storage-access-api/storageAccess.testdriver.sub.html
+++ b/storage-access-api/storageAccess.testdriver.sub.html
@@ -16,6 +16,7 @@
     const wwwAlt = "https://{{hosts[alt][www]}}:{{ports[https][0]}}";
 
     promise_test(async t => {
+      await SetFirstPartyCookie(wwwAlt);
       await MaybeSetStorageAccess("*", "*", "blocked");
       t.add_cleanup(async () => {
         await test_driver.delete_all_cookies();
@@ -25,7 +26,7 @@
       const responder_html = `${wwwAlt}/storage-access-api/resources/script-with-cookie-header.py?script=embedded_responder.js`;
       const frame = await CreateFrame(responder_html);
 
-      assert_false(await CanFrameWriteCookies(frame), "Cross-site iframe should not be allowed to write cookies via document.cookie.");
+      assert_false(await HasUnpartitionedCookie(frame), "Cross-site iframe should not be allowed to read unpartitioned cookies via document.cookie.");
     });
   </script>
 </body>


### PR DESCRIPTION
[We aren't sure what to do with this endpoint](https://github.com/privacycg/storage-access/issues/162), but it seems reasonable to not test a more strict behavior than used elsewhere, as shown by this being the only use of the `CanFrameWriteCookies` helper.

@annevk @johannhof - is this a friendly change?
