### PR TITLE
Move scoped custom element registry for createElement and attachShadow

### DIFF
--- a/custom-elements/registries/Document-createElement.html
+++ b/custom-elements/registries/Document-createElement.html
@@ -58,6 +58,18 @@ test(() => {
     assert_equals(element.__proto__.constructor.name, 'HTMLElement');
 }, 'createElement should create an upgrade candidate when there is no matching definition in the specified registry');
 
+test((t) => {
+    assert_equals(document.createElement('div', {customElementRegistry: null}).customElementRegistry, null);
+}, `document.createElement should create a builtin element with null registry if customElementRegistry is set to null`);
+
+test((t) => {
+    assert_equals(document.createElement('c-d', {customElementRegistry: null}).customElementRegistry, null);
+}, `document.createElement should create a custom element candidate with null registry if customElementRegistry is set to null`);
+
+test((t) => {
+    assert_equals(document.createElement('a-b', {customElementRegistry: null}).customElementRegistry, null);
+}, `document.createElement should create a custom element candidate with null registry if customElementRegistry is set to null even if there is a custom element of the same name in the glboal registry`);
+
 test(() => {
     class CDElement extends HTMLElement { }
     const registry = new CustomElementRegistry;

--- a/custom-elements/registries/Document-createElementNS.html
+++ b/custom-elements/registries/Document-createElementNS.html
@@ -57,6 +57,18 @@ test(() => {
     assert_equals(element.__proto__.constructor.name, 'HTMLElement');
 }, 'createElementNS should create an upgrade candidate when there is no matching definition in the specified registry');
 
+test((t) => {
+    assert_equals(document.createElementNS('http://www.w3.org/1999/xhtml', 'div', {customElementRegistry: null}).customElementRegistry, null);
+}, `document.createElement should create a builtin element with null registry if customElement is set to null`);
+
+test((t) => {
+    assert_equals(document.createElementNS('http://www.w3.org/1999/xhtml', 'c-d', {customElementRegistry: null}).customElementRegistry, null);
+}, `document.createElement should create a custom element candidate with null registry if customElement is set to null`);
+
+test((t) => {
+    assert_equals(document.createElementNS('http://www.w3.org/1999/xhtml', 'a-b', {customElementRegistry: null}).customElementRegistry, null);
+}, `document.createElement should create a defined custom element with null registry if customElement is set to null`);
+
 test(() => {
     class CDElement extends HTMLElement { }
     const registry = new CustomElementRegistry;

--- a/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -9,6 +9,9 @@
 <body>
 <script>
 
+class GlobalABElement extends HTMLElement {};
+customElements.define('a-b', GlobalABElement);
+
 test(() => {
     const shadowRoot = document.createElement('div').attachShadow({mode: 'closed'});
     assert_equals(shadowRoot.customElementRegistry, window.customElements);
@@ -45,6 +48,24 @@ test(() => {
     const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
     assert_equals(shadowRoot.customElementRegistry, null);
 }, 'attachShadow() should use null registry when customElementRegistry is null (host uses custom registry)');
+
+test((test) => {
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
+    assert_equals(shadowRoot.customElementRegistry, null);
+}, `attchShadow on a builtin element with null customElementRegistry should create a ShadowRoot with null registry`);
+
+test((test) => {
+    const host = document.createElement('c-d');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
+    assert_equals(shadowRoot.customElementRegistry, null);
+}, `attchShadow on a custom elememnt candidate with null customElementRegistry should create a ShadowRoot with null registry`);
+
+test((test) => {
+    const host = document.createElement('a-b');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
+    assert_equals(shadowRoot.customElementRegistry, null);
+}, `attchShadow on a custom elememnt with null customElementRegistry should create a ShadowRoot with null registry`);
 
 test(() => {
     const registry = new CustomElementRegistry;

--- a/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
+++ b/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html
@@ -31,19 +31,6 @@ function runBasicTests(makeIframe, elementName, elementDescription) {
 
     test((test) => {
         const [doc, win] = makeIframe(test);
-        assert_equals(doc.createElement(elementName, {customElementRegistry: null}).customElementRegistry, null);
-        assert_equals(doc.createElementNS('http://www.w3.org/1999/xhtml', 'div', {customElementRegistry: null}).customElementRegistry, null);
-    }, `document.createElement should create a ${elementDescription} with null registry if customElement is set to null`);
-
-    test((test) => {
-        const [doc, win] = makeIframe(test);
-        const host = doc.createElement(elementName);
-        const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null})
-        assert_equals(shadowRoot.customElementRegistry, null);
-    }, `attchShadow on a ${elementDescription} with null customElementRegistry should create a ShadowRoot with null registry`);
-
-    test((test) => {
-        const [doc, win] = makeIframe(test);
         const element = doc.createElement(elementName);
         assert_equals(element.customElementRegistry, win.customElements);
         element.setAttribute('customelementregistry', '');
@@ -65,6 +52,16 @@ function runBasicTests(makeIframe, elementName, elementDescription) {
 runBasicTests(makeIframe, 'div', 'builtin element');
 runBasicTests(makeIframe, 'a-b', 'custom element candidate');
 runBasicTests(makeIframeWithABElement, 'a-b', 'custom element');
+
+test((test) => {
+    const [doc, win] = makeIframe(test);
+    win.customElements.define('c-d', class CDElement extends win.HTMLElement { });
+    const container = doc.createElement('div', {customElementRegistry: null});
+    container.innerHTML = '<a-b><c-d></c-d><e-f customelementregistry></e-f></a-b>';
+    assert_equals(container.querySelector('a-b').customElementRegistry, null);
+    assert_equals(container.querySelector('c-d').customElementRegistry, null);
+    assert_equals(container.querySelector('e-f').customElementRegistry, null);
+}, 'Descendants of an element with customelementregistry should use null registry');
 
 test((test) => {
     const [doc, win] = makeIframe(test);

--- a/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
+++ b/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
@@ -87,6 +87,17 @@ test((test) => {
     assert_equals(shadowRoot.customElementRegistry, registry);
 }, 'Inserting the shadow host of a shadow root with a scoped custom element registry does not change the registry');
 
+test((test) => {
+    const [doc1, win1] = makeIframe(test);
+    const [doc2, win2] = makeIframe(test);
+    win2.customElements.define('a-b', class ABElement extends win2.HTMLElement { });
+    const elementFromDoc1 = doc1.createElement('a-b');
+    assert_equals(elementFromDoc1.customElementRegistry, null);
+    doc2.body.appendChild(elementFromDoc1);
+    assert_equals(elementFromDoc1.customElementRegistry, win2.customElements);
+    assert_true(elementFromDoc1 instanceof ABElement);
+}, 'Inserting a node from another document results in the custom element registry to be set and upgraded.');
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
Also add a test case for specifying null custom element registry in an ancestor element.