### PR TITLE
Fix #55888

### DIFF
--- a/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html
+++ b/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html
@@ -37,8 +37,8 @@
           assert_equals(reports[0].body.sample, "");
           assert_equals(reports[0].body.disposition, "enforce");
           assert_equals(reports[0].body.statusCode, 200);
-          assert_equals(reports[0].body.lineNumber, 53);
-          assert_equals(reports[0].body.columnNumber, 0);
+          assert_equals(reports[0].body.lineNumber, 54);
+          assert_equals(reports[0].body.columnNumber, 5);
         });
 
         t3.done();
@@ -46,9 +46,13 @@
       observer.observe();
     }, "Report is observable to ReportingObserver");
   </script>
-  <img src='/content-security-policy/support/fail.png'
+  <img id="theImage"
        onload='t1.unreached_func("The image should not have loaded");'
        onerror='t1.done();'>
+
+  <script>
+    theImage.src = '/content-security-policy/support/fail.png'
+  </script>
 
   <script async defer src='../support/checkReport.sub.js?reportField=effectiveDirective&reportValue=img-src%20%27none%27'></script>
 </body>

--- a/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html
+++ b/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html
@@ -51,7 +51,8 @@
        onerror='t1.done();'>
 
   <script>
-    theImage.src = '/content-security-policy/support/fail.png'
+    const theImage = document.getElementById('theImage');
+    theImage.src = '/content-security-policy/support/fail.png';
   </script>
 
   <script async defer src='../support/checkReport.sub.js?reportField=effectiveDirective&reportValue=img-src%20%27none%27'></script>


### PR DESCRIPTION
This addresses the test described in #55888 that seemingly breaks with spec. This is a suggested edit, as it still keeps what the original test intends to test for, but a test should probably also be written, where this test returns source file null and line/column numbers as 0/null.

We've removed the src attribute from img to not trigger an immediate load. The spec says that only when javascript is running, source file, line number and column should be reported as per 2.4.1 https://w3c.github.io/webappsec-csp/#create-violation-for-global in step 2.

This change will make the load happen when script is actually running, on line 54 and line 54 should therefore be reported.