### PR TITLE
Update the 'animation-name' tests cases using css-wide keywords

### DIFF
--- a/css/css-animations/parsing/animation-name-computed.html
+++ b/css/css-animations/parsing/animation-name-computed.html
@@ -26,23 +26,6 @@ test_computed_value("animation-name", '"something"', 'something');
 test_computed_value("animation-name", '"---\\22---"', '---\\\"---');
 test_computed_value("animation-name", '"multi word string"', 'multi\\ word\\ string');
 
-// Restricted keywords as strings
-test_computed_value("animation-name", '"none"');
-test_computed_value("animation-name", '"none", "INITIAL", "inherit"');
-test_computed_value("animation-name", '"none", both, ease-in');
-test_computed_value("animation-name", '"NoNe"');
-test_computed_value("animation-name", '"initial"');
-test_computed_value("animation-name", '"INITIAL"');
-test_computed_value("animation-name", '"inherit"');
-test_computed_value("animation-name", '"INHERIT"');
-test_computed_value("animation-name", '"revert"');
-test_computed_value("animation-name", '"REVERT"');
-test_computed_value("animation-name", '"revert-layer"');
-test_computed_value("animation-name", '"REVERT-LAYER"');
-test_computed_value("animation-name", '"unset"');
-test_computed_value("animation-name", '"UNSET"');
-test_computed_value("animation-name", '"default"');
-test_computed_value("animation-name", '"DEFAULT"');
 </script>
 </body>
 </html>

--- a/css/css-animations/parsing/animation-name-invalid.html
+++ b/css/css-animations/parsing/animation-name-invalid.html
@@ -20,6 +20,25 @@ test_invalid_value("animation-name", 'one, unset');
 test_invalid_value("animation-name", 'default, two');
 test_invalid_value("animation-name", 'revert, three');
 test_invalid_value("animation-name", 'revert-layer, four');
+
+test_invalid_value("animation-name", '""');
+
+// Restricted keywords as strings
+test_invalid_value("animation-name", '"none"');
+test_invalid_value("animation-name", '"NoNe"');
+test_invalid_value("animation-name", '"initial"');
+test_invalid_value("animation-name", '"INITIAL"');
+test_invalid_value("animation-name", '"inherit"');
+test_invalid_value("animation-name", '"INHERIT"');
+test_invalid_value("animation-name", '"revert"');
+test_invalid_value("animation-name", '"REVERT"');
+test_invalid_value("animation-name", '"revert-layer"');
+test_invalid_value("animation-name", '"REVERT-LAYER"');
+test_invalid_value("animation-name", '"unset"');
+test_invalid_value("animation-name", '"UNSET"');
+test_invalid_value("animation-name", '"default"');
+test_invalid_value("animation-name", '"DEFAULT"');
+
 </script>
 </body>
 </html>

--- a/css/css-animations/parsing/animation-name-valid.html
+++ b/css/css-animations/parsing/animation-name-valid.html
@@ -25,23 +25,6 @@ test_valid_value("animation-name", '"something"', 'something');
 test_valid_value("animation-name", '"---\\22---"', '---\\\"---');
 test_valid_value("animation-name", '"multi word string"', 'multi\\ word\\ string');
 
-// Restricted keywords as strings
-test_valid_value("animation-name", '"none"');
-test_valid_value("animation-name", '"none", "INITIAL", "inherit"');
-test_valid_value("animation-name", '"none", both, ease-in');
-test_valid_value("animation-name", '"NoNe"');
-test_valid_value("animation-name", '"initial"');
-test_valid_value("animation-name", '"INITIAL"');
-test_valid_value("animation-name", '"inherit"');
-test_valid_value("animation-name", '"INHERIT"');
-test_valid_value("animation-name", '"revert"');
-test_valid_value("animation-name", '"REVERT"');
-test_valid_value("animation-name", '"revert-layer"');
-test_valid_value("animation-name", '"REVERT-LAYER"');
-test_valid_value("animation-name", '"unset"');
-test_valid_value("animation-name", '"UNSET"');
-test_valid_value("animation-name", '"default"');
-test_valid_value("animation-name", '"DEFAULT"');
 </script>
 </body>
 </html>


### PR DESCRIPTION
Per resolution:

https://github.com/w3c/csswg-drafts/issues/2435#issuecomment-428646888

A [PR  12985](https://github.com/w3c/csswg-drafts/pull/12985) has been merged to update the spec accordingly. 

This PR updates the corresponding tests to move the css-wide and other reserved keywords to the the invalid.html test. 

Additionally, a new invalid test case for the invalid.html test has been added, based on the agreement reached in [issue 7762](https://github.com/w3c/csswg-drafts/issues/7762)