### PR TITLE
webdriver: Improve argument extraction of (async) script execution 

### DIFF
--- a/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/webdriver/tests/classic/execute_async_script/arguments.py
@@ -205,3 +205,32 @@ def test_element_reference(session, get_test_page, expression, expected_type):
         resolve(arguments[0] == {expression})
         """, [reference])
     assert_success(result, True)
+
+
+@pytest.mark.parametrize("expression, expected_type", [
+    ("window.frames[0]", WebFrame),
+    ("document.querySelector('div')", WebElement),
+    ("document.querySelector('custom-element').shadowRoot", ShadowRoot),
+    ("window", WebWindow)
+], ids=["frame", "node", "shadow-root", "window"])
+def test_object_with_identifier_not_first_key(session, get_test_page, expression, expected_type):
+    session.url = get_test_page(as_frame=False)
+
+    result = execute_async_script(session, f"arguments[0]({expression})")
+    reference = assert_success(result)
+    value = {
+        "foo": "bar",
+        expected_type.identifier: reference.id,
+        "baz": 1314
+    }
+
+    result = execute_async_script(
+        session,
+        """
+        let resolve = arguments[1];
+        resolve(arguments[0]);
+        """,
+        args=[value]
+    )
+    reference = assert_success(result)
+    assert isinstance(reference, expected_type)

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -190,3 +190,24 @@ def test_element_reference(session, get_test_page, expression, expected_type):
 
     result = execute_script(session, f"return arguments[0] == {expression}", [reference])
     assert_success(result, True)
+
+@pytest.mark.parametrize("expression, expected_type", [
+    ("window.frames[0]", WebFrame),
+    ("document.querySelector('div')", WebElement),
+    ("document.querySelector('custom-element').shadowRoot", ShadowRoot),
+    ("window", WebWindow)
+], ids=["frame", "node", "shadow-root", "window"])
+def test_object_with_identifier_not_first_key(session, get_test_page, expression, expected_type):
+    session.url = get_test_page(as_frame=False)
+    
+    result = execute_script(session, f"return {expression}")
+    reference = assert_success(result)
+    value = {
+        "foo": "bar",
+         expected_type.identifier: reference.id,
+        "baz": 1314
+    }
+
+    result = execute_script(session, "return arguments[0]", args=[value])
+    reference = assert_success(result)
+    assert isinstance(reference, expected_type)

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -199,7 +199,7 @@ def test_element_reference(session, get_test_page, expression, expected_type):
 ], ids=["frame", "node", "shadow-root", "window"])
 def test_object_with_identifier_not_first_key(session, get_test_page, expression, expected_type):
     session.url = get_test_page(as_frame=False)
-    
+
     result = execute_script(session, f"return {expression}")
     reference = assert_success(result)
     value = {


### PR DESCRIPTION
According to [spec](https://w3c.github.io/webdriver/#dfn-json-deserialize), we should regard an object as webelement/shadowroot/webframe//webwindow, as long as one of the key is the corresponding identifier. Moreover, the order matters. This PR addresses this.

Testing: Added 8 subtests to wdspec.
Fixes: Part of #<!-- nolink -->38083.
Reviewed in servo/servo#39783