### PR TITLE
Map various tests to web-features (03)

### DIFF
--- a/accname/name/WEB_FEATURES.yml
+++ b/accname/name/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: alt-text-generated-content
+  files:
+  - comp_name_*content*

--- a/appmanifest/file_handlers-member/WEB_FEATURES.yml
+++ b/appmanifest/file_handlers-member/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: app-file-handlers
+  files: "**"

--- a/css/CSS2/cascade-import/WEB_FEATURES.yml
+++ b/css/CSS2/cascade-import/WEB_FEATURES.yml
@@ -1,0 +1,11 @@
+features:
+- name: alternative-style-sheets
+  files:
+  - cascade-import-005.xht
+  - cascade-import-006.xht
+  - cascade-import-007.xht
+  - cascade-import-008.xht
+  - cascade-import-009.xht
+  - cascade-import-010.xht
+  - cascade-import-011.xht
+  - cascade-import-012.xht

--- a/css/css-cascade/WEB_FEATURES.yml
+++ b/css/css-cascade/WEB_FEATURES.yml
@@ -9,3 +9,6 @@ features:
 - name: revert-value
   files:
   - revert-val-*
+- name: all
+  files:
+  - all-prop-*

--- a/css/css-position/WEB_FEATURES.yml
+++ b/css/css-position/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: absolute-positioning
+  files:
+  - '*absolute*'

--- a/css/css-position/WEB_FEATURES.yml
+++ b/css/css-position/WEB_FEATURES.yml
@@ -1,4 +1,4 @@
 features:
 - name: absolute-positioning
   files:
-  - '*absolute*'
+  - 'position-absolute-*'

--- a/css/css-position/static-position/WEB_FEATURES.yml
+++ b/css/css-position/static-position/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: absolute-positioning
+  files:
+  - '*absolute*'

--- a/css/css-position/static-position/WEB_FEATURES.yml
+++ b/css/css-position/static-position/WEB_FEATURES.yml
@@ -1,4 +1,0 @@
-features:
-- name: absolute-positioning
-  files:
-  - '*absolute*'

--- a/css/cssom/WEB_FEATURES.yml
+++ b/css/cssom/WEB_FEATURES.yml
@@ -9,3 +9,6 @@ features:
   files:
   - caretPositionFromPoint-with-transformation.html
   - caretPositionFromPoint.html
+- name: all
+  files:
+  - "*-all-*"

--- a/css/cssom/WEB_FEATURES.yml
+++ b/css/cssom/WEB_FEATURES.yml
@@ -12,3 +12,12 @@ features:
 - name: all
   files:
   - "*-all-*"
+- name: alternative-style-sheets
+  files:
+  - HTMLLinkElement-disabled-002.html
+  - HTMLLinkElement-disabled-003.html
+  - HTMLLinkElement-disabled-004.html
+  - HTMLLinkElement-disabled-005.html
+  - HTMLLinkElement-disabled-006.html
+  - HTMLLinkElement-disabled-007.html
+  - HTMLLinkElement-disabled-alternate.html

--- a/fetch/api/abort/WEB_FEATURES.yml
+++ b/fetch/api/abort/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: abortable-fetch
+  files: "**"

--- a/html/dom/WEB_FEATURES.yml
+++ b/html/dom/WEB_FEATURES.yml
@@ -1,4 +1,7 @@
 features:
+- name: accesskey
+  files:
+  - access-key-label.html
 - name: aria-attribute-reflection
   files:
   - aria-attribute-reflection.html

--- a/html/semantics/links/following-hyperlinks/WEB_FEATURES.yml
+++ b/html/semantics/links/following-hyperlinks/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: a
+  files: "**"

--- a/html/semantics/links/links-created-by-a-and-area-elements/WEB_FEATURES.yml
+++ b/html/semantics/links/links-created-by-a-and-area-elements/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: a
+  files: "**"

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/WEB_FEATURES.yml
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: mutation-events
+  files:
+  - mutation-events.window.js

--- a/html/webappapis/user-prompts/WEB_FEATURES.yml
+++ b/html/webappapis/user-prompts/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: alerts
+  files: "**"

--- a/uievents/interface/WEB_FEATURES.yml
+++ b/uievents/interface/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: accesskey
+  files:
+  - keyboard-accesskey-click-event.html

--- a/uievents/legacy-domevents-tests/submissions/Microsoft/WEB_FEATURES.yml
+++ b/uievents/legacy-domevents-tests/submissions/Microsoft/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+features:
+- name: mutation-events
+  files:
+  - DOMNodeInserted.html
+  - DOMNodeRemoved.html
+  - DOMSubtreeModified.html
+  - MutationEvent.*


### PR DESCRIPTION
@foolip I'm building up some tooling to make my commits a little more useful (and guard against typos). Right now, each commit just summarizes the number of matching files. I'm open to suggestions for enhancements! Perhaps calculating those stats in terms of tests (using the manifest rather than the file system) and/or including full directory listings with `[x]` and `[ ]` prefxies...