### PR TITLE
css/css-anchor-position/anchor-position-inline-00[1234].html: wait for fonts to load before checking layout

### DIFF
--- a/css/css-anchor-position/anchor-position-inline-001.html
+++ b/css/css-anchor-position/anchor-position-inline-001.html
@@ -21,7 +21,12 @@
   position: absolute;
 }
 </style>
-<body onload="checkLayoutForAnchorPos('.target')">
+<script>
+  function onload() {
+    document.fonts.ready.then(() => checkLayoutForAnchorPos('.target'));
+  }
+</script>
+<body onload="onload()">
   <div id="container">
     <div>spacer</div>
     <div>

--- a/css/css-anchor-position/anchor-position-inline-002.html
+++ b/css/css-anchor-position/anchor-position-inline-002.html
@@ -21,7 +21,12 @@
   position: absolute;
 }
 </style>
-<body onload="checkLayoutForAnchorPos('.target')">
+<script>
+  function onload() {
+    document.fonts.ready.then(() => checkLayoutForAnchorPos('.target'));
+  }
+</script>
+<body onload="onload()">
   <div id="container">
     <div>spacer</div>
     <div>

--- a/css/css-anchor-position/anchor-position-inline-003.html
+++ b/css/css-anchor-position/anchor-position-inline-003.html
@@ -21,7 +21,12 @@
   position: absolute;
 }
 </style>
-<body onload="checkLayoutForAnchorPos('.target')">
+<script>
+  function onload() {
+    document.fonts.ready.then(() => checkLayoutForAnchorPos('.target'));
+  }
+</script>
+<body onload="onload()">
   <div id="container">
     <div>spacer</div>
     <div>

--- a/css/css-anchor-position/anchor-position-inline-004.html
+++ b/css/css-anchor-position/anchor-position-inline-004.html
@@ -51,7 +51,12 @@ body > div {
   height: anchor-size(--a1 height);
 }
 </style>
-<body onload="checkLayoutForAnchorPos('.target')">
+<script>
+  function onload() {
+    document.fonts.ready.then(() => checkLayoutForAnchorPos('.target'));
+  }
+</script>
+<body onload="onload()">
   <!-- The inline anchor appear in a single line inline containing block. -->
   <div class="cb">
     <div>spacer</div>


### PR DESCRIPTION
These tests are failing in Safari because the layout is checked before the Ahem font has finished loading. Fix the tests to wait for the font to load before checking layout. This follows the same spirit as https://github.com/web-platform-tests/wpt/pull/54768.