### PR TITLE
Map "svg-filters" and "svg-discouraged" web-features

### DIFF
--- a/svg/extensibility/foreignObject/WEB_FEATURES.yml
+++ b/svg/extensibility/foreignObject/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: svg-filters
+  files:
+  - filter-repaint.html
+  - foreign-object-circular-filter-reference-crash.html

--- a/svg/import/WEB_FEATURES.yml
+++ b/svg/import/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg-filters
+  files:
+  - "filters-*"

--- a/svg/linking/reftests/WEB_FEATURES.yml
+++ b/svg/linking/reftests/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg-filters
+  files:
+  - href-filter-element.html

--- a/svg/render/order/WEB_FEATURES.yml
+++ b/svg/render/order/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: z-index
   files:
   - z-index.svg
+- name: svg-filters
+  files:
+  - clip-path-filter-order.svg

--- a/svg/shapes/reftests/WEB_FEATURES.yml
+++ b/svg/shapes/reftests/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg-filters
+  files:
+  - polygon-with-filtered-marker.html

--- a/svg/svg-in-svg/WEB_FEATURES.yml
+++ b/svg/svg-in-svg/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg-filters
+  files:
+  - svg-in-svg-circular-filter-reference-crash.html

--- a/svg/types/scripted/WEB_FEATURES.yml
+++ b/svg/types/scripted/WEB_FEATURES.yml
@@ -1,0 +1,8 @@
+features:
+- name: svg-discouraged
+  files:
+  - SVGPoint.html
+- name: svg-filters
+  files:
+  - SVGAnimatedEnumeration-SVGFilterElement.html
+  - SVGAnimatedEnumeration-SVGFEColorMatrixElement.html


### PR DESCRIPTION
Feature: `svg-discouraged`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/svg-discouraged.yml

Notable exclusions

1. Files that use `xlink:href` or other SVG 1.1 features as infrastructure rather than testing them
    - Most files in search results use `xlink:href` but test other features (href attribute behavior, resource loading, etc.)
    - Files with `baseProfile` attribute that test SVG rendering rather than the deprecated attribute itself

---

Feature: `svg-filters`

Reference: https://github.com/web-platform-dx/web-features/blob/main/features/svg-filters.yml

Notable exclusions

1. CSS masking tests that use filters as infrastructure
    - `css/css-masking/mask-svg-content/mask-with-filter*.svg`