### PR TITLE
[wdspec] fix `realm_destroyed/realm_destroyed.py:test_dedicated_worker`

### DIFF
--- a/webdriver/tests/bidi/script/realm_destroyed/realm_destroyed.py
+++ b/webdriver/tests/bidi/script/realm_destroyed/realm_destroyed.py
@@ -264,7 +264,7 @@ async def test_dedicated_worker(
         REALM_DESTROYED_EVENT, on_realm_destroyed_event
     )
 
-    worker_url = inline("while(true){}", doctype="js")
+    worker_url = inline("setInterval(()=>{}, 1)", doctype="js")
     url = inline(
         f"""<script>
         const worker = new Worker('{worker_url}');


### PR DESCRIPTION
`while(true){}` in worker does not allow the worker to process `worker.terminate();` command. Replaced with `setInterval`.