### PR TITLE
layout: Handle `<select>` as a widget

### DIFF
--- a/html/rendering/replaced-elements/the-select-element/select-display-inline-ref.html
+++ b/html/rendering/replaced-elements/the-select-element/select-display-inline-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Test Reference</title>
+<link rel="author" title="Oriol Brufau" href="obrufau:obrufau@igalia.com">
+
+<select style="margin-left: 100px">
+  <option>option</option>
+</select>

--- a/html/rendering/replaced-elements/the-select-element/select-display-inline.html
+++ b/html/rendering/replaced-elements/the-select-element/select-display-inline.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>&lt;select&gt; with display:inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau:obrufau@igalia.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-select-element-2">
+<link rel="help" href="https://github.com/servo/servo/issues/39927">
+<link rel="match" href="select-display-inline-ref.html">
+<meta name="assert" content="
+  A <select> is a widget, so it's atomic when it has display:inline.
+  In particular, this implies that it's transformable.
+">
+
+<select style="display: inline; transform: translateX(100px)">
+  <option>option</option>
+</select>


### PR DESCRIPTION
For example, it will now be atomic with `display: inline`, so its block-level contents won't be able to split it, and it will be transformable.

Testing: Adding new test
Fixes: #<!-- nolink -->39927

Reviewed in servo/servo#39970