### PR TITLE
Fix navigate-anchor-cross-origin.html so it properly runs with Web…

### DIFF
--- a/navigation-api/navigate-event/navigate-anchor-cross-origin.html
+++ b/navigation-api/navigate-event/navigate-anchor-cross-origin.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<a id="a" href="https://does-not-exist/foo.html"></a>
+<script src="/common/get-host-info.sub.js"></script>
+<a id="a"></a>
 <script>
 async_test(t => {
   navigation.onnavigate = t.step_func_done(e => {
@@ -12,7 +13,7 @@ async_test(t => {
     assert_false(e.hashChange);
     assert_equals(e.formData, null);
     assert_equals(e.downloadRequest, null);
-    assert_equals(e.destination.url, "https://does-not-exist/foo.html");
+    assert_equals(e.destination.url, a.href);
     assert_false(e.destination.sameDocument);
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
@@ -20,6 +21,7 @@ async_test(t => {
     assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
   });
+  a.href = get_host_info().HTTPS_REMOTE_ORIGIN + "/does-not-exist.html";
   a.click();
 }, "<a> cross-origin navigate event");
 </script>


### PR DESCRIPTION
…Kit infrastructure

The WebKit infrastructure rejects all non-local loads in tests. This test was trying to load "https://does-not-exist/foo.html", which is not local.

Since the test simply wants to load a cross-origin URL, I am updating the test to load `get_host_info().HTTPS_REMOTE_ORIGIN + "/does-not-exist.html"` which is cross-origin and does not exist. It should not change the behavior of the test.

This is upstreaming from WebKit https://github.com/WebKit/WebKit/pull/53320.