### PR TITLE
maps "window-controls-overlay" web feature

### DIFF
--- a/appmanifest/display-override-member/WEB_FEATURES.yml
+++ b/appmanifest/display-override-member/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: window-controls-overlay
+  files:
+  - '*window-controls-overlay*'

--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml
@@ -9,3 +9,6 @@ features:
 - name: registerprotocolhandler
   files:
   - protocol-*
+- name: window-controls-overlay
+  files:
+  - navigator-window-controls-overlay.tentative.html


### PR DESCRIPTION
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/window-controls-overlay.yml

Note: The `display_override: ["window-controls-overlay"]` web application manifest member enables progressive web apps to extend their content into the title bar area on desktop devices. This feature includes the Navigator.windowControlsOverlay API and CSS environment variables for titlebar area positioning.

Results:
- Total matches found: 54
- Filtered: 4 files

WEB_FEATURES.yml files created:
✅ appmanifest/display-override-member/WEB_FEATURES.yml - Display override tests (3 files) using '*window-controls-overlay*' pattern

WEB_FEATURES.yml files updated:
✅ html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml - Navigator API test (1 file)

Excluded (6 files):
❌ css/mediaqueries/display-mode.tentative.html - Tests display-mode media query parsing, not WCO feature specifically (1 file)

originally in https://github.com/web-platform-tests/wpt/pull/55663