### PR TITLE
Map `shared-storage` and `shared-storage-locks` web feature

### DIFF
--- a/shared-storage/WEB_FEATURES.yml
+++ b/shared-storage/WEB_FEATURES.yml
@@ -1,0 +1,8 @@
+features:
+- name: shared-storage
+  files:
+  - "*"
+  - "!web-locks*"
+- name: shared-storage-locks
+  files:
+  - web-locks*


### PR DESCRIPTION
Feature: Shared storage & shared storage locks
Reference:
- https://github.com/web-platform-dx/web-features/blob/main/features/shared-storage.yml
- https://github.com/web-platform-dx/web-features/blob/main/features/shared-storage-locks.yml

Notable exclusions:
- shared-storage-selecturl-limit/* - This is so closely tied to Fenced Frames that I decided to exclude, especially given that there is a pending issue to move the Navigation Entropy Budget section of the spec to Fenced Frames.