### PR TITLE
Classify resource-size tests

### DIFF
--- a/resource-timing/WEB_FEATURES.yml
+++ b/resource-timing/WEB_FEATURES.yml
@@ -1,9 +1,11 @@
 features:
 - name: resource-timing
   files:
+  - "*"
+  - "initiator-type/*"
+  - "tentative/*"
   - "!load-from-mem-cache-transfer-size*"
   - "!resource_timing_content_length*"
-  - "**"
 - name: resource-size
   files:
   - "load-from-mem-cache-transfer-size*"

--- a/resource-timing/WEB_FEATURES.yml
+++ b/resource-timing/WEB_FEATURES.yml
@@ -2,8 +2,6 @@ features:
 - name: resource-timing
   files:
   - "*"
-  - "initiator-type/*"
-  - "tentative/*"
   - "!load-from-mem-cache-transfer-size*"
   - "!resource_timing_content_length*"
 - name: resource-size

--- a/resource-timing/WEB_FEATURES.yml
+++ b/resource-timing/WEB_FEATURES.yml
@@ -1,3 +1,10 @@
 features:
 - name: resource-timing
-  files: "**"
+  files:
+  - "!load-from-mem-cache-transfer-size*"
+  - "!resource_timing_content_length*"
+  - "**"
+- name: resource-size
+  files:
+  - "load-from-mem-cache-transfer-size*"
+  - "resource_timing_content_length*"

--- a/resource-timing/initiator-type/WEB_FEATURES.yml
+++ b/resource-timing/initiator-type/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: resource-timing
+  files:
+  - "*"

--- a/resource-timing/tentative/WEB_FEATURES.yml
+++ b/resource-timing/tentative/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: resource-timing
+  files:
+  - "*"


### PR DESCRIPTION
Grep report for [`(decodedBodySize|encodedBodySize|transferSize)`](https://github.com/user-attachments/files/23777541/20251120165513-XXXXXXXX.txt)

A couple of the tests in `resource-timing` seemed to match well enough here to be classified with `resource-size` instead -- I think...

A few others came close but definitely seemed too large in scope to only be targeting these features.
