### PR TITLE
wdspec tests: Check correct node type instead of asserting error for script execution

### DIFF
--- a/webdriver/tests/classic/execute_async_script/node.py
+++ b/webdriver/tests/classic/execute_async_script/node.py
@@ -84,8 +84,9 @@ def test_node_type(session, inline, expression, expected_type):
     response = execute_async_script(
         session,
         f"""
+    const [resolve] = arguments;
     const result = {expression};
-    arguments[0]({{
+    resolve({{
         'result': result,
         'type': result.nodeType
     }});""",

--- a/webdriver/tests/classic/execute_async_script/node.py
+++ b/webdriver/tests/classic/execute_async_script/node.py
@@ -70,17 +70,9 @@ def test_element_reference(session, get_test_page, expression, expected_type):
     assert isinstance(reference, expected_type)
 
 
-@pytest.mark.parametrize("expression", [
-    (""" document.querySelector("svg").attributes[0] """),
-    (""" document.querySelector("div#text-node").childNodes[1] """),
-    (""" document.querySelector("foo").childNodes[1] """),
-    (""" document.createProcessingInstruction("xml-stylesheet", "href='foo.css'") """),
-    (""" document.querySelector("div#comment").childNodes[0] """),
-    (""" document"""),
-    (""" document.doctype"""),
-], ids=["attribute", "text", "cdata", "processing_instruction", "comment", "document", "doctype"])
-def test_not_supported_nodes(session, inline, expression):
+def test_queryselector_null_child_access_errors(session, inline):
     session.url = inline(PAGE_DATA)
 
+    expression = "document.querySelector('foo').childNodes[1]"
     result = execute_async_script(session, f"arguments[0]({expression})")
     assert_error(result, "javascript error")

--- a/webdriver/tests/classic/execute_async_script/node.py
+++ b/webdriver/tests/classic/execute_async_script/node.py
@@ -68,8 +68,7 @@ def test_stale_element(session, get_test_page, as_frame):
         """, args=[element])
     assert_error(result, "stale element reference")
 
-
-@pytest.mark.parametrize("expression, expected_type", [
+test_cases = [
     (""" document.querySelector("svg").attributes[0] """, "attribute"),
     (""" document.querySelector("div#text-node").childNodes[1] """, "text"),
     (""" document.implementation.createDocument("", "root", null).createCDATASection("foo") """, "cdata"),
@@ -77,7 +76,9 @@ def test_stale_element(session, get_test_page, as_frame):
     (""" document.querySelector("div#comment").childNodes[0] """, "comment"),
     (""" document""", "document"),
     (""" document.doctype""", "doctype"),
-], ids=["attribute", "text", "cdata", "processing_instruction", "comment", "document", "doctype"])
+]
+
+@pytest.mark.parametrize("expression, expected_type", test_cases, ids=[case[1] for case in test_cases])
 def test_node_type(session, inline, expression, expected_type):
     session.url = inline(PAGE_DATA)
 
@@ -97,10 +98,3 @@ def test_element_reference(session, get_test_page, expression, expected_type):
     reference = assert_success(result)
     assert isinstance(reference, expected_type)
 
-
-def test_queryselector_null_child_access_errors(session, inline):
-    session.url = inline(PAGE_DATA)
-
-    expression = "document.querySelector('foo').childNodes[1]"
-    result = execute_async_script(session, f"arguments[0]({expression})")
-    assert_error(result, "javascript error")

--- a/webdriver/tests/classic/execute_async_script/node.py
+++ b/webdriver/tests/classic/execute_async_script/node.py
@@ -81,10 +81,6 @@ def test_stale_element(session, get_test_page, as_frame):
 def test_node_type(session, inline, expression, expected_type):
     session.url = inline(PAGE_DATA)
 
-    response = execute_async_script(session, f"arguments[0]({expression}.nodeType)")
-    result = assert_success(response)
-    assert result == NODE_TYPE[expected_type]
-
     response = execute_async_script(
         session,
         f"""
@@ -96,11 +92,13 @@ def test_node_type(session, inline, expression, expected_type):
     )
     result = assert_success(response)
 
+    assert result["type"] == NODE_TYPE[expected_type]
+
     if expected_type == "document":
         assert 'location' in result['result']
     else:
         assert result['result'] == {}
