### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=302533

### DIFF
--- a/css/css-masking/parsing/mask-size-computed.html
+++ b/css/css-masking/parsing/mask-size-computed.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: getComputedStyle().maskSize</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-size">
+<meta name="assert" content="mask-size computed value is a list, each item a pair of sizes (one per axis) each represented as either a keyword or a computed length-percentage value.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("mask-size", "1px", "1px auto");
+test_computed_value("mask-size", "1px auto", "1px auto");
+test_computed_value("mask-size", "2% 3%");
+test_computed_value("mask-size", "auto");
+test_computed_value("mask-size", "auto auto", "auto");
+test_computed_value("mask-size", "auto 4%");
+test_computed_value("mask-size", "contain");
+test_computed_value("mask-size", "cover");
+test_computed_value("mask-size", "calc(10px + 0.5em) calc(10px - 0.5em)", "30px 0px");
+test_computed_value("mask-size", "calc(10px - 0.5em) calc(10px + 0.5em)", "0px 30px");
+test_computed_value("mask-size", "auto 1px, 2% 3%, contain", "auto 1px");
+
+document.getElementById("target").style['mask-image'] = "none, none";
+test_computed_value("mask-size", "auto", "auto, auto", "multiple values");
+test_computed_value("mask-size", "auto, 100%", "auto, 100% auto", "multiple values");
+test_computed_value("mask-size", "100%", "100% auto, 100% auto", "multiple values");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/mask-size-invalid.html
+++ b/css/css-masking/parsing/mask-size-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing mask-size with invalid values</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-size">
+<meta name="assert" content="mask-size supports only the grammar '<bg-size>#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("mask-size", "-1px");
+test_invalid_value("mask-size", "2% -3%");
+test_invalid_value("mask-size", "1px 2px 3px");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/mask-size-valid.html
+++ b/css/css-masking/parsing/mask-size-valid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing mask-size with valid values</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-size">
+<meta name="assert" content="mask-size supports the full grammar '<bg-size>#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("mask-size", "1px");
+test_valid_value("mask-size", "1px auto");
+test_valid_value("mask-size", "2% 3%");
+test_valid_value("mask-size", "auto");
+test_valid_value("mask-size", "auto auto", "auto");
+test_valid_value("mask-size", "auto 4%");
+test_valid_value("mask-size", "contain");
+test_valid_value("mask-size", "cover");
+test_valid_value("mask-size", "auto 1px, 2% 3%, contain");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (STP 232): comma-separated values for mask-size: auto gets unset](https://bugs.webkit.org/show_bug.cgi?id=302533)