### PR TITLE
WPTs for CSS Linked Parameters

### DIFF
--- a/svg/styling/css-linked-parameters/circle-green-ref.html
+++ b/svg/styling/css-linked-parameters/circle-green-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="green" stroke-width="2"/>
+</svg>

--- a/svg/styling/css-linked-parameters/circle-green-with-stroke-ref.html
+++ b/svg/styling/css-linked-parameters/circle-green-with-stroke-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="green" stroke-width="2" stroke="blue"/>
+</svg>

--- a/svg/styling/css-linked-parameters/circle-green.svg
+++ b/svg/styling/css-linked-parameters/circle-green.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="green"/>
+</svg>

--- a/svg/styling/css-linked-parameters/circle-green.svg
+++ b/svg/styling/css-linked-parameters/circle-green.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
-  <circle cx="50" cy="50" r="48" fill="green"/>
-</svg>

--- a/svg/styling/css-linked-parameters/circle-with-parameters.svg
+++ b/svg/styling/css-linked-parameters/circle-with-parameters.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="param(--color, black)" stroke="param(--stroke)" stroke-width="2"/>
+</svg>

--- a/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html
+++ b/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - URL fragment takes precedence over link-parameters property</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#setting">
+<link rel="match" href="circle-green-ref.html"/>
+<style>
+  img {
+  link-parameters: param(--color, red);
+  }
+</style>
+
+<img src="circle-with-parameters.svg#param(--color, green)">

--- a/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html
+++ b/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - url function with modifier take precedence over URL fragment identifier</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#setting">
+<link rel="match" href="circle-green-ref.html"/>
+<style>
+  .image-with-params {
+  width:100px;
+  height:100px;
+  background-image: url("circle-with-parameters.svg#param(--color,red)" param(--color, green));
+  }
+</style>
+<div class="image-with-params"></div>

--- a/svg/styling/css-linked-parameters/img-with-linked-parameters-1.html
+++ b/svg/styling/css-linked-parameters/img-with-linked-parameters-1.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - img element with link-parameters property</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#link-param-prop">
+<link rel="match" href="circle-green-ref.html"/>
+<style>
+  img {
+  link-parameters: param(--color, green);
+  }
+</style>
+
+<img src="circle-with-parameters.svg">

--- a/svg/styling/css-linked-parameters/img-with-linked-parameters-2.html
+++ b/svg/styling/css-linked-parameters/img-with-linked-parameters-2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - img element with multiple link-parameters</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#link-param-prop">
+<link rel="match" href="circle-green-with-stroke-ref.html"/>
+<style>
+  img {
+  link-parameters: param(--color, green), param(--stroke, blue);
+  }
+</style>
+
+<img src="circle-with-parameters.svg">

--- a/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html
+++ b/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - img element with url fragment identifier</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
+<link rel="match" href="circle-green-ref.html"/>
+<img src="circle-with-parameters.svg#param(--color, green)">

--- a/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html
+++ b/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - img element with multiple url fragment identifiers</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
+<link rel="match" href="circle-green-with-stroke-ref.html"/>
+<img src="circle-with-parameters.svg#param(--color, green), param(--stroke, blue)">

--- a/svg/styling/css-linked-parameters/img-with-url-function-1.html
+++ b/svg/styling/css-linked-parameters/img-with-url-function-1.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - img element with url function and url modifier</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#setting-url">
+<link rel="help" href="https://www.w3.org/TR/css-values/#url-values"/>
+<link rel="match" href="circle-green-ref.html"/>
+<style>
+  .image-with-params {
+  width:100px;
+  height:100px;
+  background-image: url("circle-with-parameters.svg" param(--color, green));
+  }
+</style>
+<div class="image-with-params"></div>

--- a/svg/styling/css-linked-parameters/img-with-url-function-2.html
+++ b/svg/styling/css-linked-parameters/img-with-url-function-2.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - img element with url function and multiple url modifiers</title>
+<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#setting-url">
+<link rel="help" href="https://www.w3.org/TR/css-values/#url-values"/>
+<link rel="match" href="circle-green-with-stroke-ref.html"/>
+<style>
+  .image-with-params {
+  width:100px;
+  height:100px;
+  background-image: url("circle-with-parameters.svg" param(--color, green) param(--stroke, blue));
+  }
+</style>
+<div class="image-with-params"></div>


### PR DESCRIPTION
[CSS Linked Parameters spec](https://drafts.csswg.org/css-link-params/) introduces a way to pass CSS values into linked resources, such as SVG images, so that they can be used as CSS custom environment variables in the destination resource. This allows easy reuse of "templated" SVG images, which can be adapted to a site’s theme color, etc. easily, without having to modify the source SVG.

This PR contains WPTs per the functionality in the specification.

This spec/implementation is currently not supported in any of the browsers so all the WPTs are expected to fail initially.