### PR TITLE
xpath: Enforce tree order in node sets during evaluation

### DIFF
--- a/domxpath/node-set-tree-order.html
+++ b/domxpath/node-set-tree-order.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Tree order of node sets during evaluation</title>
+  <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+  <link rel="help" href="https://github.com/servo/servo/issues/40435">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="container">
+        <span></span>
+        <p id="p"></p>
+    </div>
+    <script>
+    function toArray(result) {
+      var a = [];
+      while (true) {
+        var node = result.iterateNext();
+        if (node === null) break;
+        a.push(node);
+      }
+      return a;
+    }
+
+    let container = document.getElementById("container");
+    test(() => {
+      // If the result of "(./p | ./span)" is not in tree order then "last()" will filter the wrong element,
+      // causing the span to be returned.
+
+      let result = document.evaluate("(./p | ./span)[last()]", container, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+      assert_array_equals(toArray(result), [document.getElementById("p")])
+    }, "Temporary node sets created during evaluation must be in tree order");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This change adds `NodeSet`, which is more or less a `Vec<Node>` that knows whether it is sorted, and can sort itself if it isn't. This allows us to efficiently enforce tree order in intermediary node sets that occur during evaluation.

Notably, in many cases it is not necessary to sort at all, because all location step expressions yield node sets that are either already sorted (`Axis::DescendantOrSelf` for example), or that are in inverse tree order (`Axis::PrecedingSiblings` for example).

There's still optimization work left to be done. When merging two node sets that are already sorted then we could use merge sort instead of appending one to the other and naively sorting. But I suspect that the sorting algorithm used by the standard library is already well tuned to handle such cases...

Testing: This change adds a web platform test
Fixes https://github.com/servo/servo/issues/40435

Reviewed in servo/servo#40451