### PR TITLE
Make variants excluding SFrameDecrypterStream & SFrameEncrypterStream from Interop 2025

### DIFF
--- a/webrtc-encoded-transform/idlharness.https.window.js
+++ b/webrtc-encoded-transform/idlharness.https.window.js
@@ -1,5 +1,5 @@
-// META: variant=?exclude=(SFrameEncrypterStream|SFrameDecrypterStream|SFrameTransform.*)
-// META: variant=?include=(SFrameEncrypterStream|SFrameDecrypterStream|SFrameTransform.*)
+// META: variant=?exclude=(SFrameDecrypterStream|SFrameEncrypterStream|SFrameTransform.*)
+// META: variant=?include=(SFrameDecrypterStream|SFrameEncrypterStream|SFrameTransform.*)
 // META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js

--- a/webrtc-encoded-transform/idlharness.https.window.js
+++ b/webrtc-encoded-transform/idlharness.https.window.js
@@ -1,5 +1,5 @@
-// META: variant=?exclude=(SFrameEncrypterStream|SFrameTransform.*)
-// META: variant=?include=(SFrameEncrypterStream|SFrameTransform.*)
+// META: variant=?exclude=(SFrameEncrypterStream.*|SFrameTransform.*)
+// META: variant=?include=(SFrameEncrypterStream.*|SFrameTransform.*)
 // META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js

--- a/webrtc-encoded-transform/idlharness.https.window.js
+++ b/webrtc-encoded-transform/idlharness.https.window.js
@@ -1,5 +1,5 @@
-// META: variant=?exclude=SFrameTransform.*
-// META: variant=?include=SFrameTransform.*
+// META: variant=?exclude=(SFrameEncrypterStream|SFrameTransform.*)
+// META: variant=?include=(SFrameEncrypterStream|SFrameTransform.*)
 // META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js

--- a/webrtc-encoded-transform/idlharness.https.window.js
+++ b/webrtc-encoded-transform/idlharness.https.window.js
@@ -1,5 +1,5 @@
-// META: variant=?exclude=(SFrameEncrypterStream.*|SFrameTransform.*)
-// META: variant=?include=(SFrameEncrypterStream.*|SFrameTransform.*)
+// META: variant=?exclude=(SFrameEncrypterStream|SFrameDecrypterStream|SFrameTransform.*)
+// META: variant=?include=(SFrameEncrypterStream|SFrameDecrypterStream|SFrameTransform.*)
 // META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js


### PR DESCRIPTION
This was added 2 days ago by https://github.com/web-platform-tests/wpt/commit/650d0619997a7d3b0d427c8e3c4ca819f43c93f2

Corresponding WPT metadata change: https://github.com/web-platform-tests/wpt-metadata/pull/8123