### PR TITLE
classifies wasm-mutable-globals and wasm-string-builtins

### DIFF
--- a/wasm/jsapi/esm-integration/WEB_FEATURES.yml
+++ b/wasm/jsapi/esm-integration/WEB_FEATURES.yml
@@ -3,3 +3,7 @@ features:
   files:
   - "global-exports-live-bindings.tentative.any.js"
   - "mutable-global-sharing.tentative.any.js"
+- name: wasm-string-builtins
+  files:
+  - "source-phase-string-builtins.tentative.any.js"
+  - "string-builtins.tentative.any.js"

--- a/wasm/jsapi/esm-integration/WEB_FEATURES.yml
+++ b/wasm/jsapi/esm-integration/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: wasm-mutable-globals
+  files:
+  - "global-exports-live-bindings.tentative.any.js"
+  - "mutable-global-sharing.tentative.any.js"

--- a/wasm/jsapi/js-string/WEB_FEATURES.yml
+++ b/wasm/jsapi/js-string/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm-string-builtins
+  files: "**"


### PR DESCRIPTION
I bundled these two features together in one PR to minimize potential merge conflicts later. These two features both refer to tests in `wasm/jsapi/esm-integration`.

Web feature docs:
- [wasm-mutable-globals](https://github.com/web-platform-dx/web-features/blob/main/features/wasm-mutable-globals.yml)
- [wasm-string-builtins](https://github.com/web-platform-dx/web-features/blob/main/features/wasm-string-builtins.yml)

See additional notes for "wasm-mutable-globals" classification in [commit](https://github.com/bocoup/wpt/commit/06bb984dea6d4620a80aed3826dfb2e3076e06bf). 