### PR TITLE
classifies user-agent-sniffing

### DIFF
--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml
@@ -12,3 +12,6 @@ features:
 - name: window-controls-overlay
   files:
   - navigator-window-controls-overlay.tentative.html
+- name: user-agent-sniffing
+  files:
+  - navigator.any.js

--- a/workers/WEB_FEATURES.yml
+++ b/workers/WEB_FEATURES.yml
@@ -16,3 +16,6 @@ features:
   files:
   - Worker-postMessage-happens-in-parallel.https.html
   - postMessage_*
+- name: user-agent-sniffing
+  files:
+  - WorkerNavigator_userAgent.htm

--- a/workers/interfaces/WorkerUtils/navigator/WEB_FEATURES.yml
+++ b/workers/interfaces/WorkerUtils/navigator/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: user-agent-sniffing
+  files:
+  - 005.html


### PR DESCRIPTION
@foolip The [user-agent-sniffing web feature documentation](https://github.com/web-platform-dx/web-features/blob/main/features/user-agent-sniffing.yml) was a little confusing for me, since the description seems to be a recommendation for how the user agent string should be used:
> description: "The `navigator.userAgent` property is the user agent string for the current browser. Selectively showing content based on the user agent string is unreliable. Consider using feature detection instead."

I opted to classify off of the list of API's in the compat_features field instead, although I did find a number of other kinds of tests that seem to incidentally perform browser detection via the user agent string. 

Let me know if this UA-API-based list of tests is correct, or if we should be searching for tests by some other criteria instead.  