### PR TITLE
Digital Credentials: fix abort controller test

### DIFF
--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -227,13 +227,14 @@
     const mediations = ["silent", "optional", "conditional", "required"];
     const abortController = new AbortController();
     const { signal } = abortController;
-    abortController.abort();
     for (const mediation of mediations) {
-      const requestPromise = navigator.credentials.get({
+      await test_driver.bless("user activation");
+      const requestPromise = navigator.credentials.get(makeGetOptions({
         mediation,
         signal,
-      });
-      await promise_rejects_dom(t, "AbortError", requestPromise);
+      }));
+      abortController.abort(new Error("Aborted for testing"));
+      await promise_rejects_js(t, Error, requestPromise);
     }
   }, "Mediation is implicitly required and hence ignored. Request is aborted regardless.");
 

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -223,17 +223,15 @@
   }, "navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe.");
 
   promise_test(async (t) => {
-    /** @type sequence<CredentialMediationRequirement> */
-    const mediations = ["silent", "optional", "conditional", "required"];
-    const abortController = new AbortController();
-    const { signal } = abortController;
-    for (const mediation of mediations) {
+    for (const mediation of ["silent", "optional", "conditional", "required"]) {
+      const abortController = new AbortController();
+      const { signal } = abortController;
       await test_driver.bless("user activation");
       const requestPromise = navigator.credentials.get(makeGetOptions({
         mediation,
         signal,
       }));
-      abortController.abort(new Error("Aborted for testing"));
+      abortController.abort(new Error(`Aborted for testing mediation "${mediation}"`));
       await promise_rejects_js(t, Error, requestPromise);
     }
   }, "Mediation is implicitly required and hence ignored. Request is aborted regardless.");


### PR DESCRIPTION
The test was calling abort() before making the request, which immediately rejects the promise. 