### PR TITLE
Remove invalid test for lang() selector

### DIFF
--- a/css/cssom/selectorSerialize.html
+++ b/css/cssom/selectorSerialize.html
@@ -70,7 +70,6 @@
             test(function(){
                 assert_selector_serializes_to(':lang(ja)', ':lang(ja)');
                 assert_selector_serializes_to(':lang( ja )', ':lang(ja)');
-                assert_selector_serializes_to(':lang( j\\ a )', ':lang(j\\ a)');
             }, 'single pseudo (simple) selector "lang" which accepts arguments in the sequence of simple selectors that is not a universal selector')
 
 


### PR DESCRIPTION
Remove a test checking the serialization of `:lang( j\\ a )` because that is an invalid value according to the specs.

References:

- https://www.w3.org/TR/selectors-4/#the-lang-pseudo
- https://www.rfc-editor.org/rfc/rfc4647.html