### PR TITLE
layout: Treat `<audio>` as replaced and do not display when there is no `controls` attribute

### DIFF
--- a/html/semantics/embedded-content/the-audio-element/audio-with-replaced-after-pseudo-crash.html
+++ b/html/semantics/embedded-content/the-audio-element/audio-with-replaced-after-pseudo-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<title>HTML5 Media Elements: An 'audio' element with a replaced ::after shouldn't crash</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/41183">
+
+<style>
+audio::after {
+  content: url("/css/support/60x60-red.png");
+}
+</style>
+<audio controls></audio>
+<script src="/common/media.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script>
+(async function() {
+  const audio = document.querySelector("audio");
+  audio.src = getAudioURI("/media/sound_5");
+  for (let i = 0; i < 10; ++i) {
+    await waitForAtLeastOneFrame();
+    await audio.play();
+    document.body.style.color = "cyan";
+    await waitForAtLeastOneFrame();
+    audio.pause();
+    await waitForAtLeastOneFrame();
+    document.body.style.color = "magenta";
+  }
+  document.documentElement.removeAttribute("class");
+})();
+</script>
+</html>


### PR DESCRIPTION
Add an important UA style to ensure that `<audio>` isn't displayed at all when it doesn't have the `controls` attribute. This matches Gecko, Blink and WebKit.

When it does have the attribute, then treat it as replaced. For example, this means that it won't stretch by default if it's block-level, that it will be atomic if inline-level, and that it won't generate boxes for its children (including `::before` and `::after`).

Previously we were generating `::before` and `::after`, but there was a bug: if they had some replaced content, the controls of the `<audio>` would be duplicated, and also appear on the pseudo-element. Then, since the various boxes for the controls would be backed by the same elements, Servo could panic because of a double borrow. This is now avoided.

Testing: Some WPT are now passing, also adding a new crashtest. There is one failure about `innerText`, but the test is probably wrong, now we match other browsers.
Fixes: #<!-- nolink -->40693
Fixes: #<!-- nolink -->41183

Reviewed in servo/servo#41262