### PR TITLE
servodriver: Shut down Servo elegantly when all tests finish

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -144,11 +144,11 @@ class ServoWebDriverBrowser(WebDriverBrowser):
         return True
 
     def stop(self, force=False):
-        conn = HTTPConnection(self.host, self.port)
         while self.is_alive():
             self.logger.info("Trying to shut down gracefully by extension command")
             while True:
                 try:
+                    conn = HTTPConnection(self.host, self.port)
                     conn.request("DELETE", "/session/dummy-session-id/servo/shutdown")
                     res = conn.getresponse()
                     self.logger.info(f"Got response status for shutdown command: {res.status}")

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -136,7 +136,7 @@ class ServoWebDriverBrowser(WebDriverBrowser):
         if not super().is_alive():
             return False
         try:
-            requests.get(f"http://{self.host}:{self.port}/status", timeout=3)    
+            requests.get(f"http://{self.host}:{self.port}/status", timeout=3)
         except requests.exceptions.Timeout:
             # FIXME: This indicates a hanged browser. Reasons need to be investigated further.
             # It happens with ~0.1% probability in our CI runs.
@@ -166,7 +166,7 @@ class ServoWebDriverBrowser(WebDriverBrowser):
             except requests.exceptions.Timeout:
                 self.logger.debug("Request timed out")
                 break
-                
+
             retry_cnt += 1
             if retry_cnt >= self.shutdown_retry_attempts:
                 self.logger.warn("Max retry exceeded to normally shut down. Killing instead.")


### PR DESCRIPTION
Previously, we always kill the instance when tests finish instead of normally shutting down. That blocked clean-ups works, such as Code Coverage we wanted to add, and other things I'm not aware of.

Testing: We have tested for a week and checked the logs of CI to confirm it works normally now.

Reviewed in servo/servo#40455