### PR TITLE
Add style as potential preload destination

### DIFF
--- a/preload/download-resources.html
+++ b/preload/download-resources.html
@@ -23,8 +23,8 @@
         if (numberOfResourceTimingEntries("resources/dummy.js") == 1 &&
             numberOfResourceTimingEntries("resources/dummy.css") == 1 &&
             numberOfResourceTimingEntries("/fonts/CanvasTest.ttf") == 1 &&
-            numberOfResourceTimingEntries("resources/white.mp4") == 1 &&
-            numberOfResourceTimingEntries("resources/sound_5.oga") == 1 &&
+            numberOfResourceTimingEntries("resources/white.mp4") == 0 &&
+            numberOfResourceTimingEntries("resources/sound_5.oga") == 0 &&
             numberOfResourceTimingEntries("resources/foo.vtt") == 1 &&
             numberOfResourceTimingEntries("resources/dummy.xml?foo=bar") == 0 &&
             numberOfResourceTimingEntries("resources/dummy.xml?novalue") == 0 &&
@@ -37,8 +37,8 @@
             verifyNumberOfResourceTimingEntries("resources/dummy.js", 1);
             verifyNumberOfResourceTimingEntries("resources/dummy.css", 1);
             verifyNumberOfResourceTimingEntries("/fonts/CanvasTest.ttf", 1);
-            verifyNumberOfResourceTimingEntries("resources/white.mp4", 1);
-            verifyNumberOfResourceTimingEntries("resources/sound_5.oga", 1);
+            verifyNumberOfResourceTimingEntries("resources/white.mp4", 0);
+            verifyNumberOfResourceTimingEntries("resources/sound_5.oga", 0);
             verifyNumberOfResourceTimingEntries("resources/foo.vtt", 1);
             verifyNumberOfResourceTimingEntries("resources/dummy.xml?foo=bar", 0);
             verifyNumberOfResourceTimingEntries("resources/dummy.xml?novalue", 0);


### PR DESCRIPTION
This was missed during the previous implementation and was the reason that the CSP tests weren't working.

It also updates a test to ensure that audio and video are not preloaded. No browsers do that and with this fix, the test now passes in Chrome. In Firefox it still fails as it doesn't implement `.vtt` support.

Part of #<!-- nolink -->35035
Reviewed in servo/servo#39549