### PR TITLE
[Navigation API] Change opener-postMessage to use onpageshow

### DIFF
--- a/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html
+++ b/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html
@@ -6,11 +6,11 @@
 <script>
 promise_test(async t => {
   // Open a cross-origin window.
-  let w = window.open(get_host_info().HTTP_REMOTE_ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onload.html");
+  let w = window.open(get_host_info().HTTP_REMOTE_ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html");
   await new Promise(resolve => window.onmessage = resolve);
 
   // Navigate the opened window to this origin.
-  w.location = get_host_info().ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onload.html";
+  w.location = get_host_info().ORIGIN + "/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html";
   await new Promise(resolve => window.onmessage = resolve);
   assert_equals(w.navigation.entries().length, 1);
   assert_equals(w.navigation.currentEntry.index, 0);

--- a/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html
+++ b/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html
@@ -8,10 +8,10 @@
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  let w = window.open("resources/opener-postMessage-onload.html");
+  let w = window.open("resources/opener-postMessage-onpageshow.html");
   await new Promise(resolve => window.onmessage = resolve);
   // Navigate to a url that will notify us when the navigation is complete.
-  w.navigation.navigate("opener-postMessage-onload.html?1");
+  w.navigation.navigate("opener-postMessage-onpageshow.html?1");
 
   await new Promise(resolve => window.onmessage = resolve);
   assert_equals(w.navigation.entries().length, 2);

--- a/navigation-api/navigate-event/resources/opener-postMessage-onload.html
+++ b/navigation-api/navigate-event/resources/opener-postMessage-onload.html
@@ -1,6 +1,0 @@
-<!doctype html>
-<head>
-<script>
-window.onload = () => opener.postMessage("onload", "*");
-</script>
-</head>

--- a/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html
+++ b/navigation-api/navigate-event/resources/opener-postMessage-onpageshow.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<head>
+<script>
+window.onpageshow = () => opener.postMessage("onpageshow", "*");
+</script>
+</head>


### PR DESCRIPTION
The page may be cached. In that scenario, once it's restored, the onload event won't fire. But the onpageshow event will. To make the test work, we change it to use onpageshow instead of onload.