### PR TITLE
[css-grid-3] Add alternative grid-lanes orientation switch

### DIFF
--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-001.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-001.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-002.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-002.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-003.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-003.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-004.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-004.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-005.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-005.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-006.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-006.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-007.html
+++ b/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-007.html
@@ -6,6 +6,7 @@
 <style>
 .grid-lanes {
     display: grid-lanes;
+    grid-auto-flow: column;
     grid-lanes-direction: row;
     background: gray;
     item-tolerance: 0;

--- a/css/css-grid/grid-lanes/tentative/item-placement/row-negative-margin-001.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/row-negative-margin-001.html
@@ -8,6 +8,7 @@
     display: grid-lanes;
     item-tolerance: 0;
     grid-lanes-direction: row;
+    grid-template-rows: auto;
 }
 </style>
 <body>


### PR DESCRIPTION
The syntax for changing the orientation of grid-lanes layouts is still under discussion, and different implementations have implemented different tentative syntaxes. Add in WebKit's current syntax alongside Blink's so that these tests run and return meaningful results.