### PR TITLE
html: The queued <media> `volumechange` event should be cancellable

### DIFF
--- a/html/semantics/embedded-content/media-elements/event_volumechange.html
+++ b/html/semantics/embedded-content/media-elements/event_volumechange.html
@@ -65,6 +65,17 @@ function volumechange_test(tagName) {
       }
     });
   }, "setting " + tagName + ".volume/muted repeatedly fires volumechange repeatedly");
+
+  async_test(function(t) {
+    var e = document.createElement(tagName);
+    e.muted = !e.muted;
+    e.volume = 1 - e.volume;
+    e.load();
+    e.onvolumechange = t.unreached_func();
+    t.step_timeout(() => {
+      t.done();
+    }, 1000);
+  }, "setting " + tagName + ".volume/muted before load will not fire volumechange");
 }
 
 volumechange_test("audio");


### PR DESCRIPTION
Following the HTML specification, on the `volume` or `mute` attrubute changes the user agent must queue a media element task given the media element to fire an event named `volumechange` at the media element (the `generation_id` value will be captured to allow cancel this task - `media-element-load-algorithm` steps 3-5)

See https://html.spec.whatwg.org/multipage/#event-media-volumechange
See https://html.spec.whatwg.org/multipage/#media-element-load-algorithm

Changed the naming of the `playbackRate` and `defaultPlaybackRate` members to match Rust naming conventions (`snake_case`).

Testing: Added the `cancellable` subtest to `event_volumechange` test
- html/semantics/embedded-content/media-elements/event_volumechange.html

Reviewed in servo/servo#40763