### PR TITLE
adjust explanation of webkit-line-clamp test

### DIFF
--- a/css/css-overflow/line-clamp/webkit-line-clamp-008.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-008-ref.html">
-<meta name="assert" content="-webkit-line-clamp should apply to all flex items in a -webkit-box or -webkit-inline-box flex container independently.">
+<meta name="assert" content="When -webkit-line-clamp applies to a -webkit-box or -webkit-inline-box flex container, it becomes flow-root, there's no flexing, and clamping applies normally to the inflow children within the same FC. Lines in IFC are skipped.">
 <style>
 .clamp {
   display: -webkit-box;


### PR DESCRIPTION
Per spec, when `(-webkit-)line-clamp` applies to a display: `-webkit-box` element, that element is no longer a flex box, and becomes BFC (`display: flow-root`).

Therefore, not only is there no flex-children to speak of, the line counting doesn't apply to each child independently, but instead, counts lines jointly through all the inflow children of the clamping context, skipping lines in any independent FC in the way.