### PR TITLE
Fix reference for `/css/css-nesting/nesting-basic.html`

### DIFF
--- a/css/css-nesting/nesting-basic-ref.html
+++ b/css/css-nesting/nesting-basic-ref.html
@@ -27,4 +27,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>


### PR DESCRIPTION
This reftest got broken by #55065, since it modified the test but forgot to update the reference accordingly.