### PR TITLE
Adjust `infrastructure/testdriver/` expectations for `chrome`

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_gatt_disconnection.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_gatt_disconnection.https.html.ini
@@ -1,3 +1,4 @@
 [simulate_gatt_disconnection.https.html]
   expected:
     if product != "chrome": ERROR
+    [OK, ERROR]

--- a/infrastructure/metadata/infrastructure/testdriver/click_nested.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_nested.html.ini
@@ -1,0 +1,3 @@
+[click_nested.html]
+  expected:
+    if product == "chrome": [OK, TIMEOUT]

--- a/infrastructure/metadata/infrastructure/testdriver/click_nested_crossorigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_nested_crossorigin.sub.html.ini
@@ -1,0 +1,3 @@
+[click_nested_crossorigin.sub.html]
+  expected:
+    if product == "chrome": [OK, TIMEOUT]


### PR DESCRIPTION
Some intermittent `TIMEOUT`s and `ERROR`s seen in:
* https://github.com/web-platform-tests/wpt/pull/55583/checks?check_run_id=53610817621
* https://github.com/web-platform-tests/wpt/pull/55552/checks?check_run_id=53223525409