### PR TITLE
Add anonymized user data documentation under docs/testing (Fixes #55936)

### DIFF
--- a/docs/testing/anonymized-user-data.md
+++ b/docs/testing/anonymized-user-data.md
@@ -1,0 +1,30 @@
+# Anonymized User Data — Guidelines
+
+This document explains how anonymized user data should be handled in tests and benchmark files within this repository.
+
+## What is anonymized data?
+Anonymized data is user-related information that has been modified so that it cannot reasonably identify a real individual. Examples:
+- Removing direct identifiers  
+- Replacing identifiers with random tokens  
+- Masking IP addresses  
+- Generalizing precise values  
+
+## When should anonymized data be used?
+- When including user-like content in tests  
+- When copying example content from third-party sources  
+- When verifying behavior without exposing any real personal data  
+
+## Techniques for anonymization
+- Tokenization (`user-001`, `id-xyz`)  
+- Hashing (non-reversible)  
+- Masking (`192.0.2.xxx`)  
+- Using test-only ranges (RFC 5737 for IPs)  
+- Generalization (city → country)
+
+## Notes for contributors
+- Do **not** include real personal data in tests.  
+- Update documentation/benchmark text to **anonymized** spelling if needed.  
+- Test fixtures (like those under `conformance-checkers/`) may intentionally use different spellings or casings – check with maintainers before modifying them.
+
+## Related issue
+This documentation relates to clarifying anonymized data usage for issue #55936.

--- a/tools/third_party/html5lib/benchmarks/data/html.html
+++ b/tools/third_party/html5lib/benchmarks/data/html.html
@@ -903,7 +903,7 @@
   device, or from network to network, their IP address will change; similarly, NAT routing, proxy
   servers, and shared computers enable packets that appear to all come from a single IP address to
   actually map to multiple users. Technologies such as onion routing can be used to further
-  anonymise requests so that requests from a single user at one node on the Internet appear to come
+  anonymize requests so that requests from a single user at one node on the Internet appear to come
   from many disparate parts of the network.</p>
 
   <p>However, the IP address used for a user's requests is not the only mechanism by which a user's


### PR DESCRIPTION
This PR adds a new documentation file at:

docs/testing/anonymized-user-data.md

The purpose of this document is to provide clear guidance on:
- What “anonymized user data” means in the context of WPT
- When anonymized data should be used in tests and benchmarks
- Common anonymization techniques (tokenization, masking, hashing, etc.)
- Best practices for contributors writing tests involving user-like data
- Notes on spelling consistency (using “anonymized”) and when not to modify test fixtures

This helps clarify the difference between documentation/benchmark text and
intentional test-case variations found under conformance-checkers.

This documentation is related to issue #55936 and supports ongoing efforts
to standardize wording and prevent accidental inclusion of real personal data.

Fixes #55936
