### PR TITLE
Map `stretch` web-feature

### DIFF
--- a/css/css-sizing/stretch/WEB_FEATURES.yml
+++ b/css/css-sizing/stretch/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: stretch
+  files: "**"


### PR DESCRIPTION
Feature: `stretch`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/stretch.yml

**Notable exclusions**

1. `css/css-sizing/*` - These tests verify multiple sizing keywords together, not exclusively the `stretch` keyword

2. `css/css-sizing/replaced-aspect-ratio-stretch-fit-*` - These mention "stretch-fit" but don't actually use the `stretch` sizing keyword