### PR TITLE
Add Tests for line clamp

### DIFF
--- a/css/css-overflow/line-clamp/line-clamp-auto-039.html
+++ b/css/css-overflow/line-clamp/line-clamp-auto-039.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>CSS Overflow: `line-clamp: auto` empty div</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
+<link rel="match" href="reference/line-clamp-auto-039-ref.html">
+<meta name="assert" content="Checks that the clamp point is after, rather than before, an empty div, and that this results in no ellipsis being inserted as the last thing before the clamp point isn't a line">
+<style>
+.clamp {
+  line-clamp: auto;
+  max-height: 4lh;
+  background-color: yellow;
+}
+</style>
+<div class="clamp">
+Line 1<br>
+Line 2<br>
+Line 3<br>
+Line 4<br>
+<div></div>
+Line 5
+</div>

--- a/css/css-overflow/line-clamp/line-clamp-auto-040.html
+++ b/css/css-overflow/line-clamp/line-clamp-auto-040.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>CSS Overflow: `line-clamp: auto` zero-height div</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#line-clamp">
+<link rel="match" href="reference/line-clamp-auto-040-ref.html">
+<meta name="assert" content="Checks that the clamp point is after, rather than before, an non-empty div with zero-height, and that this results in the content of that div being retained and ellipsis being inserted on its the last line">
+<style>
+.clamp {
+  line-clamp: auto;
+  max-height: 4lh;
+  background-color: yellow;
+}
+.zero {
+  height: 0;
+}
+</style>
+<div class="clamp">
+Line 1<br>
+Line 2<br>
+Line 3<br>
+Line 4<br>
+<div class=zero>
+Line 5<br>
+Line 6
+</div>
+Line 7
+</div>

--- a/css/css-overflow/line-clamp/reference/line-clamp-auto-039-ref.html
+++ b/css/css-overflow/line-clamp/reference/line-clamp-auto-039-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>CSS Overflow: test ref</title>
+<style>
+.clamp {
+  background-color: yellow;
+}
+</style>
+<div class="clamp">
+Line 1<br>
+Line 2<br>
+Line 3<br>
+Line 4
+</div>

--- a/css/css-overflow/line-clamp/reference/line-clamp-auto-040-ref.html
+++ b/css/css-overflow/line-clamp/reference/line-clamp-auto-040-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>CSS Overflow: test reference</title>
+<style>
+.clamp {
+  line-clamp: auto;
+  height: 4lh;
+  background-color: yellow;
+}
+.zero {
+  height: 0;
+}
+</style>
+<div class="clamp">
+Line 1<br>
+Line 2<br>
+Line 3<br>
+Line 4<br>
+<div class=zero>
+Line 5<br>
+Line 6…
+</div>
+</div>

--- a/css/css-overflow/line-clamp/reference/line-clamp-auto-040-ref.html
+++ b/css/css-overflow/line-clamp/reference/line-clamp-auto-040-ref.html
@@ -4,8 +4,6 @@
 <title>CSS Overflow: test reference</title>
 <style>
 .clamp {
-  line-clamp: auto;
-  height: 4lh;
   background-color: yellow;
 }
 .zero {


### PR DESCRIPTION
Checks that the clamp point goes after rather than before empty/zero-height divs

See https://github.com/w3c/csswg-drafts/issues/12663