### PR TITLE
Map "share" web-feature

### DIFF
--- a/web-share/WEB_FEATURES.yml
+++ b/web-share/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: share
+  files: "**"


### PR DESCRIPTION
Feature: `navigator.share()`
Reference: [https://github.com/web-platform-dx/web-features/blob/main/features/share.yml](https://github.com/web-platform-dx/web-features/blob/main/features/share.yml)

Notable exclusions:
- `fenced-frame/web-share.https.html` - Primary focus is Fenced Frame API
- `speculation-rules/prerender/web-share.https.html` - Primary focus is Speculation Rules API restrictions