### PR TITLE
script: Empty pending mutation observers when notifying mutation observers

### DIFF
--- a/dom/nodes/MutationObserver-nested-crash.html
+++ b/dom/nodes/MutationObserver-nested-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>MutationObservers: observer inside another observer's callback</title>
+
+<div id="target"></div>
+<script>
+  var observer = new MutationObserver(_ => {
+    var otherObserver = new MutationObserver(_ => {});
+    otherObserver.observe(target, {characterData: true});
+  });
+  observer.observe(target, {subtree: true, attributeOldValue: true});
+  target.setAttribute("foo", "bar");
+</script>


### PR DESCRIPTION
Empty the surrounding agent’s pending mutation observers when notifying mutation observers according to the spec. Also, the code in the method MutationObserver::queue_a_mutation_record and the corresponding specification have diverged over the years. These changes bring the code into conformity with the specification.

Testing: Added a new crash test
Fixes: #<!-- nolink -->39434 #<!-- nolink -->39531

Reviewed in servo/servo#39456