### PR TITLE
Navigation API: Fix navigation-api/navigation-history-entry/entry-after-detach.html to be spec compliant

### DIFF
--- a/navigation-api/navigation-history-entry/entry-after-detach.html
+++ b/navigation-api/navigation-history-entry/entry-after-detach.html
@@ -12,7 +12,7 @@ async_test(t => {
     assert_not_equals(i_entry.id, "");
     i.remove();
     assert_false(i_entry.sameDocument);
-    assert_equals(i_entry.url, null);
+    assert_equals(i_entry.url, "");
     assert_equals(i_entry.key, "");
     assert_equals(i_entry.id, "");
   });


### PR DESCRIPTION
Spec says that if there's no active document the empty string should be returned yet the test tests for null.

https://html.spec.whatwg.org/#dom-navigationhistoryentry-url step 2 says: 
```
If document is not [fully active](https://html.spec.whatwg.org/#fully-active), then return the empty string.
```

@zcorpan @jgraham - can you please bring in appropriate people from chrome and the like?