### PR TITLE
script: Chain up `scrollIntoView()` scrolling to parent `<iframe>`s

### DIFF
--- a/css/cssom-view/scrollIntoView-iframes.html
+++ b/css/cssom-view/scrollIntoView-iframes.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSOM View Test: scrollIntoView in iframes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<meta name="assert" content="Checks that scrollIntoView inside and iframe can scroll in the parent document if it has the same origin.">
+
+<style>
+.scroller {
+  overflow: hidden;
+  height: 500px;
+  border: solid;
+}
+.scroller::before {
+  content: "";
+  display: block;
+  height: 500px;
+}
+.scroller::after {
+  content: "";
+  display: block;
+  height: 300px;
+}
+iframe {
+  height: 1000px;
+  border: none;
+}
+</style>
+
+<div id="log"></div>
+
+<div class="scroller">
+  <iframe id="same-origin-iframe"></iframe>
+</div>
+<div class="scroller">
+  <iframe id="cross-origin-iframe" sandbox="allow-scripts"></iframe>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let sameOriginIframe = document.getElementById("same-origin-iframe");
+let crossOriginIframe = document.getElementById("cross-origin-iframe");
+let sameOriginWindow = sameOriginIframe.contentWindow;
+let crossOriginWindow = crossOriginIframe.contentWindow;
+
+promise_setup(() => Promise.all([
+  new Promise(resolve => {
+    sameOriginIframe.addEventListener("load", resolve);
+    sameOriginIframe.src = "support/scrollIntoView-iframes-child.html";
+  }),
+  new Promise(resolve => {
+    crossOriginIframe.addEventListener("load", resolve);
+    crossOriginIframe.src = "support/scrollIntoView-iframes-child.html";
+  })
+]));
+
+promise_test(async () => {
+  assert_equals(sameOriginWindow.scrollY, 100, "scrollY");
+}, "scrollIntoView in same-origin iframe can scroll in inner window");
+
+promise_test(async () => {
+  assert_equals(sameOriginIframe.parentElement.scrollTop, 1200, "scrollTop");
+}, "scrollIntoView in same-origin iframe can scroll in parent window");
+
+promise_test(async () => {
+  let scrollY = await new Promise(resolve => {
+    addEventListener("message", event => {
+      if (event.source === crossOriginWindow) {
+        resolve(event.data);
+      }
+    });
+    crossOriginWindow.postMessage("scrollY", "*");
+  });
+  assert_equals(scrollY, 100, "scrollY");
+}, "scrollIntoView in cross-origin iframe can scroll in inner window");
+
+promise_test(async () => {
+  assert_equals(crossOriginIframe.parentElement.scrollTop, 0, "scrollTop");
+}, "scrollIntoView in cross-origin iframe can't scroll in parent window");
+</script>

--- a/css/cssom-view/support/scrollIntoView-iframes-child.html
+++ b/css/cssom-view/support/scrollIntoView-iframes-child.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+body {
+  margin: 0;
+  padding-top: 1000px;
+}
+#target {
+  height: 100px;
+  width: 100px;
+  background: green;
+}
+</style>
+<div id="target"></div>
+<script>
+target.scrollIntoView({block: "center"});
+
+addEventListener("message", event => {
+  if (event.data === "scrollY") {
+    event.source.postMessage(scrollY, "*");
+  }
+});
+</script>


### PR DESCRIPTION
Calling `scrollIntoView()` on an element within an `<iframe>` will now scroll scrolling boxes from the parent document(s), as long as they have the same origin.

Testing: One existing subtest passes, and adding a new test.

Reviewed in servo/servo#39475