### PR TITLE
Add test for overconstrained sticky view rectangle

### DIFF
--- a/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html
+++ b/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>position:sticky elements with width larger than the space available between left and right</title>
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that the end edge is adjusted when the sticky view rectangle width ends up smaller than the width of the sticky element border box" />
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+.scroller {
+  width: 100px;
+  height: 100px;
+  overflow: auto;
+  position: relative;
+  display: flex;
+}
+.padding {
+  width: 200px;
+  height: 100px;
+  flex: none;
+}
+.sticky {
+  position: sticky;
+  background: green;
+  left: 20px;
+  right: 0;
+  width: 200px;
+  height: 100px;
+  flex: none;
+}
+</style>
+
+<body>
+  <div class="scroller">
+    <div class="padding"></div>
+    <div class="sticky"></div>
+    <div class="padding"></div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 0;
+  assert_equals(element.offsetLeft, 20);
+}, 'start of scroll container');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 160;
+    assert_equals(element.offsetLeft, 180);
+}, 'right before the in-flow position of the sticky box');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 220;
+    assert_equals(element.offsetLeft, 240);
+}, 'right after the in-flow position the sticky box');
+
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 500;
+  assert_equals(element.offsetLeft, 400);
+}, 'end of scroll container');
+</script>

--- a/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html
+++ b/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>position:sticky elements with height larger than the space available between top and bottom</title>
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that the end edge is adjusted when the sticky view rectangle height ends up smaller than the height of the sticky element border box" />
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+.scroller {
+  height: 100px;
+  overflow: auto;
+  position: relative;
+}
+.padding {
+  height: 200px;
+}
+.sticky {
+  position: sticky;
+  background: green;
+  top: 20px;
+  bottom: 0;
+  height: 200px;
+}
+</style>
+
+<body>
+  <div class="scroller">
+    <div class="padding"></div>
+    <div class="sticky"></div>
+    <div class="padding"></div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollTop = 0;
+  assert_equals(element.offsetTop, 20);
+}, 'start of scroll container');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollTop = 160;
+    assert_equals(element.offsetTop, 180);
+}, 'right before the in-flow position of the sticky box');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollTop = 220;
+    assert_equals(element.offsetTop, 240);
+}, 'right after the in-flow position the sticky box');
+
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollTop = 500;
+  assert_equals(element.offsetTop, 400);
+}, 'end of scroll container');
+</script>


### PR DESCRIPTION
There seems to be no tests for when the border box of the sticky element is taller than the initial sticky view rectangle. 

In that case
> the effective [end](https://www.w3.org/TR/css-writing-modes-4/#end)-edge inset in the affected axis is reduced (possibly becoming negative) to bring the sticky view rectangle’s size up to the size of the border box in that axis

https://www.w3.org/TR/css-position-3/#sticky-pos