### PR TITLE
[event-timing] Wait for pointerdown instead of mousedown on `retrievability.html`

### DIFF
--- a/event-timing/retrievability.html
+++ b/event-timing/retrievability.html
@@ -13,7 +13,7 @@
 
 <script>
   function validateEntries() {
-    const entriesByName = performance.getEntriesByName('mousedown', 'event');
+    const entriesByName = performance.getEntriesByName('pointerdown', 'event');
     const entriesByType = performance.getEntriesByType('event');
     const allEntries = performance.getEntries();
     assert_equals(entriesByName.length, 0, 'Event Timing entry should not be retrievable by getEntriesByName');
@@ -32,7 +32,7 @@
   async_test(function(t) {
     assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     new PerformanceObserver(t.step_func(entryList => {
-      if (entryList.getEntriesByName('mousedown').length > 0) {
+      if (entryList.getEntriesByName('pointerdown').length > 0) {
         validateEntries();
         t.done();
       }


### PR DESCRIPTION
The `event-timing/retrievability.html` test assumes a mousedown event will be generated by `test_driver.click(target)`. This doesn't happen in safaridriver, causing the test to time out.

My understanding is that safaridriver isn't wrong: https://www.w3.org/TR/webdriver2/#element-click doesn't guarantee the mousedown, and compatibility mouse events [aren't mandatory](https://www.w3.org/TR/pointerevents/#dfn-compatibility-mouse-events). Therefore, waiting for a pointerdown is more correct.