### PR TITLE
Fix typo: recieve -> receive in WebSocket handler

### DIFF
--- a/websockets/handlers/msg_channel_wsh.py
+++ b/websockets/handlers/msg_channel_wsh.py
@@ -150,8 +150,8 @@ def run_read(request, uuid, queue):
      close - Close the reader queue
 
     In addition there's a thread that listens for messages on the
-    socket itself. Typically this socket shouldn't recieve any
-    messages, but it can recieve an explicit "close" message,
+    socket itself. Typically this socket shouldn't receive any
+    messages, but it can receive an explicit "close" message,
     indicating the socket should be disconnected.
     """
 


### PR DESCRIPTION
This PR fixes a spelling error in the documentation for the WebSocket message channel handler.

**What was fixed:**
- Changed 'recieve' to 'receive' (correct spelling) in two locations within the docstring

**Location:**
websockets/handlers/msg_channel_wsh.py - in the documentation for the main loop of read-type connections

**Impact:**
- Documentation-only change
- No functional changes
- Improves code documentation quality

This is a simple typo fix that makes the codebase more professional and easier to read.