### PR TITLE
wpt: avoid checking if worker is instanceof SharedWorker in abrupt-completion.html

### DIFF
--- a/workers/abrupt-completion.html
+++ b/workers/abrupt-completion.html
@@ -34,10 +34,10 @@ async function testWorker(worker) {
       resolve();
     };
 
-    if (worker instanceof SharedWorker) {
-      worker.port.postMessage("", [channel.port2]);
-    } else {
+    if ('onmessage' in worker) { // dedicated worker
       worker.postMessage("", [channel.port2]);
+    } else { // shared worker
+      worker.port.postMessage("", [channel.port2]);
     }
   });
 }


### PR DESCRIPTION
Since we don't implement SharedWorker this tests ended up failing also for the dedicate worker case, with this patch we resort to checking the existence of the onmessage property, making sure that we actually pass this test.

Testing: a new test pass for worker

Reviewed in servo/servo#40208