### PR TITLE
classifies webrtc web feature

### DIFF
--- a/webrtc/WEB_FEATURES.yml
+++ b/webrtc/WEB_FEATURES.yml
@@ -1,4 +1,8 @@
 features:
+- name: webrtc
+  files:
+  - '*'
+  - '!RTCSctpTransport-*'
 - name: webrtc-sctp
   files:
   - RTCSctpTransport-*

--- a/webrtc/legacy/WEB_FEATURES.yml
+++ b/webrtc/legacy/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: webrtc
+  files: '**'

--- a/webrtc/protocol/WEB_FEATURES.yml
+++ b/webrtc/protocol/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: webrtc
+  files: '**'

--- a/webrtc/simulcast/WEB_FEATURES.yml
+++ b/webrtc/simulcast/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: webrtc
+  files: '**'


### PR DESCRIPTION
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/webrtc.yml

Because we needed an exclusion pattern in the root directory for the `webrtc-sctp` tests, I added additional yml files in subdirectories to cover the rest of the tests. 

Subdirectories included:
- `legacy/`: Tests for deprecated WebRTC API patterns (offerToReceive, onaddstream, etc.)
- `protocol/`: SDP protocol negotiation, codec filtering, bundle policy, crypto suites
- `simulcast/`: Simulcast encoding tests for various codecs (AV1, H.264, VP8, VP9) with scalability mode