### PR TITLE
classifies "fetch" and "fetch-later" web features

### DIFF
--- a/fetch/api/basic/WEB_FEATURES.yml
+++ b/fetch/api/basic/WEB_FEATURES.yml
@@ -1,4 +1,8 @@
 features:
+- name: fetch
+  files:
+  - "*"
+  - "!request-upload*"
 - name: fetch-request-streams
   files:
   - request-upload*

--- a/fetch/api/body/WEB_FEATURES.yml
+++ b/fetch/api/body/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/cors/WEB_FEATURES.yml
+++ b/fetch/api/cors/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/crashtests/WEB_FEATURES.yml
+++ b/fetch/api/crashtests/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/credentials/WEB_FEATURES.yml
+++ b/fetch/api/credentials/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/headers/WEB_FEATURES.yml
+++ b/fetch/api/headers/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/policies/WEB_FEATURES.yml
+++ b/fetch/api/policies/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/redirect/WEB_FEATURES.yml
+++ b/fetch/api/redirect/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/api/request/WEB_FEATURES.yml
+++ b/fetch/api/request/WEB_FEATURES.yml
@@ -1,4 +1,8 @@
 features:
+- name: fetch
+  files:
+  - "*"
+  - "!request-init-priority.any.js"
 - name: fetch-priority
   files:
   - request-init-priority.any.js

--- a/fetch/api/response/WEB_FEATURES.yml
+++ b/fetch/api/response/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/connection-pool/WEB_FEATURES.yml
+++ b/fetch/connection-pool/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/content-length/WEB_FEATURES.yml
+++ b/fetch/content-length/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/content-type/WEB_FEATURES.yml
+++ b/fetch/content-type/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/corb/WEB_FEATURES.yml
+++ b/fetch/corb/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/cross-origin-resource-policy/WEB_FEATURES.yml
+++ b/fetch/cross-origin-resource-policy/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/data-urls/WEB_FEATURES.yml
+++ b/fetch/data-urls/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/fetch-later/WEB_FEATURES.yml
+++ b/fetch/fetch-later/WEB_FEATURES.yml
@@ -1,3 +1,3 @@
 features:
-- name: fetchLater
+- name: fetchlater
   files: "**"

--- a/fetch/fetch-later/WEB_FEATURES.yml
+++ b/fetch/fetch-later/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetchLater
+  files: "**"

--- a/fetch/h1-parsing/WEB_FEATURES.yml
+++ b/fetch/h1-parsing/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/http-cache/WEB_FEATURES.yml
+++ b/fetch/http-cache/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/images/WEB_FEATURES.yml
+++ b/fetch/images/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/nosniff/WEB_FEATURES.yml
+++ b/fetch/nosniff/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/orb/WEB_FEATURES.yml
+++ b/fetch/orb/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/origin/WEB_FEATURES.yml
+++ b/fetch/origin/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/range/WEB_FEATURES.yml
+++ b/fetch/range/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/redirect-navigate/WEB_FEATURES.yml
+++ b/fetch/redirect-navigate/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/redirects/WEB_FEATURES.yml
+++ b/fetch/redirects/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/security/WEB_FEATURES.yml
+++ b/fetch/security/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/fetch/stale-while-revalidate/WEB_FEATURES.yml
+++ b/fetch/stale-while-revalidate/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"


### PR DESCRIPTION
Recursively classifies most of the subdirectories within the `fetch/` directory to the `fetch` web feature, with the following exceptions.

**Mapped to other features**:
    - `metadata/` → fetch-metadata
    - `fetch-later/` → fetchLater
    - `content-encoding/zstd/` → zstd (I opted to exclude the[ rest of this folder](https://github.com/bocoup/wpt/tree/web-features-fetch/fetch/content-encoding) as well, although I couldn't suitable web feature alternatives).
    - `api/abort/` → abortable-fetch
    - [`api/basic/` (partial) → fetch-request-streams](https://github.com/bocoup/wpt/commit/f6cf8bac5bbef3afbd90521b1a13a59b37b044c6#diff-5d62c4cacf82c68f229556cf6e7198f6382b01db96d4eb29850956acf1419fc6)
    - [`api/request/` (partial) → fetch-priority](https://github.com/bocoup/wpt/commit/f6cf8bac5bbef3afbd90521b1a13a59b37b044c6#diff-2f61e9cebffc97b8f918c0627dc0b5d14433bbde181e19476f001d460b518a1d)

**Other exclusions**:
- `local-network-access/` → Should be mapped to ["local-network-access" web feature](https://github.com/web-platform-tests/wpt/pull/56516)
- `compression-dictionary/` → [Separate IETF draft spec](https://github.com/bocoup/wpt/blob/web-features-fetch/fetch/compression-dictionary/README.md#L3)