### PR TITLE
docs: clarify no trailing whitespace rule in style guidelines

### DIFF
--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -181,6 +181,7 @@ not uniformly enforced throughout the existing tests, but will be for
 new tests. Any of these rules may be broken if the test demands it:
 
  * No trailing whitespace
+ * Trailing whitespace often causes unnecessary diffs and may cause tests to fail lint checks. Keeping lines clean avoids formatting noise during review.
  * Use spaces rather than tabs for indentation
  * Use UNIX-style line endings (i.e. no CR characters at EOL)
 


### PR DESCRIPTION
This PR expands the existing “No trailing whitespace” rule by adding an
explanation for why this requirement exists. Trailing whitespace causes
unnecessarily large diffs and may trigger lint failures, so clarifying
this helps contributors avoid formatting noise.

Documentation-only change.

— @vardhan30016
