### PR TITLE
Limit the events fired by a stopped MediaRecorder in case of change of track states

### DIFF
--- a/mediacapture-record/MediaRecorder-stop.html
+++ b/mediacapture-record/MediaRecorder-stop.html
@@ -220,6 +220,56 @@
         assertSequenceIn(events, ["start", "dataavailable", "stop"]);
     }, "MediaRecorder will fire only start and stop events in a basic recording flow.");
 
+    promise_test(async t => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const audioTrack = stream.getAudioTracks()[0];
+        const videoTrack = stream.getVideoTracks()[0];
+        t.add_cleanup(() => {
+            audioTrack.stop();
+            videoTrack.stop();
+        });
+        const recorder = new MediaRecorder(stream);
+
+        let events = [];
+        recorder.onstart = ()=> events.push("start");
+        recorder.onstop = ()=> events.push("stop");
+        recorder.onerror = ()=> events.push("error");
+        recorder.ondataavailable = ()=> events.push("data");
+
+        recorder.start();
+        await new Promise(resolve => t.step_timeout(resolve, 0));
+
+        stream.removeTrack(stream.getAudioTracks()[0]);
+        recorder.stop();
+        await new Promise(resolve => t.step_timeout(resolve, 500));
+        assert_array_equals(events, ["start", "data", "stop"]);
+    }, "MediaRecorder will not fire an error event if a recorder is stopped synchronously after a track is removed");
+
+    promise_test(async t => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const audioTrack = stream.getAudioTracks()[0];
+        const videoTrack = stream.getVideoTracks()[0];
+        t.add_cleanup(() => {
+            audioTrack.stop();
+            videoTrack.stop();
+        });
+        const recorder = new MediaRecorder(stream);
+
+        let events = [];
+        recorder.onstart = ()=> events.push("start");
+        recorder.onstop = ()=> events.push("stop");
+        recorder.onerror = ()=> events.push("error");
+        recorder.ondataavailable = ()=> events.push("data");
+
+        recorder.start();
+        await new Promise(resolve => t.step_timeout(resolve, 0));
+
+        audioTrack.stop();
+        videoTrack.stop();
+        recorder.stop();
+        await new Promise(resolve => t.step_timeout(resolve, 500));
+        assert_array_equals(events, ["start", "data", "stop"]);
+    }, "MediaRecorder will not fire an error event if a recorder is stopped synchronously after all tracks are ended");
 </script>
 </body>
 </html>

--- a/mediacapture-record/MediaRecorder-stop.html
+++ b/mediacapture-record/MediaRecorder-stop.html
@@ -221,7 +221,7 @@
     }, "MediaRecorder will fire only start and stop events in a basic recording flow.");
 
     promise_test(async t => {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const {stream} = createFlowingAudioVideoStream(t);
         const audioTrack = stream.getAudioTracks()[0];
         const videoTrack = stream.getVideoTracks()[0];
         t.add_cleanup(() => {
@@ -230,10 +230,19 @@
         });
         const recorder = new MediaRecorder(stream);
 
+        let resolve;
+        const promise = new Promise((resolve_, reject) => {
+            resolve = resolve_;
+            t.step_timeout(() => reject("stop event time out"), 2000);
+        });
+
         let events = [];
-        recorder.onstart = ()=> events.push("start");
-        recorder.onstop = ()=> events.push("stop");
-        recorder.onerror = ()=> events.push("error");
+        recorder.onstart = () => events.push("start");
+        recorder.onstop = () => {
+            events.push("stop");
+            resolve();
+        }
+        recorder.onerror = () => events.push("error");
         recorder.ondataavailable = ()=> events.push("data");
 
         recorder.start();
@@ -241,12 +250,12 @@
 
         stream.removeTrack(stream.getAudioTracks()[0]);
         recorder.stop();
-        await new Promise(resolve => t.step_timeout(resolve, 500));
+        await promise;
         assert_array_equals(events, ["start", "data", "stop"]);
     }, "MediaRecorder will not fire an error event if a recorder is stopped synchronously after a track is removed");
 
     promise_test(async t => {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const {stream} = createFlowingAudioVideoStream(t);
         const audioTrack = stream.getAudioTracks()[0];
         const videoTrack = stream.getVideoTracks()[0];
         t.add_cleanup(() => {
@@ -255,9 +264,18 @@
         });
         const recorder = new MediaRecorder(stream);
 
+        let resolve;
+        const promise = new Promise((resolve_, reject) => {
+            resolve = resolve_;
+            t.step_timeout(() => reject("stop event time out"), 2000);
+        });
+
         let events = [];
         recorder.onstart = ()=> events.push("start");
-        recorder.onstop = ()=> events.push("stop");
+        recorder.onstop = () => {
+            events.push("stop");
+            resolve();
+        }
         recorder.onerror = ()=> events.push("error");
         recorder.ondataavailable = ()=> events.push("data");
 
@@ -267,7 +285,7 @@
         audioTrack.stop();
         videoTrack.stop();
         recorder.stop();
-        await new Promise(resolve => t.step_timeout(resolve, 500));
+        await promise;
         assert_array_equals(events, ["start", "data", "stop"]);
     }, "MediaRecorder will not fire an error event if a recorder is stopped synchronously after all tracks are ended");
 </script>


### PR DESCRIPTION
Export of WebKit PR, see https://bugs.webkit.org/show_bug.cgi?id=299601