### PR TITLE
Update links to CSS FXTF specs in META files

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -3,7 +3,7 @@ Introduction
 
 This directory contains testsuites for CSS WG specifications, including ones
 that do not strictly speaking define CSS features, e.g.,
-[Geometry Interfaces](https://drafts.fxtf.org/geometry/).
+[Geometry Interfaces](https://drafts.csswg.org/geometry/).
 
 The directories should be named like the specification's shortname, but without
 any level suffix.

--- a/css/compositing/META.yml
+++ b/css/compositing/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.fxtf.org/compositing/
+spec: https://drafts.csswg.org/compositing/
 suggested_reviewers:
   - chrishtr
   - plinss

--- a/css/css-masking/META.yml
+++ b/css/css-masking/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.fxtf.org/css-masking/
+spec: https://drafts.csswg.org/css-masking/
 suggested_reviewers:
   - dirkschulze
   - birtles

--- a/css/fill-stroke/META.yml
+++ b/css/fill-stroke/META.yml
@@ -1,3 +1,3 @@
-spec: https://drafts.fxtf.org/fill-stroke/
+spec: https://drafts.csswg.org/fill-stroke/
 suggested_reviewers:
   - tabatkins

--- a/css/filter-effects/META.yml
+++ b/css/filter-effects/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.fxtf.org/filter-effects/
+spec: https://drafts.csswg.org/filter-effects/
 suggested_reviewers:
   - svgeesus
   - grorg

--- a/css/geometry/META.yml
+++ b/css/geometry/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.fxtf.org/geometry/
+spec: https://drafts.csswg.org/geometry/
 suggested_reviewers:
   - peterjoel
   - dirkschulze

--- a/css/motion/META.yml
+++ b/css/motion/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.fxtf.org/motion/
+spec: https://drafts.csswg.org/motion/
 suggested_reviewers:
   - dirkschulze
   - jihyerish


### PR DESCRIPTION
FXTF drafts have moved to the CSSWG repository and are now served under https://drafts.csswg.org/. This update adjusts the URLs accordingly in the `META.yml` files (and in a README).

Note: Many tests have a `<link rel=help>` that target https://drafts.fxtf.org/ and that would need to be updated (880 occurrences in >600 files). Applying find-and-replace in bulk should work. Not done for now as I wasn't clear whether this could trigger side effects. Happy to give it a try (here or in a separate pull request).