### PR TITLE
webdriver: Fix JS serialization for object with special key

### DIFF
--- a/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/webdriver/tests/classic/execute_async_script/arguments.py
@@ -23,7 +23,8 @@ def test_null(session):
     ("foo", "string"),
     ("foo\"bar", 'string'),
     ('"); alert(1); //', "string"),
-], ids=["boolean", "number", "string", "string_quote", "string_injection"])
+    ({"foo-bar":"bar-foo"}, "object")
+], ids=["boolean", "number", "string", "string_quote", "string_injection", "special_key_object"])
 def test_primitives(session, value, expected_type):
     result = execute_async_script(session, """
         arguments[1]([typeof arguments[0], arguments[0]])

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -21,7 +21,8 @@ def test_null(session):
     ("foo", "string"),
     ("foo\"bar", 'string'),
     ('"); alert(1); //', "string"),
-], ids=["boolean", "number", "string", "string_quote", "string_injection"])
+    ({"foo-bar":"bar-foo"}, "object")
+], ids=["boolean", "number", "string", "string_quote", "string_injection", "special_key_object"])
 def test_primitives(session, value, expected_type):
     result = execute_script(session, "return [typeof arguments[0], arguments[0]]", args=[value])
     actual = assert_success(result)


### PR DESCRIPTION
Previously, the JS deserialization is wrong for object like `{"-": 3}`. This was because we never generate a valid JSON string literal from the request.

Now I share @Loirooriol's laughter: "We just fixed something very basic, but there is no existing test covering this", after fixing a bunch of things in past few days.

Testing: Added two new subtests to [wdspec](https://web-platform-tests.org/writing-tests/wdspec.html).
Fixes: #<!-- nolink -->38083
Reviewed in servo/servo#39804