### PR TITLE
Adjust descriptions

### DIFF
--- a/css/css-overflow/line-clamp/webkit-line-clamp-007.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-007.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-007-ref.html">
-<meta name="assert" content="-webkit-line-clamp should apply to a flex item in a -webkit-box or -webkit-inline-box flex container.">
+<meta name="assert" content="When -webkit-line-clamp applies to a -webkit-box or -webkit-inline-box flex container, it becomes flow-root, there's no flexing, and clamping applies normally to an inflow child.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-009.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-009.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-009-ref.html">
-<meta name="assert" content="-webkit-line-clamp should count lines in non-BFC block children of the flex items.">
+<meta name="assert" content="-webkit-line-clamp should count lines in non-BFC block descendents.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-010.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-010.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-010-ref.html">
-<meta name="assert" content="-webkit-line-clamp should count lines in non-BFC block children of the flex items.">
+<meta name="assert" content="-webkit-line-clamp should count lines in non-BFC block descendents.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-011.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-011.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-011-ref.html">
-<meta name="assert" content="-webkit-line-clamp should skip lines in BFC children of the flex items.">
+<meta name="assert" content="-webkit-line-clamp should skip lines in BFC descendents.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-012.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-012.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-012-ref.html">
-<meta name="assert" content="-webkit-line-clamp should skip lines in independent formatting contexts in the flex items.">
+<meta name="assert" content="-webkit-line-clamp should skip lines in independent formatting contexts.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-013.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-013.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-013-ref.html">
-<meta name="assert" content="-webkit-line-clamp should skip lines in independent formatting contexts in the flex items.">
+<meta name="assert" content="-webkit-line-clamp should skip lines in independent formatting contexts.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-016.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-016.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-016-ref.html">
-<meta name="assert" content="-webkit-line-clamp value on the flex child should be ignored.">
+<meta name="assert" content="-webkit-line-clamp value on the child of the clamping context should be ignored (since it doesn't carry -webkit-box nor webkit-box-orient:vertical itself.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-029.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-029.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-029-ref.html">
-<meta name="assert" content="-webkit-line-clamp should apply to flex items that are scrollable.">
+<meta name="assert" content="-webkit-line-clamp should not count lines in descendents that are scrollable, since they establish a new BFC.">
 <style>
 .clamp {
   display: -webkit-box;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-030.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-030.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-030-ref.html">
-<meta name="assert" content="-webkit-line-clamp should apply to flex items when the container is scrollable.">
+<meta name="assert" content="-webkit-line-clamp should apply when the container is scrollable.">
 <style>
 .clamp {
   display: -webkit-box;


### PR DESCRIPTION
Tests were correct, but the descriptions are a little misleading, often invoking the concept of flex children even though the box isn't a flexbox when clamp applies