### PR TITLE
script: Fix script string transfered to mozjs with wrong encoding

### DIFF
--- a/trusted-types/cjk-string-assignment-to-paragraph-ref.html
+++ b/trusted-types/cjk-string-assignment-to-paragraph-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CJK characters should remain the same in trusted script evaluation</title>
+</head>
+<body>
+    <p id="test-chinese">中文</p>
+    <p id="test-japanese">日本語</p>
+    <p id="test-korean">한국어</p>
+</body>
+</html>

--- a/trusted-types/cjk-string-assignment-to-paragraph.html
+++ b/trusted-types/cjk-string-assignment-to-paragraph.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CJK characters should remain the same in trusted script evaluation</title>
+    <link rel="match" href="cjk-string-assignment-to-paragraph-ref.html">
+    <meta name="assert" content="CJK characters should remain the same in trusted script evaluation">
+</head>
+<body>
+    <p id="test-chinese">Chinese</p>
+    <p id="test-japanese">Japanese</p>
+    <p id="test-korean">Korean</p>
+
+    <script>
+        const policy = trustedTypes.createPolicy('test', {
+            createScript: script => script
+        });
+        const trustedScript = policy.createScript(`
+            document.getElementById("test-chinese").textContent = "中文";
+            document.getElementById("test-japanese").textContent = "日本語";
+            document.getElementById("test-korean").textContent = "한국어"
+        `);
+        eval(trustedScript);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
The current implementation would transfer the script string to `mozjs` without telling `mozjs` that the string is UTF-8 encoded, causing problems when the script carries Chinese characters. This PR fixes this by using a correct API `mozjs::jsapi::JS_NewStringCopyUTF8N`. Also changed `TrustedXxx::data()` to return a `&DOMString` to reduce one unnecessary cloning when transferring script string to `mozjs`

Testing: Manual testing. Would like to ask for community ideas on introducing new test covering this

Reviewed in servo/servo#39799