### PR TITLE
Map `spellcheck` web-feature

### DIFF
--- a/html/editing/editing-0/spelling-and-grammar-checking/WEB_FEATURES.yml
+++ b/html/editing/editing-0/spelling-and-grammar-checking/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: spellcheck
+  files: "**"


### PR DESCRIPTION
Feature: `spellcheck`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/spellcheck.yml

Notable inclusions:
- `spelling-markers-[001|002|007|008|009|010].html` These tests ensure that spellcheck doesn't apply to readonly input elements

Notable exclusions
- `css/css-ui/caret-*.html` These tests use `spellcheck="false"` as test infrastructure to disable spellcheck so it doesn't interfere with visual caret tests