### PR TITLE
script: Don't try to evaluate xpath variable references

### DIFF
--- a/domxpath/variables-in-expression-crash.html
+++ b/domxpath/variables-in-expression-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/36971">
+    <meta name="assert" content="Using variables in xpath expression should not crash.">
+</head>
+<body>
+    <script>
+      // The exact behaviour here is not defined. Firefox throws an error, Chrome doesn't.
+      document.evaluate("$foo", document.createElement("div"));
+    </script>
+</body>


### PR DESCRIPTION
Variables in xpath via the javascript bindings are a bit mysterious, as there is no way that a variable can be specified. We currently panic when encountering a variable, which is not good. Instead we now throw an error.

We keep parsing the variables because the code is already there and it seems realistic that their behaviour will be specified in the future. I'm fine with removing them too if that is preferred.

Testing: This behaviour is unspecified and different browser produce different results. There is no "correct" way to do this, but we should not crash
Part of: https://github.com/servo/servo/issues/34527

Reviewed in servo/servo#39395