### PR TITLE
[css-grid] grid-auto-flow specified value serialization maybe shouldn't drop keywords

### DIFF
--- a/css/css-grid/parsing/grid-auto-flow-valid.html
+++ b/css/css-grid/parsing/grid-auto-flow-valid.html
@@ -14,8 +14,8 @@
 <script>
 test_valid_value("grid-auto-flow", "row");
 test_valid_value("grid-auto-flow", "column");
-test_valid_value("grid-auto-flow", "row dense", "dense");
-test_valid_value("grid-auto-flow", "dense row", "dense");
+test_valid_value("grid-auto-flow", "row dense");
+test_valid_value("grid-auto-flow", "dense row", "row dense");
 test_valid_value("grid-auto-flow", "dense");
 test_valid_value("grid-auto-flow", "column dense");
 test_valid_value("grid-auto-flow", "dense column", "column dense");


### PR DESCRIPTION
The specified value serialization for grid-auto-flow is not well-specified, but the specified value often doesn't drop optional keywords, but rather tries to match what the author inputted more. Dropping `row` also doesn't round-trip if we introduce a different initial value like `normal`. See https://github.com/w3c/csswg-drafts/issues/13121