### PR TITLE
layout: Ensure that `background-repeat: round` size calculation rounds to nearest natural number

### DIFF
--- a/css/css-backgrounds/background-repeat/background-repeat-image-larger-than-positioning-area-crash.html
+++ b/css/css-backgrounds/background-repeat/background-repeat-image-larger-than-positioning-area-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/41130">
+<style>
+  #span {background-repeat: round; background-image: url("../../support/60x60-green.png") }
+</style>
+<span id="span">A</span>


### PR DESCRIPTION
The previous code was just rounding to the nearest integrer, while the
specification says to round to the nearest natural number. The prevents
`inf` and `NaN` values from creeping to the results. This was leading to
a crash in WebRender.

Testing: This change adds a crash test.
Fixes: #<!-- nolink -->41130.

Reviewed in servo/servo#41158