### PR TITLE
maps "headings" web feature

### DIFF
--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/WEB_FEATURES.yml
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: headings
+  files:
+  - heading-obsolete-attributes-01.html


### PR DESCRIPTION
Unfortunately, I could only find a single test for the [headings web feature](https://github.com/web-platform-dx/web-features/blob/main/features/headings.yml). The mapped [test](https://github.com/bocoup/wpt/blob/web-features-headings-elements/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/heading-obsolete-attributes-01.html) only checks for obsolete IDL usage. 

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)