### PR TITLE
Map "system-color" web-feature

### DIFF
--- a/css/CSS2/ui/WEB_FEATURES.yml
+++ b/css/CSS2/ui/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: system-color
+  files:
+  - "system-colors-*"

--- a/css/css-color/WEB_FEATURES.yml
+++ b/css/css-color/WEB_FEATURES.yml
@@ -34,3 +34,7 @@ features:
   - rgb-*
   - rgba-*
   - hex-*
+- name: system-color
+  files:
+  - "deprecated-sameas-*"
+  - "system-color-*"

--- a/css/css-color/parsing/WEB_FEATURES.yml
+++ b/css/css-color/parsing/WEB_FEATURES.yml
@@ -7,3 +7,6 @@ features:
   files:
   - "relative-*"
   - "*-relative-*"
+- name: system-color
+  files:
+  - color-valid-system-color.html


### PR DESCRIPTION
Feature: `system-color`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/system-color.yml

Notable exclusions

1. `css/css-images/gradient/color-scheme-dependent-color-stops.html` - Tests how gradients respond to color-scheme changes, uses system colors as test infrastructure