### PR TITLE
script: Stop assuming that previous dirty root is still connected

### DIFF
--- a/dom/nodes/crashtests/document-replaceChild-input-documentElement.html
+++ b/dom/nodes/crashtests/document-replaceChild-input-documentElement.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>Node.replaceChild()</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-replacechild">
+<link rel="help" href="https://github.com/servo/servo/issues/40920">
+<script>
+document.replaceChild(document.createElement("input"), document.documentElement);
+</script>


### PR DESCRIPTION
We were trying to update the dirty root to be the common ancestor of the old dirty root and the element noted with dirty descendants. But that would panic if when the old dirty root had been disconnected.

In that case, just set the dirty root to be the element, as if the old dirty root was None.

Testing: Adding a crashtest, and one existing test now fails instead of crashing
Fixes: #<!-- nolink -->40920

Reviewed in servo/servo#40922