### PR TITLE
Fix largest-contentful-paint/image-upscaling.html to use test_driver.…

### DIFF
--- a/largest-contentful-paint/image-upscaling.html
+++ b/largest-contentful-paint/image-upscaling.html
@@ -5,6 +5,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/largest-contentful-paint-helpers.js"></script>
   <script src="/common/utils.js"></script>
   <script>

--- a/largest-contentful-paint/image-upscaling.html
+++ b/largest-contentful-paint/image-upscaling.html
@@ -4,6 +4,7 @@
 <body>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
   <script src="resources/largest-contentful-paint-helpers.js"></script>
   <script src="/common/utils.js"></script>
   <script>
@@ -12,8 +13,12 @@
     const imageURL = `${window.location.origin}/images/blue.png`;
 
     async function load_image_and_get_lcp_size(t, imageStyle = {}, containerStyle = {}) {
-      const popup = window.open();
-      t.add_cleanup(() => popup.close());
+      let popup;
+      await test_driver.bless('Open a popup', () => {
+        popup = window.open();
+        t.add_cleanup(() => popup.close());
+      });
+
       const image = popup.document.createElement('img');
       image.src = imageURL;
 


### PR DESCRIPTION
…bless for opening the popup

This test opens popup windows, which may be blocked by the UA. To avoid blocking, wrap the window.open in a test_driver.bless.

Addresses https://github.com/web-platform-tests/interop/issues/1211