### PR TITLE
Stop installing Chrome and Firefox on Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -124,8 +124,6 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.8'
-  - template: tools/ci/azure/install_chrome.yml
-  - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
   - template: tools/ci/azure/tox_pytest.yml
@@ -144,8 +142,6 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.13'
-  - template: tools/ci/azure/install_chrome.yml
-  - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
   - template: tools/ci/azure/tox_pytest.yml
@@ -234,10 +230,6 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.8'
-  # currently just using the outdated Chrome/Firefox on the VM rather than
-  # figuring out how to install Chrome Dev channel on Windows
-  # - template: tools/ci/azure/install_chrome.yml
-  # - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
   - template: tools/ci/azure/tox_pytest.yml
@@ -256,10 +248,6 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.13'
-  # currently just using the outdated Chrome/Firefox on the VM rather than
-  # figuring out how to install Chrome Dev channel on Windows
-  # - template: tools/ci/azure/install_chrome.yml
-  # - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
   - template: tools/ci/azure/tox_pytest.yml

--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,6 +1,0 @@
-steps:
-- script: |
-    set -eux -o pipefail
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask google-chrome@dev
-  displayName: 'Install Chrome Dev'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/tools/ci/azure/install_firefox.yml
+++ b/tools/ci/azure/install_firefox.yml
@@ -1,6 +1,0 @@
-steps:
-- script: |
-    set -eux -o pipefail
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask firefox@nightly
-  displayName: 'Install Firefox Nightly'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
I believe after https://github.com/web-platform-tests/wpt/pull/53309 we no longer require them to be installed; so let's just stop installing them — https://github.com/web-platform-tests/wpt/pull/53053 has the tests passing without installing them, which suggests this works.

This is mostly a follow-up to https://github.com/web-platform-tests/wpt/pull/55273 where we fixed their installation, because that seemed like a quicker/safer path to get the jobs passing.