### PR TITLE
script: Don't unregister slots from their shadow root when the whole shadow tree is being unbound

### DIFF
--- a/shadow-dom/assign-slottables-after-removing-shadow-tree-from-document.html
+++ b/shadow-dom/assign-slottables-after-removing-shadow-tree-from-document.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+    <title>Slottables should match slots when the shadow host is removed from the document</title>
+    <meta name="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+    <meta name="assert" content="Slottables should be assigned to slots even after the shadow host has been removed from the document">
+    <link rel="help" href="https://github.com/servo/servo/issues/40242">
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script defer>
+      test((t) => {
+        // Attach a shadow root with a slot named "foo" inside it
+        let host = document.createElement("div");
+        document.body.appendChild(host);
+        let root = host.attachShadow({mode: "closed"});
+        let slot = document.createElement("slot");
+        slot.name = "foo";
+        root.appendChild(slot);
+
+        // Remove the host from the document tree
+        host.remove();
+        assert_array_equals(slot.assignedNodes(), []);
+
+        // Create a slottable that should be slotted into "foo"
+        let slottable = document.createElement("div");
+        slottable.slot = "foo"
+        host.appendChild(slottable);
+        assert_array_equals(slot.assignedNodes(), [slottable]);
+      }, "Slottables should be assigned to slots even after the shadow host has been removed from the document");
+    </script>
+</body>


### PR DESCRIPTION
Each shadow root holds a map of slot names to slot elements. Slot elements dynamically register and unregister themselves at their respective shadow root when they are bound and unbound from the tree.

Previously, they were doing this too often. When a slot element is unbound from the tree then it might still be connected to its shadow root, in case the entire shadow tree is being unbound.

Fixing this requires the slot element to know whether it was in a shadow tree prior to `bind_to_tree` being called (then it's already registered and doesn't need to do so again), and whether it will be in a shadow tree after `unbind_from_tree` is called (then there's no need to unregister).

Testing: This change adds a new web platform test
Fixes: https://github.com/servo/servo/issues/40242

Reviewed in servo/servo#40278