### PR TITLE
maps virtual-sensor web feature

### DIFF
--- a/generic-sensor/WEB_FEATURES.yml
+++ b/generic-sensor/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: virtual-sensor
+  files: '**'


### PR DESCRIPTION
Despite the directory name mismatch, the [generic-sensor directory](https://github.com/web-platform-tests/wpt/blob/master/generic-sensor/META.yml#L1) and the [virtual-sensors web feature docs](https://github.com/web-platform-dx/web-features/blob/main/features/virtual-sensors.yml#L3) both reference the same spec: https://w3c.github.io/sensors/

Followed the example in this merged [compute-pressure mapping PR](https://github.com/web-platform-tests/wpt/pull/46097).