### PR TITLE
Safari wpt runner bot should set system caption style to null

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Set display color profile
         run: |-
           ./wpt macos-color-profile
+      - name: Set system caption style to ""
+        run: |-
+          defaults write com.apple.mediaaccessibility MACaptionActiveProfile -string ""
       - name: Enable safaridriver diagnostics
         if: inputs.safaridriver-diagnose
         run: |-


### PR DESCRIPTION
Add step to safari-wptrunner.yml that sets the system caption profile to an empty string, so that no styling is applied that may interfere with WebVTT ref tests.