### PR TITLE
Fix Azure Pipelines install_chrome.yml/install_firefox.yml

### DIFF
--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,11 +1,6 @@
 steps:
-# The conflicting google-chrome and chromedriver casks are first uninstalled.
-# The raw google-chrome@dev.rb cask URL is used to bypass caching.
 - script: |
     set -eux -o pipefail
-    HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask google-chrome || true
-    HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask chromedriver || true
-    curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/HEAD/Casks/g/google-chrome@dev.rb > google-chrome@dev.rb
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask google-chrome@dev.rb
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask google-chrome@dev
   displayName: 'Install Chrome Dev'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/tools/ci/azure/install_firefox.yml
+++ b/tools/ci/azure/install_firefox.yml
@@ -1,8 +1,6 @@
 steps:
-# The raw firefox@nightly.rb cask URL is used to bypass caching.
 - script: |
     set -eux -o pipefail
-    curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/HEAD/Casks/f/firefox@nightly.rb > firefox@nightly.rb
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask firefox@nightly.rb
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask firefox@nightly
   displayName: 'Install Firefox Nightly'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
This has been failing on Azure Pipelines for a while; latest Homebrew
actually outputs "Homebrew requires casks to be in a tap".

It's unclear what we were previously concerned about, and version
should not be significant nowadays.
