### PR TITLE
net: Relax the SVG content type detection logic.

### DIFF
--- a/html/semantics/embedded-content/the-img-element/content-type-with-parameters-ref.html
+++ b/html/semantics/embedded-content/the-img-element/content-type-with-parameters-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG is recognized even when the 'Content-Type' header includes parameters</title>
+    <style>
+        #box {
+           width: 100px;
+           height: 100px;
+           background-color: red;
+        }
+    </style>
+</head>
+<body>
+   <div id="box"></div>
+</body>
+</html>

--- a/html/semantics/embedded-content/the-img-element/content-type-with-parameters.html
+++ b/html/semantics/embedded-content/the-img-element/content-type-with-parameters.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG is recognized even when the 'Content-Type' header includes parameters</title>
+    <link rel="author" title="Mukilan Thiyagrajan" href="mailto:mukilan@igalia.com">
+    <link rel="match" href="content-type-with-parameters-ref.html">
+</head>
+<body>
+    <img src="svg-for-content-type-with-parameters.svg">
+</body>
+</html>

--- a/html/semantics/embedded-content/the-img-element/svg-for-content-type-with-parameters.svg
+++ b/html/semantics/embedded-content/the-img-element/svg-for-content-type-with-parameters.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+    <rect width='100%' height='100%' fill='red'/>
+</svg>

--- a/html/semantics/embedded-content/the-img-element/svg-for-content-type-with-parameters.svg.headers
+++ b/html/semantics/embedded-content/the-img-element/svg-for-content-type-with-parameters.svg.headers
@@ -1,0 +1,1 @@
+Content-Type: image/svg+xml;qs=0.85;charset=utf-8


### PR DESCRIPTION
The current logic fails when the `Content-Type` header includes the character encoding other parameters like `qs`.

Fixes: #<!-- nolink -->40630
Reviewed in servo/servo#40636