### PR TITLE
script: display top-level SVG image documents.

### DIFF
--- a/svg/top-level-document/svg-image-document-svg-xml-mime-type-ref.html
+++ b/svg/top-level-document/svg-image-document-svg-xml-mime-type-ref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<meta charset="utf-8">
+<iframe src="../shapes/circle-01.svg?pipe=header(Content-Type,image/svg)">

--- a/svg/top-level-document/svg-image-document-svg-xml-mime-type.tentative.html
+++ b/svg/top-level-document/svg-image-document-svg-xml-mime-type.tentative.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Display image/svg+xml top level documents</title>
+<link rel='match' href='svg-image-document-svg-xml-mime-type-ref.html'>
+<link rel="author" title="webbeef" href="mailto:me@webbeef.org">
+<iframe src="../shapes/circle-01.svg?pipe=header(Content-Type,image/svg+xml)">


### PR DESCRIPTION
SVG images served with the image/svg+xml mime type were recognized as XML documents instead of images, so were not displayed.

Testing: compare the results of `./mach run https://raw.githubusercontent.com/servo/servo/467821598b59bd84273d91c9d8a33651e10578b8/resources/resource_protocol/servo-color-negative-no-container.svg`

Reviewed in servo/servo#39494