### PR TITLE
Assert that style element has an owner in `parse_own_css`

### DIFF
--- a/shadow-dom/crashtests/modify-style-element-in-disconnected-shadow-crash.html
+++ b/shadow-dom/crashtests/modify-style-element-in-disconnected-shadow-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Modifying a style element in a disconnected shadow tree should not crash</title>
+        <link rel="help" href="https://github.com/servo/servo/issues/37781">
+    </head>
+    <body>
+        <script>
+        let d = document.createElement('div');
+        let s = d.attachShadow({mode: "open"});
+        let s2 = document.createElement('style');
+        s.appendChild(s2);
+        s2.textContent = "lol";
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The existing `assert!(node.is_connected())` is wrong. What it *wants* to assert is that the style element has an owner, which is either a Document or a ShadowRoot that the element is a descendant of. However, if the element is descendant of a ShadowRoot which is itself not connected to a document then the assertion would fail.

Instead, we use `node.is_in_a_document_tree() || node.is_in_a_shadow_tree()`, which more accurately reflects the intent.

Testing: This change adds the test case from https://github.com/servo/servo/issues/37781 as a crashtest
Fixes https://github.com/servo/servo/issues/39457
Fixes https://github.com/servo/servo/issues/37781

Reviewed in servo/servo#39458