### PR TITLE
shadow-dom: Remove references to unused `helpers.js` file

### DIFF
--- a/shadow-dom/declarative/declarative-parser-interaction.html
+++ b/shadow-dom/declarative/declarative-parser-interaction.html
@@ -6,8 +6,6 @@
 <link rel="help" href="https://crbug.com/1203645">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="support/helpers.js"></script>
-
 
 This test should not crash, and there should be two lines of text visible below.
 <x-1>

--- a/shadow-dom/declarative/declarative-shadow-dom-attachment.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-attachment.html
@@ -5,7 +5,6 @@
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
 <script src='../../html/resources/common.js'></script>
-<script src="support/helpers.js"></script>
 
 <script>
 const shadowContent = '<span>Shadow tree</span><slot></slot>';

--- a/shadow-dom/declarative/declarative-shadow-dom-repeats.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-repeats.html
@@ -8,7 +8,6 @@
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
 <script src='../../html/resources/common.js'></script>
-<script src="support/helpers.js"></script>
 
 <div id=multiple1>
   <template shadowrootmode=open>Open</template>


### PR DESCRIPTION
This file was removed in 17743f761d9f8bd3954bc68c60b88d251f9a2239.