### PR TITLE
out-of-bounds opacity keyframes

### DIFF
--- a/web-animations/animation-model/keyframe-effects/opacity-clamping.html
+++ b/web-animations/animation-model/keyframe-effects/opacity-clamping.html
@@ -7,25 +7,7 @@
 
 <div id="log"></div>
 
-<script> // kvndy
-
-test(t => {
-  const element = createDiv(t);
-  const frames = [{ opacity:-1},{opacity:-1}];
-  const timing = {
-    duration: Infinity,
-    easing: "linear",
-    fill: "backwards",
-    composite: "add"
-  };
-  const effect = new KeyframeEffect(element, frames, timing);
-  const animation = new Animation(effect, document.timeline);
-  animation.play();
-  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
-  const expected = 1;
-  animation.cancel();
-  assert_equals(actual, expected);
-}, "Opacity clamping should conform to Firefox behavior");
+<script>
 
 test(t => {
   const element = createDiv(t);
@@ -43,6 +25,137 @@ test(t => {
   const expected = 0;
   animation.cancel();
   assert_equals(actual, expected);
-}, "Opacity clamping should conform to Chromium behavior");
+}, "opacity should allow negative number values in keyframes");
+
+test(t => {
+  const element = createDiv(t);
+  const frames = [{ opacity:-2},{opacity:-2}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 0;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow negative number values in keyframes and clamp after additive compositing");
+
+test(t => {
+  const element = createDiv(t);
+  const frames = [{ opacity:"-100%"},{opacity:"-100%"}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 0;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow negative percentage values in keyframes");
+
+test(t => {
+  const element = createDiv(t);
+  const frames = [{ opacity:"-200%"},{opacity:"-200%"}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 0;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow negative percentage values in keyframes and clamp after additive compositing");
+
+
+test(t => {
+  const element = createDiv(t);
+  element.style.opacity = -1; // this is a valid <number>
+  const frames = [{ opacity:2},{opacity:2}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 1;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow number values greater than one in keyframes");
+
+test(t => {
+  const element = createDiv(t);
+  element.style.opacity = 0;
+  const frames = [{ opacity:2},{opacity:2}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 1;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow number values greater than one in keyframes and clamp after additive compositing");
+
+test(t => {
+  const element = createDiv(t);
+  element.style.opacity = -1; // this is a valid <number>
+  const frames = [{ opacity:"200%"},{opacity:"200%"}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 1;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow percentage values greater than 100 in keyframes");
+
+test(t => {
+  const element = createDiv(t);
+  element.style.opacity = 0;
+  const frames = [{ opacity:"200%"},{opacity:"200%"}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 1;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "opacity should allow percentage values greater than 100 in keyframes and clamp after additive compositing");
 
 </script>

--- a/web-animations/animation-model/keyframe-effects/opacity-clamping.html
+++ b/web-animations/animation-model/keyframe-effects/opacity-clamping.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>opacity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+
+<div id="log"></div>
+
+<script> // kvndy
+
+test(t => {
+  const element = createDiv(t);
+  const frames = [{ opacity:-1},{opacity:-1}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 1;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "Opacity clamping should conform to Firefox behavior");
+
+test(t => {
+  const element = createDiv(t);
+  const frames = [{ opacity:-1},{opacity:-1}];
+  const timing = {
+    duration: Infinity,
+    easing: "linear",
+    fill: "backwards",
+    composite: "add"
+  };
+  const effect = new KeyframeEffect(element, frames, timing);
+  const animation = new Animation(effect, document.timeline);
+  animation.play();
+  const actual = Number(getComputedStyle(element).getPropertyValue("opacity"));
+  const expected = 0;
+  animation.cancel();
+  assert_equals(actual, expected);
+}, "Opacity clamping should conform to Chromium behavior");
+
+</script>


### PR DESCRIPTION
Opacity is of type \<number\> or \<percentage\> and allows setting element.style to values below zero and above one. Keyframes also allow setting values below zero and above one, but there are discrepancies between browsers when clamping occurs.

Additive animation benefits greatly from keyframes with values between negative one and zero, clamped after additive compositing. Chromium allows this. Firefox and Safari do not.

I filed a bug with Mozilla and submitted a patch that is still pending approval. Emilio asked for an addition to wpt. I'm not 100% sure if this is what he meant or if this is the correct behavior.

I also filed a poorly-written issue with Interop-2026 that I would be thrilled to close upon approval. [https://github.com/web-platform-tests/interop/issues/1060](https://github.com/web-platform-tests/interop/issues/1060)

Sadly, I messed up the squash and am unsure how to proceed. This PR is two commits for one new file, instead of one commit in one file, but will try again if necessary.