### PR TITLE
Digital Credentials: Refactor makeGetOptions/makeCreateOptions to use property bag

### DIFF
--- a/digital-credentials/create.disabled-by-permissions-policy.https.sub.html
+++ b/digital-credentials/create.disabled-by-permissions-policy.https.sub.html
@@ -19,7 +19,7 @@
         await promise_rejects_dom(
             test,
             "NotAllowedError",
-            navigator.credentials.create(makeCreateOptions([]))
+            navigator.credentials.create(makeCreateOptions({protocol: []}))
         );
     }, "Permissions-Policy header digital-credentials-create=() disallows the top-level document.");
 

--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -136,7 +136,7 @@
     const abortController = new AbortController();
     const { signal } = abortController;
     abortController.abort();
-    for (const options of [{ signal }, { signal, ...makeCreateOptions([]) }]) {
+    for (const options of [{ signal }, { signal, ...makeCreateOptions({protocol: []}) }]) {
       await promise_rejects_dom(
         t,
         "AbortError",
@@ -151,7 +151,7 @@
     const abortController = new iframeWindow.AbortController();
     const { signal } = abortController;
     abortController.abort();
-    for (const options of [{ signal }, { signal, ...makeCreateOptions([]) }]) {
+    for (const options of [{ signal }, { signal, ...makeCreateOptions({protocol: []}) }]) {
       await test_driver.bless("user activation");
       await promise_rejects_dom(
         t,
@@ -168,7 +168,7 @@
 
   promise_test(async (t) => {
     iframeCrossOrigin.focus();
-    for (const options of [undefined, {}, makeCreateOptions([])]) {
+    for (const options of [undefined, {}, makeCreateOptions({protocol: []})]) {
       const result = await sendMessage(iframeCrossOrigin, {
         abort: "before",
         action: "create",
@@ -182,7 +182,7 @@
   promise_test(async (t) => {
     const abortController = new AbortController();
     const { signal } = abortController;
-    const options = makeCreateOptions("openid4vci");
+    const options = makeCreateOptions({protocol: "openid4vci"});
     options.signal = signal;
     await test_driver.bless("user activation");
     const promise = promise_rejects_dom(
@@ -201,7 +201,7 @@
       abort: "after",
       action: "create",
       needsActivation: true,
-      options: makeCreateOptions("openid4vci"),
+      options: makeCreateOptions({protocol: "openid4vci"}),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");
@@ -237,7 +237,7 @@
     ];
 
     for (const badValue of throwingValues) {
-      const options = makeCreateOptions("openid4vci");
+      const options = makeCreateOptions({protocol: "openid4vci"});
       options.digital.requests[0].data = badValue;
 
       await promise_rejects_js(

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -8,6 +8,34 @@ export type CredentialMediationRequirement =
   | "silent";
 
 /**
+ * Configuration for makeGetOptions function
+ */
+export interface MakeGetOptionsConfig {
+  /**
+   * Protocol(s) to use for the request
+   */
+  protocol?: GetProtocol | GetProtocol[];
+  /**
+   * Credential mediation requirement
+   */
+  mediation?: CredentialMediationRequirement;
+}
+
+/**
+ * Configuration for makeCreateOptions function
+ */
+export interface MakeCreateOptionsConfig {
+  /**
+   * Protocol(s) to use for the request
+   */
+  protocol?: CreateProtocol | CreateProtocol[];
+  /**
+   * Credential mediation requirement
+   */
+  mediation?: CredentialMediationRequirement;
+}
+
+/**
  * @see https://w3c-fedid.github.io/digital-credentials/#the-digitalcredentialgetrequest-dictionary
  */
 export interface DigitalCredentialGetRequest {

--- a/digital-credentials/default-permissions-policy.https.sub.html
+++ b/digital-credentials/default-permissions-policy.https.sub.html
@@ -23,7 +23,7 @@
         await promise_rejects_js(
             test,
             TypeError,
-            navigator.credentials.get(makeGetOptions([]))
+            navigator.credentials.get(makeGetOptions({protocol: []}))
         );
 
         await test_feature_availability({
@@ -49,7 +49,7 @@
         await promise_rejects_js(
             test,
             TypeError,
-            navigator.credentials.create(makeCreateOptions([]))
+            navigator.credentials.create(makeCreateOptions({protocol: []}))
         );
 
         await test_feature_availability({

--- a/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -24,7 +24,7 @@
         await promise_rejects_js(
             test,
             TypeError,
-            navigator.credentials.get(makeGetOptions([]))
+            navigator.credentials.get(makeGetOptions({protocol: []}))
         );
     }, "Permissions-Policy header digital-credentials-get=(self) allows the top-level document.");
 
@@ -67,7 +67,7 @@
         await promise_rejects_js(
             test,
             TypeError,
-            navigator.credentials.create(makeCreateOptions([]))
+            navigator.credentials.create(makeCreateOptions({protocol: []}))
         );
     }, "Permissions-Policy header digital-credentials-create=(self) allows the top-level document.");
 

--- a/digital-credentials/get.disabled-by-permissions-policy.https.sub.html
+++ b/digital-credentials/get.disabled-by-permissions-policy.https.sub.html
@@ -19,7 +19,7 @@
         await promise_rejects_dom(
             test,
             "NotAllowedError",
-            navigator.credentials.get(makeGetOptions([]))
+            navigator.credentials.get(makeGetOptions({protocol: []}))
         );
     }, "Permissions-Policy header digital-credentials-get=() disallows the top-level document.");
 

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -160,7 +160,7 @@
     const abortController = new AbortController();
     const { signal } = abortController;
     abortController.abort();
-    for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
+    for (const options of [{ signal }, { signal, ...makeGetOptions({protocol: []}) }]) {
       await promise_rejects_dom(
         t,
         "AbortError",
@@ -175,7 +175,7 @@
     const abortController = new iframeWindow.AbortController();
     const { signal } = abortController;
     abortController.abort();
-    for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
+    for (const options of [{ signal }, { signal, ...makeGetOptions({protocol: []}) }]) {
       await test_driver.bless("user activation");
       await promise_rejects_dom(
         t,
@@ -192,7 +192,7 @@
 
   promise_test(async (t) => {
     iframeCrossOrigin.focus();
-    for (const options of [undefined, {}, makeGetOptions([])]) {
+    for (const options of [undefined, {}, makeGetOptions({protocol: []})]) {
       const result = await sendMessage(iframeCrossOrigin, {
         abort: "before",
         action: "get",
@@ -206,7 +206,7 @@
   promise_test(async (t) => {
     const abortController = new AbortController();
     const { signal } = abortController;
-    const options = makeGetOptions("openid4vp-v1-unsigned");
+    const options = makeGetOptions({protocol: "openid4vp-v1-unsigned"});
     options.signal = signal;
     await test_driver.bless("user activation");
     const promise = promise_rejects_dom(
@@ -225,7 +225,7 @@
       abort: "after",
       action: "get",
       needsActivation: true,
-      options: makeGetOptions("openid4vp-v1-signed"),
+      options: makeGetOptions({protocol: "openid4vp-v1-signed"}),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");
@@ -254,7 +254,7 @@ promise_test(async t => {
   ];
 
   for (const badValue of throwingValues) {
-    const options = makeGetOptions("openid4vp-v1-multisigned");
+    const options = makeGetOptions({protocol: "openid4vp-v1-multisigned"});
     options.digital.requests[0].data = badValue;
 
     await promise_rejects_js(

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -71,7 +71,7 @@
     let iframe = await createIframe();
     const DOMExceptionCtor = iframe.contentWindow.DOMException;
     let stolenNavigator = iframe.contentWindow.navigator;
-    const request = makeGetOptions("openid4vp-v1-unsigned");
+    const request = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
     await test_driver.bless("User activation", null, iframe.contentWindow);
     await iframe.focus();
     const p = promise_rejects_dom(

--- a/digital-credentials/user-activation.https.html
+++ b/digital-credentials/user-activation.https.html
@@ -14,7 +14,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
-    const options = makeGetOptions("openid4vp-v1-unsigned");
+    const options = makeGetOptions({protocol: "openid4vp-v1-unsigned"});
     await promise_rejects_dom(
       t,
       "NotAllowedError",
@@ -25,7 +25,7 @@
   promise_test(async (t) => {
     await test_driver.bless();
     const abort = new AbortController();
-    const options = makeGetOptions("openid4vp-v1-unsigned");
+    const options = makeGetOptions({protocol: "openid4vp-v1-unsigned"});
     options.signal = abort.signal;
     assert_true(
       navigator.userActivation.isActive,
@@ -46,7 +46,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
-    const options = makeCreateOptions([]);
+    const options = makeCreateOptions({protocol: []});
     await promise_rejects_dom(
       t,
       "NotAllowedError",
@@ -60,7 +60,7 @@
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."
     );
-    const options = makeCreateOptions([]);
+    const options = makeCreateOptions({protocol: []});
     await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
     assert_false(
       navigator.userActivation.isActive,


### PR DESCRIPTION
Part 1:

- Convert function signatures from positional parameters to property bag objects
- Add MakeGetOptionsConfig and MakeCreateOptionsConfig interfaces
- Update all test files to use new {protocol: ...} syntax
- Maintain backward compatibility: makeGetOptions() still defaults to 'default' protocol
- Improve type safety and extensibility for future parameters
