### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=300113

### DIFF
--- a/css/css-nesting/nesting-basic.html
+++ b/css/css-nesting/nesting-basic.html
@@ -97,6 +97,9 @@
       background-color: red;
     }
   }
+  div.test-14 {
+      div& {  background-color: green; }
+  }
 
   body * + * {
     margin-top: 8px;
@@ -120,4 +123,5 @@
   <div class="test test-11"><div></div></div>
   <div class="test test-12"></div>
   <div class="test test-13"></div>
+  <div class="test test-14"></div>
 </body>


### PR DESCRIPTION
WebKit export from bug: [Nesting selector can't be inlined if there is a tag selector in both compounds](https://bugs.webkit.org/show_bug.cgi?id=300113)