### PR TITLE
Be explicit about TypeError's realm.

### DIFF
--- a/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html
+++ b/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html
@@ -13,7 +13,8 @@
   promise_test(async t => {
     const iframe = document.createElement("iframe");
     const passThroughPolicy =
-          trustedTypes.createPolicy("passThrough", { createHTML: s => s });
+          trustedTypes.createPolicy("passThrough", { createHTML: s => s,
+                                                     createScript: s => s });
     iframe.srcdoc = passThroughPolicy.createHTML("<!DOCTYPE html><div></div>");
     await new Promise(resolve => {
       iframe.addEventListener("load", resolve);
@@ -29,7 +30,8 @@
     // realm.
     // Discussion at: https://github.com/web-platform-tests/wpt/issues/45405
     assert_throws_js(
-          divAdoptedFromIframe.ownerDocument.defaultView.TypeError,
+          divAdoptedFromIframe.constructor.constructor(
+              passThroughPolicy.createScript("return TypeError"))(),
           _ => divAdoptedFromIframe.innerHTML = 'unsafe');
   }, "Setting innerHTML on a node adopted from a subframe.");
 </script>


### PR DESCRIPTION
This fixes up the patch in #55060, to be more like #55164.

The TypeError thrown in this tests needs to belong to the same realm as the element it is thrown from, namely `divAdoptedFromIframe`. #55060 tries to solve this by accessing divAdoptedFromIframe's global object, which doesn't actually work here, since `adoptNode` has changed the global object. #55164 fixes this by executing "return TypeError" via the element's constructor's Function object, accessed via `.constructor.constructor`. This technique works across browsers, is based on fully spec-ed behaviour, and is used in a number of places across WPT. Here, we adopt the same technique.