### PR TITLE
[css-anchor-position-1] Make stacking order match between test and reference

### DIFF
--- a/css/css-anchor-position/reference/anchor-scroll-chained-003-ref.html
+++ b/css/css-anchor-position/reference/anchor-scroll-chained-003-ref.html
@@ -1,8 +1,4 @@
 <!DOCTYPE html>
-<title>Tests scroll adjustments of element anchored to another anchored element</title>
-<link rel="author" href="mailto:wangxianzhu@chromium.org">
-<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
-<link rel="match" href="reference/anchor-scroll-chained-003-ref.html">
 <style>
 body {
   margin: 0;
@@ -24,35 +20,28 @@ div {
 }
 
 #anchor {
-  anchor-name: --a1;
   height: 20px;
   background: orange;
 }
 
 #anchored1 {
   position: absolute;
-  position-anchor: --a1;
-  left: anchor(left);
-  top: anchor(bottom);
+  top: 70px;
   background: green;
-  anchor-name: --a2;
   z-index: 1;
 }
 
 #anchored2 {
   position: absolute;
-  position-anchor: --a2;
-  left: anchor(left);
-  top: anchor(bottom);
+  top: 170px;
   background: lime;
-  z-index: 1;
 }
 
 </style>
 
 <div id="anchored2"></div>
+<div id="anchored1"></div>
 <div id="scroller1">
-  <div id="anchored1"></div>
   <div style="height: 100px"></div>
   <div id="scroller2">
     <div style="height: 230px"></div>


### PR DESCRIPTION
Follow-up to https://github.com/web-platform-tests/wpt/pull/54343: Positioning a box changes its stacking order compared to non-positioned boxes, and its position in relation to other boxes also matters. This change makes the tests and references position and order the boxes the same way so that the tests and references can properly match.