### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=294206

### DIFF
--- a/svg/painting/parsing/marker-computed.svg
+++ b/svg/painting/parsing/marker-computed.svg
@@ -23,5 +23,21 @@ test(() => {
   assert_equals(result, 'url("' + resolved + '")');
 }, 'url values are made absolute');
 
+test(() => {
+  const target = document.getElementById('target');
+  target.style['marker'] = 'none';
+  target.style['marker-start'] = 'url("https://example.com/")';
+  const result = getComputedStyle(target)['marker'];
+  assert_equals(result, '');
+}, 'Setting a single marker value results in empty marker computed value');
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style['marker'] = 'url("https://example.com/")';
+  target.style['marker-start'] = 'none';
+  const result = getComputedStyle(target)['marker'];
+  assert_equals(result, '');
+}, 'Setting a single marker value to "none" results in empty marker computed value');
+
   ]]></script>
 </svg>


### PR DESCRIPTION
WebKit export from bug: [Fix computed value for `marker` (SVG)](https://bugs.webkit.org/show_bug.cgi?id=294206)