### PR TITLE
Allow webdriver to automatically accept custom protocol handlers

### DIFF
--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
@@ -35,6 +35,7 @@ function runTest({ includeNull = false } = {}) {
     }
     a.href = `${scheme}:${codePoints.join("")}`;
     a.target = "_blank";
+    console.log(a.href);
     a.click();
     await new Promise(resolve => {
       bc.onmessage = t.step_func(e => {


### PR DESCRIPTION
This reads the `protocol_handler_automation_mode` and if it is
`autoAccept`, then we should eagerly register the protocol handler.
We do this by updating the `ProtocolRegistry` in the resource thread,
where we need to clone it (since there can be ongoing fetches). To
be able to clone handlers, we need a new method on the trait.

Part of #<!-- nolink -->40615
Reviewed in servo/servo#40838