### PR TITLE
Add line clamp test

### DIFF
--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-023.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-023.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: abspos in line-clamp in zero-sized div</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
+<link rel="match" href="reference/line-clamp-with-abspos-023-ref.html">
+<meta name="assert" content="Absolute positioned boxes inside a line-clamp container are shown if their containing block is after the clamp point. This test specifically tests that this is the case where the container is an other-wise empty, zero-height div, which does fit before the clamp point.">
+<style>
+.clamp {
+  line-clamp: 4;
+  font: 16px / 32px serif;
+  background-color: yellow;
+}
+.rel {
+  position: relative;
+}
+.abspos {
+  position: absolute;
+  right: 0;
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div class="clamp">
+Line 1<br>
+Line 2<br>
+Line 3<br>
+Line 4<br>
+<div class="rel"><div class="abspos">This abspos should be visible</div></div>
+Line 5
+</div>

--- a/css/css-overflow/line-clamp/line-clamp-with-abspos-023.html
+++ b/css/css-overflow/line-clamp/line-clamp-with-abspos-023.html
@@ -7,7 +7,8 @@
 <meta name="assert" content="Absolute positioned boxes inside a line-clamp container are shown if their containing block is after the clamp point. This test specifically tests that this is the case where the container is an other-wise empty, zero-height div, which does fit before the clamp point.">
 <style>
 .clamp {
-  line-clamp: 4;
+  line-clamp: auto;
+  max-height: 4lh;
   font: 16px / 32px serif;
   background-color: yellow;
 }

--- a/css/css-overflow/line-clamp/reference/line-clamp-with-abspos-023-ref.html
+++ b/css/css-overflow/line-clamp/reference/line-clamp-with-abspos-023-ref.html
@@ -21,6 +21,6 @@
 Line 1<br>
 Line 2<br>
 Line 3<br>
-Line 4…<br>
+Line 4<br>
 <div class="rel" styl><div class="abspos">This abspos should be visible</div></div>
 </div>

--- a/css/css-overflow/line-clamp/reference/line-clamp-with-abspos-023-ref.html
+++ b/css/css-overflow/line-clamp/reference/line-clamp-with-abspos-023-ref.html
@@ -22,5 +22,5 @@ Line 1<br>
 Line 2<br>
 Line 3<br>
 Line 4<br>
-<div class="rel" styl><div class="abspos">This abspos should be visible</div></div>
+<div class="rel"><div class="abspos">This abspos should be visible</div></div>
 </div>

--- a/css/css-overflow/line-clamp/reference/line-clamp-with-abspos-023-ref.html
+++ b/css/css-overflow/line-clamp/reference/line-clamp-with-abspos-023-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: test reference</title>
+<style>
+.clamp {
+  font: 16px / 32px serif;
+  background-color: yellow;
+}
+.rel {
+  position: relative;
+}
+.abspos {
+  position: absolute;
+  right: 0;
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div class="clamp">
+Line 1<br>
+Line 2<br>
+Line 3<br>
+Line 4…<br>
+<div class="rel" styl><div class="abspos">This abspos should be visible</div></div>
+</div>


### PR DESCRIPTION
Checks that:
* abspos get displayed when their container is displained
* zero-height empty divs get retained when using line-clamp: auto (see https://github.com/w3c/csswg-drafts/issues/12663)