### PR TITLE
Update upgrade criteria test

### DIFF
--- a/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
+++ b/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
@@ -88,14 +88,14 @@ test((test) => {
 }, 'Inserting the shadow host of a shadow root with a scoped custom element registry does not change the registry');
 
 test((test) => {
-    const [doc1, win1] = makeIframe(test);
-    const [doc2, win2] = makeIframe(test);
-    win2.customElements.define('a-b', class ABElement extends win2.HTMLElement { });
-    const elementFromDoc1 = doc1.createElement('a-b');
-    assert_equals(elementFromDoc1.customElementRegistry, null);
-    doc2.body.appendChild(elementFromDoc1);
-    assert_equals(elementFromDoc1.customElementRegistry, win2.customElements);
-    assert_true(elementFromDoc1 instanceof ABElement);
+    const contentDocument = document.implementation.createHTMLDocument();
+    class ABElement extends HTMLElement { }
+    customElements.define('a-b', ABElement);
+    const elementFromContentDoc = contentDocument.createElement('a-b');
+    assert_equals(elementFromContentDoc.customElementRegistry, null);
+    document.body.appendChild(elementFromContentDoc);
+    assert_equals(elementFromContentDoc.customElementRegistry, customElements);
+    assert_true(elementFromContentDoc instanceof ABElement);
 }, 'Inserting a node from another document results in the custom element registry to be set and upgraded.');
 
 </script>

--- a/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
+++ b/custom-elements/registries/scoped-registry-append-does-not-upgrade.html
@@ -88,6 +88,17 @@ test((test) => {
 }, 'Inserting the shadow host of a shadow root with a scoped custom element registry does not change the registry');
 
 test((test) => {
+    const [doc1, win1] = makeIframe(test);
+    const [doc2, win2] = makeIframe(test);
+    win2.customElements.define('a-b', class ABElement extends win2.HTMLElement { });
+    const elementFromDoc1 = doc1.createElement('a-b');
+    assert_equals(elementFromDoc1.customElementRegistry, win1.customElements);
+    doc2.body.appendChild(elementFromDoc1);
+    assert_equals(elementFromDoc1.customElementRegistry, win2.customElements);
+    assert_true(elementFromDoc1 instanceof ABElement);
+}, 'Inserting a node from another document with global registry results in the custom element registry to be set and upgraded.');
+
+test((test) => {
     const contentDocument = document.implementation.createHTMLDocument();
     class ABElement extends HTMLElement { }
     customElements.define('a-b', ABElement);
@@ -96,7 +107,7 @@ test((test) => {
     document.body.appendChild(elementFromContentDoc);
     assert_equals(elementFromContentDoc.customElementRegistry, customElements);
     assert_true(elementFromContentDoc instanceof ABElement);
-}, 'Inserting a node from another document results in the custom element registry to be set and upgraded.');
+}, 'Inserting a node from another document with null registry results in the custom element registry to be set and upgraded.');
 
 </script>
 </body>

--- a/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
+++ b/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
@@ -129,7 +129,7 @@ test(t => {
   shadow.appendChild(node);
 
   class TestElement extends HTMLElement {};
-  customElements.define(name, TestElement);
+  registry.define(name, TestElement);
 
   assert_true(node instanceof TestElement);
 }, 'Adding definition to global registry should upgrade nodes even after the node is moved into a separate shadow tree.');

--- a/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
+++ b/custom-elements/registries/scoped-registry-define-upgrade-criteria.html
@@ -132,7 +132,7 @@ test(t => {
   registry.define(name, TestElement);
 
   assert_true(node instanceof TestElement);
-}, 'Adding definition to global registry should upgrade nodes even after the node is moved into a separate shadow tree.');
+}, 'Adding definition to scoped registry should upgrade nodes even after the node is moved into a separate shadow tree.');
 
 test(t => {
   const name = nextCustomElementName();


### PR DESCRIPTION
For the upgrade criteria test, it seems like this is the intended behavior, as the node created in the test is using scoped registry but not global registry.

Also updated the new test to upgrade a node when it's appended from another document. The test seems inaccurate as a new element created under iframe should be getting the iframe's global registry instead of null. Updated to use a separate content document to create scenario where newly created element gets null registry.

@rniwa 