### PR TITLE
Don't rely on the pagereveal event in lcp/image-upscaling.html

### DIFF
--- a/largest-contentful-paint/image-upscaling.html
+++ b/largest-contentful-paint/image-upscaling.html
@@ -20,15 +20,15 @@
         t.add_cleanup(() => popup.close());
       });
 
-      // Per spec, we should end up with a pagereveal event once the
-      // window is open. However, Gecko seems to load the initial
-      // about:blank synchronously and then asynchronously load the
-      // about:blank requested above, thus we also accept pageshow
-      // here as a sign the popup is ready.
-      await Promise.any([
-        new Promise(resolve => popup.addEventListener('pagereveal', () => resolve(), {'once': true})),
-        new Promise(resolve => popup.addEventListener('pageshow', () => resolve(), {'once': true})),
-      ]);
+      // Ensure the popup document is ready before manipulating it.
+      // Per spec, about:blank should load synchronously and should be
+      // immediately ready. In older Gecko versions this may not be the case,
+      // so we wait for pageshow if needed.
+      if (popup.document.readyState !== 'complete') {
+        await new Promise((resolve) =>
+          popup.addEventListener('pageshow', resolve, { once: true })
+        );
+      }
 
       const image = popup.document.createElement('img');
       image.src = imageURL;


### PR DESCRIPTION
After the changes in #56018 this test started to rely on `pagereveal` since the way we load the popup has changed.

`pagereveal` is a new event type that's not implemented by every browsers yet and this test is for lcp rather than the CSS view transitions, so we shouldn't rely on that.

On the other hand, if a browser doesn't expose the `pageshow` event it means that this is a sync `about:blank`, so the document should be immediately ready. That's why checking `popup.document.readyState` is simple and effective enough.

Tested it with all major browsers and it seems like it's passing in all of them.

Once Firefox lands the synchronous `about:blank` changes it would be good to remove this code all together.

Fixes #56620.