### PR TITLE
maps webvtt-cue-settings

### DIFF
--- a/webvtt/api/VTTCue/WEB_FEATURES.yml
+++ b/webvtt/api/VTTCue/WEB_FEATURES.yml
@@ -1,14 +1,16 @@
 features:
 - name: webvtt
   files:
-  - align.html
   - constructor-exceptions.html
   - getCueAsHTML.html
+  - text.html
+- name: webvtt-cue-settings
+  files:
+  - align.html
   - line.html
   - position.html
   - size.html
   - snapToLines.html
-  - text.html
   - vertical.html
 - name: webvtt-cue-alignment
   files:


### PR DESCRIPTION
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/webvtt-cue-settings.yml

Covers:
- api.VTTCue.align
- api.VTTCue.line
- api.VTTCue.position
- api.VTTCue.size
- api.VTTCue.snapToLines
- api.VTTCue.vertical

Pulled from https://github.com/web-platform-tests/wpt/pull/55821