### PR TITLE
Map `local-network-access` web-feature

### DIFF
--- a/fetch/local-network-access/WEB_FEATURES.yml
+++ b/fetch/local-network-access/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: local-network-access
+  files: "**"


### PR DESCRIPTION
Feature: local-network-access
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/local-network-access.yml

Notable exclusions

1. `fenced-frame/disallowed-navigation-*`
    - These tests use local-network-access resources (support.sub.js) to verify Fenced Frame navigation restrictions