### PR TITLE
fix http cache reconstruct response from cache after validation behaviour

### DIFF
--- a/fetch/range/cache-revalidate-construct-range-response.html
+++ b/fetch/range/cache-revalidate-construct-range-response.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+function cache_revalidation_test(expect, label) {
+    promise_test(async t => {
+        const url = new URL('resources/video-with-aged-proxy-cache.py', location.href);
+        const response_1 = await fetch(url.toString());
+        assert_equals(response_1.status, 200, 'Initial fetch should succeed with 200');
+        const response_1_blob = await response_1.blob();
+        assert_equals(response_1_blob.size, 80666, 'Initial fetch should get full content');
+        const response_2 = await fetch(url.toString(), {
+            headers: {'Range': 'bytes=0-99'}
+        });
+        assert_equals(response_2.status, 206, 'Range fetch after cache revalidation should succeed with 206');
+        const response_2_blob = await response_2.blob();
+        assert_equals(response_2_blob.size, 100, 'Range fetch after cache revalidation should get partial content');
+    }, `${label} should ${expect === 'ok' ? 'succeed' : 'fail'}`);
+}
+
+cache_revalidation_test('ok', 'Range request after cache revalidation with 200 OK response');
+</script>
+</body>

--- a/fetch/range/cache-revalidate-construct-range-response.html
+++ b/fetch/range/cache-revalidate-construct-range-response.html
@@ -4,22 +4,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
-function cache_revalidation_test(expect, label) {
-    promise_test(async t => {
-        const url = new URL('resources/video-with-aged-proxy-cache.py', location.href);
-        const response_1 = await fetch(url.toString());
-        assert_equals(response_1.status, 200, 'Initial fetch should succeed with 200');
-        const response_1_blob = await response_1.blob();
-        assert_equals(response_1_blob.size, 80666, 'Initial fetch should get full content');
-        const response_2 = await fetch(url.toString(), {
-            headers: {'Range': 'bytes=0-99'}
-        });
-        assert_equals(response_2.status, 206, 'Range fetch after cache revalidation should succeed with 206');
-        const response_2_blob = await response_2.blob();
-        assert_equals(response_2_blob.size, 100, 'Range fetch after cache revalidation should get partial content');
-    }, `${label} should ${expect === 'ok' ? 'succeed' : 'fail'}`);
-}
 
-cache_revalidation_test('ok', 'Range request after cache revalidation with 200 OK response');
+promise_test(async t => {
+    const url = new URL('resources/video-with-aged-proxy-cache.py', location.href);
+    const response_1 = await fetch(url.toString());
+    assert_equals(response_1.status, 200, 'Initial fetch should succeed with 200');
+    const response_1_blob = await response_1.blob();
+    assert_equals(response_1_blob.size, 80666, 'Initial fetch should get full content');
+    const response_2 = await fetch(url.toString(), {
+        headers: {'Range': 'bytes=0-99'}
+    });
+    const response_2_blob = await response_2.blob();
+    assert_equals(response_2.status, 206, 'Range fetch after cache revalidation should succeed with 206');
+    assert_equals(response_2_blob.size, 100, 'Range fetch after cache revalidation should get partial content');
+}, `Range request after cache revalidation with 200 OK response should succeed`);
+
 </script>
 </body>

