### PR TITLE
[wdspec] Add tentative tests for script commands bypassing CSP

### DIFF
--- a/webdriver/tests/bidi/script/__init__.py
+++ b/webdriver/tests/bidi/script/__init__.py
@@ -224,3 +224,32 @@ async def create_sandbox(bidi_session, context, sandbox_name="Test", method="eva
         raise Exception(f"Unsupported method to create a sandbox: {method}")
 
     return result["realm"]
+
+
+# Expressions used for script evaluate and call_function CSP tentative tests.
+CSP_EXPRESSIONS = {
+    "default": "2 + 1",
+    "eval": "eval('2 + 1')",
+    "new Function": "new Function('return 2 + 1')()",
+    "promise eval": """
+      new Promise(r => {
+        setTimeout(() => {
+          r(eval('2 + 1'));
+        }, 0);
+      })
+    """,
+    "async eval": """
+      (async () => {
+        await new Promise(r => setTimeout(r, 0));
+        return eval("2 + 1");
+      })()
+    """,
+    "eval from inline script": "window.inlineScriptEval()",
+    "eval from preload script": "window.preloadScriptEval()",
+    "async eval from preload script": "window.preloadScriptAsyncEval()",
+    "eval from event handler": "window.document.body.onclick()",
+    "nested eval": "eval(\"eval('2+1')\")",
+    "nested new Function": "new Function(\"return new Function('return 2 + 1')()\")()",
+    "new Function nested in eval": "eval(\"new Function('return 2 + 1')()\")",
+    "eval nested in new Function": "new Function(\"return eval('2+1')\")()",
+}

--- a/webdriver/tests/bidi/script/call_function/csp_tentative.py
+++ b/webdriver/tests/bidi/script/call_function/csp_tentative.py
@@ -1,0 +1,30 @@
+import pytest
+import asyncio
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from .. import CSP_EXPRESSIONS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expression",
+    CSP_EXPRESSIONS.values(),
+    ids=CSP_EXPRESSIONS.keys(),
+)
+async def test_default_src_unsafe_inline(
+    bidi_session, top_context, setup_csp_tentative_test, expression
+):
+    function_declaration = f"() => ({expression})"
+    result = await asyncio.wait_for(
+        asyncio.shield(
+            bidi_session.script.call_function(
+                function_declaration=function_declaration,
+                target=ContextTarget(top_context["context"]),
+                await_promise=True,
+            )
+        ),
+        timeout=2.0,
+    )
+
+    assert result == {"type": "number", "value": 3}

--- a/webdriver/tests/bidi/script/evaluate/csp_tentative.py
+++ b/webdriver/tests/bidi/script/evaluate/csp_tentative.py
@@ -1,0 +1,29 @@
+import pytest
+import asyncio
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from .. import CSP_EXPRESSIONS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expression",
+    CSP_EXPRESSIONS.values(),
+    ids=CSP_EXPRESSIONS.keys(),
+)
+async def test_default_src_unsafe_inline(
+    bidi_session, top_context, setup_csp_tentative_test, expression
+):
+    result = await asyncio.wait_for(
+        asyncio.shield(
+            bidi_session.script.evaluate(
+                expression=expression,
+                target=ContextTarget(top_context["context"]),
+                await_promise=True,
+            )
+        ),
+        timeout=2.0,
+    )
+
+    assert result == {"type": "number", "value": 3}


### PR DESCRIPTION
This adds test cases for script commands bypassing CSP.
See https://github.com/w3c/webdriver-bidi/issues/1024