### PR TITLE
Export WebKit inline speculation rules after stylesheet test

### DIFF
--- a/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https.html
+++ b/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<link rel="stylesheet" href="/css/cssom/support/black.css">
+
+<body>
+<script type="speculationrules">
+{
+  "prefetch": [{
+    "where": { "href_matches": "*prefetch.py*" },
+    "eagerness":"immediate"
+  }]
+}
+</script>
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    const url = getPrefetchUrl();
+    addLink(url);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1, 'URL should be prefetched');
+  }, 'Inline speculation rules script after an external stylesheet should work');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
This is a test added in WebKit as WebKit has different code paths for scripts before and after external stylesheets.

[Initially](https://github.com/WebKit/WebKit/pull/48322) the path for handling speculation rules registration after an external stylesheet was not well handled, and not tested. That support was [explicitly added](https://github.com/WebKit/WebKit/pull/51693) later, with [this test](https://github.com/WebKit/WebKit/pull/51730) making sure that it works.