### PR TITLE
Ignore untested members when testing the default toJSON operation

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1398,7 +1398,7 @@ IdlInterface.prototype.default_to_json_operation = function() {
         if (I.has_default_to_json_regular_operation()) {
             isDefault = true;
             for (const m of I.members) {
-                if (m.special !== "static" && m.type == "attribute" && I.array.is_json_type(m.idlType)) {
+                if (!m.untested && m.special !== "static" && m.type == "attribute" && I.array.is_json_type(m.idlType)) {
                     map.set(m.name, m.idlType);
                 }
             }


### PR DESCRIPTION
This changes the testing of the WebIDL default toJSON operation to avoid testing untested members.

For example, see (Interop 2025, Core Web Vitals) https://wpt.fyi/results/largest-contentful-paint/idlharness.html?run_id=6027028060176384 where:

 * The toJSON operation test fails with: 'assert_true: property "navigationId" should be present in the output of LargestContentfulPaint.prototype.toJSON() expected true got false'.
 * There is no 'LargestContentfulPaint interface: lcp must inherit property "navigationId" with the proper type' subtest.

We omit untested members when generating tests for members, but we don't do this when testing the default toJSON operation. This leads to oddities where the default toJSON operation subtest is the only failure, for reasons unrelated to the toJSON operation itself.

In Firefox, the above test is the only one whose result changes.

In Chrome, there's a bunch:

```
  ▶ Unexpected subtest result in /layout-instability/idlharness.html:
  └ PASS [expected FAIL] LayoutShift interface: default toJSON operation on layoutShift

  ▶ Unexpected subtest result in /longtask-timing/idlharness.window.html:
  └ PASS [expected FAIL] PerformanceLongTaskTiming interface: default toJSON operation on [object PerformanceLongTaskTiming]

  ▶ Unexpected subtest result in /longtask-timing/idlharness.window.html:
  └ PASS [expected FAIL] TaskAttributionTiming interface: default toJSON operation on [object TaskAttributionTiming]

  ▶ Unexpected subtest result in /navigation-timing/idlharness.window.html:
  └ PASS [expected FAIL] PerformanceNavigationTiming interface: default toJSON operation on performance.getEntriesByType("navigation")[0]

  ▶ Unexpected subtest result in /paint-timing/idlharness.window.html:
  └ PASS [expected FAIL] PerformancePaintTiming interface: default toJSON operation on paintTiming

  ▶ Unexpected subtest result in /resource-timing/idlharness.any.html:
  └ PASS [expected FAIL] PerformanceResourceTiming interface: default toJSON operation on resource

  ▶ Unexpected subtest result in /resource-timing/idlharness.any.worker.html:
  └ PASS [expected FAIL] PerformanceResourceTiming interface: default toJSON operation on resource

  ▶ Unexpected subtest result in /server-timing/idlharness.https.any.html:
  └ PASS [expected FAIL] PerformanceResourceTiming interface: default toJSON operation on resource

  ▶ Unexpected subtest result in /server-timing/idlharness.https.any.worker.html:
  └ PASS [expected FAIL] PerformanceResourceTiming interface: default toJSON operation on resource
```

In Safari, nothing changes.