### PR TITLE
Digital Credentials: stop defaulting mediation in helper

### DIFF
--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -146,7 +146,7 @@ const allMappings = {
  * @returns {TOptions}
  */
 function makeCredentialOptionsFromConfig(config, mapping) {
-  const { protocol, requests = [], data, mediation = "required", signal } = config;
+  const { protocol, requests = [], data, mediation, signal } = config;
 
   // Validate that we have either a protocol or requests
   if (!protocol && !requests?.length) {


### PR DESCRIPTION
We no longer default the mediation to be required, per spec. 