### PR TITLE
webdriver: Serialize script `String` argument correctly to prevent injection attack

### DIFF
--- a/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/webdriver/tests/classic/execute_async_script/arguments.py
@@ -21,7 +21,9 @@ def test_null(session):
     (True, "boolean"),
     (42, "number"),
     ("foo", "string"),
-], ids=["boolean", "number", "string"])
+    ("foo\"bar", 'string'),
+    ('"); alert(1); //', "string"),
+], ids=["boolean", "number", "string", "string_quote", "string_injection"])
 def test_primitives(session, value, expected_type):
     result = execute_async_script(session, """
         arguments[1]([typeof arguments[0], arguments[0]])

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -19,7 +19,9 @@ def test_null(session):
     (True, "boolean"),
     (42, "number"),
     ("foo", "string"),
-], ids=["boolean", "number", "string"])
+    ("foo\"bar", 'string'),
+    ('"); alert(1); //', "string"),
+], ids=["boolean", "number", "string", "string_quote", "string_injection"])
 def test_primitives(session, value, expected_type):
     result = execute_script(session, "return [typeof arguments[0], arguments[0]]", args=[value])
     actual = assert_success(result)


### PR DESCRIPTION
The previous serialization is problematic when dealing with string argument with special characters. In addition, it was vulnerable to injection attack like below:

```rust
let s = r#""); alert(1); //"#;
let args_string = format!("\"{}\"", s);
let script = format!("(function() {{ {}\n}})({})", "/* body */", args_string); 
// script becomes: (function() { /* body */ })(""); alert(1); //")
```

Testing: Added four new tests in [wdspec](https://web-platform-tests.org/writing-tests/wdspec.html). Before this PR, we would get "javascript error" for the new tests, and trigger user prompts. Now it passes. This should also fix some testdriver tests.
Reviewed in servo/servo#39715