### PR TITLE
Fix value of activeElement when focused inside Shadow DOM or details

### DIFF
--- a/html/semantics/popovers/popover-focus-5.html
+++ b/html/semantics/popovers/popover-focus-5.html
@@ -32,8 +32,8 @@
 <div data-candidate="a details element inside" data-count="1">
   <button tabindex="0" command="toggle-popover">Toggle popover</button>
   <div popover id="popover2">
-    <details data-expected="1">
-      <summary tabindex="0">A details element</summary>
+    <details>
+      <summary tabindex="0" data-expected="1">A details element</summary>
     </details>
     <button tabindex="0" command="hide-popover" data-expected="close">
       Close popover
@@ -68,7 +68,7 @@
   <div popover id="popover4">
     <my-element data-expected="1">
       <template shadowrootmode="open" delegatesfocus>
-        <button tabindex="0"></button>
+        <button tabindex="0" data-expected="shadow-1"></button>
       </template>
     </my-element>
     <button tabindex="0" command="hide-popover" data-expected="close">
@@ -110,11 +110,11 @@
     This button is where focus should land after traversing popover
   </button>
   <div popover id="popover6">
-    <my-element>
+    <my-element data-expected="2">
       <template shadowrootmode="open">
         <slot></slot>
-        <details data-expected="2">
-          <summary tabindex="0">A details element</summary>
+        <details>
+          <summary tabindex="0" data-expected="shadow-2">A details element</summary>
         </details>
       </template>
       <button tabindex="0" data-expected="1"></button>
@@ -202,6 +202,15 @@
         String(i),
         `tab press should move to active element ${i}`,
       );
+      const shadowActive = document.activeElement?.shadowRoot?.activeElement;
+      if (shadowActive) {
+        const expected = `shadow-${i}`;
+        assert_equals(
+          shadowActive.getAttribute("data-expected"),
+          expected,
+          `tab press should move to active element ${expected} in shadow dom`,
+        );
+      }
     }
     await sendTab();
     assert_equals(


### PR DESCRIPTION
- Change  the behavior of  `details/summary` inside a `popover`.
Here’s a simple demo: when we use Tab to move focus from a button, document.activeElement is the `summary`. Currently, Firefox, Chrome, and Safari all behave consistently in this case.
```html
<button>111</button>        
<details data-expected="shadow-dom-2">
    <summary tabindex="0">A details element</summary>
</details>
```
- According to the spec (https://html.spec.whatwg.org/multipage/interaction.html#dom-documentorshadowroot-activeelement-dev), when the focus is inside a Shadow DOM, the activeElement should be the shadow host.  