### PR TITLE
Add chrome flag to disable location bar autofocus on startup

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -134,6 +134,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     chrome_options["args"].append("--disable-infobars")
     # For WebNN tests.
     chrome_options["args"].append("--enable-features=WebMachineLearningNeuralNetwork")
+    chrome_options["args"].append("--disable-location-bar-focus-on-startup-for-testing")
     # For Web Speech API tests.
     chrome_options["args"].append("--enable-features=" + ",".join([
         "InstallOnDeviceSpeechRecognition",


### PR DESCRIPTION
Many tests have been failing due to focus assertions since the change to use the webdriver "new window" command as it expects about:blank to be the startup URL which causes chrome to autofocus the URL bar.

Although efforts have been made to fix some tests that were known to fail due to this a while back, there seem to be more failing due to the same issue and continuing to fix tests individually could take a while.

Instead, pass a flag that allows disabling the autofocus behavior when launching chrome.

Chromium change that introduces the flag: https://crrev.com/c/7205407