### PR TITLE
Upgrade wptrunner mozprocess version to 1.4.0

### DIFF
--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -2,7 +2,7 @@ html5lib==1.1
 mozdebug==0.3.1
 mozinfo==1.2.3  # https://bugzilla.mozilla.org/show_bug.cgi?id=1621226
 mozlog==8.0.0
-mozprocess==1.3.1
+mozprocess==1.4.0
 packaging==25.0
 pillow==10.4.0; python_version < '3.9'
 pillow==11.3.0; python_version >= '3.9'


### PR DESCRIPTION
This fixes the error in Windows when Servo shuts down normally without being killed.

Testing: Tested on Windows.
Reviewed in servo/servo#40466