### PR TITLE
Guard MediaElementAudioSourceNode against closed contexts and add crash test

### DIFF
--- a/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource_closed_context-crash.html
+++ b/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource_closed_context-crash.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Regression for MediaElementAudioSourceNode constructor crash after closing AudioContext</title>
+<video id="video"></video>
+<script>
+  var audioContext = new AudioContext();
+  audioContext.close();
+  new MediaElementAudioSourceNode(audioContext, {mediaElement:video});
+</script>


### PR DESCRIPTION
Guard MediaElementAudioSourceNode against closed contexts and add crash test

Testing: Added crash test.
Fixes: #<!-- nolink -->41083
Reviewed in servo/servo#41092