### PR TITLE
Allow absent line/column number in navigate-to-javascript-url-001.

### DIFF
--- a/trusted-types/navigate-to-javascript-url-001.html
+++ b/trusted-types/navigate-to-javascript-url-001.html
@@ -17,12 +17,19 @@
     assert_equals(violation.violatedDirective, "require-trusted-types-for");
     assert_equals(violation.disposition, "enforce");
     assert_equals(violation.sample, `Location href|${clipSampleIfNeeded(kJavaScriptURLCode)}`);
-    assert_equals(violation.lineNumber, 4);
-    // https://w3c.github.io/webappsec-csp/#create-violation-for-global does not
-    // say how to determine the location and browsers provide inconsistent
-    // values for column number, so just check it's at least the offset of the
-    // '=' character of window.
-    assert_greater_than_equal(violation.columnNumber, 9);
+
+    // https://w3c.github.io/webappsec-csp/#create-violation-for-global says,
+    // If the user agent [...] and can extract [... line and column number ...]
+    // We'll allow line and column number be absent. If either is present, we
+    // expect specific values.
+    if (violation.lineNumber || violation.columnNumber) {
+      assert_equals(violation.lineNumber, 4);
+      // https://w3c.github.io/webappsec-csp/#create-violation-for-global does
+      // not say how to determine the location and browsers provide inconsistent
+      // values for column number, so just check it's at least the offset of the
+      // '=' character of window.
+      assert_greater_than_equal(violation.columnNumber, 9);
+    }
     assert_equals(result.exception, null);
   }, "Setting window.location to a javascript: URL without a default policy should report a CSP violation instead of executing the JavaScript code.");
 </script>

--- a/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html
+++ b/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html
@@ -21,6 +21,15 @@
     });
     const divAdoptedFromIframe =
           document.adoptNode(iframe.contentDocument.body.firstElementChild);
-    assert_throws_js(TypeError, _ => divAdoptedFromIframe.innerHTML = 'unsafe');
+
+    // There are cross-browser differences about which realm a node returned
+    // by Document.adoptNode belongs to. Here, we expect that Trusted Types will
+    // throw an exception from divAdoptedFromIframe's realm, but without
+    // taking a stance about whether this should be the window's or the iframe's
+    // realm.
+    // Discussion at: https://github.com/web-platform-tests/wpt/issues/45405
+    assert_throws_js(
+          divAdoptedFromIframe.ownerDocument.defaultView.TypeError,
+          _ => divAdoptedFromIframe.innerHTML = 'unsafe');
   }, "Setting innerHTML on a node adopted from a subframe.");
 </script>


### PR DESCRIPTION
https://w3c.github.io/webappsec-csp/#create-violation-for-global specifies that line & column numbers can (optionally) be added to CSP reports. We follow that spec here, and will check line & column number when present, but will also allow them to be absent. We won't allow a mix: If either is present, both are checked.