### PR TITLE
layout: Ignore insets in Taffy for static and sticky positionings

### DIFF
--- a/css/css-position/position-static-001.html
+++ b/css/css-position/position-static-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#insets">
+<link rel="help" href="https://github.com/servo/servo/issues/39399">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Inset propeties do not apply to a statically positioned grid item.">
+
+<style>
+#grid {
+  display: grid;
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+#item {
+  width: 200px;
+  height: 200px;
+  top: 200px;
+  left: 200px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="grid">
+  <div id="item"></div>
+</div>


### PR DESCRIPTION
Taffy treats static and sticky positionings as relative. So the inset properties shifted the element in the relpos way, which was no good. It's better to just treat them as `auto` instead.

Testing: 3 existing tests pass, and adding a new one.
Fixes: #<!-- nolink -->39399

Reviewed in servo/servo#39401