### PR TITLE
css-writing-modes: Correct html::after inheritance in wm-propagation-body tests

### DIFF
--- a/css/css-writing-modes/wm-propagation-body-042-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-042-ref.html
@@ -1,26 +1,30 @@
 <!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
-  <meta charset="UTF-8">
+<style>
+  html {
+    writing-mode: vertical-rl; /* mirror test's <html> value */
+  }
 
-  <title>CSS Reftest Reference</title>
+  body {
+    writing-mode: sideways-rl;
+  }
+  /* Match the test's ::after behavior explicitly */
+  p.reftext {
+    text-orientation: upright;
+  }
+</style>
 
-  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+<img id="blue" src="support/swatch-blue.png" width="100" height="100" alt="Image download support must be enabled">
 
-  <style>
-  html
-    {
-      writing-mode: vertical-rl;
-    }
-  </style>
+<p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
 
-  <img id="blue" src="support/swatch-blue.png" width="100" height="100" alt="Image download support must be enabled">
+<!--
+The image says:
+Test passes if there is a blue square in the
+<strong>upper-right corner</strong> of the page.
+-->
 
-  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
-
-  <!--
-  The image says:
-  Test passes if there is a blue square in the
-  <strong>upper-right corner</strong> of the page.
-  -->
-
-  <p style=margin-top:-8px>This text must be written sideways: vertically, with letters rotated 90 degrees.
+<p class="reftext" style="margin-top:-8px">This text must be written vertically (upright applies in vertical modes).

--- a/css/css-writing-modes/wm-propagation-body-042.html
+++ b/css/css-writing-modes/wm-propagation-body-042.html
@@ -13,7 +13,7 @@
   -->
   <link rel="match" href="wm-propagation-body-042-ref.html">
 
-  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Finally, in order to make sure that the principal writing mode is indeed 'sideways-rl', the test checks that a simple text is not affected by 'text-orientation: upright' since 'text-orientation: upright' should have no impact and no rendering effect on it.">
+   <meta name="assert" content="This test checks two things: (1) When the root element has a &lt;body&gt; child, the principal writing mode (USED value on the root) is taken from &lt;body&gt; (here, 'sideways-rl'). (2) Pseudo-elements of &lt;html&gt; (e.g., html::after) inherit from the root’s COMPUTED value, not the propagated used value; therefore with html { writing-mode: vertical-rl }, 'text-orientation: upright' DOES apply to html::after.">
 
   <!--
   Tests 032 to 035: html's writing-mode is not specified
@@ -39,7 +39,12 @@
     {
       content: "This text must be written sideways: vertically, with letters rotated 90 degrees.";
       text-orientation: upright;
-      /* 'text-orientation: upright' has no effect with 'sideways-rl', but does with 'vertical-rl' */
+       /* IMPORTANT:
+         Pseudo-elements inherit from <html>'s COMPUTED value.
+         Body→root propagation changes only the root's USED value.
+         Therefore html::after inherits 'vertical-rl' from <html> (computed),
+         so 'text-orientation: upright' DOES apply here.
+      */
     }
 
   body

--- a/css/css-writing-modes/wm-propagation-body-047-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-047-ref.html
@@ -22,7 +22,6 @@
       margin-left: 1em;
       margin-bottom: -8px;
     }
-    
 .reftext {
   text-orientation: upright;
 }

--- a/css/css-writing-modes/wm-propagation-body-047-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-047-ref.html
@@ -9,7 +9,7 @@
   <style>
   html
     {
-      writing-mode: sideways-lr;div
+      writing-mode: sideways-lr;
     }
 
   img
@@ -22,6 +22,11 @@
       margin-left: 1em;
       margin-bottom: -8px;
     }
+    
+.reftext {
+  text-orientation: upright;
+}
+
   </style>
 
   <img src="support/swatch-teal.png" width="100" height="100" alt="Image download support must be enabled">

--- a/css/css-writing-modes/wm-propagation-body-047.html
+++ b/css/css-writing-modes/wm-propagation-body-047.html
@@ -13,7 +13,7 @@
   -->
   <link rel="match" href="wm-propagation-body-047-ref.html">
 
-  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element.">
+  <meta name="assert" content="This test checks two things: (1) the principal writing mode (USED value on the root) is taken from &lt;body&gt; (here, 'sideways-lr'); (2) html::after inherits the root's COMPUTED writing mode (here, 'vertical-lr'), so 'text-orientation: upright' DOES apply to the pseudo.">
 
   <!--
   Tests 032 to 035: html's writing-mode is not specified
