### PR TITLE
Move H2ConnectionGuard lock to be connection-specific

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -758,11 +758,10 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
 
 class H2ConnectionGuard:
     """H2Connection objects are not threadsafe, so this keeps thread safety"""
-    lock = threading.Lock()
-
     def __init__(self, obj):
         assert isinstance(obj, H2Connection)
         self.obj = obj
+        self.lock = threading.Lock()
 
     def __enter__(self):
         self.lock.acquire()


### PR DESCRIPTION
This helps avoid #51981, where we frequently saw timeouts from the H2
server, by avoiding holding a global lock across all connections to
the H2 server.
