### PR TITLE
Use cleanup function in scrollend-event-not-fired-on-no-scroll.html

### DIFF
--- a/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html
+++ b/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html
@@ -59,7 +59,7 @@
       let delta_x = 0;
       let delta_y = -50;
       let actions = new test_driver.Actions()
-      .scroll(x, y, delta_x, delta_y, {origin: scrolling_element});
+        .scroll(x, y, delta_x, delta_y, {origin: scrolling_element});
       await actions.send();
     } else if (scroll_type == "keys") {
       const num_keydowns = 5;
@@ -73,8 +73,10 @@
   async function testScrollendNotFiredOnNoScroll(test, scrolling_element,
                                                  listening_element,
                                                  button_element, scroll_type) {
-    await resetScrollers(test);
-    await waitForCompositorCommit();
+    test.add_cleanup(async () => {
+      await resetScrollers(test);
+      await waitForCompositorCommit();
+    });
 
     assert_greater_than(scrolling_element.scrollHeight,
                         scrolling_element.clientHeight);


### PR DESCRIPTION
(Instead of cleaning up at the beginning of the test)