### PR TITLE
[wdspec] Default unhandled prompt behavior should be dismiss and notify

### DIFF
--- a/webdriver/tests/bidi/session/capabilities/unhandled_prompt_behavior/file/dismiss.py
+++ b/webdriver/tests/bidi/session/capabilities/unhandled_prompt_behavior/file/dismiss.py
@@ -4,6 +4,10 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
+# default value for unhandledPromptBehavior capability should be dismiss and notify
+async def test_no_capabilities(assert_file_dialog_canceled):
+    await assert_file_dialog_canceled()
+
 @pytest.mark.capabilities({"unhandledPromptBehavior": 'dismiss'})
 async def test_string_dismiss(assert_file_dialog_canceled):
     await assert_file_dialog_canceled()

--- a/webdriver/tests/bidi/session/capabilities/unhandled_prompt_behavior/file/ignore.py
+++ b/webdriver/tests/bidi/session/capabilities/unhandled_prompt_behavior/file/ignore.py
@@ -4,10 +4,6 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-async def test_no_capabilities(assert_file_dialog_not_canceled):
-    await assert_file_dialog_not_canceled()
-
-
 @pytest.mark.capabilities({"unhandledPromptBehavior": 'ignore'})
 async def test_string_ignore(assert_file_dialog_not_canceled):
     await assert_file_dialog_not_canceled()


### PR DESCRIPTION
@sadym-chromium trying to implement input.fileDialogOpened in Firefox at the moment, and I feel like the [default value for the unhandledPromptBehavior capability](https://w3c.github.io/webdriver/#ref-for-dfn-user-prompt-handler-2:~:text=Defaults%20to%20%22dismiss%20and%20notify%22%2E) should be `dismiss and notify`, but it seems that at the moment Chrome is using `ignore` as default value.

Can you check?