### PR TITLE
Add XPath tests for root-adjacent nodes (comment, PI, doctype)

### DIFF
--- a/domxpath/document.tentative.html
+++ b/domxpath/document.tentative.html
@@ -28,4 +28,72 @@ test(function() {
   }
   assert_array_equals(matched, [document]);
 });
+
+// Root-adjacent comment: create a comment node as a sibling of documentElement
+test(function() {
+  var comment = document.createComment("root-adjacent comment");
+  document.insertBefore(comment, document.documentElement);
+  try {
+    var result = document.evaluate("..", // expression
+                                  comment, // context node
+                                  null, // resolver
+                                  XPathResult.ANY_TYPE, // type
+                                  null); // result
+    var matched = [];
+    var cur;
+    while ((cur = result.iterateNext()) !== null) {
+      matched.push(cur);
+    }
+    assert_array_equals(matched, [document]);
+  } finally {
+    // Clean up so other tests are not affected
+    document.removeChild(comment);
+  }
+});
+
+// Processing instruction: create via DOM and place adjacent to the documentElement
+test(function() {
+  if (typeof document.createProcessingInstruction !== 'function') {
+    // Not all HTML-oriented implementations expose this; mark test as effectively skipped
+    assert_true(true, "createProcessingInstruction not supported in this environment");
+    return;
+  }
+  var pi = document.createProcessingInstruction("test-pi", "data");
+  document.insertBefore(pi, document.documentElement);
+  try {
+    var result = document.evaluate("..", // expression
+                                  pi, // context node
+                                  null, // resolver
+                                  XPathResult.ANY_TYPE, // type
+                                  null); // result
+    var matched = [];
+    var cur;
+    while ((cur = result.iterateNext()) !== null) {
+      matched.push(cur);
+    }
+    assert_array_equals(matched, [document]);
+  } finally {
+    document.removeChild(pi);
+  }
+});
+
+// DocumentType: if present, its parent should be the Document; ensure XPath sees the parent
+test(function() {
+  var dt = document.doctype;
+  if (!dt) {
+    assert_true(true, "No doctype in this document");
+    return;
+  }
+  var result = document.evaluate("..", // expression
+                                dt, // context node
+                                null, // resolver
+                                XPathResult.ANY_TYPE, // type
+                                null); // result
+  var matched = [];
+  var cur;
+  while ((cur = result.iterateNext()) !== null) {
+    matched.push(cur);
+  }
+  assert_array_equals(matched, [document]);
+});
 </script>


### PR DESCRIPTION
Addresses https://github.com/w3c/web-platform-tests/pull/10055#issuecomment-373666278

This PR adds tests for XPath evaluation with root-adjacent nodes:

- **Root-adjacent comments**: Tests that XPath correctly identifies the Document node as the parent of a comment node inserted adjacent to documentElement
- **Root-adjacent processing instructions**: Tests PI nodes created via DOM (with fallback for environments that don't support createProcessingInstruction)
- **Root-adjacent doctypes**: Tests that the doctype node correctly reports the Document as its parent via XPath

All tests follow the pattern established in the existing test and verify that the ".." XPath expression correctly returns the Document node when evaluated with these root-adjacent nodes as context.