### PR TITLE
Update web-font-styled-text-resize-swap-after-interaction.html

### DIFF
--- a/largest-contentful-paint/web-font-styled-text-resize-swap-after-interaction.html
+++ b/largest-contentful-paint/web-font-styled-text-resize-swap-after-interaction.html
@@ -68,7 +68,7 @@
     assert_own_property(window, 'PerformanceResourceTiming', "ResourceTiming not supported");
     let url = '/fonts/AD.woff';
     var absoluteURL = new URL(url, location.href).href;
-    assert_equals(performance.getEntriesByName(absoluteURL).length, 1, 'Web font should be downloaded.');
+    assert_equals(performance.getEntriesByName(absoluteURL).filter((e) => e.initiatorType == 'css').length, 1, 'Web font should be downloaded.');
 
     // Verify web font is available.
     assert_true(document.fonts.check('16px ADTestFaceInteraction'), 'Font should be the web font added');


### PR DESCRIPTION
Add filter for initiatorType = 'css'.

This filters out other initiatorTypes, especially 'link', because Chrome sometimes generates an additional ResourceTimingEntry, probably due to preload scanning. See also https://github.com/web-platform-tests/interop/issues/1231

While this modifies a test that's part of the interop 2025, the intent is to keep the spirit, subject, and essence of the test intact, and not cause any breakages for other browsers, while allowing the test to reflect that Chrome does in fact support the feature that's being tested. Thanks for considering.