### PR TITLE
Fix mutable default argument in do_print function

### DIFF
--- a/webdriver/tests/classic/print/__init__.py
+++ b/webdriver/tests/classic/print/__init__.py
@@ -1,4 +1,5 @@
-def do_print(session, options={}):
+def do_print(session, options=None):
+    options = options or {}
     params = {}
 
     if options.get("background", None) is not None:


### PR DESCRIPTION
Based on https://github.com/web-platform-tests/wpt/pull/55524 which was closed for some reason and we didn't get a reply.

We need to fix that to prevent side-effects for printing tests in WebDriver classic when options were passed in and then be kept for further invocations.