### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=298878

### DIFF
--- a/css/css-view-transitions/finished-promise-defers-cleanup.html
+++ b/css/css-view-transitions/finished-promise-defers-cleanup.html
@@ -37,7 +37,7 @@ promise_test(async t => {
       requestAnimationFrame(() => {
         t.step_timeout(() => {
           assert_equals(getComputedStyle(document.documentElement, "::view-transition").display, "block");
-          assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed");
+          assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "absolute");
           resolve();
         }, 0);
       });


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Use `position: absolute` on `::view-transition`](https://bugs.webkit.org/show_bug.cgi?id=298878)