### PR TITLE
classifies media elements web features

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/WEB_FEATURES.yml
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/WEB_FEATURES.yml
@@ -1,10 +1,13 @@
 features:
+- name: img
+  files:
+  - "img-*"
 - name: video
   files:
   - "video-*"
 - name: object
   files:
-  - "object-*"
-- name: audio
+  - "object_*"
+- name: picture
   files:
-  - audio-controls-intrinsic-size.html
+  - "picture-*"

--- a/html/rendering/replaced-elements/images/WEB_FEATURES.yml
+++ b/html/rendering/replaced-elements/images/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: img
+  files:
+  - "img-*"

--- a/html/semantics/embedded-content/media-elements/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/media-elements/WEB_FEATURES.yml
@@ -1,4 +1,7 @@
 features:
+- name: video
+  files:
+  - video_*
 - name: preserves-pitch
   files:
   - preserves-pitch.html

--- a/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
@@ -2,21 +2,25 @@ features:
 - name: img
   files:
   - "*"
+  # Exclude `loading-lazy`. Keep in sync with `loading-lazy` mappings below.
   - "!*loading-lazy*"
   - "!image-loading-subpixel-clip.html"
   - "!move-element-and-scroll.html"
   - "!relevant-mutations-lazy.html"
   - "!remove-element-and-scroll.html"
   - "!scrolling-below-viewport-image-lazy-loading-in-iframe.html"
+  # Exclude `base`. Keep in sync with `base` mappings below.
   - "!document-adopt-base-url.html"
   - "!document-base-url.html"
   - "!image-base-url.html"
   - "!image-loading-lazy-base-url.html"
+  # Exclude `srcset`. Keep in sync with `srcset mappings below.
   - "!responsive-image-select-print.html"
   - "!update-the-source-set.html"
   - "!null-image-source.html"
 - name: loading-lazy
   files:
+  # Keep in sync with `img` mappings.
   - "*loading-lazy*"
   - image-loading-subpixel-clip.html
   - move-element-and-scroll.html
@@ -25,12 +29,14 @@ features:
   - scrolling-below-viewport-image-lazy-loading-in-iframe.html
 - name: base
   files:
+  # Keep in sync with `img` mappings.
   - document-adopt-base-url.html
   - document-base-url.html
   - image-base-url.html
   - image-loading-lazy-base-url.html
 - name: srcset
   files:
+  # Keep in sync with `img` mappings.
   - responsive-image-select-print.html
   - update-the-source-set.html
   - null-image-source.html

--- a/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
@@ -1,4 +1,20 @@
 features:
+- name: img
+  files:
+  - "*"
+  - "!*loading-lazy*"
+  - "!image-loading-subpixel-clip.html"
+  - "!move-element-and-scroll.html"
+  - "!relevant-mutations-lazy.html"
+  - "!remove-element-and-scroll.html"
+  - "!scrolling-below-viewport-image-lazy-loading-in-iframe.html"
+  - "!document-adopt-base-url.html"
+  - "!document-base-url.html"
+  - "!image-base-url.html"
+  - "!image-loading-lazy-base-url.html"
+  - "!responsive-image-select-print.html"
+  - "!update-the-source-set.html"
+  - "!null-image-source.html"
 - name: loading-lazy
   files:
   - "*loading-lazy*"

--- a/html/semantics/embedded-content/the-object-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-object-element/WEB_FEATURES.yml
@@ -1,4 +1,8 @@
 features:
+- name: object
+  files:
+  - "*"
+  - "!object-setcustomvalidity.html"
 - name: constraint-validation
   files:
   - object-setcustomvalidity.html

--- a/html/semantics/embedded-content/the-video-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-video-element/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: video
+  files: "**"


### PR DESCRIPTION
Batching a set of related media-element web features to minimize future merge conflicts, as the tests and existing web feature yml's were all concentrated in the same subdirectories. 

**Features classified**:
- [`<video>`](https://github.com/web-platform-dx/web-features/blob/main/features/video.yml)
- [`<picture>`](https://github.com/web-platform-dx/web-features/blob/main/features/picture.yml)
- [`<img>`](https://github.com/web-platform-dx/web-features/blob/main/features/img.yml)
- [`<object>`](https://github.com/web-platform-dx/web-features/blob/main/features/object.yml)
