### PR TITLE
Verify script enforcement applies even if the source text is modified before require-trusted-types-for 'script' is set.

### DIFF
--- a/trusted-types/script-enforcement-012.html
+++ b/trusted-types/script-enforcement-012.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<script src="support/script-messages.js"></script>
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts">
+<!-- This is similar to script-enforcement-001.html, but the CSP policy to
+     enforce TrustedTypes is only set *after* the script source is modified. -->
+<div id="container"></div>
+<script>
+  promise_test(async t => {
+    await no_script_message_for(_ => {
+      let script = create_html_script_with_trusted_source_text(";");
+      script.appendChild(document.createTextNode(LOG_RUN_MESSAGE));
+      document.head.insertAdjacentHTML("beforeend", `<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">`)
+      container.appendChild(script);
+    });
+  }, "HTML script is untrusted even if its source was set before TrustedTypes got enabled.");
+</script>

--- a/trusted-types/script-enforcement-013.html
+++ b/trusted-types/script-enforcement-013.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/namespaces.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<script src="support/script-messages.js"></script>
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts">
+<!-- This is similar to script-enforcement-012.html, but for SVG script. -->
+<svg>
+  <script type="unknown">;</script>
+</svg>
+<svg id="container"></svg>
+<script>
+  promise_test(async t => {
+    await no_script_message_for(_ => {
+      let script = create_svg_script_with_trusted_source_text(";");
+      script.appendChild(document.createTextNode(LOG_RUN_MESSAGE));
+      document.head.insertAdjacentHTML("beforeend", `<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">`)
+      container.appendChild(script);
+    });
+  }, "SVG script is untrusted even if source was set before TrustedTypes got enabled.");
+</script>

--- a/trusted-types/script-enforcement-014.html
+++ b/trusted-types/script-enforcement-014.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<script src="support/script-messages.js"></script>
+<meta id="requireTrustedTypesForScriptMetaTag" http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts">
+<link rel="help" href="https://www.w3.org/TR/CSP3/#meta-element">
+<!-- This is similar to script-enforcement-001.html, but the meta tag for
+     require-trusted-types-for is removed at the beginning of the test. Per
+     the CSP specification, TrustedTypes should still be enforced. -->
+<div id="container"></div>
+<script>
+  promise_test(async t => {
+    requireTrustedTypesForScriptMetaTag.remove();
+    await no_script_message_for(_ => {
+      let script = create_html_script_with_trusted_source_text(";");
+      script.appendChild(document.createTextNode(LOG_RUN_MESSAGE));
+      container.appendChild(script);
+    });
+  }, "HTML script is untrusted even if meta tag for require-trusted-types-for is removed.");
+</script>

--- a/trusted-types/script-enforcement-015.html
+++ b/trusted-types/script-enforcement-015.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/namespaces.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<script src="support/script-messages.js"></script>
+<meta id="requireTrustedTypesForScriptMetaTag" http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts">
+<link rel="help" href="https://www.w3.org/TR/CSP3/#meta-element">
+<!-- This is similar to script-enforcement-014.html, but for SVG script. -->
+<svg>
+  <script type="unknown">;</script>
+</svg>
+<svg id="container"></svg>
+<script>
+  promise_test(async t => {
+    requireTrustedTypesForScriptMetaTag.remove();
+    await no_script_message_for(_ => {
+      let script = create_svg_script_with_trusted_source_text(";");
+      script.appendChild(document.createTextNode(LOG_RUN_MESSAGE));
+      container.appendChild(script);
+    });
+  }, "SVG script is untrusted even if meta tag for require-trusted-types-for is removed.");
+</script>

--- a/trusted-types/script-enforcement-016.html
+++ b/trusted-types/script-enforcement-016.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<script src="support/script-messages.js"></script>
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts">
+<!-- This is the same as script-enforcement-012.html but for modules. -->
+<div id="container"></div>
+<script>
+  promise_test(async t => {
+    await no_script_message_for(_ => {
+      let script = create_html_script_with_trusted_source_text(";");
+      script.setAttribute("type", "module");
+      script.appendChild(document.createTextNode(LOG_RUN_MESSAGE));
+      document.head.insertAdjacentHTML("beforeend", `<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">`)
+      container.appendChild(script);
+    });
+  }, "HTML script with type=module is untrusted even if its source was set before TrustedTypes got enabled.");
+</script>

--- a/trusted-types/script-enforcement-017.html
+++ b/trusted-types/script-enforcement-017.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/namespaces.js"></script>
+<script src="support/passthroughpolicy.js"></script>
+<script src="support/script-messages.js"></script>
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts">
+<!-- This is similar to script-enforcement-016.html, but for SVG script. -->
+<svg>
+  <script type="unknown">;</script>
+</svg>
+<svg id="container"></svg>
+<script>
+  promise_test(async t => {
+    await no_script_message_for(_ => {
+      let script = create_svg_script_with_trusted_source_text(";");
+      script.setAttribute("type", "module");
+      script.appendChild(document.createTextNode(LOG_RUN_MESSAGE));
+      document.head.insertAdjacentHTML("beforeend", `<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">`)
+      container.appendChild(script);
+    });
+  }, "SVG script with type=module is untrusted even if source was set before TrustedTypes got enabled.");
+</script>


### PR DESCRIPTION
Current spec [1] essentially caches the "script text" associated to a script element: it is initially empty and updated by various APIs calls. The "prepare the script element" algorithm is modified [2], so that "child text content" would go through the default policy if it does not match the cached "script text" [3].

Script enforcement could be alternatively be implemented by flags [4]. In that case, it might be tempting not to update the flags when the API calls modifying a script are performed before Trusted Types are actually enforced, with the rationale that these API calls are not considered untrusted at that time. For a cache-based implementations, this would be equivalent to not caching the "script text" until the first time it is set in a context when Trusted Types is enforced.

However, WebKit and Chromium follow the spec and really try and run the default policy on the script text, even if the script text was modified before TrustedTypes enforcement got enabled. This PR adds a test to verify this behavior for HTML and SVG scripts.

[1] https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts
[2] https://w3c.github.io/trusted-types/dist/spec/#slot-value-verification
[3] https://w3c.github.io/trusted-types/dist/spec/#prepare-the-script-text
[4] https://github.com/w3c/trusted-types/pull/579