### PR TITLE
[digital-credentials] Remove `undefined` from invalid data test cases

### DIFF
--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -29,7 +29,7 @@
   });
 
   promise_test(async (t) => {
-    const invalidData = [null, undefined, "", 123, true, false];
+    const invalidData = [null, "", 123, true, false];
     for (const data of invalidData) {
       const options = makeGetOptions({ data });
       await test_driver.bless("user activation");


### PR DESCRIPTION
Updates `digital-credentials/get.tentative.https.html` to remove `undefined` from the list of values tested as invalid data inputs. After [this PR](https://github.com/web-platform-tests/wpt/commit/db7e90790db81992a56885aafd9163f48566d241#diff-e42a1b6fb6d49fc7b30d7d4cdeea8b24c331cb4197a1670446bcdfd0b9fbd67eR111-R130), `undefined` is no longer considered an invalid type for the data property in this test context since it is being automatically converted to the default canonical `data`.

This is simpler than updating the test suite to take an extra parameter whether to respect the `undefined`.