### PR TITLE
battery-status: Avoid false positives

### DIFF
--- a/battery-status/battery-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
+++ b/battery-status/battery-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
@@ -3,6 +3,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/permissions-policy/resources/permissions-policy.js></script>
+<script src="resources/battery-status-helpers.js"></script>
 <script>
 'use strict';
 
@@ -20,6 +21,7 @@ async_test(t => {
 }, `${header} allows same-origin relocation.`);
 
 async_test(t => {
+  assert_implements_battery();
   test_feature_availability(
       'navigator.getBattery()', t, cross_origin_src,
       expect_feature_unavailable_default, 'battery');

--- a/battery-status/battery-allowed-by-permissions-policy.https.sub.html
+++ b/battery-status/battery-allowed-by-permissions-policy.https.sub.html
@@ -17,12 +17,12 @@ promise_test(
 
 async_test(t => {
   test_feature_availability('navigator.getBattery()', t, same_origin_src,
-      expect_feature_available_default);
+      expect_feature_available_default, 'battery');
 }, `${header} allows same-origin iframes.`);
 
 async_test(t => {
   test_feature_availability('navigator.getBattery()', t, cross_origin_src,
-      expect_feature_available_default);
+      expect_feature_available_default, 'battery');
 }, `${header} allows cross-origin iframes.`);
 </script>
 </body>

--- a/battery-status/battery-default-permissions-policy.https.sub.html
+++ b/battery-status/battery-default-permissions-policy.https.sub.html
@@ -3,6 +3,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/permissions-policy/resources/permissions-policy.js></script>
+<script src="resources/battery-status-helpers.js"></script>
 <script>
 'use strict';
 
@@ -21,6 +22,7 @@ async_test(t => {
 }, `${header} allows same-origin iframes.`);
 
 async_test(t => {
+  assert_implements_battery();
   test_feature_availability('navigator.getBattery()', t, cross_origin_src,
       expect_feature_unavailable_default);
 }, `${header} disallows cross-origin iframes.`);

--- a/battery-status/battery-disabled-by-permissions-policy.https.sub.html
+++ b/battery-status/battery-disabled-by-permissions-policy.https.sub.html
@@ -3,6 +3,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/permissions-policy/resources/permissions-policy.js></script>
+<script src="resources/battery-status-helpers.js"></script>
 <script>
 'use strict';
 
@@ -16,11 +17,13 @@ promise_test(async t => {
 }, `${header} disallows the top-level document.`);
 
 async_test(t => {
+  assert_implements_battery();
   test_feature_availability('navigator.getBattery()', t, same_origin_src,
       expect_feature_unavailable_default);
 }, `${header} disallows same-origin iframes.`);
 
 async_test(t => {
+  assert_implements_battery();
   test_feature_availability('navigator.getBattery()', t, cross_origin_src,
       expect_feature_unavailable_default);
 }, `${header} disallows cross-origin iframes.`);

--- a/battery-status/resources/battery-status-helpers.js
+++ b/battery-status/resources/battery-status-helpers.js
@@ -11,6 +11,10 @@
 
 let mockBatteryMonitor = undefined;
 
+function assert_implements_battery() {
+  assert_implements(navigator.battery, 'missing navigator.battery');
+}
+
 function battery_status_test(func, name, properties) {
   promise_test(async t => {
     if (mockBatteryMonitor === undefined) {


### PR DESCRIPTION
Some Battery Status API tests that validate that the API is disallowed by permissions policies are passing in Firefox and Safari even though the feature is not implemented there.

So assert navigator.battery is implemented first before checking that it is blocked by the policy or otherwise.

Also, fix a bug in battery-allowed-by-permissions-policy.https.sub.html which didn't pass the 'battery' feature name when calling `test_feature_availability()`.