### PR TITLE
Map `text-tracks` web-feature

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: text-tracks
+  files:
+  - addTextTrack.html
+  - textTracks.html

--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-tracks
+  files: "**"

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-tracks
+  files: "**"

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-tracks
+  files: "**"

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrackCueList/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrackCueList/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-tracks
+  files: "**"

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-tracks
+  files: "**"

--- a/html/semantics/embedded-content/media-elements/interfaces/TrackEvent/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/TrackEvent/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-tracks
+  files: "**"

--- a/html/semantics/embedded-content/media-elements/track/track-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/track/track-element/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: text-tracks
+  files:
+  - "*"
+  - "!track-webvtt-*"


### PR DESCRIPTION
Feature: `text-tracks`

Reference: https://github.com/web-platform-dx/web-features/blob/main/features/text-tracks.yml

Notable exclusions

1. WebVTT specific tests (parsing, rendering, VTT cues), use text tracks but focus on vtt format
   - `webvtt/*`
   - `html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-*`