### PR TITLE
Revert "Fix reference for anchor-scroll-position-try-012 due to mistaken containing block"

### DIFF
--- a/css/css-anchor-position/anchor-scroll-position-try-012-ref.html
+++ b/css/css-anchor-position/anchor-scroll-position-try-012-ref.html
@@ -25,9 +25,9 @@
 <div id="scroller">
   <div class="box"></div>
   <div class="box"></div>
-  <div id="anchored"></div>
-  <div class="box" id="anchor"></div>
   <div class="box"></div>
+  <div class="box" id="anchor"></div>
+  <div id="anchored"></div>
   <div class="box"></div>
   <div class="box"></div>
   <div class="box"></div>


### PR DESCRIPTION
Reverts web-platform-tests/wpt#55774

This update was incorrect - but the rationale was correct that there should be no fallback occuring.

The base style of the anchored element has:
`top: anchor(bottom)`

E.g. It should be placed at the bottom of the anchor, but the update to the expectation has placed it above the anchor.

This reverts the incorrect update.
