### PR TITLE
feat(css): Add reftest for grid-template-areas

### DIFF
--- a/css/css-grid/grid-template-areas-basic-001-ref.html
+++ b/css/css-grid/grid-template-areas-basic-001-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Reference for grid-template-areas basic layout</title>
+  <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
+  <style>
+    .grid {
+      display: grid;
+      width: 200px;
+      height: 200px;
+      grid-template-rows: 100px 100px;
+      grid-template-columns: 100px 100px;
+      background: red;
+    }
+    .header {
+      grid-row: 1;
+      grid-column: 1 / 3; /* Spans 2 columns */
+      background-color: green;
+    }
+    .main {
+      grid-row: 2;
+      grid-column: 1;
+      background-color: blue;
+    }
+    .sidebar {
+      grid-row: 2;
+      grid-column: 2;
+      background-color: yellow;
+    }
+  </style>
+</head>
+<body>
+  <p>Test passes if you see a 2x2 grid with no red.</p>
+  <p>Top row: solid green. Bottom row: blue on left, yellow on right.</p>
+  <div class="grid">
+    <div class="header"></div>
+    <div class="main"></div>
+    <div class="sidebar"></div>
+  </div>
+</body>
+</html>

--- a/css/css-grid/grid-template-areas-basic-001.html
+++ b/css/css-grid/grid-template-areas-basic-001.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CSS Grid Test: grid-template-areas basic layout</title>
+  <link rel="author" title="Deepith N" href="mailto:deepithdeekshith@gmail.com">
+  <link rel="help" href="https://www.w3.org/TR/css-grid-1/#named-grid-areas">
+  <link rel="match" href="grid-template-areas-basic-001-ref.html">
+  <meta name="assert" content="This test checks that grid-template-areas correctly places items in named areas spanning multiple cells.">
+  <style>
+    .grid {
+      display: grid;
+      width: 200px;
+      height: 200px;
+      grid-template-rows: 100px 100px;
+      grid-template-columns: 100px 100px;
+      grid-template-areas:
+        "header header"
+        "main   sidebar";
+      background: red; /* Fail-safe: shows red if layout fails */
+    }
+    .header {
+      grid-area: header;
+      background-color: green;
+    }
+    .main {
+      grid-area: main;
+      background-color: blue;
+    }
+    .sidebar {
+      grid-area: sidebar;
+      background-color: yellow;
+    }
+  </style>
+</head>
+<body>
+  <p>Test passes if you see a 2x2 grid with no red.</p>
+  <p>Top row: solid green. Bottom row: blue on left, yellow on right.</p>
+  <div class="grid">
+    <div class="header"></div>
+    <div class="main"></div>
+    <div class="sidebar"></div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a reftest to verify that `grid-template-areas` correctly assigns grid items to named areas, including spanning behavior.

The test uses `grid-template-areas` to place items in named areas ("header", "main", "sidebar"), where the header spans two columns. The reference file achieves the same layout using explicit `grid-row` and `grid-column` positioning. Both files should render identically.

**Spec Reference:** https://www.w3.org/TR/css-grid-1/#named-grid-areas