### PR TITLE
html: Provide a stable state for the media resource selection

### DIFF
--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-in-sync-event.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-in-sync-event.html
@@ -19,11 +19,11 @@ var t = async_test(function(t) {
   assert_equals(v.networkState, v.NETWORK_NO_SOURCE, 'networkState after click()');
   v.removeAttribute('src');
 });
+</script>
+<!-- now resource selection will continue its sync section (the </script> tag below provides a stable state) -->
+<!-- will find neither src nor source, so sets networkState to NETWORK_EMPTY -->
+<script>
 t.step(function() {
-  // now the sync section of resource selection should have run and should
-  // have found no src="" or <source> thus networkState being set to NETWORK_EMPTY.
-  // if the sync section was run when onclick returned, then networkState
-  // would be either NETWORK_LOADING or NETWORK_NO_SOURCE.
   assert_equals(v.networkState, v.NETWORK_EMPTY, 'networkState after src removed');
   t.done();
 });


### PR DESCRIPTION
The media resource selection algorithm is not able to execute the sync section steps because the script doesn't provide any posibility for it, so let's move the latest checking of the networkState to separate script.

See https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm