### PR TITLE
Verify that maction doesn't react to click events

### DIFF
--- a/mathml/relations/html5-tree/maction-click-ref.html
+++ b/mathml/relations/html5-tree/maction-click-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>maction click (reference)</title>
+  </head>
+  <body>
+    <p>This test passes if you see a green square.</p>
+    <math>
+      <mrow>
+        <mspace width="150px" height="150px" style="background: green"/>
+      </mrow>
+    </math>
+  </body>
+</html>
+

--- a/mathml/relations/html5-tree/maction-click.html
+++ b/mathml/relations/html5-tree/maction-click.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <meta charset="utf-8"/>
+    <title>maction click</title>
+    <link rel="help" href="https://www.w3.org/TR/MathML3/chapter3.html#presm.maction"/>
+    <link rel="help" href="https://w3c.github.io/mathml-core/#dfn-maction"/>
+    <link rel="match" href="maction-click-ref.html"/>
+    <meta name="assert" content="Verify that maction doesn't respond to click events."/>
+    <script type="text/javascript">
+      function test() {
+        var event = new MouseEvent("click", { bubbles: true, cancelable: true });
+        document.getElementById("target").dispatchEvent(event);
+        document.documentElement.className = "";
+      }
+    </script>
+  </head>
+  <body onload="test()">
+    <p>This test passes if you see a green square.</p>
+    <math>
+      <maction actiontype="toggle" id="target">
+        <mspace width="150px" height="150px" style="background: green"/>
+        <mspace width="150px" height="150px" style="background: red"/>
+      </maction>
+    </math>
+  </body>
+</html>
+


### PR DESCRIPTION
The MathML Core spec says about [`maction`](https://w3c.github.io/mathml-core/#dfn-maction):

> This specification does not define any observable behavior that is specific to the `actiontype` and `selection` attributes.

This test checks that the element is not clickable even when the `toggle` action is defined.