### PR TITLE
Remove `transform-origin: middle left` from transform-014.html

### DIFF
--- a/css/css-break/transform-014.html
+++ b/css/css-break/transform-014.html
@@ -6,7 +6,7 @@
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div style="display:flow-root; writing-mode:vertical-rl; width:100px; height:100px; background:red;">
   <div style="columns:3; column-fill:auto; gap:0; inline-size:150px; block-size:100px; margin-block-start:100px; margin-inline-start:-50px;">
-    <div style="transform:rotate(180deg); transform-origin:middle left; block-size:77px;">
+    <div style="transform:rotate(180deg); block-size:77px;">
       <div style="position:absolute; inset-block-start:100px; inline-size:100%; block-size:200px; background:green;"></div>
     </div>
   </div>


### PR DESCRIPTION
There's no value named `middle` for transform-origin, only `center`.