### PR TITLE
Add cleanup so that lone pointerdown events do get a pointerup

### DIFF
--- a/event-timing/interactionid-aux-pointerdown-and-pointerdown.html
+++ b/event-timing/interactionid-aux-pointerdown-and-pointerdown.html
@@ -21,6 +21,10 @@
   // pointerdown entry with a valid/non-trivial interactionId.
   promise_test(async t => {
     assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    // Workaround https://bugs.webkit.org/show_bug.cgi?id=213060, which causes
+    // WebKit-based browsers to never release the pointerdown, breaking
+    // subsequent tests.
+    t.add_cleanup(() => orphanAuxPointerup(document.getElementById('target')).catch(() => {}));
     // This test is not applicable to platforms like Windows where contextmenu
     // is triggered on aux pointerup. So we do a platform behavior test first to
     // distinguish and skip those platforms who do not dispatch contextmenu on

--- a/event-timing/interactionid-aux-pointerdown.html
+++ b/event-timing/interactionid-aux-pointerdown.html
@@ -21,6 +21,10 @@
   // pointerdown entry with a valid/non-trivial interactionId.
   promise_test(async t => {
     assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    // Workaround https://bugs.webkit.org/show_bug.cgi?id=213060, which causes
+    // WebKit-based browsers to never release the pointerdown, breaking
+    // subsequent tests.
+    t.add_cleanup(() => orphanAuxPointerup(document.getElementById('target')).catch(() => {}));
     // This test is not applicable to platforms like Windows where contextmenu
     // is triggered on aux pointerup. So we do a platform behavior test first to
     // distinguish and skip those platforms who do not dispatch contextmenu on

--- a/event-timing/resources/event-timing-test-utils.js
+++ b/event-timing/resources/event-timing-test-utils.js
@@ -381,6 +381,20 @@ async function auxPointerdown(target) {
     .send();
 }
 
+async function orphanAuxPointerup(target) {
+  const actions = new test_driver.Actions();
+  await actions.addPointer("mousePointer", "mouse")
+    .pointerMove(0, 0, { origin: target })
+    .pointerUp({ button: actions.ButtonType.RIGHT })
+    .send();
+
+  // Orphan pointerup doesn't get triggered in some browsers. Sending a
+  // non-pointer related event to make sure that at least an event gets handled.
+  // If a browsers sends an orphan pointerup, it will always be before the
+  // keydown, so the test will correctly handle it.
+  await pressKey(target, 'a');
+}
+
 // The testdriver.js, testdriver-vendor.js need to be included to use this
 // function.
 async function pressKey(target, key) {


### PR DESCRIPTION
This is a workaround for https://bugs.webkit.org/show_bug.cgi?id=213060, a long-standing WebKit bug affecting the WebDriver Release Actions command.

Fixing this will cause `/event-timing/toJSON.html` to progress in STP as a result of the `click` event it triggers now succeeding.

We have pre-existing coverage of the bug this was showing up in: https://github.com/web-platform-tests/wpt/blob/9a168da399005cfc990ccb957c381d4f731027c9/webdriver/tests/classic/perform_actions/pointer_contextmenu.py#L50 

And that subtest does [duly fail](https://wpt.fyi/results/webdriver/tests/classic/perform_actions/pointer_contextmenu.py?q=subtest%3Atest_release_control_click&run_id=5166491013218304&run_id=5195040633913344&run_id=4890863600926720&run_id=5070158218657792&run_id=5085155976019968&run_id=5173836749471744) in the WebKit-based browsers we have on wpt.fyi.
