### PR TITLE
fix(docs): replace outdated w3c-test.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Publication
 ===========
 
 The master branch is automatically synced to [wpt.live](https://wpt.live/) and
-[w3c-test.org](https://w3c-test.org/).
+[web-platform-tests.org](https://web-platform-tests.org/).
+
 
 Contributing
 ============

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -39,7 +39,7 @@ explicitly-managed secret.
 
 - (unknown registrar): https://web-platform-tests.org
   - jgraham@hoppipolla.co.uk
-- (unknown registrar): https://w3c-test.org
+- (unknown registrar): https://web-platform-tests.org
   - mike@w3.org
 - (unknown registrar): http://testthewebforward.org
   - web-human@w3.org

--- a/docs/running-tests/from-web.md
+++ b/docs/running-tests/from-web.md
@@ -1,7 +1,7 @@
 # Running Tests from the Web
 
 Tests that have been merged on GitHub are mirrored at
-[wpt.live](https://wpt.live) and [w3c-test.org](https://w3c-test.org).
+[wpt.live](https://wpt.live) and [web-platform-tests.org](https://web-platform-tests.org).
 [On properly-configured systems](from-local-system), local files may also be
 served from the URL [http://web-platform.test](http://web-platform.test).
 

--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -27,7 +27,7 @@
         <code>./wpt run</code> is a more well-supported runner, see the documentation on
         <a href="https://web-platform-tests.org/running-tests/">running tests</a>.
         <script>
-        if (location.host == "w3c-test.org") {
+        if (location.host == "web-platform-tests.org") {
             document.getElementById("runner-contact-info")
                 .innerHTML = ' If this runner isn’t working, contact'
                     + ' <a href="mailto:mike@w3.org">mike@w3.org</a>. '
@@ -114,26 +114,26 @@
     <ul>
       <li><code>/</code> - runs all of the tests from the root down</li>
       <li><code>/websockets</code> - runs all of the
-          <a href="http://w3c-test.org/websockets/">websockets</a> tests</li>
+          <a href="http://web-platform-tests.org/websockets/">websockets</a> tests</li>
       <li><code>/websockets/constructor</code> - runs all of the
-          <a href="http://w3c-test.org/websockets/constructor/">websockets/constructor</a> tests</li>
+          <a href="http://web-platform-tests.org/websockets/constructor/">websockets/constructor</a> tests</li>
       <li><code>/html/syntax/parsing</code> - runs all of the
-          <a href="http://w3c-test.org/html/syntax/parsing/">html/syntax/parsing</a> tests</li>
+          <a href="http://web-platform-tests.org/html/syntax/parsing/">html/syntax/parsing</a> tests</li>
     </ul>
     <p>
       Multiple test paths can be specified by separating them with comma or whitespace. For example,
-      <code>/js, /html</code> will run the <a href="http://w3c-test.org/js/">js</a> <em>and</em> <a href="http://w3c-test.org/html/">html</a>
+      <code>/js, /html</code> will run the <a href="http://web-platform-tests.org/js/">js</a> <em>and</em> <a href="http://w3c-test.org/html/">html</a>
       tests.
     </p>
     <p>
       <a href="http://www.w3schools.com/jsref/jsref_obj_regexp.asp" target="_blank">Javascript regular expressions</a> are also supported for filtering. When the option is checked,
       only a test path matching the regex pattern will run. For example, you can specify <code>^/js/|^/html/</code>
-      to run the <a href="http://w3c-test.org/js/">js</a> <em>and</em> <a href="http://w3c-test.org/html/">html</a>
+      to run the <a href="http://web-platform-tests.org/js/">js</a> <em>and</em> <a href="http://w3c-test.org/html/">html</a>
       tests.
     </p>
     <p>
       If the test runner is run online, the set of tests available to run can be found in the
-      <a href="http://w3c-test.org/">w3c-test.org</a> test repository.
+      <a href="http://web-platform-tests.org/">web-platform-tests.org</a> test repository.
     </p>
     <p>
       Tests will run in a new window. For reftests and manual tests it’s best

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -239,9 +239,9 @@ def write_results(log, results, iterations, pr_number=None, use_details=False):
                                                   else "test"))
 
     for test_name, test in results.items():
-        baseurl = "http://w3c-test.org/submissions"
+        baseurl = "baseurl = https://web-platform-tests.org/submissions"
         if "https" in os.path.splitext(test_name)[0].split(".")[1:]:
-            baseurl = "https://w3c-test.org/submissions"
+            baseurl = "baseurl = https://web-platform-tests.org/submissions"
         title = test_name
         if use_details:
             log("<details>\n")


### PR DESCRIPTION
This PR replaces old references to w3c-test.org with the correct domain web-platform-tests.org.
