### PR TITLE
Revert "[no-op][wdspec] apply nullable and maybe in `tools/webdriver/webdriver/bidi/modules/browser.py`"

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/browser.py
+++ b/tools/webdriver/webdriver/bidi/modules/browser.py
@@ -1,7 +1,7 @@
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, MutableMapping, Optional, Union
 
 from ._module import BidiModule, command
-from ..undefined import UNDEFINED, Maybe, Nullable
+from ..undefined import UNDEFINED, Undefined
 
 
 class Browser(BidiModule):
@@ -29,15 +29,22 @@ class Browser(BidiModule):
 
     @command
     def create_user_context(
-            self, accept_insecure_certs: Maybe[bool] = UNDEFINED,
-            proxy: Maybe[Mapping[str, Any]] = UNDEFINED,
-            unhandled_prompt_behavior: Maybe[Mapping[str, str]] = UNDEFINED,
+        self, accept_insecure_certs: Optional[bool] = None,
+        proxy: Optional[Mapping[str, Any]] = None,
+        unhandled_prompt_behavior: Optional[Mapping[str, str]] = None,
     ) -> Mapping[str, Any]:
-        return {
-            "acceptInsecureCerts": accept_insecure_certs,
-            "proxy": proxy,
-            "unhandledPromptBehavior": unhandled_prompt_behavior
-        }
+        params: MutableMapping[str, Any] = {}
+
+        if accept_insecure_certs is not None:
+            params["acceptInsecureCerts"] = accept_insecure_certs
+
+        if proxy is not None:
+            params["proxy"] = proxy
+
+        if unhandled_prompt_behavior is not None:
+            params["unhandledPromptBehavior"] = unhandled_prompt_behavior
+
+        return params
 
     @create_user_context.result
     def _create_user_context(self, result: Mapping[str, Any]) -> Any:
@@ -61,19 +68,26 @@ class Browser(BidiModule):
 
     @command
     def remove_user_context(
-            self, user_context: str
+        self, user_context: str
     ) -> Mapping[str, Any]:
-        return {
-            "userContext": user_context
-        }
+        params: MutableMapping[str, Any] = {}
+
+        if user_context is not None:
+            params["userContext"] = user_context
+
+        return params
 
     @command
     def set_download_behavior(
-            self, download_behavior: Nullable[Mapping[str, Any]],
-            user_contexts: Maybe[List[str]] = UNDEFINED
+            self, download_behavior: Optional[Mapping[str, Any]] = None,
+            user_contexts: Union[Undefined, List[str]] = UNDEFINED
 
     ) -> Mapping[str, Any]:
-        return {
+        params: MutableMapping[str, Any] = {
             "downloadBehavior": download_behavior,
-            "userContexts": user_contexts
         }
+
+        if user_contexts != UNDEFINED:
+            params["userContexts"] = user_contexts
+
+        return params

--- a/webdriver/tests/bidi/browser/remove_user_context/invalid.py
+++ b/webdriver/tests/bidi/browser/remove_user_context/invalid.py
@@ -1,11 +1,10 @@
 import pytest
 import webdriver.bidi.error as error
-from webdriver.bidi.undefined import UNDEFINED
 
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.mark.parametrize("value", [UNDEFINED, None, False, 42, {}, []])
+@pytest.mark.parametrize("value", [None, False, 42, {}, []])
 async def test_params_user_context_invalid_type(bidi_session, value):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browser.remove_user_context(user_context=value)


### PR DESCRIPTION
Reverts web-platform-tests/wpt#55278

Reason: `create_user_context` fixture is broken: https://github.com/web-platform-tests/wpt/pull/55414