### PR TITLE
classifies "meta" web feature

### DIFF
--- a/html/semantics/document-metadata/the-meta-element/WEB_FEATURES.yml
+++ b/html/semantics/document-metadata/the-meta-element/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: meta
+  files: "**"


### PR DESCRIPTION
Maps tests for the [`<meta>` element web feature](https://github.com/web-platform-dx/web-features/blob/main/features/meta.yml).

@foolip Noting that I opted to include [the `the-meta-element/color-scheme/` tests](https://github.com/web-platform-tests/wpt/tree/master/html/semantics/document-metadata/the-meta-element/color-scheme) here. However, these could arguably be mapped to the [color-scheme web-feature](https://github.com/web-platform-dx/web-features/blob/main/features/color-scheme.yml#L13) (which is so far only mapped to `css/css-color-adjust/rendering/dark-color-scheme/`). Curious if you have any thoughts here! 

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)