### PR TITLE
Add tests for fragmented spanning table rows / grid items

### DIFF
--- a/css/css-break/grid/grid-item-fragmentation-049.html
+++ b/css/css-break/grid/grid-item-fragmentation-049.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Fragmented grid items that span multiple rows should not extend into fragmentation-induced gaps between rows.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12801#issuecomment-4791494295">
+<link rel="help" href="https://drafts.csswg.org/css-break-4/#box-splitting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="columns:2; width:100px; gap:0; column-fill:auto; height:100px; background:green; position: relative;">
+  <div style="width:50px; height:40px; position:absolute; background:green;"></div>
+  <div style="width:75px; height:100px; position:absolute; background:green; left:25px; top:0px"></div>
+  <div style="display:grid; grid-template-rows: 40px 100px">
+    <div style="background:red; grid-row: 1/-1"></div>
+  </table>
+</div>

--- a/css/css-break/table/table-rowspan-002.html
+++ b/css/css-break/table/table-rowspan-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Fragmented rowspan columns should still reach the bottom of all the rows that they span.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://issues.chromium.org/issues/40252933">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="columns:2; width:100px; gap:0; column-fill:auto; height:100px; background:red; position: relative;">
+  <div style="width:50px; height:60px; position:absolute; background:green; top:40px;"></div>
+  <table cellpadding="0" cellspacing="0">
+    <tr>
+      <td style="width:25px; height:20px; background:green;"></td>
+      <td style="width:25px; height:20px; background:green;"></td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="background:green;"></td>
+      <td style="height:20px; background:green;"></td>
+    </tr>
+    <!-- Break goes here. Gap is covered by abspos div above. -->
+    <tr>
+      <td style="height:100px; background:green; break-inside:avoid;"></td>
+    </tr>
+  </table>
+</div>

--- a/css/css-break/table/table-rowspan-003.html
+++ b/css/css-break/table/table-rowspan-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Fragmented rowspan columns should not span through parts of a fragmentainer that have no table rows laid out into them. (i.e. the empty space after the last row that fits on a page)</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12801#issuecomment-4791494295">
+<link rel="help" href="https://drafts.csswg.org/css-break-4/#box-splitting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="columns:2; width:100px; gap:0; column-fill:auto; height:100px; background:green; position: relative;">
+  <div style="width:50px; height:40px; position:absolute; background:green;"></div>
+  <div style="width:75px; height:100px; position:absolute; background:green; left:25px; top:0px"></div>
+  <table cellpadding="0" cellspacing="0">
+    <tr>
+      <td style="width:25px; height:20px;"></td>
+      <td style="width:25px; height:20px;"></td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="background:red;"></td>
+      <td style="height:20px;"></td>
+    </tr>
+    <!-- Break goes here. Anything but the gap is covered by the abspos divs above. -->
+    <tr>
+      <td style="height:100px; break-inside:avoid;"></td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
~~These tests correspond to the spec change currently PRed in https://github.com/w3c/csswg-drafts/pull/12805.
I'm planning to write more comprehensive tests and also ones for the `display: grid` case if the spec change gets accepted.~~

Tests for the behavior specified as a result of https://github.com/w3c/csswg-drafts/issues/12801