### PR TITLE
Map `text-align` and `text-align-last` web-features

### DIFF
--- a/css/CSS2/text/WEB_FEATURES.yml
+++ b/css/CSS2/text/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: word-spacing
   files:
   - word-spacing-*
+- name: text-align
+  files:
+  - text-align-*

--- a/css/css-display/run-in/WEB_FEATURES.yml
+++ b/css/css-display/run-in/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: text-align
+  files:
+  - text-align-applies-to-004.xht

--- a/css/css-text/parsing/WEB_FEATURES.yml
+++ b/css/css-text/parsing/WEB_FEATURES.yml
@@ -29,3 +29,12 @@ features:
 - name: tab-size
   files:
   - tab-size-*
+- name: text-align
+  files:
+  - "text-align-all-*"
+  - text-align-computed.html
+  - text-align-invalid.html
+  - text-align-valid.html
+- name: text-align-last
+  files:
+  - "text-align-last-*"

--- a/css/css-text/text-align/WEB_FEATURES.yml
+++ b/css/css-text/text-align/WEB_FEATURES.yml
@@ -1,0 +1,11 @@
+features:
+- name: text-align
+  files:
+  - "text-align-*"
+  - "!text-align-last-*"
+  - "!text-align-*-last-*"
+- name: text-align-last
+  files:
+  - "text-align-last-*"
+  - "text-align-*-last-*"
+


### PR DESCRIPTION
Feature: `text-align` and `text-align-last`

Reference:
- https://github.com/web-platform-dx/web-features/blob/main/features/text-align.yml
- https://github.com/web-platform-dx/web-features/blob/main/features/text-align-last.yml

Notable inclusions for `text-align`
1. `css-display/run-in/text-align-applies-to-004.xht` - There is an argument that this test overlaps with `display: run-in` but the test ensures that `run-in` doesn't break `test-align` or vice-versa