### PR TITLE
caret-shape: disable spellcheck in alpha tests.

### DIFF
--- a/css/css-ui/caret-shape-block-color-001.html
+++ b/css/css-ui/caret-shape-block-color-001.html
@@ -19,7 +19,7 @@
     outline: none;
   }
 </style>
-<div id="target" contenteditable>abc</div>
+<div id="target" contenteditable spellcheck="false">abc</div>
 <script>
   target.focus();
 </script>

--- a/css/css-ui/caret-shape-block-color-002.tentative.html
+++ b/css/css-ui/caret-shape-block-color-002.tentative.html
@@ -18,7 +18,7 @@
     outline: none;
   }
 </style>
-<div id="target" contenteditable>abc</div>
+<div id="target" contenteditable spellcheck="false">abc</div>
 <script>
   target.focus();
 </script>

--- a/css/css-ui/caret-shape-block-color-003.tentative.html
+++ b/css/css-ui/caret-shape-block-color-003.tentative.html
@@ -19,7 +19,7 @@
     outline: none;
   }
 </style>
-<div id="target" contenteditable>abc</div>
+<div id="target" contenteditable spellcheck="false">abc</div>
 <script>
   target.focus();
 </script>

--- a/css/css-ui/caret-shape-block-color-004.tentative.html
+++ b/css/css-ui/caret-shape-block-color-004.tentative.html
@@ -22,7 +22,7 @@
 </style>
 
 <body>
-  <div id="target" contenteditable>abc</div>
+  <div id="target" contenteditable spellcheck="false">abc</div>
   <script>
     target.focus();
     requestAnimationFrame(() => {


### PR DESCRIPTION
This is to avoid the spellchecked underlines made-up words.