### PR TITLE
[mozlog] Call LogRecord.getMessage

### DIFF
--- a/tools/third_party_modified/mozlog/mozlog/stdadapter.py
+++ b/tools/third_party_modified/mozlog/mozlog/stdadapter.py
@@ -17,7 +17,7 @@ class UnstructuredHandler(logging.Handler):
             log_func = getattr(self.structured, record.levelname.lower())
         else:
             log_func = self.logger.debug
-        log_func(record.msg)
+        log_func(record.getMessage())
 
     def handle(self, record):
         self.emit(record)


### PR DESCRIPTION
Currently, we only pass the message itself into the structured handler — however, this loses us any arguments passed to the logger. Instead, use `getMessage()` which handles these.

Note we should still aim to do better than this longer term — we still lose most of the context the LogRecord has.