### PR TITLE
Add an infrastructure reftest for devicePixelRatio

### DIFF
--- a/infrastructure/reftest/devicePixelRatio-ref.html
+++ b/infrastructure/reftest/devicePixelRatio-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<p><code>window.devicePixelRatio: <span id=dpr>1</span></code></p>

--- a/infrastructure/reftest/devicePixelRatio.html
+++ b/infrastructure/reftest/devicePixelRatio.html
@@ -1,0 +1,15 @@
+<!--
+We currently assume the devicePixelRatio is 1; however,
+this assumption may change in the future: see
+<https://github.com/web-platform-tests/rfcs/issues/220>
+
+This acts both as a pointer to that issue (comments very
+welcome!) and as a warning for those running tests in other
+configurations.
+-->
+<!doctype html>
+<link rel=match href=devicePixelRatio-ref.html>
+<p><code>window.devicePixelRatio: <span id=dpr></span></code></p>
+<script>
+document.querySelector("#dpr").textContent = window.devicePixelRatio;
+</script>


### PR DESCRIPTION
While discussions are ongoing about what the semantics should be (https://github.com/web-platform-tests/rfcs/issues/220), and thus this may change in future, let us at least test the status quo.