### PR TITLE
Extend permission-helper.js to cover "Unknown permission name" error message

### DIFF
--- a/mediacapture-streams/permission-helper.js
+++ b/mediacapture-streams/permission-helper.js
@@ -7,7 +7,7 @@ async function setMediaPermission(status="granted", scope=["camera", "microphone
       await test_driver.set_permission({ name: s }, status);
     }
   } catch (e) {
-    const noSetPermissionSupport = typeof e === "string" && e.match(/set_permission not implemented/);
+    const noSetPermissionSupport = typeof e === "string" && (e.match(/set_permission not implemented/) || e.match(/Unknown permission name/));
     if (!(noSetPermissionSupport ||
           (e instanceof Error && e.message.match("unimplemented")) )) {
       throw e;


### PR DESCRIPTION
Since Safari partially implemented `test_driver.set_permission()`, the error message has changed.