### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=301008

### DIFF
--- a/html/webappapis/timers/timer-nesting-not-inherited-in-microtask.html
+++ b/html/webappapis/timers/timer-nesting-not-inherited-in-microtask.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// queue a microtask after the timer has reached the spec-defined maximum nesting level. Then we ensure
+// the new timer did not inherit the nesting level from the outer timer task by checking that the sub-4ms
+// timeout was not clamped to 4ms.
+
+test(() => {
+    assert_equals(typeof performance.now, "function");
+}, "Test requires performance.now() to measure approximate timing of callbacks.");
+
+
+let t = async_test("Test that a timer scheduled during a microtask checkpoint does not inherit the timer nesting level of the task that just ran.");
+
+var rescheduleTimeoutCalledCount = 0;
+function rescheduleTimeout()
+{
+    if (++rescheduleTimeoutCalledCount > 15)
+        return t.done();
+    else if (rescheduleTimeoutCalledCount > 5) {
+        queueMicrotask(() => {
+            const checkNotNestedScheduledAt = performance.now();
+            setTimeout(() => {
+                const approximateDelay = performance.now() - checkNotNestedScheduledAt;
+                t.step(() => assert_less_than(approximateDelay, 4, "Timer should not be clamped to 4ms"));
+            }, 1);
+        });
+    }
+    setTimeout(rescheduleTimeout, 8);
+}
+
+window.addEventListener("load", () => setTimeout(rescheduleTimeout, 8));
+</script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [DOM timers installed during a microtask checkpoint should not inherit DOM timer nesting level from the task scope.](https://bugs.webkit.org/show_bug.cgi?id=301008)