### PR TITLE
layout: Make bottom table captions obey relative positioning offsets

### DIFF
--- a/css/css-tables/caption-relative-positioning.html
+++ b/css/css-tables/caption-relative-positioning.html
@@ -11,7 +11,7 @@
             position: relative;
             background: green;
             width: 100px;
-            height: 100px;
+            height: 50px;
             margin-left: 200px;
             left: -200px;
         }
@@ -20,7 +20,10 @@
     <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
     <div style="width: 100px; background: red;">
         <table>
-            <caption></caption>
+            <caption style="caption-side: top"></caption>
+        </table>
+        <table>
+            <caption style="caption-side: bottom"></caption>
         </table>
     </div>
 </html>


### PR DESCRIPTION
#<!-- nolink -->33426 only added support for relative positioning on captions with `caption-side: top`, but forgot about `caption-side: bottom`. This unifies the logic for both kinds of captions to avoid divergences.

Testing: Modifying an existing test to also cover this case.
Fixes: #<!-- nolink -->39386

Reviewed in servo/servo#39388