### PR TITLE
Web features simple input types

### DIFF
--- a/html/rendering/widgets/WEB_FEATURES.yml
+++ b/html/rendering/widgets/WEB_FEATURES.yml
@@ -5,3 +5,6 @@ features:
 - name: textarea
   files:
   - textarea-*
+- name: input-password
+  files:
+  - input-password-*

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -34,3 +34,7 @@ features:
 - name: input-reset
   files:
   - reset.html
+- name: input-submit
+  files:
+  - input-submit-remove-jssubmit.html
+  - input-type-change-submit.html

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -24,3 +24,6 @@ features:
 - name: input-hidden
   files:
   - hidden*
+- name: input-image
+  files:
+  - image*

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -49,3 +49,6 @@ features:
 - name: input-range
   files:
   - range*
+- name: input-password
+  files:
+  - password*

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -21,3 +21,6 @@ features:
 - name: change-event
   files:
   - change-to-empty-value.html
+- name: input-hidden
+  files:
+  - hidden*

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -27,3 +27,7 @@ features:
 - name: input-image
   files:
   - image*
+- name: input-button
+  files:
+  - button.html
+  - input-type-button.html

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -43,3 +43,6 @@ features:
   - email*
   - telephone.html
   - url.html
+- name: input-color
+  files:
+  - color*

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -38,3 +38,8 @@ features:
   files:
   - input-submit-remove-jssubmit.html
   - input-type-change-submit.html
+- name: input-email-tel-url
+  files:
+  - email*
+  - telephone.html
+  - url.html

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -46,3 +46,6 @@ features:
 - name: input-color
   files:
   - color*
+- name: input-range
+  files:
+  - range*

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -31,3 +31,6 @@ features:
   files:
   - button.html
   - input-type-button.html
+- name: input-reset
+  files:
+  - reset.html


### PR DESCRIPTION
Maps tests primarily in `html/semantics/forms/the-input-element` to the following input-related web features:
- [input-hidden](https://github.com/web-platform-dx/web-features/blob/main/features/input-hidden.yml)
- [input-image](https://github.com/web-platform-dx/web-features/blob/main/features/input-image.yml)
- [input-button](https://github.com/web-platform-dx/web-features/blob/main/features/input-button.yml)
- [input-reset](https://github.com/web-platform-dx/web-features/blob/main/features/input-reset.yml)
- [input-submit](https://github.com/web-platform-dx/web-features/blob/main/features/input-submit.yml)
- [input-email-tel-url](https://github.com/web-platform-dx/web-features/blob/main/features/input-email-tel-url.yml)
- [input-color](https://github.com/web-platform-dx/web-features/blob/main/features/input-color.yml)
- [input-range](https://github.com/web-platform-dx/web-features/blob/main/features/input-range.yml)
- [input-password](https://github.com/web-platform-dx/web-features/blob/main/features/input-password.yml)

Batched to minimize potential future merge conflicts! Will follow up this PR with more complex `<input>` classifications once this is merged. 

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)