### PR TITLE
Remove invalid assertion in `requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js`

### DIFF
--- a/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js
@@ -76,9 +76,6 @@
     assert_true(cookieStringHasCookie("foo", "bar", await FetchSubresourceCookiesFromFrame(crossSiteFrame, wwwAlt)),"crossSiteFrame making same-origin subresource request can access cookies.");
 
     assert_false(cookieStringHasCookie("foo", "bar",  await FetchSubresourceCookiesFromFrame(crossOriginFrame, wwwAlt)), "crossOriginFrame making cross-site subresource request to sibling iframe's host should not include cookies.");
-
-    assert_false(cookieStringHasCookie("cookie", "monster", await FetchSubresourceCookiesFromFrame(crossSiteFrame, www)),"crossSiteFrame making cross-site subresource request to sibling iframe's host should not include cookies.");
-
   }, "Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others.");
 
 })();


### PR DESCRIPTION
The final assert_false in this test makes a fetch request from a cross-site iframe to the sibling
iframe’s host. This request is same-site relative to the top-level frame, so Safari includes cookies
regardless of storage access grants. This ABA cookie inclusion behavior is independent of the Storage
Access API and therefore not relevant to testing cross-site sibling iframe isolation.