### PR TITLE
[WebDriver] navigate_to with a file URL should try loading a file

### DIFF
--- a/webdriver/tests/classic/navigate_to/file.py
+++ b/webdriver/tests/classic/navigate_to/file.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from tests.support.asserts import assert_success
 
 
@@ -10,15 +12,17 @@ def navigate_to(session, url):
 def test_file_protocol(session, target_platform, server_config):
     # tests that the browsing context remains the same
     # when navigated privileged documents
-    path = server_config["doc_root"]
-    if target_platform == "windows":
-        # Convert the path into the format eg. /c:/foo/bar
-        path = "/{}".format(path.replace("\\", "/"))
-    url = u"file://{}".format(path)
+    path = Path(server_config["doc_root"]) / "common" / "blank.html"
+
+    # not all borwsers support "loading" file URLs which aren't files,
+    # so check this is one
+    assert path.is_file()
+
+    # and then create the file URL
+    url = path.as_uri()
+    assert url.startswith("file://")
 
     response = navigate_to(session, url)
     assert_success(response)
 
-    if session.url.endswith('/'):
-        url += '/'
     assert session.url == url


### PR DESCRIPTION
Previously it attempted to load a the document root of the server — a
directory — which only works if the browser actually supports loading
a directory. This doesn't work in all browsers, and there's nothing to
suggest it should work in all browsers.

This therefore moves us to loading an actual file.

While we're at it, this gets us out of the business of implementing
file URL serialization, by relying on pathlib to do it for us.
