### PR TITLE
Remove bogus assertion from change-focus-then-remove-during-intercept.html

### DIFF
--- a/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html
+++ b/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html
@@ -24,10 +24,10 @@ promise_test(async t => {
 
   const finished = navigation.navigate("#1").finished;
 
+  document.body.onfocus = t.unreached_func("onfocus shouldn't fire due to focus reset");
   button.remove();
   assert_equals(document.activeElement, document.body, "Removing the element reset focus");
 
-  document.body.onfocus = t.unreached_func("onfocus shouldn't fire a second time due to focus reset");
   intercept_resolve();
   await finished;
   assert_equals(document.activeElement, document.body, "Focus remains on document.body after promise fulfills");

--- a/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html
+++ b/navigation-api/focus-reset/change-focus-then-remove-during-intercept.html
@@ -24,11 +24,8 @@ promise_test(async t => {
 
   const finished = navigation.navigate("#1").finished;
 
-  let onfocus_called = false;
-  document.body.onfocus = onfocus_called = true;
   button.remove();
   assert_equals(document.activeElement, document.body, "Removing the element reset focus");
-  assert_true(onfocus_called);
 
   document.body.onfocus = t.unreached_func("onfocus shouldn't fire a second time due to focus reset");
   intercept_resolve();


### PR DESCRIPTION
`onfocus_called` was always getting set to `true`. Furthermore, the focus fixup rule currently does not lead to a `focus` event getting emitted in existing browsers.

This is expected behavior according to https://html.spec.whatwg.org/#node-remove-focus-fixup .

This can be tested with this snippet:
```
button = document.querySelector("button");
button.focus();
button.remove();
let onfocus_called = false;
document.body.onfocus = () => { onfocus_called = true }; 
```
and checking the value of `onfocus_called`.

