### PR TITLE
Fix mutable default argument in do_print function

### DIFF
--- a/webdriver/tests/classic/print/__init__.py
+++ b/webdriver/tests/classic/print/__init__.py
@@ -1,4 +1,6 @@
-def do_print(session, options={}):
+def do_print(session, options=None):
+    if options is None:
+        options = {}
     params = {}
 
     if options.get("background", None) is not None:


### PR DESCRIPTION
This PR fixes a mutable default argument anti-pattern in the do_print helper function.

**Problem:**
The function was using options={} as a default argument, which is a common Python anti-pattern. Mutable default arguments are shared across all function calls, which can lead to unexpected behavior and bugs.

**Solution:**
Changed the default argument to options=None and initialize an empty dictionary inside the function when None is provided. This ensures each call gets a fresh dictionary.

**Impact:**
- No breaking changes - all existing calls continue to work as expected
- Prevents potential bugs from shared state between calls
- Follows Python best practices

**Testing:**
The existing test suite should continue to pass, as this change only affects the internal implementation without changing the function's external behavior.