### PR TITLE
Fix VT reftests to account for Safari dynamically colored scrollbar tracks

### DIFF
--- a/css/css-view-transitions/block-with-overflowing-text-ref.html
+++ b/css/css-view-transitions/block-with-overflowing-text-ref.html
@@ -8,6 +8,7 @@
 <style>
 :root {
   font: 20px/1 Ahem;
+  scrollbar-width: none;
 }
 
 #target {

--- a/css/css-view-transitions/block-with-overflowing-text.html
+++ b/css/css-view-transitions/block-with-overflowing-text.html
@@ -13,6 +13,7 @@
 <style>
 :root {
   font: 20px/1 Ahem;
+  scrollbar-width: none;
 }
 #target {
   text-shadow: red -20px -50px;

--- a/css/css-view-transitions/capture-with-visibility-mixed-descendants-ref.html
+++ b/css/css-view-transitions/capture-with-visibility-mixed-descendants-ref.html
@@ -5,6 +5,9 @@
 <link rel="author" href="mailto:vmpstr@chromium.org">
 
 <style>
+:root {
+  scrollbar-width: none;
+}
 body {
   background: pink;
 }

--- a/css/css-view-transitions/capture-with-visibility-mixed-descendants.html
+++ b/css/css-view-transitions/capture-with-visibility-mixed-descendants.html
@@ -8,6 +8,9 @@
 <script src="/common/reftest-wait.js"></script>
 
 <style>
+:root {
+  scrollbar-width: none;
+}
 .target {
   width: 100px;
   height: 100px;

--- a/css/css-view-transitions/content-with-clip-ref.html
+++ b/css/css-view-transitions/content-with-clip-ref.html
@@ -3,6 +3,9 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <style>
+:root {
+  scrollbar-width: none;
+}
 .target {
   contain: paint;
   width: 100px;

--- a/css/css-view-transitions/content-with-clip.html
+++ b/css/css-view-transitions/content-with-clip.html
@@ -7,6 +7,9 @@
 
 <script src="/common/reftest-wait.js"></script>
 <style>
+:root {
+  scrollbar-width: none;
+}
 .target {
   contain: paint;
   width: 100px;

--- a/css/css-view-transitions/exit-transition-with-anonymous-layout-object-ref.html
+++ b/css/css-view-transitions/exit-transition-with-anonymous-layout-object-ref.html
@@ -5,6 +5,10 @@
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <style>
+:root {
+  scrollbar-width: none;
+}
+
 body {
   width: 100vw;
   height: 100vh;

--- a/css/css-view-transitions/exit-transition-with-anonymous-layout-object.html
+++ b/css/css-view-transitions/exit-transition-with-anonymous-layout-object.html
@@ -7,6 +7,10 @@
 
 <script src="/common/reftest-wait.js"></script>
 <style>
+:root {
+  scrollbar-width: none;
+}
+
 body {
   width: 100vw;
   height: 100vh;

--- a/css/css-view-transitions/fragmented-at-start-ignored-ref.html
+++ b/css/css-view-transitions/fragmented-at-start-ignored-ref.html
@@ -4,6 +4,9 @@
 <link rel="author" href="mailto:vmpstr@chromium.org">
 
 <style>
+:root {
+  scrollbar-width: none;
+}
 body { background: pink }
 #spacer {
   width: 100px;

--- a/css/css-view-transitions/fragmented-at-start-ignored.html
+++ b/css/css-view-transitions/fragmented-at-start-ignored.html
@@ -7,6 +7,9 @@
 
 <script src="/common/reftest-wait.js"></script>
 <style>
+:root {
+  scrollbar-width: none;
+}
 #spacer {
   width: 100px;
   height: 950px;

--- a/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
@@ -5,6 +5,9 @@
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <style>
+  :root {
+    scrollbar-width: none;
+  }
   .outer {
     transform: scale3d(2, 2, 1);
     width: 100vw;

--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -9,6 +9,9 @@
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
 <style>
+  :root {
+    scrollbar-width: none;
+  }
   .outer {
     transform: scale(2);
     width: 100vw;

--- a/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html
+++ b/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="reftest-wait" style="background: lightblue;">
 <title>View transitions: capture root element with scrollbar (ref)</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/snapshot-containing-block-static.html
+++ b/css/css-view-transitions/snapshot-containing-block-static.html
@@ -10,7 +10,8 @@
 <style>
 :root {
   view-transition-name: none;
-  background-color: red;
+  background-color: limegreen;
+  box-shadow: 0 0 0 10px inset red;
 }
 
 body {


### PR DESCRIPTION
Since macOS Tahoe, Safari has started dynamically coloring the scrollbar tracks based on the root background color.

This has lead many reftests to start failing, since they are no longer using the same fixed track background like other browsers.

To fix this, we either hide the scrollbar using scrollbar-width: none when the scrollbar isn't critical to the test, or change the root background color to trump the track color heuristic.