### PR TITLE
Digital Credentials: split get/create 'enabled-on-self-origin-by-permissions-policy' tests

### DIFF
--- a/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -8,59 +8,11 @@
 <script src="/common/get-host-info.sub.js"></script>
 <body></body>
 <script type="module">
-    import { makeGetOptions } from "./support/helper.js";
     import { makeCreateOptions } from "./support/helper.js";
     const { HTTPS_REMOTE_ORIGIN } = get_host_info();
-    const get_same_origin_src =
-        "/digital-credentials/permissions-policy/get.html";
-    const get_cross_origin_src = new URL(get_same_origin_src, HTTPS_REMOTE_ORIGIN).href;
-
     const create_same_origin_src =
         "/digital-credentials/permissions-policy/create.html";
     const create_cross_origin_src = new URL(create_same_origin_src, HTTPS_REMOTE_ORIGIN).href;
-
-    promise_test(async (test) => {
-        await test_driver.bless("user activation");
-        await promise_rejects_js(
-            test,
-            TypeError,
-            navigator.credentials.get(makeGetOptions({protocol: []}))
-        );
-    }, "Permissions-Policy header digital-credentials-get=(self) allows the top-level document.");
-
-    promise_test(async (test) => {
-        await test_feature_availability({
-            feature_description: "Digital Credential API",
-            test,
-            src: get_same_origin_src,
-            expect_feature_available: expect_feature_available_default,
-            is_promise_test: true,
-            needs_focus: true,
-        });
-    }, "Permissions-Policy header digital-credentials-get=(self) allows same-origin iframes.");
-
-    promise_test(async (test) => {
-        await test_feature_availability({
-            feature_description: "Digital Credential API",
-            test,
-            src: get_cross_origin_src,
-            expect_feature_available: expect_feature_unavailable_default,
-            is_promise_test: true,
-            needs_focus: true,
-        });
-    }, "Permissions-Policy header digital-credentials-get=(self) disallows cross-origin iframes.");
-
-    promise_test(async (test) => {
-        await test_feature_availability({
-            feature_description: "Digital Credential API",
-            test,
-            src: get_cross_origin_src,
-            expect_feature_available: expect_feature_unavailable_default,
-            feature_name: "digital-credentials-get",
-            is_promise_test: true,
-            needs_focus: true,
-        });
-    }, "Permissions-Policy header explicitly set to digital-credentials-get=(self) cannot be overridden by allow attribute.");
 
     promise_test(async (test) => {
         await test_driver.bless("user activation");

--- a/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
+++ b/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: digital-credentials-create=(self)

--- a/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
+++ b/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
@@ -1,1 +1,0 @@
-Permissions-Policy: digital-credentials-get=(self), digital-credentials-create=(self)

--- a/digital-credentials/get-enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/digital-credentials/get-enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body></body>
+<script type="module">
+    import { makeGetOptions } from "./support/helper.js";
+    const { HTTPS_REMOTE_ORIGIN } = get_host_info();
+    const get_same_origin_src =
+        "/digital-credentials/permissions-policy/get.html";
+    const get_cross_origin_src = new URL(get_same_origin_src, HTTPS_REMOTE_ORIGIN).href;
+
+    promise_test(async (test) => {
+        await test_driver.bless("user activation");
+        await promise_rejects_js(
+            test,
+            TypeError,
+            navigator.credentials.get(makeGetOptions({protocol: []}))
+        );
+    }, "Permissions-Policy header digital-credentials-get=(self) allows the top-level document.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: get_same_origin_src,
+            expect_feature_available: expect_feature_available_default,
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header digital-credentials-get=(self) allows same-origin iframes.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: get_cross_origin_src,
+            expect_feature_available: expect_feature_unavailable_default,
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header digital-credentials-get=(self) disallows cross-origin iframes.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: get_cross_origin_src,
+            expect_feature_available: expect_feature_unavailable_default,
+            feature_name: "digital-credentials-get",
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header explicitly set to digital-credentials-get=(self) cannot be overridden by allow attribute.");
+</script>

--- a/digital-credentials/get-enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
+++ b/digital-credentials/get-enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: digital-credentials-get=(self)


### PR DESCRIPTION
As WebKit doesn't support create, allows WebKit to skip these tests (which timeout out on infrastructure). 