### PR TITLE
Update WEB_FEATURES for custom-elements/registries

### DIFF
--- a/custom-elements/registries/WEB_FEATURES.yml
+++ b/custom-elements/registries/WEB_FEATURES.yml
@@ -4,6 +4,15 @@ features:
   - define.html
   - per-global.html
   - upgrade.html
+  - valid-custom-element-names.html
 - name: customized-built-in-elements
   files:
   - define-customized-builtins.html
+- name: scoped-custom-element-registries
+  files:
+  - "*"
+  - "!define-customized-builtins.html"
+  - "!define.html"
+  - "!per-global.html"
+  - "!upgrade.html"
+  - "!valid-custom-element-names.html"


### PR DESCRIPTION
This adds valid-custom-element-names.html to the existing
autonomous-custom-elements feature, and then adds everything not in
the above to the scoped-custom-element-registries feature, as
practically it seems likely the majority of tests will continue to be
about it.
