### PR TITLE
Map `text-area` web-feature

### DIFF
--- a/html/rendering/bindings/the-textarea-element-0/WEB_FEATURES.yml
+++ b/html/rendering/bindings/the-textarea-element-0/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: textarea
+  files: "**"

--- a/html/rendering/widgets/WEB_FEATURES.yml
+++ b/html/rendering/widgets/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: field-sizing
   files:
   - field-sizing-*
+- name: textarea
+  files:
+  - textarea-*

--- a/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-textarea-element/WEB_FEATURES.yml
@@ -7,3 +7,10 @@ features:
 - name: change-event
   files:
   - change-to-empty-value.html
+- name: textarea
+  files:
+  - "*"
+  - "!textarea-setcustomvalidity.html"
+  - "!textarea-validity-clone.html"
+  - "!textarea-validity-valueMissing-inside-datalist.html"
+  - "!change-to-empty-value.html"


### PR DESCRIPTION
Feature: `textarea`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/textarea.yml

Notable exclusions

1. Tests mapped to other features in `html/semantics/forms/the-textarea-element/`
   - `change-to-empty-value.html` (mapped to `change-event`)
   - `textarea-setcustomvalidity.html` and `textarea-validity-*.html` (mapped to `constraint-validation`)

2. Vertical writing mode tests
   - `css/css-writing-modes/forms/* covered by `vertical-form-controls`

3. Drag and drop tests
   - `html/editing/dnd/interactiveelements/draggable_textarea.html` and similar tests are primarily about drag and drop functionality

4. CSS UI appearance tests
   - `css/css-ui/appearance-textarea-001.html` is mapped to `appearance` feature