### PR TITLE
Refactor: Replace openid4vp with the latest canonical protocol strings in digital credentials WPTs

### DIFF
--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -1,4 +1,4 @@
-export type GetProtocol = "default" | "openid4vp";
+export type GetProtocol = "default" | "openid4vp-v1-unsigned";
 export type CreateProtocol = "default" | "openid4vci";
 
 export type CredentialMediationRequirement =

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -1,4 +1,4 @@
-export type GetProtocol = "default" | "openid4vp-v1-unsigned" | "openid4vp-v1-signed";
+export type GetProtocol = "default" | "openid4vp-v1-unsigned" | "openid4vp-v1-signed" | "openid4vp-v1-multisigned";
 export type CreateProtocol = "default" | "openid4vci";
 
 export type CredentialMediationRequirement =

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -1,4 +1,4 @@
-export type GetProtocol = "default" | "openid4vp-v1-unsigned";
+export type GetProtocol = "default" | "openid4vp-v1-unsigned" | "openid4vp-v1-signed";
 export type CreateProtocol = "default" | "openid4vci";
 
 export type CredentialMediationRequirement =

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -225,7 +225,7 @@
       abort: "after",
       action: "get",
       needsActivation: true,
-      options: makeGetOptions("openid4vp-v1-unsigned"),
+      options: makeGetOptions("openid4vp-v1-signed"),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -36,7 +36,7 @@
           requests: [
             {
               data,
-              protocol: "openid4vp",
+              protocol: "openid4vp-v1-unsigned",
             },
           ],
         },
