### PR TITLE
classifies user-action-pseudos

### DIFF
--- a/css/CSS2/selectors/WEB_FEATURES.yml
+++ b/css/CSS2/selectors/WEB_FEATURES.yml
@@ -1,0 +1,8 @@
+features:
+- name: user-action-pseudos
+  files:
+  - active-selector-*
+  - hover-selector-*
+  - dom-hover-*
+  - focus-pseudo-class-*
+  - focus-selector-*

--- a/css/selectors/WEB_FEATURES.yml
+++ b/css/selectors/WEB_FEATURES.yml
@@ -29,3 +29,9 @@ features:
 - name: caret-color
   files:
   - caret-color-visited-inheritance.html
+- name: user-action-pseudos
+  files:
+  - hover-001-manual.html
+  - hover-002.html
+  - remove-hovered-element.html
+  - focus-display-none-001.html


### PR DESCRIPTION
Web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/user-action-pseudos.yml

Noting that the following tests include additional `:focus` tests but they are mixed with `focus-within` and `focus-visible` tests, so they are excluded for now:
- [focus-in-focus-event-001.html](https://github.com/bocoup/wpt/blob/web-features-user-action-pseudos/css/selectors/focus-in-focus-event-001.html)
- [focus-in-focusin-event-001.html](https://github.com/bocoup/wpt/blob/web-features-user-action-pseudos/css/selectors/focus-in-focusin-event-001.html)