@@ -44,7 +44,11 @@
     {
       content: "This text must be written sideways: vertically, with letters rotated 90 degrees.";
       text-orientation: upright; /* this has no effect with sideways-rl, but does with vertical-rl*/
-    }
+      /* Pseudo-elements inherit from <html>'s COMPUTED value.
+        Body→root propagation changes only the root's USED value.
+        Therefore html::after inherits 'vertical-lr' from <html> (computed),
+        so 'text-orientation: upright' DOES apply in this test.*/
+    } 
 
   div
     {

--- a/css/css-writing-modes/wm-propagation-body-047.html
+++ b/css/css-writing-modes/wm-propagation-body-047.html
@@ -48,7 +48,7 @@
         Body→root propagation changes only the root's USED value.
         Therefore html::after inherits 'vertical-lr' from <html> (computed),
         so 'text-orientation: upright' DOES apply in this test.*/
-    } 
+    }
 
   div
     {

--- a/css/css-writing-modes/wm-propagation-body-049-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-049-ref.html
@@ -9,12 +9,13 @@
   <style>
   html
     {
-      writing-mode: vertical-rl;
+      writing-mode: sideways-rl; /* here it mirror the test's <html> value */
     }
 
   body
     {
       margin: 0px;
+      writing-mode: vertical-rl; /* mirror the principal mode from <body> */
     }
 
   p

--- a/css/css-writing-modes/wm-propagation-body-049.html
+++ b/css/css-writing-modes/wm-propagation-body-049.html
@@ -13,7 +13,7 @@
   -->
   <link rel="match" href="wm-propagation-body-049-ref.html">
 
-  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Finally, in order to make sure that the principal writing mode is indeed 'vertical-rl', the test checks that a simple text is affected by 'text-orientation: upright' since 'text-orientation: upright' should have a rendering effect on it.">
+  <meta name="assert" content="This test checks two things: (1) the principal writing mode (USED value on the root) is taken from &lt;body&gt; (here, 'vertical-rl'); (2) html::after inherits the root's COMPUTED writing mode (here, 'sideways-rl'), so 'text-orientation: upright' has NO effect on the pseudo.">
 
   <!--
   Tests 032 to 035: html's writing-mode is not specified
@@ -39,7 +39,14 @@
     {
       content: "This text must be vertical, with letters upright.";
       text-orientation: upright;
-      /* 'text-orientation: upright' has no effect with 'sideways-rl', but does with 'vertical-rl' */
+       /* Pseudo-elements inherit from <html>'s computed value.
+         Body to root propagation changes only the root's USED value.
+         Therefore html::after inherits 'sideways-rl' from <html> (computed),
+         so 'text-orientation: upright' has NO effect in this test.
+          Pseudo-elements inherit from <html>'s COMPUTED value.
+        Body→root propagation changes only the root's USED value.
+         Therefore html::after inherits 'sideways-rl' from <html> (computed),
+        so 'text-orientation: upright' has NO effect in this test. */
     }
 
   body

--- a/css/css-writing-modes/wm-propagation-body-054-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-054-ref.html
@@ -9,13 +9,19 @@
   <style>
   html
     {
-      writing-mode: vertical-lr;
+       writing-mode: sideways-lr; /* modifying to mirror the test's <html> value */
     }
 
-  div
+      body
+    {
+      writing-mode: vertical-lr;
+      margin: 0;
+    }
+
+  /* div  
     {
       text-orientation: upright;
-    }
+    } */
   </style>
 
 

--- a/css/css-writing-modes/wm-propagation-body-054-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-054-ref.html
@@ -18,7 +18,7 @@
       margin: 0;
     }
 
-  /* div  
+  /* div
     {
       text-orientation: upright;
     } */

--- a/css/css-writing-modes/wm-propagation-body-054.html
+++ b/css/css-writing-modes/wm-propagation-body-054.html
@@ -39,7 +39,10 @@
     {
       content: "This text must be vertical, with letters upright.";
       text-orientation: upright;
-      /* 'text-orientation: upright' has no effect with 'sideways-lr', but does with 'vertical-lr' */
+       /* Pseudo-elements inherit from <html>'s COMPUTED value.
+         Body→root propagation changes only the root's USED value.
+         Therefore html::after inherits 'sideways-lr' from <html> (computed),
+         so 'text-orientation: upright' has NO effect in this test.  */
       margin-top: 8px;
     }
 


### PR DESCRIPTION
Fixes #51227.

These four tests assumed html::after followed <body>’s propagated writing-mode. Per spec, body→root changes only the used value; pseudo-elements inherit the root’s computed value (<html>).

Updates:

Clarify meta/comments; align -ref.html to <html>’s mode.
042/047: upright applies (vertical-* on <html>).
049/054: upright no effect (sideways-* on <html>).

