### PR TITLE
The communication of dispatcher is cancelled when page is navigating.

### DIFF
--- a/common/dispatcher/dispatcher.js
+++ b/common/dispatcher/dispatcher.js
@@ -78,6 +78,7 @@ const sendItem = async function (uuid, resolver, message) {
       try {
         let response = await fetch(dispatcher_url + `?uuid=${uuid}`, {
           method: 'POST',
+          keepalive: true,
           body: message
         })
         if (await response.text() == "done") {

--- a/common/dispatcher/remote-executor.html
+++ b/common/dispatcher/remote-executor.html
@@ -5,7 +5,7 @@
 </body>
 <script src="./dispatcher.js"
         crossorigin
-        integrity="sha256-daCATx8B9i1s6ixqZvCGcGQOv3a+VMoor6aS9UNUoiY=">
+        integrity="sha256-XZ2RxxHB3PF14zUZkzgB3mgWSn3R8JCPuDfZURvajRI=">
 </script>
 <script>
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Added `keepalive: true` to ensure dispatcher can complete its communication during the navigation.

#55487

Original fix in WebKit: https://commits.webkit.org/299594@main