### PR TITLE
`css/css-anchor-position/anchor-scroll-position-try-{013,014}`: adjust scroll amount to eliminate ambiguity

### DIFF
--- a/css/css-anchor-position/anchor-scroll-position-try-013.html
+++ b/css/css-anchor-position/anchor-scroll-position-try-013.html
@@ -49,18 +49,24 @@
 <script>
 promise_test(async () => {
   await waitUntilNextAnimationFrame();
+  await waitUntilNextAnimationFrame();
+
   assert_fallback_position(abspos, anchor, 'top');
 });
 
 promise_test(async () => {
-  scroller.scrollTop = 50;
+  scroller.scrollTop = 110;
   await waitUntilNextAnimationFrame();
+  await waitUntilNextAnimationFrame();
+
   assert_fallback_position(abspos, anchor, 'bottom');
 });
 
 promise_test(async () => {
   scroller.scrollTop = 40;
   await waitUntilNextAnimationFrame();
+  await waitUntilNextAnimationFrame();
+
   assert_fallback_position(abspos, anchor, 'top');
 });
 </script>

--- a/css/css-anchor-position/anchor-scroll-position-try-014.html
+++ b/css/css-anchor-position/anchor-scroll-position-try-014.html
@@ -52,18 +52,24 @@
 <script>
 promise_test(async () => {
   await waitUntilNextAnimationFrame();
+  await waitUntilNextAnimationFrame();
+
   assert_fallback_position(abspos, anchor, 'bottom');
 });
 
 promise_test(async () => {
-  scroller.scrollTop = -100;
+  scroller.scrollTop = -110;
   await waitUntilNextAnimationFrame();
+  await waitUntilNextAnimationFrame();
+
   assert_fallback_position(abspos, anchor, 'top');
 });
 
 promise_test(async () => {
-  scroller.scrollTop = -50;
+  scroller.scrollTop = -40;
   await waitUntilNextAnimationFrame();
+  await waitUntilNextAnimationFrame();
+
   assert_fallback_position(abspos, anchor, 'bottom');
 });
 </script>


### PR DESCRIPTION
The tests set `scrollTop` of the scroller to values that both the original style and fallback style would work (don't overflow). Combined with last successful position option, this mean the browser would keep using the last successful position option, instead of the other option. This was caught in Safari, but not Chrome, apparently because Chrome doesn't record the last successful position option until at least two animation frame. If the tests were modified to wait two frames after setting scrollTop before asserting values, then the tests would fail in Chrome.

Change the scroll offset to values that guarantee only one option would work.