### PR TITLE
Always create a default structured logger for wptrunner tests

### DIFF
--- a/tools/wptrunner/wptrunner/tests/conftest.py
+++ b/tools/wptrunner/wptrunner/tests/conftest.py
@@ -1,0 +1,20 @@
+from typing import Generator
+
+import pytest
+from mozlog import structuredlog
+
+
+@pytest.fixture(autouse=True)
+def mozlog_default_logger(request: pytest.FixtureRequest) -> Generator[structuredlog.StructuredLogger, None, None]:
+    """Create a new StructuredLogger and make it the default"""
+    nodeid = request.node.nodeid
+
+    old_default_logger = structuredlog._default_logger_name
+    try:
+        logger = structuredlog.StructuredLogger(nodeid)
+        logger.reset_state()
+        structuredlog.set_default_logger(logger)
+        yield logger
+        logger.reset_state()
+    finally:
+        structuredlog._default_logger_name = old_default_logger


### PR DESCRIPTION
This currently works if you run the whole test suite, but if you run
individual files you can get errors because there is no default
structured logger set.

For the sake of isolation, this creates a new structured logger for
each test, setting it as the default for the duration of the test.
