### PR TITLE
webdriver: Enable implicit wait on error

### DIFF
--- a/webdriver/tests/classic/find_element/find.py
+++ b/webdriver/tests/classic/find_element/find.py
@@ -119,3 +119,29 @@ def test_htmldocument(session, inline, using, value):
     session.url = inline("")
     response = find_element(session, using, value)
     assert_success(response)
+
+
+def test_implicit_wait(session, inline):
+    session.url = inline("""
+        <script>
+            setTimeout(() => {
+                document.body.innerHTML = '<div id="delayed"></div>';
+            }, 300);
+        </script>
+    """)
+    session.timeouts.implicit = 1
+
+    response = find_element(session, "css selector", "#delayed")
+    value = assert_success(response)
+
+    expected = session.execute_script("return document.getElementById('delayed')")
+    assert_same_element(session, value, expected)
+
+
+def test_implicit_wait_timeout(session, inline):
+    session.url = inline("")
+    session.timeouts.implicit = 0.5
+
+    # Element never created
+    response = find_element(session, "css selector", "#nonexistent")
+    assert_error(response, "no such element")


### PR DESCRIPTION
... and reduce code duplication in element retrieval. Note that we are not using the functionality of "wait on error" yet.

Testing: We added WPT tests for "Find element", "Find element from element", "Find element from shadow root" for both successful implicit wait and timeout case.
Reviewed in servo/servo#40836