### PR TITLE
Map `popover-hint` web-feature

### DIFF
--- a/html/semantics/popovers/WEB_FEATURES.yml
+++ b/html/semantics/popovers/WEB_FEATURES.yml
@@ -1,6 +1,17 @@
 features:
 - name: popover
-  files: "**"
+  files:
+  - "*"
+  - "!popover-hint-crash.html"
+  - "!popover-light-dismiss-hint.html"
+  - "!popover-top-layer-nesting-hints.html"
+  - "!popover-types-with-hints.html"
 - name: closewatcher
   files:
   - "popover-close-request.html"
+- name: popover-hint
+  files:
+  - popover-hint-crash.html
+  - popover-light-dismiss-hint.html
+  - popover-top-layer-nesting-hints.html
+  - popover-types-with-hints.html


### PR DESCRIPTION
Feature: `popover-hint`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/popover-hint.yml

> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).