### PR TITLE
Map "target" web-feature

### DIFF
--- a/css/selectors/old-tests/WEB_FEATURES.yml
+++ b/css/selectors/old-tests/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: target
+  files:
+  - "css3-modsel-21*"
+  - "css3-modsel-66*"

--- a/html/browsers/browsing-the-web/scroll-to-fragid/WEB_FEATURES.yml
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: target
+  files:
+  - target-pseudo-after-reinsertion.html

--- a/svg/struct/reftests/WEB_FEATURES.yml
+++ b/svg/struct/reftests/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: target
+  files:
+  - "use-external-resource-target-pseudo-*"


### PR DESCRIPTION
Feature: `target`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/target.yml

**Notable exclusions**

1. `::target-text` pseudo-element tests - Primary focus: `::target-text` pseudo-element (already mapped to `target-text`)
   - `css/css-pseudo/target-text-*.html`
   - `css/css-highlight-api/painting/css-target-text-decoration-001.html`
   - `css/css-highlight-api/painting/custom-highlight-painting-below-target-text.html`

2. Scroll marker `:target-current`, `:target-before`, `:target-after` pseudo-classes - Primary focus: CSS scroll markers
   - `css/css-overflow/scroll-target-group-*.html`
   - `css/css-overflow/scroll-marker-*-target-*.html`
   - `css/css-overflow/column-scroll-marker-*-target-*.html`
   - `css/css-overflow/html-scroll-marker-target-before-after.html`