### PR TITLE
Ignore WEB_FEATURES.yml for update-wasm-tests workflow

### DIFF
--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -30,10 +30,9 @@ jobs:
       - name: Convert WAST tests to WPT
         run: wasm-spec/test/build.py --dont-recompile --html wasm-spec/out/
       - name: Copy Wasm tests to WPT
-        # Replace wasm/core entirely.
+        # Replace wasm/core entirely, but preserve WEB_FEATURES.yml files.
         run: |
-          rm -rf wpt/wasm/core
-          cp -r wasm-spec/out/ wpt/wasm/core/
+          rsync -a --delete --exclude 'WEB_FEATURES.yml' wasm-spec/out/ wpt/wasm/core/
       - name: Commit changes
         id: commit
         continue-on-error: true


### PR DESCRIPTION
Currently, the update-wasm-tests workflow removes all the existing WASM test files before copying over the new tests.

This means that we cannot land WEB_FEATURES.yml files for WASM because they would be removed during the next run of the workflow.

This change moves to using rsync and excludes WEB_FEATURES.yml files.

This will allow WEB_FEATURES.yml files to persist between workflow runs.

Given these generated PRs are still manually reviewed, incoming PRs with changes to the file names will be caught by the WEB_FEATURES linter And reviewers can update them if needed.