### PR TITLE
Remove -o- (opera) prefixes from WebVTT ::cue animation test cases

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_animation_with_timestamp.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_animation_with_timestamp.html
@@ -6,16 +6,7 @@
 html { overflow:hidden }
 body { margin:0 }
 ::cue(b:past) {
-    -o-animation: test 9s steps(2, start);
     animation: test 9s steps(2, start);
-}
-@-o-keyframes test {
-    0% {
-        color: #ffffff;
-    }
-    100% {
-        color: #00ff00;
-    }
 }
 @keyframes test {
     0% {

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_animation_with_timestamp.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_animation_with_timestamp.html
@@ -6,16 +6,7 @@
 html { overflow:hidden }
 body { margin:0 }
 ::cue(c:past) {
-    -o-animation: test 9s steps(2, start);
     animation: test 9s steps(2, start);
-}
-@-o-keyframes test {
-    0% {
-        color: #ffffff;
-    }
-    100% {
-        color: #00ff00;
-    }
 }
 @keyframes test {
     0% {

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_animation_with_timestamp.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_animation_with_timestamp.html
@@ -6,16 +6,7 @@
 html { overflow:hidden }
 body { margin:0 }
 ::cue(i:past) {
-    -o-animation: test 9s steps(2, start);
     animation: test 9s steps(2, start);
-}
-@-o-keyframes test {
-    0% {
-        color: #ffffff;
-    }
-    100% {
-        color: #00ff00;
-    }
 }
 @keyframes test {
     0% {

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_animation_with_timestamp.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_animation_with_timestamp.html
@@ -6,16 +6,7 @@
 html { overflow:hidden }
 body { margin:0 }
 ::cue(u:past) {
-    -o-animation: test 9s steps(2, start);
     animation: test 9s steps(2, start);
-}
-@-o-keyframes test {
-    0% {
-        color: #ffffff;
-    }
-    100% {
-        color: #00ff00;
-    }
 }
 @keyframes test {
     0% {

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_animation_with_timestamp.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_animation_with_timestamp.html
@@ -6,16 +6,7 @@
 html { overflow:hidden }
 body { margin:0 }
 ::cue(v:past) {
-    -o-animation: test 9s steps(2, start);
     animation: test 9s steps(2, start);
-}
-@-o-keyframes test {
-    0% {
-        color: #ffffff;
-    }
-    100% {
-        color: #00ff00;
-    }
 }
 @keyframes test {
     0% {


### PR DESCRIPTION
This is just clean-up patch to remove -o- (opera) prefix from WebVTT test cases.