### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=298965

### DIFF
--- a/css/css-view-transitions/new-content-captures-different-size.html
+++ b/css/css-view-transitions/new-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-different-size-ref.html">
-<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-15393">
+<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-15518">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html {

--- a/css/filter-effects/backdrop-filter-edge-pixels-2.html
+++ b/css/filter-effects/backdrop-filter-edge-pixels-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name=fuzzy content="maxDifference=0-25;totalPixels=0-30000">
+<meta name=fuzzy content="maxDifference=0-28;totalPixels=0-30000">
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="author" href="mailto:flackr@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">

--- a/css/filter-effects/fixed-pos-filter-clip-001.html
+++ b/css/filter-effects/fixed-pos-filter-clip-001.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-399">
 <title>filter + fixed pos clipping</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
 <link rel="author" title="Mozilla" href="https://mozilla.org">


### PR DESCRIPTION
WebKit export from bug: [\[Filters\] Enable CoreGraphics GaussianBlur filter for layout tests](https://bugs.webkit.org/show_bug.cgi?id=298965)