### PR TITLE
Prevent nesting-basic.html from depending on font metrics

### DIFF
--- a/css/css-nesting/nesting-basic.html
+++ b/css/css-nesting/nesting-basic.html
@@ -90,8 +90,7 @@
 
   .test-13::before {
     background-color: green;
-    color: green;
-    content: "text";
+    content: "";
   }
   .test-13::before {
     & {


### PR DESCRIPTION
This test was broken by #55065 on some browsers or platforms, because that change assumed that the string "text" with the default font would not be wider than 30px. That's not a safe assumption.

In fact the text was completely unnecessary, since what was relevant was just the background-color. So I'm just removing it.