### PR TITLE
webdriver: Deserialize `WebFrame` and report error correctly for script execution + Fix wrong tests

### DIFF
--- a/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/webdriver/tests/classic/execute_async_script/arguments.py
@@ -181,11 +181,24 @@ def test_no_such_window_for_window_with_invalid_value(session, get_test_page):
     assert isinstance(frame, WebFrame)
 
     window_reference = WebWindow(session, frame.id)
+
+    result = execute_async_script(session, "arguments[1](true)", args=(window_reference,))
+    assert_error(result, "no such window")
+
+
+def test_no_such_frame_for_frame_with_invalid_value(session, get_test_page):
+    session.url = get_test_page()
+
+    result = execute_async_script(session, "arguments[0]([window, window.frames[0]]);")
+    [window, frame] = assert_success(result)
+
+    assert isinstance(window, WebWindow)
+    assert isinstance(frame, WebFrame)
+
     frame_reference = WebFrame(session, window.id)
 
-    for reference in [window_reference, frame_reference]:
-        result = execute_async_script(session, "arguments[1](true)", args=(reference,))
-        assert_error(result, "no such window")
+    result = execute_async_script(session, "arguments[1](true)", args=(frame_reference,))
+    assert_error(result, "no such frame")
 
 
 @pytest.mark.parametrize("expression, expected_type", [

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -169,7 +169,7 @@ def test_no_such_window_for_window_with_invalid_value(session, get_test_page):
     assert isinstance(frame, WebFrame)
 
     window_reference = WebWindow(session, frame.id)
-    
+
     result = execute_script(session, "return true", args=(window_reference,))
     assert_error(result, "no such window")
 
@@ -184,7 +184,7 @@ def test_no_such_frame_for_frame_with_invalid_value(session, get_test_page):
     assert isinstance(frame, WebFrame)
 
     frame_reference = WebFrame(session, window.id)
-    
+
     result = execute_script(session, "return true", args=(frame_reference,))
     assert_error(result, "no such frame")
 

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -169,11 +169,24 @@ def test_no_such_window_for_window_with_invalid_value(session, get_test_page):
     assert isinstance(frame, WebFrame)
 
     window_reference = WebWindow(session, frame.id)
-    frame_reference = WebFrame(session, window.id)
+    
+    result = execute_script(session, "return true", args=(window_reference,))
+    assert_error(result, "no such window")
 
-    for reference in [window_reference, frame_reference]:
-        result = execute_script(session, "return true", args=(reference,))
-        assert_error(result, "no such window")
+
+def test_no_such_frame_for_frame_with_invalid_value(session, get_test_page):
+    session.url = get_test_page()
+
+    result = execute_script(session, "return [window, window.frames[0]];")
+    [window, frame] = assert_success(result)
+
+    assert isinstance(window, WebWindow)
+    assert isinstance(frame, WebFrame)
+
+    frame_reference = WebFrame(session, window.id)
+    
+    result = execute_script(session, "return true", args=(frame_reference,))
+    assert_error(result, "no such frame")
 
 
 @pytest.mark.parametrize("expression, expected_type", [


### PR DESCRIPTION
This is ~slightly~ quite different from the last PR for `WebWindow`. This time, we need to consult constellation to verify the existence of browsing context, without diving into script. But constellation requires `BrowsingContextId` object to check the HashMap. As a result, we added a regex check to convert the given `reference: string` to `BrowsingContextId`.

Testing: 14 newly passing tests. Two of them are newly created, as previous tests themselves are wrong and outdated with spec. We now fully pass `execute_{async_}script/arguments.py`.
Reviewed in servo/servo#39919