### PR TITLE
classifies "widow-orphans" web feature

### DIFF
--- a/css/CSS2/pagination/WEB_FEATURES.yml
+++ b/css/CSS2/pagination/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: widows-orphans
+  files:
+  - 'orphans-*'
+  - 'widows-*'


### PR DESCRIPTION
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/widows-orphans.yml

Note: The `widows` and `orphans` CSS properties establish minimum line thresholds for text fragments that result from page, column, or region breaks. These properties help control how text breaks across pages or columns, preventing isolated lines from appearing alone at boundaries.

Search strategy: Searched for tests referencing "widows" and "orphans" properties.

Results:
- Total matches found: 288 unique files
- Filtered: 10 files

WEB_FEATURES.yml files created:
✅ css/CSS2/pagination/WEB_FEATURES.yml - CSS2.1 widows and orphans property tests (10 files)

Excluded (278 files):
- css/css-break/ (65 files): Already mapped to widows-orphans in existing WEB_FEATURES.yml with orphans-* and widows-* patterns
- css/css-multicol/ (112 files): Primary focus is multicol layout and column balancing, using widows/orphans incidentally
- css/CSS2/pagination/ (15 files): Other pagination tests (page-break-* properties), not widows/orphans
- css/css-flexbox/interactive/ (13 files): Primary focus is flexbox; sets widows:1/orphans:1 to prevent page breaks
- css/css-inline/text-box-trim/ (13 files): Primary focus is text-box-trim feature
- css/css-overflow/ (8 files): Overflow tests using these properties incidentally
- Crashtests (11 files): Incidental inclusion
- Other directories (41 files): Various tests using widows/orphans for layout control, not testing the properties themselves

Extracted from https://github.com/web-platform-tests/wpt/pull/55663