### PR TITLE
Map "Barcode detector" to web-features

### DIFF
--- a/interfaces/WEB_FEATURES.yml
+++ b/interfaces/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: barcode
+  files:
+  - shape-detection-api.idl

--- a/shape-detection/WEB_FEATURES.yml
+++ b/shape-detection/WEB_FEATURES.yml
@@ -1,0 +1,25 @@
+features:
+- name: barcode
+  files:
+  - detected-boundingBox-read-only.https.html
+  - detected-postMessage.https.html
+  - detection-Blob.https.window.js
+  - detection-HTMLCanvasElement.https.html
+  - detection-HTMLImageElement-empty-src.https.html
+  - detection-HTMLImageElement-zero-dimension-image.https.html
+  - detection-HTMLImageElement.https.html
+  - detection-HTMLVideoElement.https.html
+  - detection-ImageBitmap-closed.https.window.js
+  - detection-ImageBitmap.https.html
+  - detection-ImageData-detached.https.html
+  - detection-ImageData.https.html
+  - detection-SVGImageElement.https.window.js
+  - detection-VideoFrame.https.window.js
+  - detection-getSupportedFormats.https.html
+  - detection-on-worker.https.worker.js
+  - detection-options.https.html
+  - detection-security-test.https.html
+  - detector-same-object.https.html
+  - idlharness.https.any.js
+  - shapedetection-cross-origin.sub.https.html
+  - single-barcode-detection.https.html


### PR DESCRIPTION
Re-submitted from gh-55697 for independent consideration. As noted there:

> > Web features only includes one of the Shape Detection API's two proposed interfaces, but almost all the WPT tests include subtests for both (along with a third which seems to have been deprecated). Should we create a web feature for Face Detection? And if so, how should we classify it?
>
> I think that given how the test suite is organized, we can't map these tests correctly. It would be good to keep a list of infeasible mapping and add "Barcode detector" to that. At the end of this project we can review that list and see what we if anything we'd like to see as future followup on those.