### PR TITLE
[wdspec] fix setExtraHeaders multiple values test to expect header override

### DIFF
--- a/webdriver/tests/bidi/network/set_extra_headers/headers.py
+++ b/webdriver/tests/bidi/network/set_extra_headers/headers.py
@@ -50,8 +50,7 @@ async def test_multiple_headers(bidi_session, top_context,
         }],
         contexts=[top_context["context"]])
     new_headers = await get_headers_methods_invariant(top_context)
-    assert new_headers["some_header_name"] == [
-        "some_header_value_1, some_header_value_2"]
+    assert new_headers["some_header_name"] == ["some_header_value_2"]
     assert new_headers["another_header_name"] == ["another_header_value"]
 
     await set_extra_headers(headers=[], contexts=[top_context["context"]])


### PR DESCRIPTION
cc @sadym-chromium 

Based on https://www.w3.org/TR/webdriver-bidi/#update-headers I think the value of the second cookie in the list should override the first one? 

> Note: This always overwrites the existing value, if any. In particular it doesn’t append cookies to an existing `Set-Cookie` header.

I see chrome currently passes this test on wpt.fyi. Let me know if you understand the spec differently.