### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=273759

### DIFF
--- a/svg/coordinate-systems/out-of-flow-svg-root-ref.html
+++ b/svg/coordinate-systems/out-of-flow-svg-root-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://www.w3.org/TR/SVG2/coords.html">
+<style>
+    section { margin-bottom: 10px; }
+    div { background: rgba(255, 0, 0, 0.15) }
+    svg { background: rgba(0, 0, 255, 0.15) }
+</style>
+<body>
+    <section>
+        <div style="position: relative; width: 240px; height: 340px;">
+            <svg style="position: absolute;" width="240" height="240"
+                xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+    </section>
+    <section>
+        <div style="position: relative; width: 300px; height: 200px">
+            <div style="position: absolute; width: 300px; height: 200px;">
+                <svg style="position: absolute;" width="200" height="200"
+                    xmlns="http://www.w3.org/2000/svg"></svg>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/svg/coordinate-systems/out-of-flow-svg-root.html
+++ b/svg/coordinate-systems/out-of-flow-svg-root.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://www.w3.org/TR/SVG2/coords.html">
+<link rel="match"  href="out-of-flow-svg-root-ref.html">
+<style>
+    section { margin-bottom: 10px; }
+    div { background: rgba(255, 0, 0, 0.15) }
+    svg { background: rgba(0, 0, 255, 0.15) }
+</style>
+<body>
+    <section>
+        <div style="position: relative; width: 200px; height: 300px; padding: 20px">
+            <svg style="position: absolute; top: 0; left: 0; right: 0" viewBox="0 0 1 1"
+                xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+    </section>
+    <section>
+        <div style="position: relative; width: 300px; height: 200px">
+            <div style="position: absolute; top: 0; left: 0; bottom: 0; right: 0; padding: 20px;">
+                <svg style="position: absolute; top: 0; left: 0; height: 100%" viewBox="0 0 1 1"
+                    xmlns="http://www.w3.org/2000/svg"></svg>
+            </div>
+        </div>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [SVGs with absolute positioning are incorrectly sized when ancestor has padding](https://bugs.webkit.org/show_bug.cgi?id=273759)