### PR TITLE
Fix new-content-transform-position-fixed.html to pass with colored scrollbars

### DIFF
--- a/css/css-view-transitions/new-content-transform-position-fixed.html
+++ b/css/css-view-transitions/new-content-transform-position-fixed.html
@@ -10,6 +10,7 @@
 <style>
 :root {
   background: lightpink;
+  box-shadow: 10px 0 0 0 inset red;
 }
 
 .box {

--- a/css/css-view-transitions/new-content-transform-position-fixed.html
+++ b/css/css-view-transitions/new-content-transform-position-fixed.html
@@ -8,6 +8,10 @@
 <script src="/common/reftest-wait.js"></script>
 <script src="../../../../../resources/ui-helper.js"></script>
 <style>
+:root {
+  background: lightpink;
+}
+
 .box {
   background: lightblue;
   width: 100px;


### PR DESCRIPTION
Add lightpink background to root element so macOS Tahoe scrollbar heuristic picks up lightpink instead of white as scrollbar background. Red box-shadow is added on the root to distinguish it from the `::view-transition` pseudo-element.