### PR TITLE
wpt.browser.Browser is meant to be abstract

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -89,9 +89,7 @@ def get_file_github(repo: str, ref: str, path: str) -> bytes:
     return data
 
 
-class Browser:
-    __metaclass__ = ABCMeta
-
+class Browser(metaclass=ABCMeta):
     def __init__(self, logger):
         self.logger = logger
 
@@ -1584,7 +1582,7 @@ class HeadlessShell(ChromeChromiumBase):
         return "N/A"
 
 
-class ChromeAndroidBase(Browser):
+class ChromeAndroidBase(Browser, metaclass=ABCMeta):
     """A base class for ChromeAndroid and AndroidWebView.
 
     On Android, WebView is based on Chromium open source project, and on some
@@ -1592,7 +1590,6 @@ class ChromeAndroidBase(Browser):
     a very similar WPT runner implementation.
     Includes webdriver installation.
     """
-    __metaclass__ = ABCMeta  # This is an abstract class.
 
     def __init__(self, logger):
         super().__init__(logger)

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -24,7 +24,7 @@ def test_all_browser_abc():
     # products in unit tests.
     classes = inspect.getmembers(browser)
     for name, cls in classes:
-        if cls in (browser.Browser, browser.ChromeAndroidBase):
+        if cls in (browser.Browser, browser.ChromeChromiumBase, browser.ChromeAndroidBase):
             continue
         if inspect.isclass(cls) and issubclass(cls, browser.Browser):
             assert not inspect.isabstract(cls), "%s is abstract" % name


### PR DESCRIPTION
The Python 2 syntax has stopped doing anything a long time ago, so
update it, and fix the test to also exempt ChromeChromiumBase from its
list of abstract subclasses.
