### PR TITLE
dom: Avoid crashing on empty favicon `href` attribute

### DIFF
--- a/html/links/icon/empty-href-crash.html
+++ b/html/links/icon/empty-href-crash.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test for #41047: Panic when the href attribute of a link is empty.</title>
+<link rel="icon" href="">


### PR DESCRIPTION
Add a check to handle_favicon_url() similar to the ones done in similar functions: handle_stylesheet_url() and fetch_and_process_prefetch_link()

Testing: Check that loading http://chiptune.com/  doesn't crash anymore.
Fixes: https://github.com/servo/servo/issues/41047

Reviewed in servo/servo#41056