### PR TITLE
classifies webauthn web features

### DIFF
--- a/webauthn/WEB_FEATURES.yml
+++ b/webauthn/WEB_FEATURES.yml
@@ -2,3 +2,8 @@ features:
 - name: webauthn-public-key-easy
   files:
   - createcredential-getpublickey.https.html
+- name: webauthn-signals
+  files:
+  - signal-all-accepted-credentials.https.html
+  - signal-current-user-details.https.html
+  - signal-unknown-credential.https.html

--- a/webauthn/WEB_FEATURES.yml
+++ b/webauthn/WEB_FEATURES.yml
@@ -1,4 +1,9 @@
 features:
+- name: webauthn
+  files:
+  - '*'
+  - '!createcredential-getpublickey.https.html'
+  - '!signal-*'
 - name: webauthn-public-key-easy
   files:
   - createcredential-getpublickey.https.html


### PR DESCRIPTION
Covers [webauthn](https://github.com/web-platform-dx/web-features/blob/main/features/webauthn.yml) and [webauthn-signals](https://github.com/web-platform-dx/web-features/blob/main/features/webauthn-signals.yml) web features. Excludes existing classification for "webauthn-public-key-easy".

Pulled from https://github.com/web-platform-tests/wpt/pull/55821