### PR TITLE
layout: Let min-content size break before each unbreakable segment run

### DIFF
--- a/css/css-text/white-space/reference/white-space-intrinsic-size-022-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-022-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<div style="width: 4ic; border: solid">
+  中文中文
+</div>
+<div style="width: 1ic; border: solid">
+  中<br>文<br>中<br>文
+</div>

--- a/css/css-text/white-space/white-space-intrinsic-size-022.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-022.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text Test: intrinsic sizing and 'white-space: normal' with Chinese characters</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#line-breaking">
+<link rel="match" href="reference/white-space-intrinsic-size-022-ref.html">
+<meta name="assert" content="
+  The max-content size puts all ideographs on the same line.
+  The min-content size puts every ideograph on a different line.
+">
+
+<div style="width: max-content; border: solid">
+  中文中文
+</div>
+<div style="width: min-content; border: solid">
+  中文中文
+</div>

--- a/css/css-text/white-space/white-space-intrinsic-size-023.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-023.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text Test: intrinsic sizing and 'white-space: normal' with Chinese characters</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#line-breaking">
+<link rel="match" href="reference/white-space-intrinsic-size-022-ref.html">
+<meta name="assert" content="
+  The max-content size puts all ideographs on the same line.
+  The min-content size puts every ideograph on a different line.
+">
+
+<div style="width: max-content; border: solid">
+  中文<span>中文</span>
+</div>
+<div style="width: min-content; border: solid">
+  中文<span>中文</span>
+</div>


### PR DESCRIPTION
We were only allowing a soft wrap opportunity before the first run in a `TextRunSegment`, but not before the other runs. For example, this meant that the min-content size of `中文中文` would be 4ic instead of just 1ic.

The change brings the logic in `ContentSizesComputation::process_item()` closer to `TextRunSegment::layout_into_line_items()`.

Testing: Adding new tests. There is also a new failure because we don't support `word-break: auto-phrase`.
Fixes: #<!-- nolink -->39728

Reviewed in servo/servo#39830