### PR TITLE
Make IndexedDB tests use strict mode, fix errors

### DIFF
--- a/IndexedDB/bindings-inject-keys-bypass.any.js
+++ b/IndexedDB/bindings-inject-keys-bypass.any.js
@@ -1,8 +1,8 @@
 // META: global=window,worker
 // META: title=IndexedDB: ES bindings - Inject a key into a value - Keys bypass setters
 // META: script=resources/support-promises.js
+'use strict';
 
-'use_strict';
 
 promise_test(async t => {
   const db = await createDatabase(t, db => {

--- a/IndexedDB/bindings-inject-values-bypass.any.js
+++ b/IndexedDB/bindings-inject-values-bypass.any.js
@@ -1,8 +1,8 @@
 // META: global=window,worker
 // META: title=IndexedDB: ES bindings - Inject a key into a value - Values bypass chain and setters
 // META: script=resources/support-promises.js
+'use strict';
 
-'use_strict';
 
 promise_test(async t => {
   const db = await createDatabase(t, db => {

--- a/IndexedDB/blob-composite-blob-reads.any.js
+++ b/IndexedDB/blob-composite-blob-reads.any.js
@@ -1,6 +1,7 @@
 // META: title=IDB-backed composite blobs maintain coherency
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
 // This test file is intended to help validate browser handling of complex blob
 // scenarios where one or more levels of multipart blobs are used and varying

--- a/IndexedDB/blob-contenttype.any.js
+++ b/IndexedDB/blob-contenttype.any.js
@@ -1,6 +1,7 @@
 // META: title=Blob Content Type
 // META: script=resources/support.js
 // META: timeout=long
+'use strict';
 
 indexeddb_test(
     function upgrade(t, db) {

--- a/IndexedDB/blob-delete-objectstore-db.any.js
+++ b/IndexedDB/blob-delete-objectstore-db.any.js
@@ -1,5 +1,6 @@
 // META: title=Blob Delete Object Store
 // META: script=resources/support.js
+'use strict';
 
 let key = "blob key";
 

--- a/IndexedDB/blob-valid-after-abort.any.js
+++ b/IndexedDB/blob-valid-after-abort.any.js
@@ -1,6 +1,7 @@
 // META: title=Blob Valid After Abort
 // META: global=window,worker
 // META: script=resources/support.js
+'use strict';
 
 let key = "key";
 

--- a/IndexedDB/blob-valid-after-deletion.any.js
+++ b/IndexedDB/blob-valid-after-deletion.any.js
@@ -1,5 +1,6 @@
 // META: title=Blob Valid After Deletion
 // META: script=resources/support.js
+'use strict';
 
 let key = "key";
 
@@ -12,13 +13,12 @@ indexeddb_test(
     const blobBContent = "Blob B content";
     const blobA = new Blob([blobAContent], {"type" : "text/plain"});
     const blobB = new Blob([blobBContent], {"type" : "text/plain"});
-    value = { a0: blobA, a1: blobA, b0: blobB };
+    const value = { a0: blobA, a1: blobA, b0: blobB };
 
     const tx = db.transaction('store', 'readwrite');
     var store = tx.objectStore('store');
 
     store.put(value, key);
-    value = null;
 
     const trans = db.transaction('store', 'readonly');
     store = trans.objectStore('store');

--- a/IndexedDB/blob-valid-before-commit.any.js
+++ b/IndexedDB/blob-valid-before-commit.any.js
@@ -1,5 +1,6 @@
 // META: title=Blob Valid Before Commit
 // META: script=resources/support.js
+'use strict';
 
 let key = "key";
 

--- a/IndexedDB/crashtests/create-index.any.js
+++ b/IndexedDB/crashtests/create-index.any.js
@@ -2,8 +2,8 @@
 // META: title=IndexedDB: assure no crash when populating index
 // META: script=../resources/support.js
 // See https://crbug.com/434115938 for additional context and credits.
+'use strict';
 
-'use_strict';
 
 indexeddb_test(
   (t, db, tx) => {

--- a/IndexedDB/fire-upgradeneeded-event-exception.any.js
+++ b/IndexedDB/fire-upgradeneeded-event-exception.any.js
@@ -1,6 +1,7 @@
 // META: global=window,worker
 // META: title=Fire upgradeneeded event - Exception thrown
 // META: script=resources/support.js
+'use strict';
 
 // Spec: "https://w3c.github.io/IndexedDB/#fire-a-version-change-event"
 

--- a/IndexedDB/get-databases.any.js
+++ b/IndexedDB/get-databases.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support-promises.js
+'use strict';
 
 promise_test(async testCase => {
   let result = indexedDB.databases();
@@ -55,7 +56,7 @@ promise_test(async testCase => {
       expected_result.length,
       "The result of databases() should contain one result per database.");
   for ( let i = 0; i < expected_result.length; i += 1 ) {
-    result = expected_result[i];
+    const result = expected_result[i];
     assert_true(
         databases_result.some(
             e => e.name === result.name && e.version === result.version),

--- a/IndexedDB/idb-explicit-commit-throw.any.js
+++ b/IndexedDB/idb-explicit-commit-throw.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support-promises.js
+'use strict';
 
 setup({allow_uncaught_exception:true});
 

--- a/IndexedDB/idb-explicit-commit.any.js
+++ b/IndexedDB/idb-explicit-commit.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support-promises.js
+'use strict';
 
 promise_test(async testCase => {
   const db = await createDatabase(testCase, db => {

--- a/IndexedDB/idbcursor-request.any.js
+++ b/IndexedDB/idbcursor-request.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 function cursorRequestTest({ useIndex, useKeyCursor }) {
   indexeddb_test(

--- a/IndexedDB/idbdatabase_deleteObjectStore.any.js
+++ b/IndexedDB/idbdatabase_deleteObjectStore.any.js
@@ -3,8 +3,8 @@
 // META: script=resources/support.js
 // @author Microsoft <https://www.microsoft.com>
 // @author Odin Hørthe Omdal <mailto:odinho@opera.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
     let db;

--- a/IndexedDB/idbindex-getAll-enforcerange.any.js
+++ b/IndexedDB/idbindex-getAll-enforcerange.any.js
@@ -2,6 +2,7 @@
 // META: global=window,worker
 // META: script=resources/support.js
 // Spec: "https://w3c.github.io/IndexedDB/#index-interface"
+'use strict';
 
 indexeddb_test(
     (t, db) => {

--- a/IndexedDB/idbindex-getAllKeys-enforcerange.any.js
+++ b/IndexedDB/idbindex-getAllKeys-enforcerange.any.js
@@ -2,6 +2,7 @@
 // META: global=window,worker
 // META: script=resources/support.js
 // Spec: "https://w3c.github.io/IndexedDB/#index-interface"
+'use strict';
 
 indexeddb_test(
     (t, db) => {

--- a/IndexedDB/idbindex-objectStore-SameObject.any.js
+++ b/IndexedDB/idbindex-objectStore-SameObject.any.js
@@ -2,6 +2,7 @@
 // META: global=window,worker
 // META: script=resources/support.js
 // Spec: "https://w3c.github.io/IndexedDB/#dom-idbindex-objectstore"
+'use strict';
 
 indexeddb_test(
     (t, db) => {

--- a/IndexedDB/idbindex_count.any.js
+++ b/IndexedDB/idbindex_count.any.js
@@ -4,8 +4,8 @@
 // @author Microsoft <https://www.microsoft.com>
 // @author Odin Hørthe Omdal <mailto:odinho@opera.com>
 // @author Intel <http://www.intel.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
     let db;

--- a/IndexedDB/idbindex_get.any.js
+++ b/IndexedDB/idbindex_get.any.js
@@ -3,8 +3,8 @@
 // META: script=resources/support.js
 // @author Microsoft <https://www.microsoft.com>
 // @author Intel <http://www.intel.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
   let db;

--- a/IndexedDB/idbindex_getAll-options.any.js
+++ b/IndexedDB/idbindex_getAll-options.any.js
@@ -5,8 +5,8 @@
 // META: script=resources/support-get-all.js
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
-'use_strict';
 
 index_get_all_values_with_options_test(
     /*storeName=*/ 'out-of-line', /*options=*/ {query: 'C'}, 'Single item get');

--- a/IndexedDB/idbindex_getAll.any.js
+++ b/IndexedDB/idbindex_getAll.any.js
@@ -5,8 +5,8 @@
 // META: script=resources/support-get-all.js
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
-'use_strict';
 
 index_get_all_values_test(
     /*storeName=*/ 'out-of-line', /*options=*/ {query: 'C'}, 'Single item get');

--- a/IndexedDB/idbindex_getAllKeys-options.any.js
+++ b/IndexedDB/idbindex_getAllKeys-options.any.js
@@ -5,8 +5,8 @@
 // META: script=resources/support-get-all.js
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
-'use_strict';
 
 index_get_all_keys_with_options_test(
     /*storeName=*/ 'out-of-line', /*options=*/ {query: 'C'}, 'Single item get');

--- a/IndexedDB/idbindex_getAllKeys.any.js
+++ b/IndexedDB/idbindex_getAllKeys.any.js
@@ -5,8 +5,8 @@
 // META: script=resources/support-get-all.js
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
-'use_strict';
 
 index_get_all_keys_test(
     /*storeName=*/ 'out-of-line', /*options=*/ {query: 'C'}, 'Single item get');

--- a/IndexedDB/idbindex_getAllRecords.any.js
+++ b/IndexedDB/idbindex_getAllRecords.any.js
@@ -5,8 +5,8 @@
 // META: script=resources/support-get-all.js
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
-'use_strict';
 
 index_get_all_records_test(
     /*storeName=*/ 'out-of-line', /*options=*/ {query: /*key=*/ 'C'},

--- a/IndexedDB/idbindex_getKey.any.js
+++ b/IndexedDB/idbindex_getKey.any.js
@@ -3,8 +3,8 @@
 // META: script=resources/support.js
 // @author Microsoft <https://www.microsoft.com>
 // @author Intel <http://www.intel.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
     let db;

--- a/IndexedDB/idbindex_indexNames.any.js
+++ b/IndexedDB/idbindex_indexNames.any.js
@@ -1,8 +1,8 @@
 // META: global=window,worker
 // META: title=IDBObjectStore.indexNames
 // META: script=resources/support.js
+'use strict';
 
-'use_strict';
 
 async_test(t => {
   let db;

--- a/IndexedDB/idbindex_keyPath.any.js
+++ b/IndexedDB/idbindex_keyPath.any.js
@@ -1,5 +1,6 @@
 // META: title=IndexedDB: IDBIndex keyPath attribute
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/idbindex_openCursor.any.js
+++ b/IndexedDB/idbindex_openCursor.any.js
@@ -1,8 +1,8 @@
 // META: global=window,worker
 // META: title=IDBIndex.openCursor()
 // META: script=resources/support.js
+'use strict';
 
-'use_strict';
 
 async_test(t => {
   const open_rq = createdb(t);

--- a/IndexedDB/idbindex_reverse_cursor.any.js
+++ b/IndexedDB/idbindex_reverse_cursor.any.js
@@ -1,5 +1,6 @@
 // META: title=Reverse Cursor Validity
 // META: script=resources/support-promises.js
+'use strict';
 
 async function iterateAndReturnAllCursorResult(testCase, cursor) {
   return new Promise((resolve, reject) => {
@@ -31,7 +32,7 @@ promise_test(async testCase => {
 
   const txn4 = db.transaction(['objectStore'], 'readonly');
   const txnWaiter = promiseForTransaction(testCase, txn4);
-  cursor = txn4.objectStore('objectStore').index('index').openCursor(IDBKeyRange.bound(0, 10), "prev");
+  const cursor = txn4.objectStore('objectStore').index('index').openCursor(IDBKeyRange.bound(0, 10), "prev");
   let results = await iterateAndReturnAllCursorResult(testCase, cursor);
 
   assert_equals(results.length, 1);
@@ -52,7 +53,7 @@ promise_test(async testCase => {
 
   const txn2 = db.transaction(['objectStore'], 'readonly');
   const txnWaiter = promiseForTransaction(testCase, txn2);
-  cursor = txn2.objectStore('objectStore').index('index').openCursor(IDBKeyRange.bound(0, 10), "prev");
+  const cursor = txn2.objectStore('objectStore').index('index').openCursor(IDBKeyRange.bound(0, 10), "prev");
   let results = await iterateAndReturnAllCursorResult(testCase, cursor);
 
   assert_equals(1, results.length);

--- a/IndexedDB/idbindex_tombstones.any.js
+++ b/IndexedDB/idbindex_tombstones.any.js
@@ -1,5 +1,6 @@
 // META: title=Index Tombstones
 // META: script=resources/support-promises.js
+'use strict';
 
 // This test is used to trigger a special case in Chrome with how it deals with
 // index creation & modification. This had caused issues before.
@@ -42,7 +43,7 @@ async function run_test(testCase, transactionMode, direction) {
   await createTombstones(testCase, db);
 
   const txn = db.transaction(['objectStore'], transactionMode);
-  cursor = txn.objectStore('objectStore').index('index').openCursor(
+  const cursor = txn.objectStore('objectStore').index('index').openCursor(
       IDBKeyRange.bound(-11, 11), direction);
   let results = await iterateAndReturnAllCursorResult(testCase, cursor);
   assert_equals(results.length, 3);

--- a/IndexedDB/idbobjectstore_add.any.js
+++ b/IndexedDB/idbobjectstore_add.any.js
@@ -3,8 +3,8 @@
 // META: script=resources/support.js
 // @author Microsoft <https://www.microsoft.com>
 // @author Intel <http://www.intel.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
     let db;
@@ -256,7 +256,7 @@ async_test(t => {
     const open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {
       let rq;
-      db = e.target.result;
+      const db = e.target.result;
       const objStore = db.createObjectStore("store", { keyPath: "key" });
 
       assert_throws_dom("DataError", function() {

--- a/IndexedDB/idbobjectstore_delete.any.js
+++ b/IndexedDB/idbobjectstore_delete.any.js
@@ -2,8 +2,8 @@
 // META: title=IDBObjectStore.delete()
 // META: script=resources/support.js
 // @author Microsoft <https://www.microsoft.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
     let db;

--- a/IndexedDB/idbobjectstore_deleteIndex.any.js
+++ b/IndexedDB/idbobjectstore_deleteIndex.any.js
@@ -2,8 +2,8 @@
 // META: title=IDBObjectStore.deleteIndex()
 // META: script=resources/support.js
 // @author Microsoft <https://www.microsoft.com>
+'use strict';
 
-'use_strict';
 
 async_test(t => {
     let db;

--- a/IndexedDB/idbobjectstore_keyPath.any.js
+++ b/IndexedDB/idbobjectstore_keyPath.any.js
@@ -1,5 +1,6 @@
 // META: title=IndexedDB: IDBObjectStore keyPath attribute - same object
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/idlharness.any.js
+++ b/IndexedDB/idlharness.any.js
@@ -2,6 +2,7 @@
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 // META: timeout=long
+'use strict';
 
 idl_test(
   ['IndexedDB'],

--- a/IndexedDB/reading-autoincrement-indexes-cursors.any.js
+++ b/IndexedDB/reading-autoincrement-indexes-cursors.any.js
@@ -1,6 +1,7 @@
 // META: global=window,dedicatedworker,sharedworker,serviceworker
 // META: script=resources/support-promises.js
 // META: script=resources/reading-autoincrement-common.js
+'use strict';
 
 promise_test(async testCase => {
   const database = await setupAutoincrementDatabase(testCase);

--- a/IndexedDB/reading-autoincrement-indexes.any.js
+++ b/IndexedDB/reading-autoincrement-indexes.any.js
@@ -1,6 +1,7 @@
 // META: global=window,dedicatedworker,sharedworker,serviceworker
 // META: script=resources/support-promises.js
 // META: script=resources/reading-autoincrement-common.js
+'use strict';
 
 promise_test(async testCase => {
   const database = await setupAutoincrementDatabase(testCase);

--- a/IndexedDB/reading-autoincrement-store-cursors.any.js
+++ b/IndexedDB/reading-autoincrement-store-cursors.any.js
@@ -1,6 +1,7 @@
 // META: global=window,dedicatedworker,sharedworker,serviceworker
 // META: script=resources/support-promises.js
 // META: script=resources/reading-autoincrement-common.js
+'use strict';
 
 promise_test(async testCase => {
   const database = await setupAutoincrementDatabase(testCase);

--- a/IndexedDB/reading-autoincrement-store.any.js
+++ b/IndexedDB/reading-autoincrement-store.any.js
@@ -1,6 +1,7 @@
 // META: global=window,dedicatedworker,sharedworker,serviceworker
 // META: script=resources/support-promises.js
 // META: script=resources/reading-autoincrement-common.js
+'use strict';
 
 promise_test(async testCase => {
   const database = await setupAutoincrementDatabase(testCase);

--- a/IndexedDB/resources/idbworker.js
+++ b/IndexedDB/resources/idbworker.js
@@ -1,3 +1,4 @@
+'use strict';
 var db
 
 self.addEventListener('message', MessageHandler, false)

--- a/IndexedDB/resources/interleaved-cursors-common.js
+++ b/IndexedDB/resources/interleaved-cursors-common.js
@@ -1,4 +1,5 @@
 // Infrastructure shared by interleaved-cursors-{small,large}.html
+'use strict';
 
 // Number of objects that each iterator goes over.
 const itemCount = 10;

--- a/IndexedDB/resources/reading-autoincrement-common.js
+++ b/IndexedDB/resources/reading-autoincrement-common.js
@@ -1,4 +1,5 @@
 // Returns the "name" property written to the object with the given ID.
+'use strict';
 function nameForId(id) {
   return `Object ${id}`;
 }

--- a/IndexedDB/resources/request-event-ordering-common.js
+++ b/IndexedDB/resources/request-event-ordering-common.js
@@ -1,3 +1,4 @@
+'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB
 // engines that have special code paths for large values.

--- a/IndexedDB/resources/support.js
+++ b/IndexedDB/resources/support.js
@@ -1,3 +1,4 @@
+'use strict';
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/IndexedDB/storage-buckets.https.any.js
+++ b/IndexedDB/storage-buckets.https.any.js
@@ -2,6 +2,7 @@
 // META: global=window,worker
 // META: script=resources/support-promises.js
 // META: script=/storage/buckets/resources/util.js
+'use strict';
 
 promise_test(async testCase => {
   await prepareForBucketTest(testCase);

--- a/IndexedDB/structured-clone.any.js
+++ b/IndexedDB/structured-clone.any.js
@@ -8,6 +8,7 @@
 // META: variant=?61-80
 // META: variant=?81-100
 // META: variant=?101-last
+'use strict';
 
 // Tests Indexed DB coverage of HTML's Safe "passing of structured data"
 // https://html.spec.whatwg.org/multipage/structured-data.html

--- a/IndexedDB/transaction-lifetime-empty.any.js
+++ b/IndexedDB/transaction-lifetime-empty.any.js
@@ -4,21 +4,6 @@
 
 'use strict';
 
-// Call with a test object and array of expected values. Returns a
-// function to call with each actual value. Once the expected number
-// of values is seen, asserts that the value orders match and completes
-// the test.
-function expect(t, expected) {
-  let results = [];
-  return result => {
-    results.push(result);
-    if (results.length === expected.length) {
-      assert_array_equals(results, expected);
-      t.done();
-    }
-  };
-}
-
 indexeddb_test(
     (t, db) => {
       db.createObjectStore('store');

--- a/IndexedDB/transaction-relaxed-durability.any.js
+++ b/IndexedDB/transaction-relaxed-durability.any.js
@@ -1,5 +1,6 @@
 // META: script=resources/support-promises.js
 // META: timeout=long
+'use strict';
 
 /**
  * This file contains the webplatform smoke tests for the optional

--- a/IndexedDB/transaction-scheduling-across-connections.any.js
+++ b/IndexedDB/transaction-scheduling-across-connections.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/transaction-scheduling-across-databases.any.js
+++ b/IndexedDB/transaction-scheduling-across-databases.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/transaction-scheduling-mixed-scopes.any.js
+++ b/IndexedDB/transaction-scheduling-mixed-scopes.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/transaction-scheduling-ordering.any.js
+++ b/IndexedDB/transaction-scheduling-ordering.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/transaction-scheduling-ro-waits-for-rw.any.js
+++ b/IndexedDB/transaction-scheduling-ro-waits-for-rw.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/transaction-scheduling-rw-scopes.any.js
+++ b/IndexedDB/transaction-scheduling-rw-scopes.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/transaction-scheduling-within-database.any.js
+++ b/IndexedDB/transaction-scheduling-within-database.any.js
@@ -1,4 +1,5 @@
 // META: script=resources/support.js
+'use strict';
 
 indexeddb_test(
   (t, db) => {

--- a/IndexedDB/value.any.js
+++ b/IndexedDB/value.any.js
@@ -2,8 +2,8 @@
 // META: title=IndexedDB: keys and values
 // META: script=resources/support.js
 // @author Odin Hørthe Omdal <mailto:odinho@opera.com>
+'use strict';
 
-'use_strict';
 
 function setOnUpgradeNeeded(t, predicate, _instanceof, value) {
   createdb(t).onupgradeneeded = t.step_func(e => {

--- a/IndexedDB/worker-termination-aborts-upgrade.window.js
+++ b/IndexedDB/worker-termination-aborts-upgrade.window.js
@@ -1,5 +1,6 @@
 // META: title=Worker Termination Aborts a Pending Upgrade
 // META: script=resources/support-promises.js
+'use strict';
 
 // This test verifies that if a Worker's shutdown races an IndexedDB
 // versionchange transaction that is creating a database that the next attempt


### PR DESCRIPTION
The IndexedDB tests have some issues because they don't run in strict mode:

- Using `'use_strict'` instead of `'use strict'` (note incorrect `_` character)
- Assigning variables without using `var`/`let`/`const`
- Re-declaring the `expect` function when it's already declared

This PR fixes that. It shouldn't cause any changes to test assertions or expectations.