### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295504

### DIFF
--- a/css/css-anchor-position/no-anchor-anchor-center-ref.html
+++ b/css/css-anchor-position/no-anchor-anchor-center-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests that 'anchor-center' behaves as 'center' when no anchor in containing block</title>
+<style>
+.anchor {
+  background: orange;
+  width: 100px;
+  background-color: orange;
+}
+.container {
+  position: fixed;
+  top: 20px;
+  left: 50px;
+  width: 300px;
+  height: 200px;
+  display: flex;
+  background: green;
+  justify-content: center;
+}
+.target {
+  position: absolute;
+  margin: 0 auto;
+  width: 80px;
+  border: 1px #000 solid;
+  background: lime;
+}
+</style>
+<div class="anchor">anchor</div>
+<div class="container">
+  <div class="target">target 1</div>
+</div>

--- a/css/css-anchor-position/no-anchor-anchor-center.html
+++ b/css/css-anchor-position/no-anchor-anchor-center.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Tests that 'anchor-center' behaves as 'center' when no anchor in containing block</title>
+<link rel="match" href="no-anchor-anchor-center-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#valdef-justify-self-anchor-center">
+<style>
+.anchor {
+  anchor-name: --dropdownAnchor;
+  background: orange;
+  width: 100px;
+  background-color: orange;
+}
+.container {
+  position: fixed;
+  top: 20px;
+  left: 50px;
+  width: 300px;
+  height: 200px;
+  background: green;
+}
+.target {
+  position-anchor: --dropdownAnchor;
+  display: flow;
+  left: 10px;
+  right: 10px;
+  position: absolute;
+  justify-self: anchor-center;
+  width: 80px;
+  border: 1px #000 solid;
+  background: lime;
+}
+</style>
+<div class="anchor">anchor</div>
+<div class="container">
+  <div class="target">target 1</div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[css-anchor-position-1\] Wrong anchor-center behavior when target is absolute child of fixed element](https://bugs.webkit.org/show_bug.cgi?id=295504)