### PR TITLE
Fix viewport-segments mapping

### DIFF
--- a/viewport/WEB_FEATURES.yml
+++ b/viewport/WEB_FEATURES.yml
@@ -1,3 +1,4 @@
 features:
-- name: viewport
-  files: "**"
+- name: viewport-segments
+  files:
+  - "viewport-segments.html"


### PR DESCRIPTION
The current web feature id of `viewport` does not exist in webdx. Given this is in a generic `viewport` directory, I explicitly map the identifier to the test file instead of using the wildcard.