### PR TITLE
layout: Cleanup for replaced elements with widgets

### DIFF
--- a/css/css-sizing/aspect-ratio/replaced-element-049-ref.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-049-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio reference: video with controls</title>
+
+<style>
+video {
+  display: block;
+  border: solid green;
+  width: 300px;
+  height: 300px;
+}
+</style>
+<video controls></video>

--- a/css/css-sizing/aspect-ratio/replaced-element-049.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-049.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: video with controls</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<link rel="help" href="https://github.com/servo/servo/issues/40770">
+<link rel="match" href="replaced-element-049-ref.html">
+
+<style>
+video {
+  display: block;
+  border: solid green;
+  width: 300px;
+  aspect-ratio: 1;
+}
+</style>
+<video controls></video>


### PR DESCRIPTION
This cleans up the changes done in #<!-- nolink -->40578.

In particular, it removes the unnecessary `Contents::ReplacedWithWidget` since we can handle that with `Contents::Replaced`. It also removes `IndependentFormattingContextContents::ReplacedWithWidget` in favor of `IndependentFormattingContextContents::Replaced`, by adding an optional parameter for the widget.

That ensures that the behavior of replaced elements won't accidentally diverge dependign on whether they have a widget. For example, #<!-- nolink -->40578 forgot to handle `ReplacedWithWidget` in `tentative_block_content_size()`.

Additionally, this removes the hardcoded especial behavior for `<video>` that was added in `ServoThreadSafeLayoutElement::with_pseudo()`.

Testing: Adding a reftest
Fixes: #<!-- nolink -->40708
Fixes: #<!-- nolink -->40770
Reviewed in servo/servo#40769