### PR TITLE
Avoid TypeError from successful stability checker

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -586,7 +586,7 @@ def start(**kwargs: Any) -> int:
         elif kwargs["list_tests_json"]:
             list_tests_json(**kwargs)
         elif kwargs["verify"] or kwargs["stability"]:
-            rv = check_stability(**kwargs)
+            rv = check_stability(**kwargs) or 0
         else:
             rv = not run_tests(**kwargs)[0]
     finally:


### PR DESCRIPTION
7902cfcbc7 (https://github.com/web-platform-tests/wpt/pull/55145) removed the `or logged_critical.has_log` from the stability checker run, and now when it returns `None` this causes a TypeError when we compare `rv`, because we're no longer guaranteed to have `Union[int, bool]`.
