### PR TITLE
Use "switch_to_parent_frame" instead "switch_frame("parent")"

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -793,7 +793,7 @@ class WebDriverTestDriverProtocolPart(TestDriverProtocolPart):
             raise ValueError from e
 
     def _switch_to_parent_frame(self):
-        self.webdriver.switch_frame("parent")
+        self.webdriver.switch_to_parent_frame()
 
 
 class WebDriverGenerateTestReportProtocolPart(GenerateTestReportProtocolPart):


### PR DESCRIPTION
An option to `switch_frame` method of webdriver client with `parent` argument was removed in https://github.com/web-platform-tests/wpt/pull/55594. But we still have one place where we use it, we have to update it to use new `switch_to_parent_frame` method.