### PR TITLE
Fix focus related failures due to URL bar being focused on launch

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus-multiple-times.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus-multiple-times.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/common.js"></script>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/common.js"></script>

--- a/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
@@ -3,6 +3,7 @@
 <link rel=author href="mailto:falken@chromium.org">
 <link rel=help href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=242848">
+<script src="/resources/testdriver.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -32,6 +33,9 @@ window.onload = frameLoaded;
 
 promise_test(async () => {
   await framesLoadedPromise;
+  // Chrome and edge auto-focus the URL bar when the browser is launched.
+  // This is needed to ensure the 'focus' events fire below.
+  await test_driver.click(document.body);
 
   function testFocus(element, expectFocus) {
     let focusedElement = null;

--- a/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
@@ -36,7 +36,7 @@ promise_test(async () => {
   await framesLoadedPromise;
   // Chrome and edge auto-focus the URL bar when the browser is launched.
   // This is needed to ensure the 'focus' events fire below.
-  await test_driver.click(document.body);
+  await test_driver.click(document.documentElement);
 
   function testFocus(element, expectFocus) {
     let focusedElement = null;

--- a/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
@@ -4,6 +4,7 @@
 <link rel=help href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=242848">
 <script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html
@@ -34,15 +34,8 @@ dialog {
 
 function testFocus(element, expectFocus) {
     test(function() {
-        var focusedElement = null;
-        element.addEventListener('focus', function() { focusedElement = element; }, false);
         element.focus();
-        var theElement = element;
-        if (expectFocus) {
-            assert_equals(focusedElement, theElement);
-        } else {
-            assert_not_equals(focusedElement, theElement);
-        }
+        assert_equals(element === document.activeElement, expectFocus);
     }, `#${CSS.escape(element.id)} is ${expectFocus ? "" : "not "} focusable`);
 }
 

--- a/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html
@@ -3,6 +3,8 @@
 <head>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#blocked-by-a-modal-dialog">
 <meta name="assert" content="Checks that, when opening modal dialogs, inert nodes are not focusable.">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -33,9 +35,16 @@ dialog {
 // The test passses if only the topmost dialog and its button are focusable.
 
 function testFocus(element, expectFocus) {
-    test(function() {
+    promise_test(async function() {
+        var focusedElement = null;
+        element.addEventListener('focus', function() { focusedElement = element; }, false);
         element.focus();
-        assert_equals(element === document.activeElement, expectFocus);
+        var theElement = element;
+        if (expectFocus) {
+            assert_equals(focusedElement, theElement);
+        } else {
+            assert_not_equals(focusedElement, theElement);
+        }
     }, `#${CSS.escape(element.id)} is ${expectFocus ? "" : "not "} focusable`);
 }
 
@@ -49,7 +58,8 @@ function testTree(element, expectFocus) {
 
 var bottomDialog = document.getElementById('bottom-dialog');
 var topDialog = document.getElementById('top-dialog');
-setup(function() {
+promise_setup(async function() {
+    await test_driver.click(document.documentElement);
     bottomDialog.showModal();
     topDialog.showModal();
     add_completion_callback(function() {

--- a/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html
+++ b/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -12,11 +14,18 @@
 <script>
 "use strict";
 function testFocus(element, expectFocus) {
+    var focusedElement = null;
+    element.addEventListener('focus', function() { focusedElement = element; }, false);
     element.focus();
-    assert_equals(element === document.activeElement, expectFocus);
+    var theElement = element;
+    assert_equals(focusedElement === theElement, expectFocus, element.id);
 }
 
-test(function() {
+promise_setup(async function() {
+    await test_driver.click(document.documentElement);
+})
+
+promise_test(async function() {
     var dialog = document.querySelector('dialog');
     dialog.showModal();
 

--- a/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html
+++ b/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html
@@ -12,11 +12,8 @@
 <script>
 "use strict";
 function testFocus(element, expectFocus) {
-    var focusedElement = null;
-    element.addEventListener('focus', function() { focusedElement = element; }, false);
     element.focus();
-    var theElement = element;
-    assert_equals(focusedElement === theElement, expectFocus, element.id);
+    assert_equals(element === document.activeElement, expectFocus);
 }
 
 test(function() {

--- a/html/semantics/interactive-elements/the-dialog-element/resources/common.js
+++ b/html/semantics/interactive-elements/the-dialog-element/resources/common.js
@@ -14,5 +14,6 @@ function waitUntilLoadedAndAutofocused() {
           if (loaded)
               resolve();
       }, false);
+      test_driver.click(document.documentElement);
     });
 }

--- a/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html
+++ b/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/common.js"></script>

--- a/inert/inert-node-is-unfocusable.html
+++ b/inert/inert-node-is-unfocusable.html
@@ -48,7 +48,7 @@ function testTree(element, expectFocus, excludeCurrent) {
 promise_setup(async () => {
     // Chrome and edge auto-focus the URL bar when the browser is launched.
     // This is needed to ensure the 'focus' events fire below.
-    await test_driver.click(document.body);
+    await test_driver.click(document.documentElement);
 });
 
 promise_test(async function() {

--- a/inert/inert-node-is-unfocusable.html
+++ b/inert/inert-node-is-unfocusable.html
@@ -5,6 +5,7 @@
     <title>inert nodes are unfocusable</title>
     <link rel="author" title="Alice Boxhall" href="aboxhall@chromium.org">
     <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>

--- a/inert/inert-node-is-unfocusable.html
+++ b/inert/inert-node-is-unfocusable.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>inert nodes are unfocusable</title>
     <link rel="author" title="Alice Boxhall" href="aboxhall@chromium.org">
+    <script src="/resources/testdriver.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>
@@ -43,30 +44,35 @@ function testTree(element, expectFocus, excludeCurrent) {
         testTree(childNodes[i], expectFocus);
 }
 
+promise_setup(async () => {
+    // Chrome and edge auto-focus the URL bar when the browser is launched.
+    // This is needed to ensure the 'focus' events fire below.
+    await test_driver.click(document.body);
+});
 
-test(function() {
+promise_test(async function() {
     testFocus(document.getElementById('focusable'), true);
 }, "Button outside of inert container is focusable.");
 
-test(function() {
+promise_test(async function() {
     testFocus(document.getElementById('inert'), false);
 }, "Button with inert atribute is unfocusable.");
 
-test(function() {
+promise_test(async function() {
     testTree(document.getElementById('container'), false);
 }, "All focusable elements inside inert subtree are unfocusable");
 
-test(function() {
+promise_test(async function() {
     assert_false(document.getElementById("focusable").inert, "Inert not set explicitly is false")
     assert_true(document.getElementById("inert").inert, "Inert set explicitly is true");
     assert_true(document.getElementById("container").inert, "Inert set on container is true");
 }, "Can get inert via property");
 
-test(function() {
+promise_test(async function() {
     assert_false(document.getElementById("text").inert, "Elements inside of inert subtrees return false when getting inert");
 }, "Elements inside of inert subtrees return false when getting 'inert'");
 
-test(function() {
+promise_test(async function() {
     document.getElementById('focusable').inert = true;
     testFocus(document.getElementById('focusable'), false);
     document.getElementById('inert').inert = false;


### PR DESCRIPTION
Chromium-based browsers automatically focus the URL bar on launch which can prevent focus events from firing. Fix this by ensuring the page has focus first.