@@ -206,7 +206,7 @@
   promise_test(async (t) => {
     const abortController = new AbortController();
     const { signal } = abortController;
-    const options = makeGetOptions("openid4vp");
+    const options = makeGetOptions("openid4vp-v1-unsigned");
     options.signal = signal;
     await test_driver.bless("user activation");
     const promise = promise_rejects_dom(
@@ -225,7 +225,7 @@
       abort: "after",
       action: "get",
       needsActivation: true,
-      options: makeGetOptions("openid4vp"),
+      options: makeGetOptions("openid4vp-v1-unsigned"),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");
@@ -252,7 +252,7 @@ promise_test(async t => {
   ];
 
   for (const badValue of throwingValues) {
-    const options = makeGetOptions("openid4vp");
+    const options = makeGetOptions("openid4vp-v1-unsigned");
     options.digital.requests[0].data = badValue;
 
     await promise_rejects_js(

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -252,7 +252,7 @@ promise_test(async t => {
   ];
 
   for (const badValue of throwingValues) {
-    const options = makeGetOptions("openid4vp-v1-unsigned");
+    const options = makeGetOptions("openid4vp-v1-multisigned");
     options.digital.requests[0].data = badValue;
 
     await promise_rejects_js(

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -71,7 +71,7 @@
     let iframe = await createIframe();
     const DOMExceptionCtor = iframe.contentWindow.DOMException;
     let stolenNavigator = iframe.contentWindow.navigator;
-    const request = makeGetOptions("openid4vp");
+    const request = makeGetOptions("openid4vp-v1-unsigned");
     await test_driver.bless("User activation", null, iframe.contentWindow);
     await iframe.focus();
     const p = promise_rejects_dom(

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -134,7 +134,8 @@ function makeDigitalCredentialGetRequest(protocol = "protocol", data = {}) {
 
 /**
  * Representation of an OpenID4VP request.
- *
+ * 
+ * @param {string} identifier
  * @returns {DigitalCredentialGetRequest}
  **/
 function makeOID4VPDict(identifier = "openid4vp-v1-unsigned") {

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -39,6 +39,7 @@ function _makeOptionsInternal(requestsInputArray, mediation, requestMapping) {
 const allMappings = {
   get: {
     "openid4vp-v1-unsigned": () => makeOID4VPDict(),
+    "openid4vp-v1-signed": () => makeOID4VPDict(),
     "default": () => makeDigitalCredentialGetRequest(undefined, undefined),
   },
   create: {
@@ -96,7 +97,7 @@ function _makeOptionsUnified(type, requestsToUse, mediation) {
 /**
  * Creates options for getting credentials.
  * @export
- * @param {string | string[]} [requestsToUse] - Request types ('default', 'openid4vp-v1-unsigned', or an array). Defaults to ['default'].
+ * @param {string | string[]} [requestsToUse] - Request types ('default', 'openid4vp-v1-unsigned', 'openid4vp-v1-signed', or an array). Defaults to ['default'].
  * @param {string} [mediation="required"] - Credential mediation requirement ("required", "optional", "silent").
  * @returns {{ digital: { requests: any[] }, mediation: string }}
  */

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -134,7 +134,7 @@ function makeDigitalCredentialGetRequest(protocol = "protocol", data = {}) {
 
 /**
  * Representation of an OpenID4VP request.
- * 
+ *
  * @param {string} identifier
  * @returns {DigitalCredentialGetRequest}
  **/

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -40,6 +40,7 @@ const allMappings = {
   get: {
     "openid4vp-v1-unsigned": () => makeOID4VPDict(),
     "openid4vp-v1-signed": () => makeOID4VPDict(),
+    "openid4vp-v1-multisigned": () => makeOID4VPDict(),
     "default": () => makeDigitalCredentialGetRequest(undefined, undefined),
   },
   create: {
@@ -97,7 +98,7 @@ function _makeOptionsUnified(type, requestsToUse, mediation) {
 /**
  * Creates options for getting credentials.
  * @export
- * @param {string | string[]} [requestsToUse] - Request types ('default', 'openid4vp-v1-unsigned', 'openid4vp-v1-signed', or an array). Defaults to ['default'].
+ * @param {string | string[]} [requestsToUse] - Request types ('default', 'openid4vp-v1-unsigned', 'openid4vp-v1-signed', 'openid4vp-v1-multisigned', or an array). Defaults to ['default'].
  * @param {string} [mediation="required"] - Credential mediation requirement ("required", "optional", "silent").
  * @returns {{ digital: { requests: any[] }, mediation: string }}
  */

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -38,9 +38,9 @@ function _makeOptionsInternal(requestsInputArray, mediation, requestMapping) {
 
 const allMappings = {
   get: {
-    "openid4vp-v1-unsigned": () => makeOID4VPDict(),
-    "openid4vp-v1-signed": () => makeOID4VPDict(),
-    "openid4vp-v1-multisigned": () => makeOID4VPDict(),
+    "openid4vp-v1-unsigned": () => makeOID4VPDict("openid4vp-v1-unsigned"),
+    "openid4vp-v1-signed": () => makeOID4VPDict("openid4vp-v1-signed"),
+    "openid4vp-v1-multisigned": () => makeOID4VPDict("openid4vp-v1-multisigned"),
     "default": () => makeDigitalCredentialGetRequest(undefined, undefined),
   },
   create: {
@@ -137,8 +137,8 @@ function makeDigitalCredentialGetRequest(protocol = "protocol", data = {}) {
  *
  * @returns {DigitalCredentialGetRequest}
  **/
-function makeOID4VPDict() {
-  return makeDigitalCredentialGetRequest("openid4vp-v1-unsigned", {
+function makeOID4VPDict(identifier = "openid4vp-v1-unsigned") {
+  return makeDigitalCredentialGetRequest(identifier, {
     // Canonical example of an OpenID4VP request coming soon.
   });
 }

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -38,7 +38,7 @@ function _makeOptionsInternal(requestsInputArray, mediation, requestMapping) {
 
 const allMappings = {
   get: {
-    "openid4vp": () => makeOID4VPDict(),
+    "openid4vp-v1-unsigned": () => makeOID4VPDict(),
     "default": () => makeDigitalCredentialGetRequest(undefined, undefined),
   },
   create: {
@@ -96,7 +96,7 @@ function _makeOptionsUnified(type, requestsToUse, mediation) {
 /**
  * Creates options for getting credentials.
  * @export
- * @param {string | string[]} [requestsToUse] - Request types ('default', 'openid4vp', or an array). Defaults to ['default'].
+ * @param {string | string[]} [requestsToUse] - Request types ('default', 'openid4vp-v1-unsigned', or an array). Defaults to ['default'].
  * @param {string} [mediation="required"] - Credential mediation requirement ("required", "optional", "silent").
  * @returns {{ digital: { requests: any[] }, mediation: string }}
  */
@@ -136,7 +136,7 @@ function makeDigitalCredentialGetRequest(protocol = "protocol", data = {}) {
  * @returns {DigitalCredentialGetRequest}
  **/
 function makeOID4VPDict() {
-  return makeDigitalCredentialGetRequest("openid4vp", {
+  return makeDigitalCredentialGetRequest("openid4vp-v1-unsigned", {
     // Canonical example of an OpenID4VP request coming soon.
   });
 }

--- a/digital-credentials/user-activation.https.html
+++ b/digital-credentials/user-activation.https.html
@@ -14,7 +14,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
-    const options = makeGetOptions("openid4vp");
+    const options = makeGetOptions("openid4vp-v1-unsigned");
     await promise_rejects_dom(
       t,
       "NotAllowedError",
@@ -25,7 +25,7 @@
   promise_test(async (t) => {
     await test_driver.bless();
     const abort = new AbortController();
-    const options = makeGetOptions("openid4vp");
+    const options = makeGetOptions("openid4vp-v1-unsigned");
     options.signal = abort.signal;
     assert_true(
       navigator.userActivation.isActive,


### PR DESCRIPTION
Instead of `openid4vp`, the canonical protocol identifier are used, namely `openid4vp-v1-unsigned`, `openid4vp-v1-signed` and `openid4vp-v1-multisigned` in the digital credentials web platform tests. 

This change ensures the tests align with the latest canonical protocol identifier specified in the OpenID4VP specification ([Appendix A.1](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-A.1)), eliminating potential confusion.