### PR TITLE
script: Don't crash when encountering unexpected node types in `Range::createContextualFragment`

### DIFF
--- a/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
+++ b/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+    <title>createContextualFragment should not crash when the end node is a processing instruction</title>
+    <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-range-createcontextualfragment">
+    <link rel="help" href="https://github.com/servo/servo/issues/40719">
+</head>
+<body>
+    <script>
+      let pi =
+          document.createProcessingInstruction("xml-stylesheet",
+					   'href="mycss.css" type="text/css"');
+      let range = document.createRange();
+      range.setEnd(pi, 0)
+      range.createContextualFragment("<div>A</div>");
+    </script>
+</body>

--- a/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
+++ b/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
@@ -7,9 +7,7 @@
 </head>
 <body>
     <script>
-      let pi =
-          document.createProcessingInstruction("xml-stylesheet",
-					   'href="mycss.css" type="text/css"');
+      let pi = document.createProcessingInstruction("xml-stylesheet", 'href="mycss.css" type="text/css"');
       let range = document.createRange();
       range.setEnd(pi, 0)
       range.createContextualFragment("<div>A</div>");


### PR DESCRIPTION
The spec says that all node types other than element, text and comment should be treated as `None`. We were panicking on a few instead. 

Testing: This change adds a simple crashtest
Fixes: https://github.com/servo/servo/issues/40719

Reviewed in servo/servo#40762