### PR TITLE
Stop assuming scrollbar track is always opaque in cross-axis-scrollbar.html

### DIFF
--- a/css/css-flexbox/cross-axis-scrollbar.html
+++ b/css/css-flexbox/cross-axis-scrollbar.html
@@ -20,10 +20,8 @@ body {
 .flexbox::before {
     content: "";
     background-color: red;
-    inset: 0;
-    width: 100%;
-    height: 100%;
     position: absolute;
+    inset: 0;
     z-index: -1;
 }
 

--- a/css/css-flexbox/cross-axis-scrollbar.html
+++ b/css/css-flexbox/cross-axis-scrollbar.html
@@ -12,7 +12,19 @@ body {
 }
 
 .flexbox {
+    position: relative;
+    background-color: green;
+}
+
+/* Don't use a red background on .flexbox as it might show behind scrollbars on platforms where the track may be transparent */
+.flexbox::before {
+    content: "";
     background-color: red;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    z-index: -1;
 }
 
 .vertical-rl {


### PR DESCRIPTION

Starting macOS Tahoe, the scrollbar track is no longer fully opaque, so it starts revealing a red background behind it.