### PR TITLE
media: Fix the order of events for autoplay media

### DIFF
--- a/html/semantics/embedded-content/media-elements/ready-states/autoplay.html
+++ b/html/semantics/embedded-content/media-elements/ready-states/autoplay.html
@@ -26,7 +26,7 @@ function autoplay_test(tagName, src) {
     var e = document.createElement(tagName);
     e.src = src;
     e.autoplay = true;
-    expect_events(t, e, ['canplay', 'play', 'playing', 'canplaythrough']);
+    expect_events(t, e, ['canplay', 'canplaythrough', 'play', 'playing']);
   }, tagName + '.autoplay');
 
   async_test(function(t) {
@@ -35,7 +35,7 @@ function autoplay_test(tagName, src) {
     e.autoplay = true;
     e.pause(); // sets the autoplaying flag to false
     e.load(); // sets the autoplaying flag to true
-    expect_events(t, e, ['canplay', 'play', 'playing', 'canplaythrough']);
+    expect_events(t, e, ['canplay', 'canplaythrough', 'play', 'playing']);
   }, tagName + '.autoplay and load()');
 
   async_test(function(t) {


### PR DESCRIPTION
Following the HTML specification, the expected order of events for autoplaying media tests (`<video autoplay>`) has been corrected:
- non-autoplay: `canplay`, `canplaythrough` (same as before)
- autoplay: `canplay`, `canplaythrough`, `play`, `playing` (`canplaythrough` should be right after `canplay`, not after `playing`)

https://html.spec.whatwg.org/multipage/#ready-states:event-media-canplaythrough

WhatWG PR: https://github.com/whatwg/html/pull/1409