### PR TITLE
Map `srcset` web-feature

### DIFF
--- a/density-size-correction/WEB_FEATURES.yml
+++ b/density-size-correction/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: srcset
+  files:
+  - "srcset*.html"

--- a/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
@@ -7,3 +7,8 @@ features:
   - relevant-mutations-lazy.html
   - remove-element-and-scroll.html
   - scrolling-below-viewport-image-lazy-loading-in-iframe.html
+- name: srcset
+  files:
+  - responsive-image-select-print.html
+  - update-the-source-set.html
+  - null-image-source.html

--- a/html/semantics/embedded-content/the-img-element/sizes/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/sizes/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: srcset
+  files: "**"

--- a/html/semantics/embedded-content/the-img-element/srcset/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/srcset/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: srcset
+  files: "**"


### PR DESCRIPTION
Feature: `srcset`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/srcset.yml

**Notable inclusions**

1. `srcset/srcset-media-dynamic.html` - Tests `<source>` element srcset with media queries in `<picture>` context, combines srcset with picture/media query features

**Notable exclusions**

1. Resource Timing API tests, cross-cutting concern

   - `resource-timing/initiator-type/img-srcset.html`, `resource-timing/initiator-type/picture.html`, `resource-timing/sizes-cache.any.js`, `resource-timing/sizes-redirect-img.html`, `resource-timing/sizes-redirect.any.js`, `resource-timing/body-size-cross-origin.https.html`

2. Preload tests with imagesrcset attribute, primarily about preload

   - `preload/dynamic-adding-preload-imagesrcset.html`, `preload/link-header-preload-imagesrcset.html`

3. Files already mapped to other features

   - `image-loading-lazy-srcset.html`