### PR TITLE
Map "settimeout" and "setinterval" web-features

### DIFF
--- a/html/webappapis/timers/WEB_FEATURES.yml
+++ b/html/webappapis/timers/WEB_FEATURES.yml
@@ -1,8 +1,14 @@
 features:
 - name: settimeout
   files:
-  - 'cleartimeout-clearinterval.any.js'
   - 'evil-spec-example.any.js'
   - 'negative-settimeout.any.js'
   - 'settimeout-cross-realm-callback-report-exception.html'
   - 'type-long-settimeout.any.js'
+- name: setinterval
+  files:
+  - 'clearinterval-from-callback.any.js'
+  - 'missing-timeout-setinterval.any.js'
+  - 'negative-setinterval.any.js'
+  - 'setinterval-cross-realm-callback-report-exception.html'
+  - 'type-long-setinterval.any.js'

--- a/html/webappapis/timers/WEB_FEATURES.yml
+++ b/html/webappapis/timers/WEB_FEATURES.yml
@@ -1,0 +1,8 @@
+features:
+- name: settimeout
+  files:
+  - 'cleartimeout-clearinterval.any.js'
+  - 'evil-spec-example.any.js'
+  - 'negative-settimeout.any.js'
+  - 'settimeout-cross-realm-callback-report-exception.html'
+  - 'type-long-settimeout.any.js'

--- a/workers/WEB_FEATURES.yml
+++ b/workers/WEB_FEATURES.yml
@@ -2,6 +2,9 @@ features:
 - name: request-animation-frame-workers
   files:
   - WorkerGlobalScope_requestAnimationFrame.worker.js
+- name: settimeout
+  files:
+  - 'WorkerGlobalScope_setTimeout.htm'
 - name: ua-client-hints
   files:
   - WorkerNavigator_userAgentData.http.html

--- a/workers/WEB_FEATURES.yml
+++ b/workers/WEB_FEATURES.yml
@@ -2,6 +2,9 @@ features:
 - name: request-animation-frame-workers
   files:
   - WorkerGlobalScope_requestAnimationFrame.worker.js
+- name: setinterval
+  files:
+  - 'WorkerGlobalScope_setInterval.htm'
 - name: settimeout
   files:
   - 'WorkerGlobalScope_setTimeout.htm'

--- a/workers/interfaces/WorkerGlobalScope/close/WEB_FEATURES.yml
+++ b/workers/interfaces/WorkerGlobalScope/close/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: settimeout
+  files:
+  - 'setTimeout.html'

--- a/workers/interfaces/WorkerGlobalScope/close/WEB_FEATURES.yml
+++ b/workers/interfaces/WorkerGlobalScope/close/WEB_FEATURES.yml
@@ -1,4 +1,7 @@
 features:
+- name: setinterval
+  files:
+  - 'setInterval.html'
 - name: settimeout
   files:
   - 'setTimeout.html'

--- a/workers/interfaces/WorkerUtils/WindowTimers/WEB_FEATURES.yml
+++ b/workers/interfaces/WorkerUtils/WindowTimers/WEB_FEATURES.yml
@@ -1,3 +1,10 @@
 features:
+- name: setinterval
+  files:
+  - '003.html'
+  - '004.html'
+  - '005.html'
 - name: settimeout
-  files: '*.html'
+  files:
+  - '001.html'
+  - '002.html'

--- a/workers/interfaces/WorkerUtils/WindowTimers/WEB_FEATURES.yml
+++ b/workers/interfaces/WorkerUtils/WindowTimers/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: settimeout
+  files: '*.html'


### PR DESCRIPTION
Feature: `settimeout`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/settimeout.yml

Feature: `setinterval`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/setinterval.yml

**Notable inclusions**

1. I included a number of worker tests because `api.setTimeout.worker_support`, `- api.clearTimeout.worker_support`, etc are listed in the `compat_features`

**Notable exclusions**

1. CSP tests - Primary focus: Content Security Policy enforcement
   - `content-security-policy/unsafe-eval/eval-scripts-setTimeout-allowed.sub.html`
   - `content-security-policy/unsafe-eval/eval-scripts-setTimeout-blocked.sub.html`
   - `content-security-policy/script-src/worker-set-timeout.sub.html`
   - `content-security-policy/script-src/worker-data-set-timeout.sub.html`
   etc.

2. Dynamic import tests - Primary focus: Module loading and credentials
   - `html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-credentials-setTimeout.sub.html`
   - `html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-*.html`

3. window.onerror tests - Primary focus: Error handling, not setTimeout behavior
   - `html/webappapis/scripting/processing-model-2/compile-error-in-setTimeout.html`
   - `html/webappapis/scripting/processing-model-2/runtime-error-in-setTimeout.html`
   - `html/webappapis/scripting/processing-model-2/compile-error-cross-origin-setTimeout.html`
   - `html/webappapis/scripting/processing-model-2/runtime-error-cross-origin-setTimeout.html`
   etc.
