### PR TITLE
Map `position` web-feature

### DIFF
--- a/css/css-position/animations/WEB_FEATURES.yml
+++ b/css/css-position/animations/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: position
+  files:
+  - position-interpolation.html

--- a/css/css-position/parsing/WEB_FEATURES.yml
+++ b/css/css-position/parsing/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: z-index
   files:
   - z-index-*
+- name: position
+  files:
+  - position-*


### PR DESCRIPTION
Feature: `position`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/position.yml

Left out most uses of `position` which are testing a specific value for the property and are mapped accordingly ('absolute-positioning','fixed-positioning', etc)

> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).