### PR TITLE
Update interface name to HTMLOrSVGOrMathMLElement

### DIFF
--- a/mathml/relations/html5-tree/html-or-svg-or-mathml-element-interfaces.tentative.html
+++ b/mathml/relations/html5-tree/html-or-svg-or-mathml-element-interfaces.tentative.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>MathML 'HTMLOrForeignElement` Mixin Tests</title>
+    <title>MathML 'HTMLOrSVGOrMathMLElement` Mixin Tests</title>
     <link rel="help" href="https://w3c.github.io/mathml-core/#dom-and-javascript"/>
     <style>
       mi {
@@ -14,7 +14,7 @@
     </style>
     <meta
       name="assert"
-      content="MathMLElements incorporate a functional HTMLOrForeignElement interface"
+      content="MathMLElements incorporate a functional HTMLOrSVGOrMathMLElement interface"
     />
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
@@ -22,7 +22,7 @@
   <body tabindex="-1">
     <span tabindex="-1"
       >This tests the presence and functionality of features of
-      `HTMLOrForeignElement` (currently `HTMLOrSVGElement`)</span
+      `HTMLOrSVGOrMathMLElement` (currently `HTMLOrSVGElement`)</span
     >
     <math tabindex="-1">
       <mi>E</mi>


### PR DESCRIPTION
Based on 9/25 WHATNOT meeting - 

Plans to update the following files to verify... (for discussion)

- [ ]  mathml/relations/html5-tree/html-or-svg-or-mathml-element-interfaces.tentative.html
The name of the interface is changed and functions as we expect.. everything would be default tab index -1

- [ ] mathml/relations/html5-tree/tabindex-001.tentative.html / 002
No existing mathml-core element has any default tabindex but -1, regardless of if it has an href

- [ ] mathml/relations/html5-tree/tabindex-focus-001.tentative.html
Because it includes href

- [ ] mathml/relations/html5-tree/href-click-001.tentative.html / 002 / 003
I don't think these are necessary since they are all testing something about hrefs and really the only thing we'd be checking now is the opposite? Just 'does nothing'.

- [ ] mathml/relations/html5-tree/dynamic-href-001.tentative.html / 002
Necessary?

- [ ] mathml/relations/html5-tree/{new anchor element test}
I think we need to add this, but I expect it's step 2?

