### PR TITLE
Split intersection-ratio-ib-split.html test into 2 subtests

### DIFF
--- a/intersection-observer/intersection-ratio-ib-split.html
+++ b/intersection-observer/intersection-ratio-ib-split.html
@@ -22,8 +22,8 @@
 // Account for rounding differences when viewport sizes can't cleanly divide.
 const epsilon = 1;
 
-promise_test(async function() {
-  for (let element of document.querySelectorAll("inline, block")) {
+for (let element of document.querySelectorAll("inline, block")) {
+  promise_test(async function() {
     let entries = await new Promise(resolve => {
       new IntersectionObserver(resolve).observe(element);
     });
@@ -40,6 +40,6 @@ promise_test(async function() {
 
     assert_rects_equal(entries[0].boundingClientRect, element.getBoundingClientRect(), element.nodeName + ": boundingClientRect should match");
     assert_rects_equal(entries[0].intersectionRect, entries[0].boundingClientRect, element.nodeName + ": intersectionRect should match entry.boundingClientRect");
-  }
-}, "IntersectionObserver on an IB split gets the right intersection ratio");
+  }, "IntersectionObserver on an IB split gets the right intersection ratio - " + element.tagName);
+}
 </script>


### PR DESCRIPTION
This test was checking 2 cases in the same subtest. Servo fails the 1st one, which was hiding the fact that the 2nd one would time out because of #<!-- nolink -->39831. Therefore, it seems better to split the test into 2 subtests.

Testing: This only modifies a test

Reviewed in servo/servo#39832