### PR TITLE
Map `print` and `print-events` web-features

### DIFF
--- a/html/webappapis/user-prompts/WEB_FEATURES.yml
+++ b/html/webappapis/user-prompts/WEB_FEATURES.yml
@@ -1,3 +1,12 @@
 features:
 - name: alerts
-  files: "**"
+  files:
+  - "*"
+  - "!print-*"
+- name: print
+  files:
+  - "print-*"
+  - "!print-manual.html"
+- name: print-events
+  files:
+  - print-manual.html

--- a/html/webappapis/user-prompts/cannot-show-simple-dialogs/WEB_FEATURES.yml
+++ b/html/webappapis/user-prompts/cannot-show-simple-dialogs/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: alerts
+  files: "**"

--- a/print/WEB_FEATURES.yml
+++ b/print/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: print
+  files: "**"


### PR DESCRIPTION
Feature: `print` and `print-events`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/print.yml
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/print-events.yml

> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

**Note** that this PR includes a reduction in the mapping for `alerts`

Notable exclusions

1. CSS Page tests using `window.print()` as trigger
   - `css/css-page/crashtests/counter-containment-001.html`
   - `css/css-page/crashtests/counter-containment-002.html`