### PR TITLE
webdriver: Report error instead of panic for invalid `WebElement`&`ShadowRoot` reference 

### DIFF
--- a/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/webdriver/tests/classic/execute_async_script/arguments.py
@@ -162,9 +162,9 @@ def test_stale_element_reference(session, stale_element, as_frame):
     assert_error(result, "stale element reference")
 
 
-@pytest.mark.parametrize("type", [WebFrame, WebWindow], ids=["frame", "window"])
+@pytest.mark.parametrize("type", [WebFrame, WebWindow, WebElement, ShadowRoot], ids=["frame", "window", "element", "shadow_root"])
 @pytest.mark.parametrize("value", [None, False, 42, [], {}])
-def test_invalid_argument_for_window_with_invalid_type(session, type, value):
+def test_invalid_argument_for_reference_with_invalid_type(session, type, value):
     reference = type(session, value)
 
     result = execute_async_script(session, "arguments[1](true)", args=(reference,))

--- a/webdriver/tests/classic/execute_script/arguments.py
+++ b/webdriver/tests/classic/execute_script/arguments.py
@@ -150,9 +150,9 @@ def test_stale_element_reference(session, stale_element, as_frame):
     assert_error(result, "stale element reference")
 
 
-@pytest.mark.parametrize("type", [WebFrame, WebWindow], ids=["frame", "window"])
+@pytest.mark.parametrize("type", [WebFrame, WebWindow, WebElement, ShadowRoot], ids=["frame", "window", "element", "shadow_root"])
 @pytest.mark.parametrize("value", [None, False, 42, [], {}])
-def test_invalid_argument_for_window_with_invalid_type(session, type, value):
+def test_invalid_argument_for_reference_with_invalid_type(session, type, value):
     reference = type(session, value)
 
     result = execute_script(session, "return true", args=(reference,))


### PR DESCRIPTION
It is possible that the reference of `WebElement` and `ShadowRoot` in the request is not String. Instead of panic, we should return "invalid argument" same as the `WebWindow` and `WebFrame`.

Testing: Added 4 new subtests. There was only tests for `WebWindow` and `WebFrame` somehow.
Reviewed in servo/servo#39976