### PR TITLE
Classify path-shape web feature

### DIFF
--- a/css/css-shapes/shape-functions/WEB_FEATURES.yml
+++ b/css/css-shapes/shape-functions/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: path-shape
+  files:
+  - 'path-function*'


### PR DESCRIPTION
Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

There were a few other references to the path function throughout, but I felt this was the only test actually testing this API specifically.

The others were testing animation/masking/etc using these paths, and the SVG folder didn't feel like it rose to the level of being classified as a part of this API since it wasn't mentioned in the `compat_features` in https://github.com/web-platform-dx/web-features/blob/main/features/path-shape.yml#L5

[`git grep -E \\Wpath\\\(`](https://github.com/user-attachments/files/24113121/2025-12-11T172333-_Wpath__.txt)
