### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=298646

### DIFF
--- a/css/css-anchor-position/pseudo-element-with-slotted-anchor-ref.html
+++ b/css/css-anchor-position/pseudo-element-with-slotted-anchor-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+my-anchor {
+  display: block;
+}
+
+span {
+  display: block;
+  anchor-name: --anchor;
+  padding: 2rem;
+  background: red;
+  color: white;
+  inline-size: fit-content;
+}
+
+my-anchor::after {
+  content: 'target';
+  position: absolute;
+  position-anchor: --anchor;
+  position-area: bottom center;
+  background: lightblue;
+  padding: 1rem;
+}
+</style>
+<my-anchor>
+  <span>anchor</span>
+</my-anchor>

--- a/css/css-anchor-position/pseudo-element-with-slotted-anchor.html
+++ b/css/css-anchor-position/pseudo-element-with-slotted-anchor.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Slotted anchor with anchored pseudo-element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#target-anchor-element">
+<link rel="match" href="pseudo-element-with-slotted-anchor-ref.html">
+<my-anchor>
+  <template shadowrootmode="open">
+    <style>
+    :host {
+      display: block;
+    }
+
+    ::slotted(*) {
+      display: block;
+      anchor-name: --anchor;
+      padding: 2rem;
+      background: red;
+      color: white;
+      inline-size: fit-content;
+    }
+
+    :host::after {
+      content: 'target';
+      position: absolute;
+      position-anchor: --anchor;
+      position-area: bottom center;
+      background: lightblue;
+      padding: 1rem;
+    }
+    </style>
+    <slot></slot>
+  </template>
+  <span>anchor</span>
+</my-anchor>


### PR DESCRIPTION
WebKit export from bug: [Anchoring a pseudo element to a slotted element in a Shadow DOM causes browser crash](https://bugs.webkit.org/show_bug.cgi?id=298646)