### PR TITLE
Remove opacity: 0.99999 from backdrop-filter-fixed-clip.html

### DIFF
--- a/css/filter-effects/backdrop-filter-fixed-clip.html
+++ b/css/filter-effects/backdrop-filter-fixed-clip.html
@@ -4,7 +4,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="backdrop-filter-fixed-clip-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-54400">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-54400">
 
 <div style="width:600px;">
   <p>Expected: A green box, overlapping red box, and a small, inset cyan box. The<br>

--- a/css/filter-effects/backdrop-filter-fixed-clip.html
+++ b/css/filter-effects/backdrop-filter-fixed-clip.html
@@ -30,7 +30,6 @@ div {
   left: 10px;
 }
 #B {
-  opacity: 0.99999;
   background:green;
 }
 #F {


### PR DESCRIPTION
It's causing unnecessary fuzziness and compositing differences that are not necessary to test backdrop-filter.