### PR TITLE
Fix mungeLevel function to zero-pad single-digit H.264 level hex values

### DIFF
--- a/webrtc/protocol/h264-profile-levels.https.html
+++ b/webrtc/protocol/h264-profile-levels.https.html
@@ -10,7 +10,7 @@
 <script>
 
 function mungeLevel(sdp, level) {
-  level_hex = Math.round(level * 10).toString(16);
+  level_hex = Math.round(level * 10).toString(16).padStart(2, '0');
   return {
     type: sdp.type,
     sdp: sdp.sdp.replace(/(profile-level-id=....)(..)/g,


### PR DESCRIPTION
The mungeLevel function is not zero-padding hex values, therefore breaking level encoding for H264 levels 1, 1.1, 1.2, and 1.3. Without padding, single-digit hex values create invalid profile-level-id strings with only 5 total characters instead of 6. The profile-level-id should have a size of 3 bytes.

For example, for level 1.0:
1 * 10 = 10, equal to hex 'a' which leads to 0x42e0a instead of 0x42e00a.

This patch ensures all hex values are zero-padded to 2-digits.