### PR TITLE
Wait until h2 believes the stream is closed before removing the queue

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -501,6 +501,11 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                 with self.conn as connection:
                     frames = connection.receive_data(data)
                     window_size = connection.remote_settings.initial_window_size
+                    non_closed_streams = {
+                        stream_id
+                        for stream_id, stream in connection.streams.items()
+                        if not stream.closed
+                    }
 
                 self.logger.debug('(%s) Frames Received: ' % self.uid + str(frames))
 
@@ -513,14 +518,17 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                         for stream_id, (thread, queue) in stream_queues.items():
                             queue.put(frame)
 
-                    elif hasattr(frame, 'stream_id'):
+                    elif hasattr(frame, 'stream_id') and frame.stream_id != 0:
+                        # Stream ID 0 is reserved for connection control messages (RFC 9113 § 5.1.1)
+                        # and is handled directly by h2, so we only create streams for stream IDs > 0
                         if frame.stream_id not in stream_queues:
                             queue = Queue()
                             stream_queues[frame.stream_id] = (self.start_stream_thread(frame, queue), queue)
                         stream_queues[frame.stream_id][1].put(frame)
 
-                        if isinstance(frame, StreamEnded) or getattr(frame, "stream_ended", False):
-                            del stream_queues[frame.stream_id]
+                for closed_id in set(stream_queues.keys()) - non_closed_streams:
+                    self.logger.debug(f'({self.uid}) Stream {closed_id} is closed, removing queue')
+                    del stream_queues[closed_id]
 
         except OSError as e:
             self.logger.error(f'({self.uid}) Closing Connection - \n{str(e)}')


### PR DESCRIPTION
This reduces the effect and frequency of #51981, where we frequently
saw timeouts from the H2 server, because we no longer repeatedly
create new threads and new queues when we receive further events after
StreamEnded, or an event with a reference to a StreamEnded.

See the state diagram in
https://httpwg.org/specs/rfc9113.html#StreamStates, noting that
receiving StreamEnded only closes the connection when the stream is in
the half-closed (local) state.

This also means we treat a stream as closed when we send/receive a
RST_STREAM frame.
