### PR TITLE
[Navigation API] navigate-replace-same-document.html is written in a way that doesn't catch exceptions

### DIFF
--- a/navigation-api/navigation-methods/navigate-replace-same-document.html
+++ b/navigation-api/navigation-methods/navigate-replace-same-document.html
@@ -2,21 +2,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-async_test(t => {
+promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  window.onload = () => t.step_timeout(t.step_func_done(async () => {
-    let start_length = navigation.entries().length;
-    let start_history_length = history.length;
-    let key1 = navigation.currentEntry.key;
-    await navigation.navigate("#1").committed;
-    let key2 = navigation.currentEntry.key;
-    assert_not_equals(key1, key2);
-    await navigation.navigate("#2", { history: "replace" }).committed;
-    let key3 = navigation.currentEntry.key;
-    assert_equals(key2, key3);
-    assert_equals(navigation.entries().length, start_length + 1);
-    assert_equals(history.length, start_history_length + 1);
-  }), 0);
+  await new Promise(resolve => window.onload = resolve);
+  await new Promise(resolve => t.step_timeout(resolve, 0));
+
+  let start_length = navigation.entries().length;
+  let start_history_length = history.length;
+  let key1 = navigation.currentEntry.key;
+  await navigation.navigate("#1").committed;
+  let key2 = navigation.currentEntry.key;
+  assert_not_equals(key1, key2);
+  await navigation.navigate("#2", { history: "replace" }).committed;
+  let key3 = navigation.currentEntry.key;
+  assert_equals(key2, key3);
+  assert_equals(navigation.entries().length, start_length + 1);
+  assert_equals(history.length, start_history_length + 1);
 }, "navigate() with history: 'replace' option");
 </script>


### PR DESCRIPTION
This test is written in a way such that the harness does not catch the exception.
Currently, WebKit hits one of the asserts in the test, but the test still passes
because the harness isn't catching the exception. We rewrite the test in a way
that allows the exception to be caught and the test to fail properly.