### PR TITLE
[css-anchor-position-1] Ensure scrollable area matches between reference and test

### DIFF
--- a/css/css-anchor-position/reference/anchor-scroll-chained-002-ref.html
+++ b/css/css-anchor-position/reference/anchor-scroll-chained-002-ref.html
@@ -44,7 +44,7 @@ div {
     <div id="anchor"></div>
     <div style="height: 230px"></div>
   </div>
-  <div style="height: 250px"></div>
+  <div style="height: 100px"></div>
 </div>
 <div id="anchored1"></div>
 <div id="anchored2"></div>

--- a/css/css-anchor-position/reference/anchor-scroll-chained-004-ref.html
+++ b/css/css-anchor-position/reference/anchor-scroll-chained-004-ref.html
@@ -50,7 +50,7 @@ div {
     <div id="anchor1"></div>
     <div style="height: 230px"></div>
   </div>
-  <div style="height: 250px"></div>
+  <div style="height: 100px"></div>
 </div>
 <div id="anchored1">
   <div id="scroller3">


### PR DESCRIPTION
Translated absolutely positioned boxes contribute at their translated position
per https://www.w3.org/TR/css-overflow/#scrollable [and implementations](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0A%3Cdiv%20style%3D%22border%3A%20solid%20orange%2020px%3B%20position%3A%20absolute%3B%20top%3A%20300px%3B%20transform%3A%20translateY(-300px)%22%3E%3C%2Fdiv%3E)
so there's no reason for the extra space to differ between the two.
(Besides, that would be really annoying to users!)