### PR TITLE
Digital Credentials: formatting cleanup and helper.js polish

### DIFF
--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -182,7 +182,7 @@
   promise_test(async (t) => {
     const abortController = new AbortController();
     const { signal } = abortController;
-    const options = makeCreateOptions({ protocol: "openid4vci", signal });
+    const options = makeCreateOptions({ signal });
     await test_driver.bless("user activation");
     const promise = promise_rejects_dom(
       t,
@@ -200,7 +200,7 @@
       abort: "after",
       action: "create",
       needsActivation: true,
-      options: makeCreateOptions({protocol: "openid4vci"}),
+      options: makeCreateOptions(),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");
@@ -236,7 +236,7 @@
     ];
 
     for (const badValue of throwingValues) {
-      const options = makeCreateOptions({protocol: "openid4vci"});
+      const options = makeCreateOptions();
       options.digital.requests[0].data = badValue;
 
       await promise_rejects_js(

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -15,7 +15,7 @@ export type CredentialMediationRequirement =
 /**
  * @see https://www.iso.org/obp/ui#iso:std:iso-iec:ts:18013:-7:ed-2:v1:en
  */
-export interface mDocRequest {
+export interface MobileDocumentRequest {
   /**
    * Information required for encryption, typically a base64-encoded string or JSON object as a string.
    * The format should comply with the requirements specified in ISO/IEC TS 18013-7.

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -16,7 +16,15 @@ export type CredentialMediationRequirement =
  * @see https://www.iso.org/obp/ui#iso:std:iso-iec:ts:18013:-7:ed-2:v1:en
  */
 export interface mDocRequest {
+  /**
+   * Information required for encryption, typically a base64-encoded string or JSON object as a string.
+   * The format should comply with the requirements specified in ISO/IEC TS 18013-7.
+   */
   readonly encryptionInfo: string;
+  /**
+   * The device request payload, usually a stringified JSON object containing the request details.
+   * This should follow the structure defined in ISO/IEC TS 18013-7 for device requests.
+   */
   readonly deviceRequest: string;
 }
 

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -41,6 +41,10 @@ export interface MakeGetOptionsConfig {
    */
   mediation?: CredentialMediationRequirement;
   /**
+   * Optional data to include in the request
+   */
+  data?: object;
+  /**
    * Optional AbortSignal for request cancellation
    */
   signal?: AbortSignal;
@@ -58,6 +62,10 @@ export interface MakeCreateOptionsConfig {
    * Credential mediation requirement
    */
   mediation?: CredentialMediationRequirement;
+  /**
+   * Optional data to include in the request
+   */
+  data?: object;
   /**
    * Optional AbortSignal for request cancellation
    */
@@ -87,7 +95,7 @@ export interface DigitalCredentialRequestOptions {
  */
 export interface CredentialRequestOptions {
   digital: DigitalCredentialRequestOptions;
-  mediation: CredentialMediationRequirement;
+  mediation?: CredentialMediationRequirement;
   signal?: AbortSignal;
 }
 
@@ -114,7 +122,7 @@ export interface DigitalCredentialCreationOptions {
  */
 export interface CredentialCreationOptions {
   digital: DigitalCredentialCreationOptions;
-  mediation: CredentialMediationRequirement;
+  mediation?: CredentialMediationRequirement;
   signal?: AbortSignal;
 }
 

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -1,11 +1,24 @@
-export type GetProtocol = "default" | "openid4vp-v1-unsigned" | "openid4vp-v1-signed" | "openid4vp-v1-multisigned";
-export type CreateProtocol = "default" | "openid4vci";
+export type OpenIDPresentationProtocol =
+  | "openid4vp-v1-unsigned"
+  | "openid4vp-v1-signed"
+  | "openid4vp-v1-multisigned";
+export type OpenIDIssuanceProtocol = "openid4vci";
+export type GetProtocol = OpenIDPresentationProtocol | "org-iso-mdoc";
+export type CreateProtocol = OpenIDIssuanceProtocol;
 
 export type CredentialMediationRequirement =
   | "conditional"
   | "optional"
   | "required"
   | "silent";
+
+/**
+ * @see https://www.iso.org/obp/ui#iso:std:iso-iec:ts:18013:-7:ed-2:v1:en
+ */
+export interface mDocRequest {
+  readonly encryptionInfo: string;
+  readonly deviceRequest: string;
+}
 
 /**
  * Configuration for makeGetOptions function
@@ -134,4 +147,18 @@ export interface EventData {
 export interface SendMessageData {
   action: IframeActionType;
   options?: CredentialRequestOptions;
+}
+
+/**
+ * The DigitalCredential interface
+ */
+export interface DigitalCredentialStatic {
+  /**
+   * Check if the user agent allows a specific protocol
+   */
+  userAgentAllowsProtocol(protocol: string): boolean;
+}
+
+declare global {
+  var DigitalCredential: DigitalCredentialStatic;
 }

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -206,7 +206,7 @@
   promise_test(async (t) => {
     const abortController = new AbortController();
     const { signal } = abortController;
-    const options = makeGetOptions({protocol: "openid4vp-v1-unsigned", signal});
+    const options = makeGetOptions({signal});
     await test_driver.bless("user activation");
     const promise = promise_rejects_dom(
       t,
@@ -224,7 +224,7 @@
       abort: "after",
       action: "get",
       needsActivation: true,
-      options: makeGetOptions({protocol: "openid4vp-v1-signed"}),
+      options: makeGetOptions(),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");
@@ -253,7 +253,7 @@ promise_test(async t => {
   ];
 
   for (const badValue of throwingValues) {
-    const options = makeGetOptions({protocol: "openid4vp-v1-multisigned"});
+    const options = makeGetOptions();
     options.digital.requests[0].data = badValue;
 
     await promise_rejects_js(

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -13,7 +13,26 @@
  * @typedef {import('../dc-types').MakeGetOptionsConfig} MakeGetOptionsConfig
  * @typedef {import('../dc-types').MakeCreateOptionsConfig} MakeCreateOptionsConfig
  * @typedef {import('../dc-types').CredentialMediationRequirement} CredentialMediationRequirement
+ * @typedef {import('../dc-types').mDocRequest} mDocRequest
  */
+
+/** @type {GetProtocol[]} */
+const GET_PROTOCOLS = /** @type {const} */ ([
+  "openid4vp-v1-unsigned",
+  "openid4vp-v1-signed",
+  "openid4vp-v1-multisigned",
+  "org-iso-mdoc",
+]);
+
+/** @type {CreateProtocol[]} */
+const CREATE_PROTOCOLS = /** @type {const} */ (["openid4vci"]);
+
+const SUPPORTED_GET_PROTOCOL = GET_PROTOCOLS.find(
+  (protocol) => DigitalCredential.userAgentAllowsProtocol(protocol)
+);
+const SUPPORTED_CREATE_PROTOCOL = CREATE_PROTOCOLS.find(
+  (protocol) => DigitalCredential.userAgentAllowsProtocol(protocol)
+);
 
 /**
  * Internal helper to build the request array from validated input.
@@ -37,6 +56,7 @@ function _makeOptionsInternal(requestsInputArray, mediation, requestMapping, sig
       throw new Error(`Unknown request type within array: ${request}`);
     }
   }
+  /** @type {{ digital: { requests: any[] }, mediation: CredentialMediationRequirement, signal?: AbortSignal }} */
   const result = { digital: { requests }, mediation };
   if (signal !== undefined) {
     result.signal = signal;
@@ -46,14 +66,13 @@ function _makeOptionsInternal(requestsInputArray, mediation, requestMapping, sig
 
 const allMappings = {
   get: {
+    "org-iso-mdoc": () => makeMDocRequest(),
     "openid4vp-v1-unsigned": () => makeOID4VPDict("openid4vp-v1-unsigned"),
     "openid4vp-v1-signed": () => makeOID4VPDict("openid4vp-v1-signed"),
     "openid4vp-v1-multisigned": () => makeOID4VPDict("openid4vp-v1-multisigned"),
-    "default": () => makeDigitalCredentialGetRequest(undefined, undefined),
   },
   create: {
     "openid4vci": () => makeOID4VCIDict(),
-    "default": () => makeDigitalCredentialCreateRequest(),
   },
 };
 
@@ -91,6 +110,7 @@ function _makeOptionsUnified(type, protocol, mediation, signal) {
   if (Array.isArray(protocol)) {
     if (protocol.length === 0) {
       // Handle empty array explicitly
+      /** @type {{ digital: { requests: any[] }, mediation: CredentialMediationRequirement, signal?: AbortSignal }} */
       const result = { digital: { requests: [] }, mediation };
       if (signal !== undefined) {
         result.signal = signal;
@@ -102,6 +122,7 @@ function _makeOptionsUnified(type, protocol, mediation, signal) {
   }
 
   // 4. Handle invalid input types (neither string nor array)
+  /** @type {{ digital: { requests: any[] }, mediation: CredentialMediationRequirement, signal?: AbortSignal }} */
   const result = { digital: { requests: [] }, mediation };
   if (signal !== undefined) {
     result.signal = signal;
@@ -116,7 +137,10 @@ function _makeOptionsUnified(type, protocol, mediation, signal) {
  * @returns {CredentialRequestOptions}
  */
 export function makeGetOptions(config = {}) {
-  const { protocol = "default", mediation = "required", signal } = config;
+  const { protocol = SUPPORTED_GET_PROTOCOL, mediation = "required", signal } = config;
+  if (!protocol) {
+    throw new Error("No Protocol. Can't make get options.");
+  }
   return _makeOptionsUnified('get', protocol, mediation, signal);
 }
 
@@ -127,7 +151,10 @@ export function makeGetOptions(config = {}) {
  * @returns {CredentialCreationOptions}
  */
 export function makeCreateOptions(config = {}) {
-  const { protocol = "default", mediation = "required", signal } = config;
+  const { protocol = SUPPORTED_CREATE_PROTOCOL, mediation = "required", signal } = config;
+  if (!protocol) {
+    throw new Error("No protocol. Can't make create options.");
+  }
   return _makeOptionsUnified('create', protocol, mediation, signal);
 }
 
@@ -177,6 +204,17 @@ function makeDigitalCredentialCreateRequest(protocol = "protocol", data = {}) {
 function makeOID4VCIDict() {
   return makeDigitalCredentialCreateRequest("openid4vci", {
     // Canonical example of an OpenID4VCI request coming soon.
+  });
+}
+
+/**
+ * Representation of an mDoc request.
+ *
+ * @returns {DigitalCredentialGetRequest}
+ **/
+function makeMDocRequest() {
+  return makeDigitalCredentialGetRequest("org-iso-mdoc", {
+    // Canonical example of an mDoc request coming soon.
   });
 }
 

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -210,9 +210,9 @@ function makeOptionsUnified(type, protocol, mediation, data, signal) {
  * @returns {CredentialRequestOptions}
  */
 export function makeGetOptions(config = {}) {
-  const { protocol = SUPPORTED_GET_PROTOCOL, mediation = "required", data, signal } = config;
+  const { protocol = SUPPORTED_GET_PROTOCOL, mediation, data, signal } = config;
   if (!protocol) {
-    throw new Error("No protocol. Can't make get options.");
+    throw new Error("No Protocol. Can't make get options.");
   }
   return /** @type {CredentialRequestOptions} */ (
     makeOptionsUnified("get", protocol, mediation, data, signal)
@@ -226,7 +226,7 @@ export function makeGetOptions(config = {}) {
  * @returns {CredentialCreationOptions}
  */
 export function makeCreateOptions(config = {}) {
-  const { protocol = SUPPORTED_CREATE_PROTOCOL, mediation = "required", data, signal } = config;
+  const { protocol = SUPPORTED_CREATE_PROTOCOL, mediation, data, signal } = config;
   if (!protocol) {
     throw new Error("No protocol. Can't make create options.");
   }
@@ -236,60 +236,10 @@ export function makeCreateOptions(config = {}) {
 }
 
 /**
- *
- * @param {string} protocol
- * @param {object} data
- * @returns {DigitalCredentialGetRequest}
- */
-function makeDigitalCredentialGetRequest(protocol = "protocol", data = {}) {
-  return {
-    protocol,
-    data,
-  };
-}
-
-/**
- * Representation of an OpenID4VP request.
- *
- * @param {string} identifier
- * @returns {DigitalCredentialGetRequest}
- **/
-function makeOID4VPDict(identifier = "openid4vp-v1-unsigned") {
-  return makeDigitalCredentialGetRequest(identifier, {
-    // Canonical example of an OpenID4VP request coming soon.
-  });
-}
-
-/**
- *
- * @param {string} protocol
- * @param {object} data
- * @returns {DigitalCredentialCreateRequest}
- */
-function makeDigitalCredentialCreateRequest(protocol = "protocol", data = {}) {
-  return {
-    protocol,
-    data,
-  };
-}
-
-
-/**
- * Representation of an mDoc request.
- *
- * @returns {DigitalCredentialGetRequest}
- **/
-function makeMDocRequest() {
-  return makeDigitalCredentialGetRequest("org-iso-mdoc", {
-    // Canonical example of an mDoc request coming soon.
-  });
-}
-
-/**
  * Sends a message to an iframe and return the response.
  *
  * @param {HTMLIFrameElement} iframe - The iframe element to send the message to.
- * @param {SendMessageData} data - The data to be sent to the iframe.
+ * @param {import("../dc-types").SendMessageData} data - The data to be sent to the iframe.
  * @returns {Promise<any>} - A promise that resolves with the response from the iframe.
  */
 export function sendMessage(iframe, data) {
@@ -297,8 +247,8 @@ export function sendMessage(iframe, data) {
     if (!iframe.contentWindow) {
       reject(
         new Error(
-          "iframe.contentWindow is undefined, cannot send message (something is wrong with the test that called this)."
-        )
+          "iframe.contentWindow is undefined, cannot send message (something is wrong with the test that called this).",
+        ),
       );
       return;
     }
@@ -322,7 +272,9 @@ export function sendMessage(iframe, data) {
 export function loadIframe(iframe, url) {
   return new Promise((resolve, reject) => {
     iframe.addEventListener("load", () => resolve(), { once: true });
-    iframe.addEventListener("error", (event) => reject(event.error), { once: true });
+    iframe.addEventListener("error", (event) => reject(event.error), {
+      once: true,
+    });
     if (!iframe.isConnected) {
       document.body.appendChild(iframe);
     }

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -13,7 +13,7 @@
  * @typedef {import('../dc-types').MakeGetOptionsConfig} MakeGetOptionsConfig
  * @typedef {import('../dc-types').MakeCreateOptionsConfig} MakeCreateOptionsConfig
  * @typedef {import('../dc-types').CredentialMediationRequirement} CredentialMediationRequirement
- * @typedef {import('../dc-types').mDocRequest} mDocRequest
+ * @typedef {import('../dc-types').MobileDocumentRequest} MobileDocumentRequest
  */
 
 /** @type {GetProtocol[]} */

--- a/digital-credentials/user-activation.https.html
+++ b/digital-credentials/user-activation.https.html
@@ -14,7 +14,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
-    const options = makeGetOptions({protocol: "openid4vp-v1-unsigned"});
+    const options = makeGetOptions();
     await promise_rejects_dom(
       t,
       "NotAllowedError",
@@ -25,7 +25,7 @@
   promise_test(async (t) => {
     await test_driver.bless();
     const abort = new AbortController();
-    const options = makeGetOptions({protocol: "openid4vp-v1-unsigned", signal: abort.signal});
+    const options = makeGetOptions({ signal: abort.signal });
     assert_true(
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."


### PR DESCRIPTION
Part 5:

- Improve JSDoc formatting and consistency across helper functions
- Fix trailing comma formatting in loadIframe error handler
- Update sendMessage type import to use relative path
- Clean up spacing and code organization