### PR TITLE
Fix Digital Credentials `.create()` tests that test the absence of `requests`

### DIFF
--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -9,7 +9,7 @@
 
 <body>
   <iframe id="same-origin"></iframe>
-  <iframe id="cross-origin"></iframe>
+  <iframe id="cross-origin" allow="digital-credentials-create"></iframe>
 </body>
 
 <script type="module">
@@ -88,8 +88,12 @@
   }, "Calling navigator.credentials.create() without a digital member same origin.");
 
   promise_test(async (t) => {
-    for (const request of [undefined, []]) {
-      const options = makeCreateOptions(request);
+    for (const r of [undefined, []]) {
+      const options = {
+        digital: {
+          requests: r
+        },
+      };
       await test_driver.bless("user activation");
       await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
     }
@@ -98,8 +102,12 @@
   promise_test(async (t) => {
     iframeSameOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
-    for (const request of [undefined, []]) {
-      const options = makeCreateOptions(request);
+    for (const r of [undefined, []]) {
+      const options = {
+        digital: {
+          requests: r
+        },
+      };
       await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
@@ -111,8 +119,12 @@
 
   promise_test(async (t) => {
     iframeCrossOrigin.focus();
-    for (const request of [undefined, []]) {
-      const options = makeCreateOptions(request);
+    for (const r of [undefined, []]) {
+      const options = {
+        digital: {
+          requests: r
+        },
+      };
       const result = await sendMessage(iframeCrossOrigin, {
         action: "create",
         options,


### PR DESCRIPTION
This patch fixes a few issues with the digital credentials issuance tests:

   - The cross-origin iframe was missing the `allow="digital-credentials-create"` attribute, which is required for the `create()` call to be allowed.
   - The `makeCreateOptions()` helper was not correctly creating the options for the `create()` call, causing the tests to fail. This has been fixed by creating the options inline. That is because `makeCreateOptions()` is configured to ignore `undefined` param and switches it to `"default"`, which produces a valid requests and falsifies the purpose of the test.