### PR TITLE
Map `execcommand` web feature

### DIFF
--- a/editing/crashtests/WEB_FEATURES.yml
+++ b/editing/crashtests/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: execcommand
+  files:
+    - 'execCommand-*.html'
+    - 'queryCommand*.html'

--- a/editing/other/WEB_FEATURES.yml
+++ b/editing/other/WEB_FEATURES.yml
@@ -2,6 +2,7 @@ features:
 - name: execcommand
   files:
     - 'exec-command-*'
+    - 'inserthtml-do-not-preserve-inline-styles.html'
     - 'legacy-edit-command.html'
     - 'non-html-document.html'
     - 'restoration.html'

--- a/editing/other/WEB_FEATURES.yml
+++ b/editing/other/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+features:
+- name: execcommand
+  files:
+    - 'exec-command-*'
+    - 'legacy-edit-command.html'
+    - 'non-html-document.html'
+    - 'restoration.html'


### PR DESCRIPTION
Feature: "execCommand()"
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/execcommand.yml

Some notable exclusions:
* `editing/plaintext-only/*` - these tests are equally testing `contenteditable`, `contenteditable=plaintextonly` and `execcommand`
* `editing/edit-context/edit-context-execCommand.tentative.https.html` is covering `edit-context` and `execcommand`