### PR TITLE
[css-anchor-position-1] Take the screenshot after re-rendering

### DIFF
--- a/css/css-anchor-position/position-visibility-anchors-visible-change-anchor.html
+++ b/css/css-anchor-position/position-visibility-anchors-visible-change-anchor.html
@@ -62,7 +62,9 @@
       scroller.scrollTop = 100;
       // #target should still be visible because it is anchored to #anchor1,
       // which is still visible.
-      takeScreenshot();
+      waitForAtLeastOneFrame().then(() => {
+        takeScreenshot();
+      });
     });
   });
 </script>


### PR DESCRIPTION
Taking the screenshot immediately after setting the scroll value doesn't give time for the style invalidation + layout + rerender to complete.

Idk if this fixes it (the test passes locally, but not in wpt.fyi on WebKit), but it seems like it might?