### PR TITLE
Hopefully make transitioncancel-003 less flaky

### DIFF
--- a/css/css-transitions/transitioncancel-003.html
+++ b/css/css-transitions/transitioncancel-003.html
@@ -17,7 +17,7 @@
 <script>
 promise_test(async t => {
   const div = addDiv(t, {
-    style: 'transition: width 100ms; width: 0px;'
+    style: 'transition: width 5000ms; width: 0px;'
   });
 
   // Flush initial state
@@ -29,8 +29,8 @@ promise_test(async t => {
     div.addEventListener('transitionrun', resolve, { once: true });
   });
 
-  // MID-TRANSITION CHANGE: Switch to 0s duration + 100ms delay
-  div.style.transition = 'width 0s 100ms';
+  // MID-TRANSITION CHANGE: Switch to 0s duration + 5000ms delay
+  div.style.transition = 'width 0s 5000ms';
   assert_not_equals(
     getComputedStyle(div).width,
     '100px',
@@ -38,12 +38,12 @@ promise_test(async t => {
   );
 
   // Trigger new width change mid-transition
-  div.style.width = '0px';
+  div.style.width = '200px';
 
   assert_not_equals(
     getComputedStyle(div).width,
-    '0px',
-    'Width should not changed to 0px immediately'
+    '200px',
+    'Width should not change to 0px immediately'
   );
 
   await waitForTransitionEnd(div);
@@ -51,8 +51,8 @@ promise_test(async t => {
   // Final computed style
   assert_equals(
     getComputedStyle(div).width,
-    '0px',
-    'Final width should be 0px'
+    '200px',
+    'Final width should be 200px'
   );
 }, 'Mid-transition transition changes affect subsequent transitions');
 </script>


### PR DESCRIPTION
This test is being flaky in [Ladybird's CI runs](https://github.com/LadybirdBrowser/ladybird/actions/runs/19396678002/job/55497632965?pr=6835#step:15:7896) and, from the looks of it, [Chromium has the same problem](https://issues.chromium.org/issues/417479566).
So I have
a) Made the transition longer.
I'm not sure if the transitions spec can be implemented in a way where, under stress, 100ms have already passed by the time the `transitionrun` event listener fires, but if that's the case the first assert could fail.

and b) Made the final value `200px` instead of `0px`.
That way it's distinct from the starting value. If (and I'm not sure if it does) the transitions spec allows implementing things in such a way that by the time `transitionrun` fires, the value hasn't started transitioning yet, then the second assert could fail when setting back to `0px` while already still at `0px`.

Neither of these should affect the correctness of the test.