### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=300093

### DIFF
--- a/css/css-backgrounds/css-box-shadow-001.html
+++ b/css/css-backgrounds/css-box-shadow-001.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-box-shadow">
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
     <link rel="match" href="reference/css-box-shadow-ref-001.html">
-    <meta name="fuzzy" content="maxDifference=0-56; totalPixels=0-250">
+    <meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-250">
     <style type="text/css">
 		.greenSquare-shadow{
             position: absolute;

--- a/css/css-ui/outline-028.html
+++ b/css/css-ui/outline-028.html
@@ -6,6 +6,7 @@
 <link rel="match" href="reference/outline-028-ref.html">
 <meta name="assert" content="Test checks that 'auto' outline works as expected in an element with floatted descendants with different margins and paddings.">
 <meta name="flags" content="ahem">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-4" />
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 .outline-container {

--- a/css/filter-effects/backdrop-filter-clip-rect-zoom.html
+++ b/css/filter-effects/backdrop-filter-clip-rect-zoom.html
@@ -4,7 +4,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="backdrop-filter-clip-rect-zoom-ref.html">
-<meta name="fuzzy" content="0-1;0-3">
+<meta name="fuzzy" content="0-56;0-169">
 
 <div class="box"></div>
 <div class="navbar">

--- a/svg/painting/reftests/marker-path-001.svg
+++ b/svg/painting/reftests/marker-path-001.svg
@@ -11,7 +11,7 @@
     <html:link rel="help"
           href="https://www.w3.org/TR/SVG2/painting.html#Markers"/>
     <html:link rel="match"  href="marker-path-001-ref.svg" />
-    <html:meta name="fuzzy" content="0-8;0-8"/>
+    <html:meta name="fuzzy" content="0-15;0-49"/>
   </g>
 
   <defs>


### PR DESCRIPTION
WebKit export from bug: [\[CoordinatedGraphics\] Compute the layers tile size instead of using a fixed value](https://bugs.webkit.org/show_bug.cgi?id=300093)