--- a/fetch/range/resources/video-with-aged-proxy-cache.py
+++ b/fetch/range/resources/video-with-aged-proxy-cache.py
@@ -1,0 +1,48 @@
+import re
+import os
+import json
+from wptserve.utils import isomorphic_decode
+
+ENTITY_TAG = b'"sine440-v1"'
+# There should be two requests made to this resource:
+# 1. A request fetch the whole video. This request should receive a
+#    200 Success response with a aged header of value more
+#    than 24 hours in the past, simulating an aged proxy cache.
+# 2. A subsequent request with a Range header to revalidate the cached content.
+#    This request should include an If-Modified-Since / If-Not-Match header
+#    and should response with a 304 Not Modified response.
+
+def main(request, response):
+    path = os.path.join(request.doc_root, u"media", "sine440.mp3")
+    total_size = os.path.getsize(path)
+
+    if_modified_since = request.headers.get(b'If-Modified-Since')
+    if_none_match = request.headers.get(b'If-Not-Match')
+
+    if(if_modified_since or if_none_match):
+        response.status = 304
+        status = 304
+        start = 0
+        end = 0
+    else:
+        response.status = 200
+        status = 200
+        start = 0
+        end = total_size
+
+    start = int(start or 0)
+    end = int(end or total_size)
+    headers = []
+    if status == 200:
+        headers.append((b"Age", b"86400"))
+        headers.append((b"Last-Modified", b"Wed, 21 Oct 2015 07:28:00 GMT"))
+        headers.append((b"ETag", ENTITY_TAG))
+        video_file = open(path, "rb")
+        video_file.seek(start)
+        content = video_file.read(end)
+    else:
+        content = b""
+    headers.append((b"Content-Length", str(end - start)))
+    headers.append((b"Content-Type", b"audio/mp3"))
+
+    return status, headers, content

--- a/fetch/range/resources/video-with-aged-proxy-cache.py
+++ b/fetch/range/resources/video-with-aged-proxy-cache.py
@@ -8,38 +8,54 @@ ENTITY_TAG = b'"sine440-v1"'
 # 1. A request fetch the whole video. This request should receive a
 #    200 Success response with a aged header of value more
 #    than 24 hours in the past, simulating an aged proxy cache.
-# 2. A subsequent request with a Range header to revalidate the cached content.
+# 2.a A subsequent request with a Range header to revalidate the cached content.
 #    This request should include an If-Modified-Since / If-Not-Match header
 #    and should response with a 304 Not Modified response.
+# 2.b A subsequent request with a Range header to fetch a range of the video.
+#    But without Http-Cache revalidation related header.
+#    This request should receive a 206 Partial Content response with the
+#    requested range of the video.
 
 def main(request, response):
     path = os.path.join(request.doc_root, u"media", "sine440.mp3")
     total_size = os.path.getsize(path)
-
     if_modified_since = request.headers.get(b'If-Modified-Since')
     if_none_match = request.headers.get(b'If-Not-Match')
+    range_header = request.headers.get(b'Range')
+    range_header_match = range_header and re.search(r'^bytes=(\d*)-(\d*)$', isomorphic_decode(range_header))
 
-    if(if_modified_since or if_none_match):
-        response.status = 304
+    if range_header_match:
+        start, end = range_header_match.groups()
+        start = int(start or 0)
+        end = int(end or total_size)
+        status = 206
+    elif if_modified_since or if_none_match:
         status = 304
         start = 0
         end = 0
     else:
-        response.status = 200
         status = 200
         start = 0
         end = total_size
 
-    start = int(start or 0)
-    end = int(end or total_size)
+    response.status = status
     headers = []
     if status == 200:
         headers.append((b"Age", b"86400"))
+        headers.append((b"Expires", b"Wed, 21 Oct 2015 07:28:00 GMT"))
         headers.append((b"Last-Modified", b"Wed, 21 Oct 2015 07:28:00 GMT"))
         headers.append((b"ETag", ENTITY_TAG))
         video_file = open(path, "rb")
         video_file.seek(start)
         content = video_file.read(end)
+    elif status == 206:
+        headers.append((b"Content-Range", b"bytes %d-%d/%d" % (start, end, total_size)))
+        headers.append((b"Accept-Ranges", b"bytes"))
+        headers.append((b"ETag", ENTITY_TAG))
+        video_file = open(path, "rb")
+        video_file.seek(start)
+        end = min(end+1, total_size)
+        content = video_file.read(end-start)
     else:
         content = b""
     headers.append((b"Content-Length", str(end - start)))


### PR DESCRIPTION
In the scenario of constructing response from cache resources after successful validation of expired cache resouce, Instead of just copying full body of the cached_resource,  check if range header exist in request, if so reuse handle_range_request function to construct response.

Testing: Should past the manual test case in Issue https://github.com/servo/servo/issues/40050
Fixes: https://github.com/servo/servo/issues/40050

Reviewed in servo/servo#40067