### PR TITLE
Disallow contraction of {scroll,view}-timeline shorthands when longhands have dissimilar cardinality

### DIFF
--- a/scroll-animations/css/scroll-timeline-shorthand.html
+++ b/scroll-animations/css/scroll-timeline-shorthand.html
@@ -100,10 +100,10 @@ test_shorthand_contraction('scroll-timeline', {
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b, --c',
   'scroll-timeline-axis': 'inline, inline',
-}, '--a inline, --b inline, --c inline');
+}, '');
 
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b',
   'scroll-timeline-axis': 'inline, inline, inline',
-}, '--a inline, --b inline');
+}, '');
 </script>

--- a/scroll-animations/css/view-timeline-shorthand.html
+++ b/scroll-animations/css/view-timeline-shorthand.html
@@ -148,17 +148,17 @@ test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b, --c',
   'view-timeline-axis': 'inline, inline',
   'view-timeline-inset': 'auto, auto',
-}, '--a inline, --b inline, --c inline');
+}, '');
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b',
   'view-timeline-axis': 'inline, inline, inline',
   'view-timeline-inset': 'auto, auto, auto',
-}, '--a inline, --b inline');
+}, '');
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b',
   'view-timeline-axis': 'inline, inline',
   'view-timeline-inset': 'auto, auto, auto',
-}, '--a inline, --b inline');
+}, '');
 </script>


### PR DESCRIPTION
According to https://drafts.csswg.org/cssom/#serializing-css-values (step 1.2) shorthands should only be contracted if they can exactly represent the values of all it's longhands - that was not the case for these tests. Take for example the test which expected

```css
scroll-timeline-name: --a, --b, --c;
scroll-timeline-axis: inline, inline;
```

to be serialized as

```css
scroll-timeline: --a inline, --b inline, --c inline;
```

The serialized value actually represents the longhand value for `scroll-timeline-axis` of `inline, inline, line` (3 elements instead of the original 2).

This matches the behavior of Chrome & Firefox.