### PR TITLE
Map `strong` web-feature

### DIFF
--- a/html/rendering/non-replaced-elements/phrasing-content-0/WEB_FEATURES.yml
+++ b/html/rendering/non-replaced-elements/phrasing-content-0/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: b
   files:
   - b-strong-styles.html
+- name: strong
+  files:
+  - b-strong-styles.html


### PR DESCRIPTION
Feature: `strong`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/strong.yml

This one is questionable. This is clearly the only test that tests `<strong>` but it also tests `<b>` and has already been mapped to `<b>`. Opening as a PR in this form to raise the question of acceptable overlap but this might be a case where we actually want to strike the mapping for both. A future enhancement could be separating this test into two.