### PR TITLE
Fix timeupdate on seek test

### DIFF
--- a/html/semantics/embedded-content/the-video-element/timeout_on_seek.py
+++ b/html/semantics/embedded-content/the-video-element/timeout_on_seek.py
@@ -12,8 +12,8 @@ def parse_range(header_value, file_size):
     return start, last
 
 def main(request, response):
-    extension = request.GET.first(b"extension").decode()
-    with open(f"media/movie_300.{extension}", "rb") as f:
+    file_extension = request.GET.first(b"extension").decode()
+    with open(f"media/movie_300.{file_extension}", "rb") as f:
         f.seek(0, os.SEEK_END)
         file_size = f.tell()
 
@@ -24,7 +24,7 @@ def main(request, response):
         response.add_required_headers = False
         response.writer.write_status(206 if range_header else 200)
         response.writer.write_header("Accept-Ranges", "bytes")
-        response.writer.write_header("Content-Type", f"video/{extension}")
+        response.writer.write_header("Content-Type", f"video/{file_extension}")
         if range_header:
             response.writer.write_header("Content-Range", f"bytes {req_start}-{req_last}/{file_size}")
         response.writer.write_header("Content-Length", str(req_last - req_start + 1))

--- a/html/semantics/embedded-content/the-video-element/timeout_on_seek.py
+++ b/html/semantics/embedded-content/the-video-element/timeout_on_seek.py
@@ -1,25 +1,23 @@
-from __future__ import print_function
 import os
 import re
-from urlparse import parse_qs
 
 def parse_range(header_value, file_size):
     if header_value is None:
         # HTTP Range header range end is inclusive
         return 0, file_size - 1
 
-    match = re.match("bytes=(\d*)-(\d*)", header_value)
+    match = re.match(r"bytes=(\d*)-(\d*)", header_value)
     start = int(match.group(1)) if match.group(1).strip() != "" else 0
     last = int(match.group(2)) if match.group(2).strip() != "" else file_size - 1
     return start, last
 
 def main(request, response):
-    file_extension = parse_qs(request.url_parts.query)["extension"][0]
+    file_extension = request.GET.first(b"extension").decode()
     with open("media/movie_300." + file_extension, "rb") as f:
         f.seek(0, os.SEEK_END)
         file_size = f.tell()
 
-        range_header = request.headers.get("range")
+        range_header = request.headers.get("range").decode()
         req_start, req_last = parse_range(range_header, file_size)
         f.seek(req_start, os.SEEK_SET)
 

--- a/html/semantics/embedded-content/the-video-element/timeout_on_seek.py
+++ b/html/semantics/embedded-content/the-video-element/timeout_on_seek.py
@@ -6,28 +6,27 @@ def parse_range(header_value, file_size):
         # HTTP Range header range end is inclusive
         return 0, file_size - 1
 
-    match = re.match(r"bytes=(\d*)-(\d*)", header_value)
+    match = re.match(r"bytes=(\d*)-(\d*)", header_value.decode())
     start = int(match.group(1)) if match.group(1).strip() != "" else 0
     last = int(match.group(2)) if match.group(2).strip() != "" else file_size - 1
     return start, last
 
 def main(request, response):
-    file_extension = request.GET.first(b"extension").decode()
-    with open("media/movie_300." + file_extension, "rb") as f:
+    extension = request.GET.first(b"extension").decode()
+    with open(f"media/movie_300.{extension}", "rb") as f:
         f.seek(0, os.SEEK_END)
         file_size = f.tell()
 
-        range_header = request.headers.get("range").decode()
+        range_header = request.headers.get("range")
         req_start, req_last = parse_range(range_header, file_size)
         f.seek(req_start, os.SEEK_SET)
 
         response.add_required_headers = False
         response.writer.write_status(206 if range_header else 200)
         response.writer.write_header("Accept-Ranges", "bytes")
-        response.writer.write_header("Content-Type", "video/mp4")
+        response.writer.write_header("Content-Type", f"video/{extension}")
         if range_header:
-            response.writer.write_header("Content-Range", "bytes %d-%d/%d" %
-                    (req_start, req_last, file_size))
+            response.writer.write_header("Content-Range", f"bytes {req_start}-{req_last}/{file_size}")
         response.writer.write_header("Content-Length", str(req_last - req_start + 1))
         response.writer.end_headers()
 

--- a/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html
+++ b/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html
@@ -23,7 +23,7 @@
 
             function videoCanPlay() {
                 video.addEventListener("timeupdate", test.step_func(onTimeUpdate));
-                video.play();
+                video.play().catch(() => test.unreached_func("play() rejected"));
                 video.currentTime = seekTime;
             }
 
@@ -40,8 +40,8 @@
         const testerVideo = document.createElement("video");
         if (testerVideo.canPlayType("video/mp4"))
             testTimeupdateOnSeek("mp4");
-        if (testerVideo.canPlayType("video/ogg"))
-            testTimeupdateOnSeek("ogv");
+        if (testerVideo.canPlayType("video/webm"))
+            testTimeupdateOnSeek("webm");
     }
 </script>
 </body>


### PR DESCRIPTION
The Python handler for this was still in Python 2 style and didn't work
at all. With these fixes the test passes in Safari, but times out in Chrome
and Firefox.

The test does appear correct per spec, where a timeout even it fired
when readyState changes from >=HAVE_FUTURE_DATA to <=HAVE_CURRENT_DATA,
which should happen if seeking into unbuffered data:
https://html.spec.whatwg.org/multipage/media.html#ready-states
