### PR TITLE
Classify document-write web feature

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/closing-the-input-stream/WEB_FEATURES.yml
+++ b/html/webappapis/dynamic-markup-insertion/closing-the-input-stream/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: document-write
+  files:
+  - "*"

--- a/html/webappapis/dynamic-markup-insertion/document-write/WEB_FEATURES.yml
+++ b/html/webappapis/dynamic-markup-insertion/document-write/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: document-write
+  files:
+  - "*"

--- a/html/webappapis/dynamic-markup-insertion/document-writeln/WEB_FEATURES.yml
+++ b/html/webappapis/dynamic-markup-insertion/document-writeln/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: document-write
+  files:
+  - "*"

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/WEB_FEATURES.yml
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: document-write
+  files:
+  - "*"


### PR DESCRIPTION
Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

`document.write` et all aren't really used that much throughout, and there seems to be a nice collection of the tests for these features in the `html/webappapis/dynamic-markup-insertion` folder

[`git grep -E document.\(write\|open\|close\)`](https://github.com/user-attachments/files/24149130/2025-12-14T051331-document__write_open_close_.txt)