-    assert result["type"] == NODE_TYPE[expected_type]
+
 
 
 @pytest.mark.parametrize("expression, expected_type", [

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -68,7 +68,7 @@ def test_stale_element(session, get_test_page, as_frame):
     assert_error(result, "stale element reference")
 
 
-test_cases = [
+@pytest.mark.parametrize("expression, expected_type", [
     (""" document.querySelector("svg").attributes[0] """, "attribute"),
     (""" document.querySelector("div#text-node").childNodes[1] """, "text"),
     (""" document.implementation.createDocument("", "root", null).createCDATASection("foo") """, "cdata"),
@@ -76,15 +76,20 @@ test_cases = [
     (""" document.querySelector("div#comment").childNodes[0] """, "comment"),
     (""" document""", "document"),
     (""" document.doctype""", "doctype"),
-]
-
-@pytest.mark.parametrize("expression, expected_type", test_cases, ids=[case[1] for case in test_cases])
+], ids=["attribute", "text", "cdata", "processing_instruction", "comment", "document", "doctype"])
 def test_node_type(session, inline, expression, expected_type):
     session.url = inline(PAGE_DATA)
 
-    response = execute_script(session, f"return {expression}")
+    response = execute_script(
+        session,
+        f"const result = {expression}; return {{'result': result, 'type': result.nodeType}}",
+    )
     result = assert_success(response)
-    print(result)
+    if expected_type == "document":
+        assert 'location' in result['result']
+    else:
+        assert result['result'] == {}
+    assert result["type"] == NODE_TYPE[expected_type]
 
 
 @pytest.mark.parametrize("expression, expected_type", [

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -69,17 +69,9 @@ def test_web_reference(session, get_test_page, expression, expected_type):
     assert isinstance(reference, expected_type)
 
 
-@pytest.mark.parametrize("expression", [
-    (""" document.querySelector("svg").attributes[0] """),
-    (""" document.querySelector("div#text-node").childNodes[1] """),
-    (""" document.querySelector("foo").childNodes[1] """),
-    (""" document.createProcessingInstruction("xml-stylesheet", "href='foo.css'") """),
-    (""" document.querySelector("div#comment").childNodes[0] """),
-    (""" document"""),
-    (""" document.doctype"""),
-], ids=["attribute", "text", "cdata", "processing_instruction", "comment", "document", "doctype"])
-def test_not_supported_nodes(session, inline, expression):
+def test_queryselector_null_child_access_errors(session, inline):
     session.url = inline(PAGE_DATA)
 
+    expression = "document.querySelector('foo').childNodes[1]"
     result = execute_script(session, f"return {expression}")
     assert_error(result, "javascript error")

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -67,7 +67,8 @@ def test_stale_element(session, get_test_page, as_frame):
         """, args=[element])
     assert_error(result, "stale element reference")
 
-@pytest.mark.parametrize("expression, expected_type", [
+
+test_cases = [
     (""" document.querySelector("svg").attributes[0] """, "attribute"),
     (""" document.querySelector("div#text-node").childNodes[1] """, "text"),
     (""" document.implementation.createDocument("", "root", null).createCDATASection("foo") """, "cdata"),
@@ -75,7 +76,9 @@ def test_stale_element(session, get_test_page, as_frame):
     (""" document.querySelector("div#comment").childNodes[0] """, "comment"),
     (""" document""", "document"),
     (""" document.doctype""", "doctype"),
-], ids=["attribute", "text", "cdata", "processing_instruction", "comment", "document", "doctype"])
+]
+
+@pytest.mark.parametrize("expression, expected_type", test_cases, ids=[case[1] for case in test_cases])
 def test_node_type(session, inline, expression, expected_type):
     session.url = inline(PAGE_DATA)
 

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -85,11 +85,14 @@ def test_node_type(session, inline, expression, expected_type):
         f"const result = {expression}; return {{'result': result, 'type': result.nodeType}}",
     )
     result = assert_success(response)
+
+    assert result["type"] == NODE_TYPE[expected_type]
+
     if expected_type == "document":
         assert 'location' in result['result']
     else:
         assert result['result'] == {}
-    assert result["type"] == NODE_TYPE[expected_type]
+
 
 
 @pytest.mark.parametrize("expression, expected_type", [

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -22,6 +22,7 @@ NODE_TYPE = {
     "element": 1,
     "attribute": 2,
     "text": 3,
+    "cdata": 4,
     "processing_instruction": 7,
     "comment": 8,
     "document": 9,
@@ -68,12 +69,13 @@ def test_stale_element(session, get_test_page, as_frame):
 
 @pytest.mark.parametrize("expression, expected_type", [
     (""" document.querySelector("svg").attributes[0] """, "attribute"),
-    (""" document.querySelector("text-node").childNodes[1] """, "text"),
+    (""" document.querySelector("div#text-node").childNodes[1] """, "text"),
+    (""" document.implementation.createDocument("", "root", null).createCDATASection("foo") """, "cdata"),
     (""" document.createProcessingInstruction("xml-stylesheet", "href='foo.css'") """, "processing_instruction"),
     (""" document.querySelector("div#comment").childNodes[0] """, "comment"),
     (""" document""", "document"),
     (""" document.doctype""", "doctype"),
-], ids=["attribute", "text", "processing_instruction", "comment", "document", "doctype"])
+], ids=["attribute", "text", "cdata", "processing_instruction", "comment", "document", "doctype"])
 def test_node_type(session, inline, expression, expected_type):
     session.url = inline(PAGE_DATA)
 

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -82,9 +82,9 @@ test_cases = [
 def test_node_type(session, inline, expression, expected_type):
     session.url = inline(PAGE_DATA)
 
-    response = execute_script(session, f"return {expression}.nodeType")
+    response = execute_script(session, f"return {expression}")
     result = assert_success(response)
-    assert result == NODE_TYPE[expected_type]
+    print(result)
 
 
 @pytest.mark.parametrize("expression, expected_type", [

--- a/webdriver/tests/classic/execute_script/node.py
+++ b/webdriver/tests/classic/execute_script/node.py
@@ -68,7 +68,7 @@ def test_stale_element(session, get_test_page, as_frame):
 
 @pytest.mark.parametrize("expression, expected_type", [
     (""" document.querySelector("svg").attributes[0] """, "attribute"),
-    (""" document.querySelector("foo").childNodes[1] """, "text"),
+    (""" document.querySelector("text-node").childNodes[1] """, "text"),
     (""" document.createProcessingInstruction("xml-stylesheet", "href='foo.css'") """, "processing_instruction"),
     (""" document.querySelector("div#comment").childNodes[0] """, "comment"),
     (""" document""", "document"),


### PR DESCRIPTION
These tests suggest that attribute nodes, document etc. are invalid node. That is simply not true based on spec.

Only Firefox pass these tests, while Chrome/Safari fails.
https://wpt.fyi/results/webdriver/tests/classic/execute_script?label=master

There is an ongoing discussion: https://github.com/w3c/webdriver/issues/1687#issuecomment-3419703187

--
EDIT: Instead of removing these tests, we check 
1. whether the node type returned is correct
2. whether the serialization for enumerable properties for fallback plain object is correct.
Reviewed in servo/servo#39988