### PR TITLE
Classify ruby & ruby-overhang web features

### DIFF
--- a/css/css-ruby/WEB_FEATURES.yml
+++ b/css/css-ruby/WEB_FEATURES.yml
@@ -1,7 +1,16 @@
 features:
+- name: ruby
+  files:
+  - "!ruby-align-*"
+  - "!ruby-position*"
+  - "!ruby-overhang*"
+  - "*"
 - name: ruby-align
   files:
   - ruby-align-*
 - name: ruby-position
   files:
   - ruby-position*
+- name: ruby-overhang
+  files:
+  - ruby-overhang*

--- a/css/css-ruby/WEB_FEATURES.yml
+++ b/css/css-ruby/WEB_FEATURES.yml
@@ -14,3 +14,4 @@ features:
 - name: ruby-overhang
   files:
   - ruby-overhang*
+# Make sure to add an exclusion to the "ruby" match when adding a new feature


### PR DESCRIPTION
Was a little mixed about `css/css-break/ruby*` and `css/css/css-ui/text-overflow-ruby.html` - but `<ruby>` tags are spread out a bit, wondering a little if others should be classified.

Greps:

* [`<(rt|rb|ruby)>`](https://github.com/user-attachments/files/23664112/20251120174258-XXXXXXXX.txt)
* [`ruby-overhang`](https://github.com/user-attachments/files/23664120/20251120174949-XXXXXXXX.txt)
