### PR TITLE
Digital Credentials: implement CANONICAL_REQUEST_OBJECTS with actual mDoc data

### DIFF
--- a/digital-credentials/allow-attribute-with-create.https.html
+++ b/digital-credentials/allow-attribute-with-create.https.html
@@ -10,7 +10,9 @@
         <script src="/resources/testharnessreport.js"></script>
         <script src="/resources/testdriver.js"></script>
         <script src="/resources/testdriver-vendor.js"></script>
-        <script>
+        <script type="module">
+            import { makeCreateOptions } from "./support/helper.js";
+
             const hostInfo = get_host_info();
             const iframeDetails = [
                 {
@@ -100,14 +102,13 @@
                 for (const details of iframeDetails) {
                     promise_test(async (test) => {
                         const iframe = await loadIframe(details);
+                        test.add_cleanup(() => {
+                            document.body.removeChild(iframe);
+                        });
                         const { expectIsAllowed } = details;
                         const action = "create";
-                        const options = {
-                            digital: {
-                                // Results in TypeError when allowed, NotAllowedError when disallowed
-                                requests: [],
-                            },
-                        };
+                        // Results in TypeError when allowed, NotAllowedError when disallowed
+                        const options = makeCreateOptions({ protocol: [] });
                         const { data } = await new Promise((resolve) => {
                             const callback = (e) => {
                                 if (e.source === iframe.contentWindow) {
@@ -131,11 +132,11 @@
                         } else {
                             assert_equals(name, "NotAllowedError", fullMessage);
                         }
-                        iframe.remove();
                     }, `With Create: Policy to use: ${details.policy}, is cross-origin: ${details.crossOrigin}, is allowed by policy: ${details.expectIsAllowed}`);
                 }
             }
+            window.onload = runTests;
         </script>
     </head>
-    <body onload="runTests()"></body>
+    <body></body>
 </html>

--- a/digital-credentials/allow-attribute-with-get.https.html
+++ b/digital-credentials/allow-attribute-with-get.https.html
@@ -10,7 +10,9 @@
         <script src="/resources/testharnessreport.js"></script>
         <script src="/resources/testdriver.js"></script>
         <script src="/resources/testdriver-vendor.js"></script>
-        <script>
+        <script type="module">
+            import { makeGetOptions } from "./support/helper.js";
+
             const hostInfo = get_host_info();
             const iframeDetails = [
                 {
@@ -90,6 +92,8 @@
                             : location.origin
                     ).href;
                     iframe.dataset.expectIsAllowed = expectIsAllowed;
+                    iframe.width = "400";
+                    iframe.height = "200";
                     document.body.appendChild(iframe);
                 });
                 iframe.focus();
@@ -100,15 +104,12 @@
                 for (const details of iframeDetails) {
                     promise_test(async (test) => {
                         const iframe = await loadIframe(details);
+                        test.add_cleanup(() => {
+                            document.body.removeChild(iframe);
+                        });
                         const { expectIsAllowed } = details;
                         const action = "get";
-                        const options = {
-                            digital: {
-                                // Results in TypeError when allowed (since the requests list is empty),
-                                // NotAllowedError when disallowed
-                                requests: [],
-                            },
-                        };
+                        const options = makeGetOptions({ protocol: [] });
                         await test_driver.bless("User activation");
                         const { data } = await new Promise((resolve) => {
                             const callback = (e) => {
@@ -133,11 +134,12 @@
                             // When the call is disallowed, it MUST result in a NotAllowedError.
                             assert_equals(name, "NotAllowedError", fullMessage);
                         }
-                        iframe.remove();
+
                     }, `With Get: Policy to use: ${details.policy}, is cross-origin: ${details.crossOrigin}, is allowed by policy: ${details.expectIsAllowed}`);
                 }
             }
+            window.onload = runTests;
         </script>
     </head>
-    <body onload="runTests()"></body>
+    <body></body>
 </html>

--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -8,8 +8,8 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-  <iframe id="same-origin"></iframe>
   <iframe id="cross-origin" allow="digital-credentials-create"></iframe>
+  <iframe id="same-origin"></iframe>
 </body>
 
 <script type="module">
@@ -236,8 +236,7 @@
     ];
 
     for (const badValue of throwingValues) {
-      const options = makeCreateOptions();
-      options.digital.requests[0].data = badValue;
+      const options = makeCreateOptions({ data: badValue });
 
       await promise_rejects_js(
         t,

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -33,17 +33,20 @@ export interface MobileDocumentRequest {
  */
 export interface MakeGetOptionsConfig {
   /**
-   * Protocol(s) to use for the request
+   * Protocol(s) to use for the request.
+   * Can be a single protocol, array of protocols, or empty array.
+   * If not provided, uses the default supported protocol.
    */
   protocol?: GetProtocol | GetProtocol[];
+  /**
+   * Explicit credential requests.
+   * When provided, these are used in addition to any protocol-based requests.
+   */
+  requests?: DigitalCredentialGetRequest[];
   /**
    * Credential mediation requirement
    */
   mediation?: CredentialMediationRequirement;
-  /**
-   * Optional data to include in the request
-   */
-  data?: object;
   /**
    * Optional AbortSignal for request cancellation
    */
@@ -55,17 +58,20 @@ export interface MakeGetOptionsConfig {
  */
 export interface MakeCreateOptionsConfig {
   /**
-   * Protocol(s) to use for the request
+   * Protocol(s) to use for the request.
+   * Can be a single protocol, array of protocols, or empty array.
+   * If not provided, uses the default supported protocol.
    */
   protocol?: CreateProtocol | CreateProtocol[];
+  /**
+   * Explicit credential requests.
+   * When provided, these are used in addition to any protocol-based requests.
+   */
+  requests?: DigitalCredentialCreateRequest[];
   /**
    * Credential mediation requirement
    */
   mediation?: CredentialMediationRequirement;
-  /**
-   * Optional data to include in the request
-   */
-  data?: object;
   /**
    * Optional AbortSignal for request cancellation
    */

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -44,6 +44,10 @@ export interface MakeGetOptionsConfig {
    */
   requests?: DigitalCredentialGetRequest[];
   /**
+   * Optional data to override canonical data for protocol-based requests.
+   */
+  data?: MobileDocumentRequest | object;
+  /**
    * Credential mediation requirement
    */
   mediation?: CredentialMediationRequirement;
@@ -68,6 +72,10 @@ export interface MakeCreateOptionsConfig {
    * When provided, these are used in addition to any protocol-based requests.
    */
   requests?: DigitalCredentialCreateRequest[];
+  /**
+   * Optional data to override canonical data for protocol-based requests.
+   */
+  data?: object;
   /**
    * Credential mediation requirement
    */

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -41,6 +41,10 @@ export interface MakeGetOptionsConfig {
    */
   mediation?: CredentialMediationRequirement;
   /**
+   * Optional data to include in the request
+   */
+  data?: object;
+  /**
    * Optional AbortSignal for request cancellation
    */
   signal?: AbortSignal;
@@ -58,6 +62,10 @@ export interface MakeCreateOptionsConfig {
    * Credential mediation requirement
    */
   mediation?: CredentialMediationRequirement;
+  /**
+   * Optional data to include in the request
+   */
+  data?: object;
   /**
    * Optional AbortSignal for request cancellation
    */
@@ -87,7 +95,7 @@ export interface DigitalCredentialRequestOptions {
  */
 export interface CredentialRequestOptions {
   digital: DigitalCredentialRequestOptions;
-  mediation: CredentialMediationRequirement;
+  mediation?: CredentialMediationRequirement;
   signal?: AbortSignal;
 }
 
@@ -114,7 +122,7 @@ export interface DigitalCredentialCreationOptions {
  */
 export interface CredentialCreationOptions {
   digital: DigitalCredentialCreationOptions;
-  mediation: CredentialMediationRequirement;
+  mediation?: CredentialMediationRequirement;
   signal?: AbortSignal;
 }
 

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -8,8 +8,8 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-  <iframe id="same-origin"></iframe>
   <iframe id="cross-origin" allow="digital-credentials-get"></iframe>
+  <iframe id="same-origin"></iframe>
 </body>
 <script type="module">
   import { makeGetOptions, sendMessage, loadIframe } from "./support/helper.js";
@@ -31,16 +31,8 @@
   promise_test(async (t) => {
     const invalidData = [null, undefined, "", 123, true, false];
     for (const data of invalidData) {
-      const options = {
-        digital: {
-          requests: [
-            {
-              data,
-              protocol: "openid4vp-v1-unsigned",
-            },
-          ],
-        },
-      };
+      const options = makeGetOptions({ data });
+      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         TypeError,
@@ -253,8 +245,7 @@ promise_test(async t => {
   ];
 
   for (const badValue of throwingValues) {
-    const options = makeGetOptions();
-    options.digital.requests[0].data = badValue;
+    const options = makeGetOptions({ data: badValue });
 
     await promise_rejects_js(
       t,

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -71,7 +71,7 @@
     let iframe = await createIframe();
     const DOMExceptionCtor = iframe.contentWindow.DOMException;
     let stolenNavigator = iframe.contentWindow.navigator;
-    const request = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    const request = makeGetOptions();
     await test_driver.bless("User activation", null, iframe.contentWindow);
     await iframe.focus();
     const p = promise_rejects_dom(

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -87,7 +87,7 @@ function makeOptionsFromRequests(requests, mediation, signal) {
  *
  * @template Req
  * @param {Protocol[]} protocols
- * @param {Record<Protocol, (data?: MobileDocumentRequest | object) => Req>} mapping
+ * @param {Record<string, (data?: MobileDocumentRequest | object) => Req>} mapping
  * @param {MobileDocumentRequest | object} [explicitData] - Explicit data for create operations
  * @returns {Req[]}
  * @throws {Error} If an unknown protocol string is encountered.
@@ -146,7 +146,7 @@ const allMappings = {
  * @returns {TOptions}
  */
 function makeCredentialOptionsFromConfig(config, mapping) {
-  const { protocol, requests = [], mediation = "required", signal } = config;
+  const { protocol, requests = [], data, mediation = "required", signal } = config;
 
   // Validate that we have either a protocol or requests
   if (!protocol && !requests?.length) {
@@ -160,7 +160,7 @@ function makeCredentialOptionsFromConfig(config, mapping) {
 
   if (protocol) {
     const protocolArray = Array.isArray(protocol) ? protocol : [protocol];
-    const protocolRequests = buildRequestsFromProtocols(protocolArray, mapping);
+    const protocolRequests = buildRequestsFromProtocols(protocolArray, mapping, data);
     allRequests.push(...protocolRequests);
   }
 
@@ -175,8 +175,8 @@ function makeCredentialOptionsFromConfig(config, mapping) {
  */
 export function makeGetOptions(config = {}) {
   const configWithDefaults = {
+    protocol: SUPPORTED_GET_PROTOCOL,
     ...config,
-    protocol: config.protocol ?? SUPPORTED_GET_PROTOCOL,
   };
 
   return /** @type {CredentialRequestOptions} */ (
@@ -192,8 +192,8 @@ export function makeGetOptions(config = {}) {
  */
 export function makeCreateOptions(config = {}) {
   const configWithDefaults = {
+    protocol: SUPPORTED_CREATE_PROTOCOL,
     ...config,
-    protocol: config.protocol ?? SUPPORTED_CREATE_PROTOCOL,
   };
 
   return /** @type {CredentialCreationOptions} */ (


### PR DESCRIPTION
Part 4:

- Add CANONICAL_REQUEST_OBJECTS with real mDoc deviceRequest and encryptionInfo data
- Update factory functions to use canonical objects as defaults
- Refactor internal architecture with new helpers
- Make mediation optional in type definitions (no longer defaults to 'required')
- Add comprehensive data parameter support to config interfaces
- Complete property bag + signal + protocol selection + canonical objects integration