### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=304170

### DIFF
--- a/service-workers/cache-storage/cache-api-nested-worker.https.html
+++ b/service-workers/cache-storage/cache-api-nested-worker.https.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Cache Storage: Verify nested worker functionality</title>
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+promise_test(async function(t) {
+   const worker = new Worker("cache-api-nested-worker1.js");
+   const result = await new Promise((resolve, reject) => {
+       worker.onmessage = e => resolve(e.data);
+       t.step_timeout(() => reject("test timed out"), 2000);
+   });
+   assert_equals(result, "PASS");
+}, "Cache API in nested worker");
+</script>

--- a/service-workers/cache-storage/cache-api-nested-worker1.js
+++ b/service-workers/cache-storage/cache-api-nested-worker1.js
@@ -1,0 +1,3 @@
+const worker2 = new Worker("cache-api-nested-worker2.js");
+worker2.onmessage = e => self.postMessage(e.data);
+

--- a/service-workers/cache-storage/cache-api-nested-worker2.js
+++ b/service-workers/cache-storage/cache-api-nested-worker2.js
@@ -1,0 +1,1 @@
+self.caches.keys().then(() => postMessage('PASS'), () => postMessage('FAIL'));


### PR DESCRIPTION
WebKit export from bug: [Cache API is broken in nested workers](https://bugs.webkit.org/show_bug.cgi?id=304170)