### PR TITLE
Undo web-features mapping for CSS Typed OM overlapping test

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/properties/WEB_FEATURES.yml
+++ b/css/css-typed-om/the-stylepropertymap/properties/WEB_FEATURES.yml
@@ -1,4 +1,0 @@
-features:
-- name: text-indent-each-line
-  files:
-  - text-indent.html


### PR DESCRIPTION
These are primarily tests for CSS Typed OM, which by necessity needs to test specific properties. However, since CSS Typed OM is the newer feature, mapping it would appear to regress support for the older features, which isn't ideal.