### PR TITLE
script: Fix IIRFilter crash on silent blocks and add crash test

### DIFF
--- a/webaudio/the-audio-api/the-iirfilternode-interface/iir-filter-silent-block-crash.html
+++ b/webaudio/the-audio-api/the-iirfilternode-interface/iir-filter-silent-block-crash.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Regression test for IIRFilter destination crash</title>
+<script>
+  var audioContext = new AudioContext();
+  var destination = audioContext.destination;
+  var filter = destination.context.createIIRFilter([1],[1]);
+  filter.connect(destination);
+</script>


### PR DESCRIPTION
Fix IIRFilter crash on silent blocks and add crash test.

Before fix: `let blocks: SmallVec<[Block; 1]> = SmallVec::new();` followed by `blocks.as_slice().iter().map(.)`, Because blocks was empty, the iterator never produced anything, so the resulting Chunk had zero blocks and caused:

```
panic: index out of bounds: the len is 0 but the index is 0 (thread AudioRenderThread, at /home/runner/.cargo/git/checkouts/media-9074def3f0bdf023/b0d3b74/audio/iir_filter_node.rs:173)
```

Now: we still use SmallVec<[Block; 1]>, but we actually push a block into it before returning: create Block::default(), call explicit_silence() on it, blocks.push(block), then Chunk { blocks }. This ensures the chunk contains one explicit silent block, which is what downstream code expects.

Actual fix is in:
https://github.com/servo/media/pull/477

This PR uses the new media version containing fix and added crash test.


Testing: added crash test.
Fixes: https://github.com/servo/servo/issues/41085


Reviewed in servo/servo#41091