### PR TITLE
Add link to latest results on wpt.fyi

### DIFF
--- a/.github/workflows/wpt_fyi_notify.yml
+++ b/.github/workflows/wpt_fyi_notify.yml
@@ -41,3 +41,18 @@ jobs:
                   toJSON(github.event.repository.name),
                   toJSON(inputs.artifact-name)
             ) }}
+      - name: "Search for existing WPT comment"
+        uses: peter-evans/find-comment@v3
+        id: findcomment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Latest results on wpt.fyi
+
+      - name: "Post latest results on WPT comment"
+        if: steps.findcomment.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            [Latest results on wpt.fyi](https://wpt.fyi/results/?label=pr_head&max-count=1&pr=${{ github.event.pull_request.number }})


### PR DESCRIPTION
I often end up clicking through multiple GitHub jobs to find the exact notation for finding the labels on wpt.fyi to see the latest results on my PRs. To make that more convenient, we can post a comment with that link whenever wpt.fyi is notified, but only do it once if such a comment does not exist.