### PR TITLE
Map invalidation tests to media pseudo-classes features

### DIFF
--- a/css/selectors/invalidation/WEB_FEATURES.yml
+++ b/css/selectors/invalidation/WEB_FEATURES.yml
@@ -4,6 +4,10 @@ features:
   - has-*
   - "*-in-has.*"
   - "*-in-has-*"
+- name: media-pseudos
+  files:
+  - media-loading-pseudo-classes-in-has.html
+  - media-pseudo-classes-in-has.html
 - name: modal
   files:
   - modal-pseudo-class-in-has.html


### PR DESCRIPTION
These tests are for the combination of :has() and the media element
pseudo-classes, but they're important to consider when implementing the
media element pseudo-classes, so label them for visibility.
