### PR TITLE
Digital Credentials: Fix loadIFrame helper to properly reject on error events

### DIFF
--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -201,8 +201,8 @@ export function sendMessage(iframe, data) {
  */
 export function loadIframe(iframe, url) {
   return new Promise((resolve, reject) => {
-    iframe.addEventListener("load", resolve, { once: true });
-    iframe.addEventListener("error", reject, { once: true });
+    iframe.addEventListener("load", () => resolve(), { once: true });
+    iframe.addEventListener("error", (event) => reject(event.error), { once: true });
     if (!iframe.isConnected) {
       document.body.appendChild(iframe);
     }


### PR DESCRIPTION
The `error` event listener now passes the actual error object to the promise's reject handler.
The `load` event listener now uses an explicit callback for consistency.