### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=299951

### DIFF
--- a/css/css-scoping/slotted-text-with-flex-ref.html
+++ b/css/css-scoping/slotted-text-with-flex-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    .content {
+        border: 2px solid blue;
+        display: flex;
+    }
+</style>
+<div id="test">
+    <div class="content">
+        This should be visible.
+        <div>This too.</div>
+    </div>
+</div>

--- a/css/css-scoping/slotted-text-with-flex.html
+++ b/css/css-scoping/slotted-text-with-flex.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Test dynamic updates with text slotted into flexbox</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/">
+<div id="test">
+    <template shadowrootmode=open>
+        <style>
+            .content {
+                border: 2px solid blue;
+                display: flex;
+            }
+        </style>
+        <div class="content">
+            <slot></slot>
+            <div id="toggle">This too.</div>
+        </div>
+    </template>
+    This should be visible.
+</div>
+
+<script>
+document.body.offsetLeft;
+const toggle = test.shadowRoot.querySelector("#toggle");
+toggle.style.display = "none";
+document.body.offsetLeft;
+toggle.style.display = "block";
+</script>


### PR DESCRIPTION
WebKit export from bug: [Slotted Text Nodes get hidden when elements next to the slot change display](https://bugs.webkit.org/show_bug.cgi?id=299951)