### PR TITLE
Use embedded_origin param to align with Permissions.set_permission

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -407,7 +407,7 @@ class WebDriverBidiPermissionsProtocolPart(BidiPermissionsProtocolPart):
     ) -> Any:
         params = {"descriptor": descriptor, "state": state, "origin": origin}
         if embedded_origin is not None:
-            params["embeddedOrigin"] = embedded_origin
+            params["embedded_origin"] = embedded_origin
 
         return await self.webdriver.bidi_session.permissions.set_permission(**params)
 


### PR DESCRIPTION
Revision to #55452: Since Permissions.set_permission accepts `embedded_origin` as a parameter, `params` in the executor should be updated to pass that, rather than `embeddedOrigin`.