### PR TITLE
wdspec: fix imports in /webdriver/tests/bidi/network/get_data/ tests

### DIFF
--- a/webdriver/tests/bidi/network/get_data/charset.py
+++ b/webdriver/tests/bidi/network/get_data/charset.py
@@ -1,4 +1,4 @@
-import webdriver.bidi.error as error
+import pytest
 
 from .. import PAGE_EMPTY_IMAGE, PAGE_EMPTY_TEXT, PAGE_OTHER_TEXT
 

--- a/webdriver/tests/bidi/network/get_data/collector.py
+++ b/webdriver/tests/bidi/network/get_data/collector.py
@@ -1,5 +1,4 @@
 import pytest
-import webdriver.bidi.error as error
 
 from .. import PAGE_EMPTY_TEXT
 


### PR DESCRIPTION
Before landing #54928 I wanted to remove an unnecessary import of webdriver.bidi.error, but I removed pytest instead.