### PR TITLE
Use window/handles to check if WebDriver is still connected

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1034,7 +1034,7 @@ class WebDriverProtocol(Protocol):
             # still alive, and allows to complete the check within the testrunner
             # 5 seconds of extra_timeout we have as maximum to end the test before
             # the external timeout from testrunner triggers.
-            self.webdriver.send_session_command("GET", "window", timeout=2)
+            self.webdriver.send_session_command("GET", "window/handles", timeout=2)
         except (OSError, webdriver_error.WebDriverException, socket.timeout,
                 webdriver_error.UnknownErrorException,
                 webdriver_error.InvalidSessionIdException):


### PR DESCRIPTION
Using `/session/{session id}/window` has the problem of failing if the current top-level browsing context is no longer open; if we instead use `/session/{session id}/window/handles` then we are using a command which should only fail if the underlying connection or session has failed.

As a motivating example:

If the `DELETE /session/{session id}/window` command fails to close the window, then we raise an exception, `raise Exception("the window remained open after sending the window close command")`, which then gets turned into an ERROR or CRASH depending on whether the WebDriver connection is still alive. If the window _has_ closed by the time we do the aliveness check then this fails with a "no such window" error, causing us to conclude that the connection/session has failed.

We could instead modify `is_alive` to ignore "no such window" errors, but that feels riskier than just changing to a command which cannot fail.