### PR TITLE
Docs: add section explaining ./wpt serve limitations

### DIFF
--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -1,0 +1,5 @@
+### Limitations of ./wpt serve
+
+- The server only works locally and is not intended for production use.
+- Some HTTPS tests may fail without correct hostnames or certificates.
+- Ports may need to be manually opened if blocked by firewall settings.


### PR DESCRIPTION
Added documentation explaining common limitations and usage notes for ./wpt serve, based on Issue #48641.