### PR TITLE
Map `tab-size` web-feature

### DIFF
--- a/css/css-text/animations/WEB_FEATURES.yml
+++ b/css/css-text/animations/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: tab-size
+  files:
+  - tab-size-interpolation.html

--- a/css/css-text/parsing/WEB_FEATURES.yml
+++ b/css/css-text/parsing/WEB_FEATURES.yml
@@ -26,3 +26,6 @@ features:
 - name: word-spacing
   files:
   - word-spacing-*
+- name: tab-size
+  files:
+  - tab-size-*

--- a/css/css-text/tab-size/WEB_FEATURES.yml
+++ b/css/css-text/tab-size/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: tab-size
+  files: "**"


### PR DESCRIPTION
Feature: `tab-size`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/tab-size.yml

**Notable inclusions**
1. tab-size interpolation in animation, there is an argument for exclusion but I opted for inclusion
   - css-text/animations/tab-size-interpolations.html

**Notable exclusions**
1. `::marker` tab size support
   - `css/css-pseudo/marker-tab-size.html`

2. `text-align` property behavior with preserved tabs
   - `css/css-text/text-align/text-align-justify-tabs-*.html`

4. White-space property behavior with tabs
   - `css/css-text/white-space/tab-stop-threshold-*.html`