### PR TITLE
New test cases for properties accepting <gradient> values

### DIFF
--- a/css/css-backgrounds/parsing/border-image-source-computed.sub.html
+++ b/css/css-backgrounds/parsing/border-image-source-computed.sub.html
@@ -21,9 +21,12 @@ test_computed_value("border-image-source", "none");
 test_computed_value("border-image-source", 'url("http://{{host}}/")');
 
 test_computed_value('border-image-source', 'linear-gradient(-45deg, red, currentcolor)', 'linear-gradient(-45deg, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value("border-image-source", 'linear-gradient(45deg, red calc(10% + 5px), blue 90%)', 'linear-gradient(45deg, rgb(255, 0, 0) calc(10% + 5px), rgb(0, 0, 255) 90%)');
 test_computed_value('border-image-source', 'repeating-linear-gradient(-45deg, red, 30%, currentcolor 70%, lime)', 'repeating-linear-gradient(-45deg, rgb(255, 0, 0), 30%, rgb(0, 0, 255) 70%, rgb(0, 255, 0))');
 test_computed_value('border-image-source', 'radial-gradient(10px at 20px 30px, currentcolor, lime)', 'radial-gradient(10px at 20px 30px, rgb(0, 0, 255), rgb(0, 255, 0))');
+test_computed_value("border-image-source", 'radial-gradient(circle at calc(50% * 2 / 4) 40%, red, blue)', 'radial-gradient(circle at 25% 40%, rgb(255, 0, 0), rgb(0, 0, 255))');
 test_computed_value('border-image-source', 'conic-gradient(from 90deg at 80% 90%, lime, black)', 'conic-gradient(from 90deg at 80% 90%, rgb(0, 255, 0), rgb(0, 0, 0))');
+test_computed_value("border-image-source", 'conic-gradient(from 2rad at 50% 50%, red, blue calc(270deg - 20deg))', 'conic-gradient(from 114.592deg, rgb(255, 0, 0), rgb(0, 0, 255) 250deg)');
 
 test(() => {
   const target = document.getElementById('target');

--- a/css/css-content/parsing/content-computed.html
+++ b/css/css-content/parsing/content-computed.html
@@ -45,6 +45,11 @@ test_computed_value_combinations("content", `counters(counter-name, ".") "potato
 test_computed_value_combinations("content", `"(" counters(counter-name, ".", counter-style) ")"`);
 test_computed_value_combinations("content", `open-quote "hello" "world" close-quote`);
 test_computed_value_combinations("content", `url("https://www.example.com/picture.svg") "hello"`);
+
+test_computed_value("content", "linear-gradient(to top right, red calc(10% + 2em), blue", "linear-gradient(to right top, rgb(255, 0, 0) calc(10% + 32px), rgb(0, 0, 255))");
+test_computed_value("content", "radial-gradient(ellipse 50% 40% at calc(2em + 10px) 30%, red, blue)", "radial-gradient(50% 40% at 42px 30%, rgb(255, 0, 0), rgb(0, 0, 255))");
+test_computed_value("content", "conic-gradient(from 1.5708rad, red 0deg, blue calc(180deg - 10deg))", "conic-gradient(from 90.0002deg, rgb(255, 0, 0) 0deg, rgb(0, 0, 255) 170deg)");
+
 </script>
 </body>
 </html>

--- a/css/css-lists/parsing/list-style-image-computed.sub.html
+++ b/css/css-lists/parsing/list-style-image-computed.sub.html
@@ -22,11 +22,16 @@ test_computed_value('list-style-image', 'none');
 test_computed_value('list-style-image', 'url("https://{{host}}/")');
 
 test_computed_value('list-style-image', 'linear-gradient(to left bottom, red , blue )', 'linear-gradient(to left bottom, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value('list-style-image', 'linear-gradient(calc(90deg - 45deg), rgb(0, 128, 0), rgb(0, 0, 255)', 'linear-gradient(45deg, rgb(0, 128, 0), rgb(0, 0, 255))');
 
 test_computed_value('list-style-image', 'radial-gradient(10px at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))');
 test_computed_value('list-style-image', 'radial-gradient(circle calc(-0.5em + 10px) at calc(-1em + 10px) calc(-2em + 10px), rgb(255, 0, 0), rgb(0, 0, 255))', 'radial-gradient(0px at -30px -70px, rgb(255, 0, 0), rgb(0, 0, 255))');
 test_computed_value('list-style-image', 'radial-gradient(ellipse calc(-0.5em + 10px) calc(0.5em + 10px) at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))', 'radial-gradient(0px 30px at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))');
 test_computed_value('list-style-image', 'radial-gradient(ellipse calc(0.5em + 10px) calc(-0.5em + 10px) at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))', 'radial-gradient(30px 0px at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value('list-style-image', 'radial-gradient(black 0% 0.5em, 25%, green 30% 60%, calc(100% * 3 / 4), white calc(100% - 20%) 100%', 'radial-gradient(rgb(0, 0, 0) 0%, rgb(0, 0, 0) 20px, 25%, rgb(0, 128, 0) 30%, rgb(0, 128, 0) 60%, 75%, rgb(255, 255, 255) 80%, rgb(255, 255, 255) 100%)');
+
+test_computed_value('list-style-image', 'conic-gradient(gold calc(100% / 2), #f06 calc(360deg * 4 / 5))', 'conic-gradient(rgb(255, 215, 0) 50%, rgb(255, 0, 102) 288deg)');
+test_computed_value('list-style-image', 'conic-gradient(black 1turn, white', 'conic-gradient(rgb(0, 0, 0) 360deg, rgb(255, 255, 255))');
 </script>
 </body>
 </html>

--- a/css/css-masking/parsing/mask-computed.html
+++ b/css/css-masking/parsing/mask-computed.html
@@ -30,6 +30,21 @@ test_computed_value('mask',
 test_computed_value('mask',
     'linear-gradient(to left bottom, red, blue) luminance',
     'linear-gradient(to left bottom, rgb(255, 0, 0), rgb(0, 0, 255)) luminance');
+test_computed_value('mask',
+   'linear-gradient(calc(90deg - 45deg), rgb(0, 128, 0), rgb(0, 0, 255)',
+   'linear-gradient(45deg, rgb(0, 128, 0), rgb(0, 0, 255))');
+test_computed_value('mask',
+   'radial-gradient(circle calc(-0.5em + 10px) at calc(-1em + 10px) calc(-2em + 10px), rgb(255, 0, 0), rgb(0, 0, 255))',
+   'radial-gradient(2px at -6px -22px, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value('mask',
+   'radial-gradient(ellipse calc(-0.5em + 10px) calc(0.5em + 10px) at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))',
+   'radial-gradient(2px 18px at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value('mask',
+   'conic-gradient(gold calc(100% / 2), #f06 calc(360deg * 4 / 5))',
+   'conic-gradient(rgb(255, 215, 0) 50%, rgb(255, 0, 102) 288deg)');
+test_computed_value('mask',
+   'conic-gradient(black 1turn, white',
+   'conic-gradient(rgb(0, 0, 0) 360deg, rgb(255, 255, 255))');
 test_computed_value('mask', 'url("https://example.com/")');
 
 // <position> [ / <bg-size> ]?

--- a/css/css-shapes/shape-outside/values/shape-outside-gradient-computed.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-gradient-computed.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: getComputedStyle().listStyleImage</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes/#shape-outside-property">
+<meta name="assert" content="list-style-image computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value('shape-outside', 'linear-gradient(45deg, red calc(25% + 10px), blue 80%)', 'linear-gradient(45deg, rgb(255, 0, 0) calc(25% + 10px), rgb(0, 0, 255) 80%)');
+test_computed_value('shape-outside', 'linear-gradient(calc(90deg - 45deg), rgb(0, 128, 0), rgb(0, 0, 255)', 'linear-gradient(45deg, rgb(0, 128, 0), rgb(0, 0, 255))');
+
+test_computed_value('shape-outside', 'radial-gradient(circle at calc(10px + 5%), red, blue)', 'radial-gradient(circle at calc(5% + 10px) 50%, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value('shape-outside', 'radial-gradient(ellipse calc(-0.5em + 10px) calc(0.5em + 10px) at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))', 'radial-gradient(0px 30px at 20px 30px, rgb(255, 0, 0), rgb(0, 0, 255))');
+test_computed_value('shape-outside', 'radial-gradient(black 0% 0.5em, 25%, green 30% 60%, calc(100% * 3 / 4), white calc(100% - 20%) 100%', 'radial-gradient(rgb(0, 0, 0) 0%, rgb(0, 0, 0) 20px, 25%, rgb(0, 128, 0) 30%, rgb(0, 128, 0) 60%, 75%, rgb(255, 255, 255) 80%, rgb(255, 255, 255) 100%)');
+
+test_computed_value('shape-outside', 'conic-gradient(from 0.5turn at 20% 30%, red, blue calc(50% - 25%))', 'conic-gradient(from 180deg at 20% 30%, rgb(255, 0, 0), rgb(0, 0, 255) 25%)');
+</script>
+</body>
+</html>

--- a/css/css-ui/parsing/cursor-computed.html
+++ b/css/css-ui/parsing/cursor-computed.html
@@ -49,6 +49,10 @@ test_computed_value("cursor", "all-scroll");
 test_computed_value("cursor", "zoom-in");
 test_computed_value("cursor", "zoom-out");
 
+test_computed_value("cursor", "linear-gradient(200grad, red 10%, blue calc(75% - 2px)), auto", "linear-gradient(rgb(255, 0, 0) 10%, rgb(0, 0, 255) calc(75% - 2px), auto");
+test_computed_value("cursor", "radial-gradient(farthest-side at calc(5px + 10%), red, blue), pointer", "radial-gradient(farthest-side at calc(10% + 5px) 50%, rgb(255, 0, 0), rgb(0, 0, 255)), pointer");
+test_computed_value("cursor", "conic-gradient(from 3.1416rad at 20% 20%, red, blue), crosshair", "conic-gradient(from 180deg at 20% 20%, rgb(255, 0, 0), rgb(0, 0, 255), pointer");
+
 // Not yet tested: // [ [<url> [<x> <y>]?,]*
 // "relative URLs converted to absolute"
 </script>


### PR DESCRIPTION
This PR adds a few test cases to verify the use of gradients in different CSS properties, like cursor, border-image-source, content and shape-outside, with emphasis on calc() functions and Angle values. 