### PR TITLE
Remove --max-restarts from Safari

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -115,7 +115,6 @@ jobs:
             --log-mach-level info \
             --channel ${{ inputs.safari-technology-preview && 'preview' || 'stable' }} \
             --kill-safari \
-            --max-restarts 100 \
             ${{ inputs.extra-options }} \
             -- \
             safari


### PR DESCRIPTION
This was added in 9c29a68172, but the underlying issue it was working around was fixed well over a year ago.
