### PR TITLE
Map `speak` and `speak-as` web-features

### DIFF
--- a/css/css-speech/speak-as/WEB_FEATURES.yml
+++ b/css/css-speech/speak-as/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: speak-as
+  files: '**'

--- a/css/css-typed-om/the-stylepropertymap/properties/WEB_FEATURES.yml
+++ b/css/css-typed-om/the-stylepropertymap/properties/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: speak
+  files:
+  - speak.html


### PR DESCRIPTION
Feature: `speak`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/speak.yml

Feature: `speak`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/speak-as.yml

I found limited tests for `speak`.

Notable exclusions
- `css/css-counter-styles/counter-style-at-rule/speak-as-syntax.html` - Tests the `speak-as` descriptor in `@counter-style` at-rules, which is explicitly different from the `speak-as` CSS property (as noted in the feature definition)