### PR TITLE
Correct subtest names

### DIFF
--- a/html/dom/documents/resource-metadata-management/document-cookie.html
+++ b/html/dom/documents/resource-metadata-management/document-cookie.html
@@ -9,9 +9,9 @@
 <script>
 
 const TEST_CASES = [
-  {value: "", expected: "", test: "Empty value"},
-  {value: "a=b", expected: "a=b", test: "A simple cookie"},
-  {value: "b=A\0Z", expected: "", test: "A null char"},
+  {value: "", expected: "", name: "Empty value"},
+  {value: "a=b", expected: "a=b", name: "A simple cookie"},
+  {value: "b=A\0Z", expected: "", name: "A null char"},
 ];
 
 test(function(){


### PR DESCRIPTION
Prior to this commit, this test was passing the `undefined` value to the `test` function due to an erroneous property reference. This causes the test harness to automatically generate nondescript subtest titles such as "document.cookie 2".

Correct the property name so that the subtests are named as per the original test author's intentions.