### PR TITLE
Map `currentcolor` web-feature

### DIFF
--- a/css/css-color/WEB_FEATURES.yml
+++ b/css/css-color/WEB_FEATURES.yml
@@ -12,6 +12,13 @@ features:
   files:
   - color-mix-*
   - nested-color-mix-with-currentcolor.html
+- name: currentcolor
+  files:
+  - currentcolor-*
+  - t44-currentcolor-*
+  - color-003.html
+  - currentcolor-visited-fallback.html
+  - t31-color-currentColor-b.xht
 - name: lab
   files:
   - lab-*

--- a/css/css-transitions/WEB_FEATURES.yml
+++ b/css/css-transitions/WEB_FEATURES.yml
@@ -11,6 +11,10 @@ features:
   - "!transition-timing-function-005-manual.html"
   - "!transition-timing-function-006-manual.html"
   - "!transition-property-017-manual.html"
+  - "!currentcolor-animation-001.html"
+- name: currentcolor
+  files:
+  - currentcolor-animation-001.html
 - name: starting-style
   files:
   - starting-style-*


### PR DESCRIPTION
Feature: `currentcolor`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/currentcolor.yml

Notable exclusions

1.  Excluded tests in `css-ui`, `css-backgrounds`, `css-images`, etc. that verify `currentcolor` support in specific properties (e.g., `caret-color: currentcolor`). These are often overlapping with other features and test the consuming property's support for the keyword. These exclusions are relatively numerous.
2.  Tests in `css/filter-effects/tainting-*` were excluded (security/tainting).
3.  Excluded canvas, gradient, and complex composition tests where `currentcolor` is just a component value.

Notable inclusions

1.  Included `css/css-transitions/currentcolor-animation-001.html` as it verifies the specific "live" interpolation behavior of `currentcolor` when `color` transitions.