### PR TITLE
[wdspec] `destinationFolder` is required in `browser.setDownloadBehavior`

### DIFF
--- a/webdriver/tests/bidi/browser/set_download_behavior/download_behavior_allowed.py
+++ b/webdriver/tests/bidi/browser/set_download_behavior/download_behavior_allowed.py
@@ -15,17 +15,6 @@ async def test_allow_and_reset(bidi_session, new_tab, temp_dir,
     assert await is_download_allowed(new_tab) == default_is_download_allowed
 
 
-async def test_allow_and_reset_no_destination_folder(bidi_session, new_tab,
-        is_download_allowed, default_is_download_allowed):
-    await bidi_session.browser.set_download_behavior(download_behavior={
-        "type": "allowed"
-    })
-    assert await is_download_allowed(new_tab) == True
-
-    await bidi_session.browser.set_download_behavior(download_behavior=None)
-    assert await is_download_allowed(new_tab) == default_is_download_allowed
-
-
 async def test_destination_folder(bidi_session, new_tab, temp_dir,
         trigger_download):
     await bidi_session.browser.set_download_behavior(download_behavior={


### PR DESCRIPTION
Remove obsolete test `test_allow_and_reset_no_destination_folder` after spec changes are landed: https://github.com/w3c/webdriver-bidi/pull/1008.