### PR TITLE
layout: Pass degrees to the WebRender hue rotate filter

### DIFF
--- a/css/filter-effects/filter-hue_rotate-002-ref.html
+++ b/css/filter-effects/filter-hue_rotate-002-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>CSS filter: hue-rotate turns red to green reference</title>
+	<link rel="author" title="Ezzeldin Ibrahim" href="mailto:ezzibrahimx@gmail.com">
+	<style type="text/css">
+		div {
+			width: 200px;
+			height: 200px;
+			background-color: #007100;
+		}
+	</style>
+</head>
+
+<body>
+	<p>You should see a green(#007100) rectangle.</p>
+
+	<div></div>
+</body>
+
+</html>

--- a/css/filter-effects/filter-hue_rotate-002-test.html
+++ b/css/filter-effects/filter-hue_rotate-002-test.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS filter: hue-rotate turns red to green</title>
+    <link rel="author" title="Ezzeldin Ibrahim" href="mailto:ezzibrahimx@gmail.com">
+    <link rel="help" href="https://www.w3.org/TR/filter-effects-1/#funcdef-filter-hue-rotate">
+    <link rel="help" href="https://www.w3.org/TR/filter-effects-1/#huerotateEquivalent">
+    <link rel="match" href="filter-hue_rotate-002-ref.html">
+
+    <meta name="assert"
+        content="Applying filter: hue-rotate(120deg) to a red rectangle should produce a green(#007100) rectangle.">
+
+    <style type="text/css">
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: red;
+            filter: hue-rotate(120deg);
+        }
+    </style>
+</head>
+
+<body>
+    <p>You should see a green(#007100) rectangle.</p>
+    <div></div>
+</body>
+
+</html>


### PR DESCRIPTION

Fixes the hue-rotate() CSS filter. The problem was that Servo used angle.radians instead of angle.degrees, so the hue rotation was applied incorrectly. Switching to degrees makes the filter render as expected.

<img width="314" height="310" alt="image" src="https://github.com/user-attachments/assets/97377c77-2e23-4fb9-9b21-4ce9483ac1b1" />

Testing: the demo html file now works as expected. Added a new test.
Fixes: #<!-- nolink -->40955 

Reviewed in servo/servo#41063