### PR TITLE
Map `text-stroke-fill` web-feature

### DIFF
--- a/compat/WEB_FEATURES.yml
+++ b/compat/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: text-stroke-fill
+  files:
+  - webkit-text-fill-color-*

--- a/css/css-lists/WEB_FEATURES.yml
+++ b/css/css-lists/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: counter-set
   files:
   - counter-set-*
+- name: text-stroke-fill
+  files:
+  - marker-webkit-text-fill-color.html

--- a/css/css-pseudo/WEB_FEATURES.yml
+++ b/css/css-pseudo/WEB_FEATURES.yml
@@ -32,3 +32,6 @@ features:
   files:
   - before-*
   - pseudo-replaced-elements.html
+- name: text-stroke-fill
+  files:
+  - highlight-styling-003.html


### PR DESCRIPTION
Feature: `text-stroke-fill`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/text-stroke-fill.yml

Notable exclusions

1. `css/selectors/text-fill-color-visited-inheritance.html`
   - Tests visited link privacy restrictions (inheritance) rather than the core text-stroke-fill feature.

2. `css/css-text-decor/text-decoration-color.html`
   - Primary focus is text-decoration-color.

3. `css/css-backgrounds/background-gradient-interpolation-*.html`
   - Tests gradient interpolation, using text-fill-color as a test case but not primarily testing it.