### PR TITLE
script: Restrict allowed node types for XPath context node

### DIFF
--- a/domxpath/invalid-context-nodes.html
+++ b/domxpath/invalid-context-nodes.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Only document/element/attribute/comment/text/PI nodes can be context nodes</title>
+        <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+<body>
+    <div id="host">/div>
+    <script>
+      const host = document.createElement("div");
+      const root = host.attachShadow({mode: "closed"});
+
+      test(() => {
+        assert_throws_dom("NotSupportedError", () => {
+          document.evaluate(".", root, null, XPathResult.ANY_TYPE, null);
+        });
+      }, "Using a ShadowRoot as a context node should throw a NotSupported Error");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
See https://searchfox.org/firefox-main/rev/b30a9b734819436853abf4eba6d768037514b3f6/dom/xslt/xpath/XPathExpression.cpp#115 for the equivalent code in firefox. Chrome also throws the same error.

Testing: This change adds a test
Part of #<!-- nolink -->34527 

Reviewed in servo/servo#39751