### PR TITLE
Map "shadow-parts" web-feature

### DIFF
--- a/css/css-shadow-parts/WEB_FEATURES.yml
+++ b/css/css-shadow-parts/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: shadow-parts
+  files: '**'

--- a/css/selectors/invalidation/WEB_FEATURES.yml
+++ b/css/selectors/invalidation/WEB_FEATURES.yml
@@ -23,3 +23,8 @@ features:
 - name: state
   files:
   - state-in-has.html
+- name: shadow-parts
+  files:
+  - part-dir.html
+  - part-lang.html
+  - part-pseudo.html

--- a/css/selectors/parsing/WEB_FEATURES.yml
+++ b/css/selectors/parsing/WEB_FEATURES.yml
@@ -15,3 +15,6 @@ features:
 - name: not
   files:
   - parse-not.html
+- name: shadow-parts
+  files:
+  - parse-part.html


### PR DESCRIPTION
Feature: `shadow-parts`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/shadow-parts.yml

**Notable inclusions**

1. Style invalidation tests in `css/selectors/invalidation/` - these test that `::part()` selectors properly invalidate when attributes change

**Notable exclusions**

1. `css/css-view-transitions/` - 7 tests that use `::part()` or shadow parts, but primary focus is View Transitions
2. `css/css-anchor-position/` - 6 tests that mention shadow/tree scopes, but primary focus is CSS Anchor Positioning
3. `scroll-animations/css/` - 3 tests involving shadow trees, but primary focus is scroll animations, timeline scoping
4. `css/css-animations/` - 3 tests with "shadow-part" in filename, but primary focus is CSS Animations `@keyframes` scoping
5. Other directories with shadow-related tests - Container Queries, CSS Cascade `@scope`, Counter Styles, CSS Mixins, Custom Elements state, and various crash/parsing tests where shadow parts are used as test infra for other features