### PR TITLE
Map "Change event" to web-features

### DIFF
--- a/dom/events/WEB_FEATURES.yml
+++ b/dom/events/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: change-event
+  files:
+  - legacy-pre-activation-behavior.window.js

--- a/html/semantics/forms/WEB_FEATURES.yml
+++ b/html/semantics/forms/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: change-event
+  files:
+  - input-change-event-properties.html

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -18,3 +18,6 @@ features:
   files:
   - type-change-file-to-text-crash.html
   - input-value-invalidstateerr.html
+- name: change-event
+  files:
+  - change-to-empty-value.html

--- a/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
@@ -4,3 +4,6 @@ features:
   - textarea-setcustomvalidity.html
   - textarea-validity-clone.html
   - textarea-validity-valueMissing-inside-datalist.html
+- name: change-event
+  files:
+  - change-to-empty-value.html


### PR DESCRIPTION
This classifier includes 4 files and excludes 292 files

---

@foolip the interesting tests for the "input" and "change" events are bound up with one another. Here's what I found:

- dom/events/Event-dispatch-click.html
- dom/events/Event-dispatch-click.tentative.html
- dom/events/Event-dispatch-detached-input-and-change.html
- html/semantics/forms/input-change-event-properties.html
- html/semantics/forms/the-input-element/input-untrusted-key-event.html
- html/semantics/forms/the-select-element/customizable-select/select-events-2.optional.html
- html/semantics/forms/the-select-element/customizable-select/select-events.optional.html
- input-events/input-events-arrow-key-on-number-input-delete-document.html
- input-events/input-events-arrow-key-on-number-input-prevent-default.html
- input-events/input-events-arrow-key-on-number-input.html
- input-events/input-events-cut-paste.html
- input-events/input-events-exec-command.html
- input-events/input-events-spin-button-click-on-number-input-delete-document.html
- input-events/input-events-spin-button-click-on-number-input-prevent-default.html
- input-events/input-events-spin-button-click-on-number-input.html
- input-events/input-events-typing.html

This significantly detracts from the quality of this set of classifications, and as far as I can tell, there are no tests which exclusively test the "input" event as described by [the `input-event` web feature](https://github.com/web-platform-dx/web-features/blob/3e3be72c98f562cc940c4cc29314f600be3004b9/features/input-event.yml). What do you think?