### PR TITLE
New Test: Validate that Sibling Elements with conditional Slots do not interfere with each other

### DIFF
--- a/shadow-dom/sibling-elements-with-conditional-slots.html
+++ b/shadow-dom/sibling-elements-with-conditional-slots.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<head>
+  <title>Shadow DOM: Sibling Elements with Conditional Slots</title>
+  <meta name="author" title="Jesse Jurman" href="mailto:j.r.jurman@gmail.com">
+  <meta name="assert" content="It should be possible to conditionally render slots in sibling elements">
+  <link rel=help href="https://bugs.webkit.org/show_bug.cgi?id=280399">
+
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+
+<body>
+  <my-app></my-app>
+  <script>
+    customElements.define('my-app', class extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+      }
+      connectedCallback() {
+        this.shadowRoot.innerHTML = `
+          <my-header>Headline</my-header>
+          <my-toggle>Some Content</my-toggle>
+        `;
+      }
+    });
+
+    customElements.define('my-header', class extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+      }
+      connectedCallback() {
+        this.shadowRoot.innerHTML = `
+          <div>
+            <slot></slot>
+          </div>
+        `;
+      }
+    });
+
+    customElements.define('my-toggle', class extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+      }
+
+      connectedCallback() {
+        this.shadowRoot.innerHTML = `
+          <button>Toggle</button>
+          ${this.hasAttribute('open') ? '<div><slot></slot></div>' : ''}
+        `;
+
+        this.shadowRoot.querySelector('button').addEventListener('click', () => {
+          this.toggleAttribute('open');
+          this.connectedCallback();
+        });
+      }
+    });
+  </script>
+</body>
+
+<script>
+'use strict';
+
+// test that we can toggle the slot in and still see the originally slotted element
+promise_test(async () => {
+  const myApp = document.querySelector('my-app');
+  const myHeader = myApp.shadowRoot.querySelector('my-header');
+  const myToggle = myApp.shadowRoot.querySelector('my-toggle');
+  const myToggleButton = myToggle.shadowRoot.querySelector('button');
+
+  // first validate that the header element has some width
+  assert_greater_than(myHeader.getBoundingClientRect().width, 0);
+
+  // click on the toggle control
+  myToggleButton.click();
+
+  // validate that the header element has not disappeared
+  assert_greater_than(myHeader.getBoundingClientRect().width, 0);
+}, 'conditional slot does not interfere with other slotted elements');
+
+</script>


### PR DESCRIPTION
See https://bugs.webkit.org/show_bug.cgi?id=280399

It was discovered that when sibling Web Components with conditional slots are inside a Web Component, the browser can exhibit some strange behaviors when those slots are removed / added. Specifically, when one element added a slot, the other element's slots would totally disappear (even if that element's own slots were not conditional in any way).

This only appears to be an issue in Safari / WebKit - Version 26.1 (21622.2.11.11.9). 
This error does not happen in Chrome, Edge, or Firefox.

> [!note]
> The test fails in Safari Technology Preview - Release 231 (WebKit 20623.1.12.19.2), but passes in  Release 232 (WebKit 21624.1.2.19.2)

I was able to reproduce this in a minimal codepen here: https://codepen.io/JRJurman/pen/vEGmWoZ
See https://github.com/shoelace-style/webawesome/issues/1771 for a slightly less contrived example.

In the process of making this, there were some strange caveats to make this bug appear (these might not be strictly true, just what I could tell trying to make this minimal example):
1. The elements with slots needed to be in a registered web component (the issue does not occur when using declarative shadow dom or light dom as a wrapper)
2. The static slot needs to be wrapped in some element (it can not be the only element in the shadow root)
3. The display type of slot must be `contents` and assigned to a `TEXT` node.

Those pieces led to the example that is in the test, but if there is a more simple repo, I'm happy to update it here.

There are, from what I can tell, no related specs to this behavior. It is a browser behavior inconsistency, and an unexpected rendering bug.