### PR TITLE
layout: Do not stretch block-level widgets by default

### DIFF
--- a/css/css-align/blocks/justify-self-widgets-ref.html
+++ b/css/css-align/blocks/justify-self-widgets-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: justify-self on block-level widgets</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+
+<style>
+.widget {
+  float: left;
+  clear: both;
+  width: auto;
+  box-sizing: border-box;
+}
+</style>
+
+<input class="widget">
+<input class="widget">
+<input class="widget" style="float: right">
+<input class="widget" style="width: 100%">
+
+<select class="widget"></select>
+<select class="widget"></select>
+<select class="widget" style="float: right"></select>
+<select class="widget" style="width: 100%"></select>
+
+<textarea class="widget"></textarea>
+<textarea class="widget"></textarea>
+<textarea class="widget" style="float: right"></textarea>
+<textarea class="widget" style="width: 100%"></textarea>

--- a/css/css-align/blocks/justify-self-widgets.html
+++ b/css/css-align/blocks/justify-self-widgets.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Box Alignment: justify-self on block-level widgets</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-align/#justify-block">
+<link rel="help" href="https://drafts.csswg.org/css-ui/#widget">
+<link rel="match" href="justify-self-widgets-ref.html">
+<meta name="assert" content="
+On block-level widgets:
+  - `justify-self: normal` behaves as `start` (not as `stretch`!).
+  - `justify-self: start` aligns to the start.
+  - `justify-self: end` aligns to the end.
+  - `justify-self: stretch` stretches the size to fill the containing block.
+">
+
+<style>
+.widget {
+  display: block;
+  width: auto;
+  box-sizing: border-box;
+}
+</style>
+
+<input class="widget" style="justify-self: normal">
+<input class="widget" style="justify-self: start">
+<input class="widget" style="justify-self: end">
+<input class="widget" style="justify-self: stretch">
+
+<select class="widget" style="justify-self: normal"></select>
+<select class="widget" style="justify-self: start"></select>
+<select class="widget" style="justify-self: end"></select>
+<select class="widget" style="justify-self: stretch"></select>
+
+<textarea class="widget" style="justify-self: normal"></textarea>
+<textarea class="widget" style="justify-self: start"></textarea>
+<textarea class="widget" style="justify-self: end"></textarea>
+<textarea class="widget" style="justify-self: stretch"></textarea>


### PR DESCRIPTION
If a widget like `<textarea>` had `display: block` and `width: auto`, we were stretching it like a `<div>`. However, similar to replaced elements, widgets should not stretch by default.

It will still be possible to opt into stretching with an explicit `justify-self: stretch` or `width: stretch`.

Testing: Adding new test.
Reviewed in servo/servo#40579