### PR TITLE
[css-multicol-1] Fix missing column-gap:0 declaration

### DIFF
--- a/css/css-multicol/resize-in-strict-containment-nested.html
+++ b/css/css-multicol/resize-in-strict-containment-nested.html
@@ -4,7 +4,7 @@
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div style="columns:2; column-gap:0; column-fill:auto; width:200px; height:100px; margin-left:-100px;">
-  <div style="columns:1;">
+  <div style="columns:1; column-gap:0;">
     <div style="height:1px; break-after:column;"></div>
     <div style="width:100px; height:100px; contain:strict; background:red;">
       <div id="target" style="width:1px; height:100px; background:green;"></div>


### PR DESCRIPTION
The test assumes that there's no gap, so it's rendering incorrectly (offset by 1em from the reference rendering).