### PR TITLE
Change lcp/image-upscaling.html to open about:blank explicitly

### DIFF
--- a/largest-contentful-paint/image-upscaling-empty-url.html
+++ b/largest-contentful-paint/image-upscaling-empty-url.html
@@ -16,19 +16,9 @@
     async function load_image_and_get_lcp_size(t, imageStyle = {}, containerStyle = {}) {
       let popup;
       await test_driver.bless('Open a popup', () => {
-        popup = window.open('about:blank');
+        popup = window.open();
         t.add_cleanup(() => popup.close());
       });
-
-      // Per spec, we should end up with a pagereveal event once the
-      // window is open. However, Gecko seems to load the initial
-      // about:blank synchronously and then asynchronously load the
-      // about:blank requested above, thus we also accept pageshow
-      // here as a sign the popup is ready.
-      await Promise.any([
-        new Promise(resolve => popup.addEventListener('pagereveal', () => resolve(), {'once': true})),
-        new Promise(resolve => popup.addEventListener('pageshow', () => resolve(), {'once': true})),
-      ]);
 
       const image = popup.document.createElement('img');
       image.src = imageURL;


### PR DESCRIPTION
See https://bugs.webkit.org/show_bug.cgi?id=301239; this also adds an lcp/image-upscaling-empty-url.html to ensure we maintain coverage of whatever the underlying bug here is.

Also related: https://github.com/web-platform-tests/interop/issues/1211.