### PR TITLE
Add feColorMatrix special value reftest

### DIFF
--- a/css/filter-effects/fecolormatrix-special-value-ref.html
+++ b/css/filter-effects/fecolormatrix-special-value-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Filter Effects: Test feColorMatrix with specific special values</title>
+	<link rel="author" title="Hans Otto Wirtz" href="mailto:hansottowirtz@gmail.com">
+</head>
+
+<body>
+    <p>You should see 3 squares in 1 even brown color.</p>
+
+    <svg viewBox='0 0 100 100' width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <rect x='0' y='0' width='100' height='100' fill="#CB4E00"></rect>
+    </svg>
+
+    <svg viewBox='0 0 100 100' width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <rect x='0' y='0' width='100' height='100' fill="#CB4E00"></rect>
+    </svg>
+
+    <svg viewBox='0 0 100 100' width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <rect x='0' y='0' width='100' height='100' fill="#CB4E00"></rect>
+    </svg>
+</body>
+
+</html>

--- a/css/filter-effects/fecolormatrix-special-value.html
+++ b/css/filter-effects/fecolormatrix-special-value.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Filter Effects: Test feColorMatrix with specific special values</title>
+	<link rel="author" title="Hans Otto Wirtz" href="mailto:hansottowirtz@gmail.com">
+	<link rel="help" href="http://www.w3.org/TR/filter-effects-1/#feColorMatrixElement">
+	<link rel="help" href="http://www.w3.org/TR/filter-effects-1/#element-attrdef-fecolormatrix-type">
+	<link rel="match" href="fecolormatrix-special-value-ref.html">
+	<meta name="assert" content="If the test runs, you should see 3 squares in 1 even brown color.">
+	<meta name=fuzzy content="maxDifference=0-2;totalPixels=0-160000">
+</head>
+
+<body>
+    <p>You should see 3 squares in 1 even brown color.</p>
+
+    <svg viewBox='0 0 100 100' width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            <linearGradient id="gradient">
+            <stop stop-color="#11a9da" offset="0%" />
+            <stop stop-color="#11a9da" offset="100%" />
+            </linearGradient>
+            <filter id="filter" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feColorMatrix type="matrix" values="8 0.1486 0.1928 0 0 1 0.1353 0.1756 0 0 0 0 0 0 0 0 0 0 1 0"></feColorMatrix>
+            </filter>
+        </defs>
+
+        <g filter="url(#filter)">
+            <rect
+            x="0"
+            y="0"
+            width="100"
+            height="100"
+            fill="url(#gradient)" />
+        </g>
+    </svg>
+
+    <img width="100" height="100"/>
+
+    <canvas width="100" height="100"></canvas>
+
+    <script>
+		const canvas = document.querySelector('canvas');
+		const svg = document.querySelector('svg');
+		const img = document.querySelector('img');
+		const svgString = new XMLSerializer().serializeToString(svg);
+		const ctx = canvas.getContext('2d');
+		img.src = "data:image/svg+xml," + encodeURIComponent(svgString);
+		img.onload = () => {
+			ctx.drawImage(img, 0, 0);
+			document.documentElement.classList.remove('reftest-wait');
+		};
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This is more of a regression test: we noticed that for these specific values, both Chromium and WebKit are buggy, with different bugs. On Chrome, the color is wrong. On Firefox, the color is correct. On Safari, the color is not even, it's a strange pattern of both the Chrome and Firefox colors.

I am not sure about the reason, so I'm not sure what to call this test.

The manually-calculated resulting color should be #CB4E00, on Firefox it is #CC4D00 (maxDifference is 1).

I added a gradient as the source image, but this also happens when the source is an embedded image. However, when we just fill the rect with a solid color, the issue on Safari disappears.

Chrome - Firefox - Safari (note the strange pattern) (all macOS)

<img width="1339" height="259" alt="Screenshot 2025-12-03 at 14 57 26" src="https://github.com/user-attachments/assets/b86b0c1a-8c9e-4601-a21c-2dd998fe2d82" />
