### PR TITLE
[css-anchor-position-1] Ignore auto margins in combination with position-area and anchor-center

### DIFF
--- a/css/css-anchor-position/auto-margins-position-area-ref.html
+++ b/css/css-anchor-position/auto-margins-position-area-ref.html
@@ -1,10 +1,5 @@
 <!DOCTYPE html>
 <title>CSS Anchor Positioning: position-area vs margins</title>
-<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#position-area">
-<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#anchor-center">
-
-<link rel="match" href="auto-margins-position-area-ref.html">
-
 <style>
   .container {
     position: absolute;
@@ -25,16 +20,15 @@
   .anchored {
     position: absolute;
     position-anchor: --anchor;
-    inset: 0;
     width: 20px;
     height: 20px;
     border: solid 1px;
     opacity: 30%;
-    margin: auto 0 0 auto;
+    margin: 0;
   }
 </style>
 <div class="container">
-  <div class="anchored" style="background: silver"></div>
+  <div class="anchored" style="background: silver; inset: auto 0 0 auto;"></div>
   <div class="anchored" style="position-area: span-all; background: maroon"></div>
   <div class="anchored" style="position-area: top center; background: orange"></div>
   <div class="anchored" style="position-area: left center; background: yellow"></div>
@@ -43,7 +37,7 @@
   <div class="anchored" style="position-area: span-bottom; background: teal"></div>
   <div class="anchored" style="position-area: right; background: blue"></div>
   <div class="anchored" style="position-area: bottom; background: purple"></div>
-  <div class="anchored" style="align-self: anchor-center; background: fuchsia"></div>
-  <div class="anchored" style="justify-self: anchor-center; background: aqua"></div>
+  <div class="anchored" style="align-self: anchor-center; background: fuchsia; right: 0"></div>
+  <div class="anchored" style="justify-self: anchor-center; background: aqua; bottom: 0"></div>
   <div class="anchor"></div>
 </div>


### PR DESCRIPTION
Because the HTML stylesheet for popovers used margins instead of alignment in order to do centering, margin: auto had to be sacrificed. See
  https://github.com/w3c/csswg-drafts/issues/10258