### PR TITLE
script: Support `keyCode`, `charCode` in KeyboardEvent constructor

### DIFF
--- a/uievents/keyboard/keyboardevent-legacy.html
+++ b/uievents/keyboard/keyboardevent-legacy.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Rakhi Sharma" href="mailto:atbrakhi@igalia.com">
 <link rel="help" href="https://w3c.github.io/uievents/#legacy-dictionary-KeyboardEventInit">
 <link rel="help" href="https://w3c.github.io/uievents/#idl-keyboardeventinit">
-<meta name="assert" content="KeyboardEvent constructor should initialize legacy keyCode and charCode events.">
+<meta name="assert" content="KeyboardEvent constructor should initialize legacy keyCode and charCode attributes.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/uievents/keyboard/keyboardevent-legacy.html
+++ b/uievents/keyboard/keyboardevent-legacy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>KeyboardEvent legacy fields initialization Test: KeyCode and charCode</title>
+<link rel="author" title="Rakhi Sharma" href="mailto:atbrakhi@igalia.com">
+<link rel="help" href="https://w3c.github.io/uievents/#legacy-dictionary-KeyboardEventInit">
+<link rel="help" href="https://w3c.github.io/uievents/#idl-keyboardeventinit">
+<meta name="assert" content="KeyboardEvent constructor should initialize legacy keyCode and charCode events.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+
+<script>
+var t = async_test("KeyboardEvent constructor should initialize legacy keyCode and charCode");
+
+t.step(function() {
+  const evPress = new KeyboardEvent("keypress", { keyCode: 65, charCode: 65 });
+  assert_equals(evPress.keyCode, 65, "keypress: initialized keyCode");
+  assert_equals(evPress.charCode, 65, "keypress: initialized charCode");
+});
+
+t.step(function() {
+  const evDown = new KeyboardEvent("keydown", { keyCode: 13, charCode: 0 });
+  assert_equals(evDown.keyCode, 13, "keydown: initialized keyCode");
+  assert_equals(evDown.charCode, 0, "keydown: initialized charCode should be 0");
+});
+
+t.done();
+</script>


### PR DESCRIPTION
Support `keyCode` and `charCode` fields in KeyboardEventInit for Speedometer 3.0

Speedometer 3.0 fails because Servo's KeyboardEvent constructor ignores 
keyCode and charCode parameters, hardcoding them to 0. This breaks frameworks 
that check `event.keyCode === 13` for Enter key detection.  This is how
[Speedometer 3.0 dispatches key events](https://github.com/WebKit/Speedometer/blob/8d67f28d0281ac4330f283495b7f48286654ad7d/resources/benchmark-runner.mjs#L166) vs [Speedometer 2.0 triggerEnter](https://github.com/WebKit/Speedometer/blob/491acc2d64307e655fbeded8c871ef0d07e21997/resources/tests.mjs#L60).

Speedometer 3.0 uses the modern KeyboardEvent constructor but passes 
[legacy fields like keyCode and charCode](https://w3c.github.io/uievents/#legacy-dictionary-KeyboardEventInit) in the init dictionary for backwards 
compatibility with older frameworks(for example: backbone.js)

This change uncomments the legacy KeyboardEventInit fields and updates 
the constructor to read them from the init dictionary instead of 
hardcoding to 0.

Testing: No new tests added. 
Fixes: part of https://github.com/servo/servo/issues/16719

Servo running Speedometer3.0 successfully
<img width="1136" height="880" alt="speedometer 3 0" src="https://github.com/user-attachments/assets/cf5199a5-d88d-4495-ae96-05fa6332b97e" />


Reviewed in servo/servo#39590