### PR TITLE
[CSS Zoom] Fix container-queries-block-size.html reference

### DIFF
--- a/css/css-viewport/zoom/reference/container-queries-block-size-ref.html
+++ b/css/css-viewport/zoom/reference/container-queries-block-size-ref.html
@@ -4,7 +4,7 @@
   .container {
     container-type: size;
     width: 100px;
-    height: 100px;
+    height: 200px;
     writing-mode: vertical-lr;
   }
   .child {


### PR DESCRIPTION
There was a mismatch with the -expected.html file from https://commits.webkit.org/301639@main