### PR TITLE
Fix test description

### DIFF
--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-001.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-001.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-002.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-002.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-003.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-003.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-004.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-004.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the initial containing block, so the abspos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-005.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-005.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-006.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-006.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-007.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-007.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-008.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the abspos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-009.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-009.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-009-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the abspos gets painted.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the abspos gets painted.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-010.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-010.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-009-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the abspos gets painted.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the abspos gets painted.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-011.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-011.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the abspos is hidden.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the abspos is hidden.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-012.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-012.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the abspos is hidden.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the abspos is hidden.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-013.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-013.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-013-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the abspos gets painted, even if its static position is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the abspos gets painted, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-014.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-014.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-013-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the abspos gets painted, even if its static position is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the abspos gets painted, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-015.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-015.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-005-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the abspos is hidden. This happens even when the containing block is an inline.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the abspos is hidden. This happens even when the containing block is an inline.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-016.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-016.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-016-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the abspos gets painted. This happens even when the containing block is an inline, and even when the static position of the abspos is after the clamp point.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the abspos gets painted. This happens even when the containing block is an inline, and even when the static position of the abspos is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-017.tentative.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-017.tentative.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-030-ref.html">
-<meta name="assert" content="Absolute positioned boxes in a line-clamp container are hidden if and only if their containing block precedes or contains the clamp point. In this case, the containing block is an inline whose start gets displaced by the ellipsis. Therefore, it counts as being all after the clamp point, and the abspos is hidden.">
+<meta name="assert" content="Absolute positioned boxes in a line-clamp container are shown if and only if their containing block precedes or contains the clamp point. In this case, the containing block is an inline whose start gets displaced by the ellipsis. Therefore, it counts as being all after the clamp point, and the abspos is hidden.">
 <style>
 .clamp {
   line-clamp: 3;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-001.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-001.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-002.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-002.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-003.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-003.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-004.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-004.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-001-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the layout viewport, so the fixed-pos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-005.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-005.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-006.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-006.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-007.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-007.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-008.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-005-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown, even if its static position is after the clamp point.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is the line-clamp container, so the fixed-pos gets shown, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-009.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-009.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-009-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the fixed-pos gets painted.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the fixed-pos gets painted.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-010.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-010.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-009-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the fixed-pos gets painted.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully before the clamp point, so the fixed-pos gets painted.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-011.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-011.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-005-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the fixed-pos is hidden.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the fixed-pos is hidden.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-012.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-012.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-005-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the fixed-pos is hidden.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block is fully after the clamp point, so the fixed-pos is hidden.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-013.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-013.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-013-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the fixed-pos gets painted, even if its static position is after the clamp point.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the fixed-pos gets painted, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;

--- a/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-014.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-fixed-pos-014.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
 <link rel="match" href="reference/line-clamp-with-abspos-013-ref.html">
-<meta name="assert" content="Fixed positioned boxes in a line-clamp container are hidden if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the fixed-pos gets painted, even if its static position is after the clamp point.">
+<meta name="assert" content="Fixed positioned boxes in a line-clamp container are shown if and only if their fixed positioning containing block precedes or contains the clamp point. In this case, the containing block contains the clamp point, so the fixed-pos gets painted, even if its static position is after the clamp point.">
 <style>
 .clamp {
   line-clamp: 4;


### PR DESCRIPTION
The tests are correct, but the description accidentally states the opposite of what it means.