### PR TITLE
Fix mutable default argument in WKTRBrowser class

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/wktr.py
+++ b/tools/wptrunner/wptrunner/browsers/wktr.py
@@ -81,8 +81,10 @@ class WKTRBrowser(Browser):
     interact with WebKitTestRunner through its protocol mode.
     """
 
-    def __init__(self, logger, binary="WebKitTestRunner", binary_args=[], **kwargs):
+    def __init__(self, logger, binary="WebKitTestRunner", binary_args=None, **kwargs):
         super().__init__(logger, **kwargs)
+        if binary_args is None:
+            binary_args = []
 
         self._args = [binary] + binary_args
         self._proc = None


### PR DESCRIPTION
This PR fixes another instance of the mutable default argument anti-pattern, this time in the WKTRBrowser class constructor.

**Problem:**
The WKTRBrowser.__init__ method was using inary_args=[] as a default argument. This is a well-known Python anti-pattern because mutable default arguments are shared across all function/method calls, which can lead to unexpected behavior and bugs.

**Solution:**
Changed the default argument to inary_args=None and initialize an empty list inside the method when None is provided. This ensures each WKTRBrowser instance gets a fresh list.

**Code Location:**
	ools/wptrunner/wptrunner/browsers/wktr.py - WKTRBrowser class constructor

**Impact:**
- No breaking changes - fully backward compatible
- Prevents potential bugs from shared state between instances
- Follows Python best practices
- The list is used to construct command-line arguments for WebKitTestRunner

**Testing:**
The existing test suite should continue to pass, as this change only affects the internal implementation without changing the class's external behavior when called with explicit arguments.