### PR TITLE
Update android.py to use API 34

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
@@ -1,4 +1,0 @@
-[elementTiming.html]
-  [TestDriver actions: element timing]
-    expected:
-      if product == "firefox_android": FAIL

--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -20,8 +20,8 @@ CMDLINE_TOOLS_VERSION_STRING = "12.0"
 CMDLINE_TOOLS_VERSION = "11076708"
 
 AVD_MANIFEST_X86_64 = {
-    "emulator_package": "system-images;android-34;default;x86_64",
-    "emulator_avd_name": "mozemulator-x86_64",
+    "emulator_package": "system-images;android-34;google_apis;x86_64",
+    "emulator_avd_name": "mozemulator-android34-x86_64",
     "emulator_extra_args": [
         "-skip-adb-auth",
         "-verbose",
@@ -30,18 +30,17 @@ AVD_MANIFEST_X86_64 = {
         "-selinux", "permissive",
         "-memory", "3072",
         "-cores", "4",
-        "-skin", "800x1280",
+        "-skin", "1080x1920",
         "-gpu", "on",
         "-no-snapstorage",
         "-no-snapshot",
         "-no-window",
-        "-no-accel",
         "-prop", "ro.test_harness=true"
     ],
     "emulator_extra_config": {
         "hw.keyboard": "yes",
         "hw.lcd.density": "320",
-        "disk.dataPartition.size": "4000MB",
+        "disk.dataPartition.size": "8192MB",
         "sdcard.size": "600M"
     }
 }

--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -20,7 +20,7 @@ CMDLINE_TOOLS_VERSION_STRING = "12.0"
 CMDLINE_TOOLS_VERSION = "11076708"
 
 AVD_MANIFEST_X86_64 = {
-    "emulator_package": "system-images;android-26;default;x86_64",
+    "emulator_package": "system-images;android-34;default;x86_64",
     "emulator_avd_name": "mozemulator-x86_64",
     "emulator_extra_args": [
         "-skip-adb-auth",

--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -20,7 +20,7 @@ CMDLINE_TOOLS_VERSION_STRING = "12.0"
 CMDLINE_TOOLS_VERSION = "11076708"
 
 AVD_MANIFEST_X86_64 = {
-    "emulator_package": "system-images;android-24;default;x86_64",
+    "emulator_package": "system-images;android-26;default;x86_64",
     "emulator_avd_name": "mozemulator-x86_64",
     "emulator_extra_args": [
         "-skip-adb-auth",

--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -21,28 +21,7 @@ CMDLINE_TOOLS_VERSION = "11076708"
 
 AVD_MANIFEST_X86_64 = {
     "emulator_package": "system-images;android-34;google_apis;x86_64",
-    "emulator_avd_name": "mozemulator-android34-x86_64",
-    "emulator_extra_args": [
-        "-skip-adb-auth",
-        "-verbose",
-        "-show-kernel",
-        "-ranchu",
-        "-selinux", "permissive",
-        "-memory", "3072",
-        "-cores", "4",
-        "-skin", "1080x1920",
-        "-gpu", "on",
-        "-no-snapstorage",
-        "-no-snapshot",
-        "-no-window",
-        "-prop", "ro.test_harness=true"
-    ],
-    "emulator_extra_config": {
-        "hw.keyboard": "yes",
-        "hw.lcd.density": "320",
-        "disk.dataPartition.size": "8192MB",
-        "sdcard.size": "600M"
-    }
+    "emulator_avd_name": "mozemulator-android34-x86_64"
 }
 
 
@@ -56,6 +35,29 @@ def do_delayed_imports(paths):
                                                 "tooltool",
                                                 "tooltool.py")
     android_device.EMULATOR_HOME_DIR = paths["emulator_home"]
+    android_device.AVD_DICT["x86_64"] = android_device.AvdInfo(
+        "Android x86_64",
+        "mozemulator-android34-x86_64",
+        [
+            "-skip-adb-auth",
+            "-verbose",
+            "-show-kernel",
+            "-ranchu",
+            "-selinux",
+            "permissive",
+            "-memory",
+            "4096",
+            "-cores",
+            "8",
+            "-prop",
+            "ro.test_harness=true",
+            "-no-snapstorage",
+            "-no-snapshot",
+            "-skin",
+            "1080x1920",
+        ],
+        True,
+    )
 
 
 def get_parser_install():
@@ -76,45 +78,6 @@ def get_parser_start():
     parser.add_argument("--device-serial",
                         help="Device serial number for Android emulator, if not emulator-5554")
     return parser
-
-
-def install_fixed_emulator_version(logger, paths):
-    # Downgrade to a pinned emulator version
-    # See https://developer.android.com/studio/emulator_archive for what we're doing here
-    from xml.etree import ElementTree
-
-    version = "32.1.15"
-    urls = {"linux": "https://redirector.gvt1.com/edgedl/android/repository/emulator-linux_x64-10696886.zip"}
-
-    os_name = platform.system().lower()
-    if os_name not in urls:
-        logger.error(f"Don't know how to install old emulator for {os_name}, using latest version")
-        # For now try with the latest version if this fails
-        return
-
-    logger.info(f"Downgrading emulator to {version}")
-    url = urls[os_name]
-
-    emulator_path = os.path.join(paths["sdk"], "emulator")
-    latest_emulator_path = os.path.join(paths["sdk"], "emulator_latest")
-    if os.path.exists(latest_emulator_path):
-        shutil.rmtree(latest_emulator_path)
-    os.rename(emulator_path, latest_emulator_path)
-
-    download_and_extract(url, paths["sdk"])
-    package_path = os.path.join(emulator_path, "package.xml")
-    shutil.copyfile(os.path.join(latest_emulator_path, "package.xml"),
-                    package_path)
-
-    with open(package_path) as f:
-        tree = ElementTree.parse(f)
-    node = tree.find("localPackage").find("revision")
-    assert len(node) == 3
-    parts = version.split(".")
-    for version_part, node in zip(parts, node):
-        node.text = version_part
-    with open(package_path, "wb") as f:
-        tree.write(f, encoding="utf8")
 
 
 def get_paths(dest):
@@ -294,8 +257,6 @@ def install(logger, dest=None, reinstall=False, prompt=True):
             install_android_packages(logger, paths, packages, prompt=prompt)
 
             install_avd(logger, paths, prompt=prompt)
-
-            install_fixed_emulator_version(logger, paths)
 
         emulator = get_emulator(paths)
     return emulator

--- a/tools/wpt/commands.json
+++ b/tools/wpt/commands.json
@@ -78,7 +78,8 @@
     "help": "Setup the x86 android emulator",
     "virtualenv": true,
     "requirements": [
-      "requirements.txt"
+      "requirements.txt",
+      "requirements_android.txt"
     ]
   },
   "start-android-emulator": {


### PR DESCRIPTION
See https://github.com/web-platform-tests/wpt/issues/55282

This PR changes the configuration for the AVD to match mozilla-central.