### PR TITLE
Update test reference to allow hyphen-minus as the hyphenation character

### DIFF
--- a/css/css-overflow/line-clamp/block-ellipsis-028.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-028.html
@@ -4,7 +4,8 @@
 <link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
-<link rel="match" href="reference/block-ellipsis-028-ref.html">
+<link rel="match" href="reference/block-ellipsis-028-ref-a.html">
+<link rel="match" href="reference/block-ellipsis-028-ref-b.html">
 <meta name="assert" content="Soft hyphens create opportunities for placement of the block-ellipsis">
 <style>
 .clamp {

--- a/css/css-overflow/line-clamp/reference/block-ellipsis-028-ref-a.html
+++ b/css/css-overflow/line-clamp/reference/block-ellipsis-028-ref-a.html
@@ -5,7 +5,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <style>
 .clamp {
-  line-clamp: 2;
   width: 63.1ch;
   border: 1px solid black;
   font-family: monospace;

--- a/css/css-overflow/line-clamp/reference/block-ellipsis-028-ref-b.html
+++ b/css/css-overflow/line-clamp/reference/block-ellipsis-028-ref-b.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: test reference</title>
+<link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+.clamp {
+  width: 63.1ch;
+  border: 1px solid black;
+  font-family: monospace;
+}
+</style>
+<div class="clamp">This time, Mark, who had always been the center of attention in
+any social gathering, walked into the room uncharacteristi-…
+</div>


### PR DESCRIPTION
The test `css/css-overflow/line-clamp/block-ellipsis-028.html` was added in #54917, including a soft hyphen in the test and a hyphen character (U+2010) in the reference.

However, unless the `hyphenate-character` CSS property is set to a string, the actual hyphen string that replaces the soft hyphen is set by the user agent, depending on the content language. In this case, the language is English, and a hyphen character might be expected. However, some user agents (such as Chromium) also take the used font into account, and might use a hyphen-minus (U+002D) instead.

This patch adds two references for this test, one using hyphen, and one using hyphen-minus. Additionally, it also updates the references to not set `line-clamp: 2`, which is the feature under test.
