### PR TITLE
classifies base "wasm" web feature 

### DIFF
--- a/wasm/jsapi/WEB_FEATURES.yml
+++ b/wasm/jsapi/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: wasm
+  files:
+  - "*"

--- a/wasm/jsapi/constructor/WEB_FEATURES.yml
+++ b/wasm/jsapi/constructor/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/jsapi/constructor/WEB_FEATURES.yml
+++ b/wasm/jsapi/constructor/WEB_FEATURES.yml
@@ -1,3 +1,8 @@
 features:
 - name: wasm
-  files: "**"
+  files:
+  - "*"
+  - "!multi-value.any.js"
+- name: wasm-multi-value
+  files:
+  - "multi-value.any.js"

--- a/wasm/jsapi/functions/WEB_FEATURES.yml
+++ b/wasm/jsapi/functions/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/jsapi/global/WEB_FEATURES.yml
+++ b/wasm/jsapi/global/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/jsapi/instance/WEB_FEATURES.yml
+++ b/wasm/jsapi/instance/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/jsapi/memory/WEB_FEATURES.yml
+++ b/wasm/jsapi/memory/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/jsapi/memory/WEB_FEATURES.yml
+++ b/wasm/jsapi/memory/WEB_FEATURES.yml
@@ -1,3 +1,12 @@
 features:
 - name: wasm
-  files: "**"
+  files:
+  - "*"
+  - "!constructor-shared.tentative.any.js"
+  - "!to-fixed-length-buffer-shared.any.js"
+  - "!to-resizable-buffer-shared.any.js"
+- name: wasm-threads
+  files:
+  - "constructor-shared.tentative.any.js"
+  - "to-fixed-length-buffer-shared.any.js"
+  - "to-resizable-buffer-shared.any.js"

--- a/wasm/jsapi/module/WEB_FEATURES.yml
+++ b/wasm/jsapi/module/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/jsapi/table/WEB_FEATURES.yml
+++ b/wasm/jsapi/table/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: wasm
+  files: "**"

--- a/wasm/webapi/WEB_FEATURES.yml
+++ b/wasm/webapi/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: wasm
+  files:
+  - "*"


### PR DESCRIPTION
Maps [base wasm web feature](https://github.com/web-platform-dx/web-features/blob/main/features/wasm.yml). 
1. **wasm/jsapi/** (excluding separate features):
    - `constructor/` - Tests for `compile()`, `instantiate()`, `validate()`
    - `module/` - Tests for `WebAssembly.Module` and its methods
    - `instance/` - Tests for `WebAssembly.Instance`
    - `memory/` - Tests for `WebAssembly.Memory`
    - `table/` - Tests for `WebAssembly.Table`
    - `global/` - Tests for `WebAssembly.Global`
    - Root files - IDL harness, interfaces, prototypes, etc.
2. **wasm/webapi/** (root level only):
    - Tests for `compileStreaming()` and `instantiateStreaming()`
    - Tests for streaming response handling, CORS, content-type validation, etc.

I interpreted this web feature to be primarily about the JS API for WebAssembly and not the WebAssembly instruction set itself (in `core/`). If this incorrect, please let me know!

To minimize potential merge conflicts later, I also included two additional features here that overlap with the wasm classifications:
- [wasm-multi-value](https://github.com/web-platform-dx/web-features/blob/main/features/wasm-multi-value.yml)
- [wasm-threads](https://github.com/web-platform-dx/web-features/blob/main/features/wasm-threads.yml)