### PR TITLE
dom: Focus scroll to the element only if it is not visible

### DIFF
--- a/css/cssom-view/scrollIntoView-nearest-visible-element.html
+++ b/css/cssom-view/scrollIntoView-nearest-visible-element.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>scrollIntoView nearest shouldn't scroll a completely visible element</title>
+  <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+  <link rel="help" href="https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<style>
+#container {
+  width: 300px;
+  height: 300px;
+  overflow: scroll;
+}
+
+#target {
+  width: 100px;
+  height: 100px;
+  position: relative;
+  top: 600px;
+  left: 800px;
+  background-color: aqua;
+}
+
+#overflowing {
+  width: 3000px;
+  height: 3000px;
+}
+</style>
+
+<div id="container">
+  <div id="target">
+  </div>
+  <div id="overflowing"></div>
+</div>
+
+<script>
+  test(function() {
+    container.scrollTop = 500;
+    container.scrollLeft = 700;
+    let initial_target_rect = target.getBoundingClientRect();
+    target.scrollIntoView({block: 'nearest', inline: 'nearest'});
+
+    let final_target_rect = target.getBoundingClientRect();
+    assert_equals(initial_target_rect.x, final_target_rect.x, 'Target x position remain unchanged');
+    assert_equals(initial_target_rect.y, final_target_rect.y, 'Target y position remain unchanged');
+  }, "scrollIntoView with `nearest` block and inline option shouldn't scroll a completely visible element");
+</script>
+</html>


### PR DESCRIPTION
Currently when we call a `Focus` we always scroll a focusable element to the center of the container. However, this would causes a different behavior where UAs wouldn't scroll when a focus is called to a visible element. This PR add implementations following the behavior of Firefox [nsFocusManager::ScrollIntoView](https://github.com/mozilla-firefox/firefox/blob/e613f4df351a21871cfeadf7d5b4043ffad157b1/dom/base/nsFocusManager.cpp#L3121), where we are scrolling to the element if it is not visible.

This would enhance the user experience of focusing an input element, where we should avoid moving the element if it is visible.

Incidentally fix a calculation bug for the calculation of `ScrollIntoView` with `nearest` block or inline option.

Testing: Private WPT for the implementation defined behavior and public WPT for the bug.
Reviewed in servo/servo#40447