### PR TITLE
Increase testharness timeout to 4 hours

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -17,7 +17,7 @@ components:
 
   wpt-testharness:
     chunks: 16
-    maxRunTime: 10800
+    maxRunTime: 14400
     vars:
       test-type: testharness
 


### PR DESCRIPTION
Addresses #56757

This does not address the larger issue of multiple tests timing out sequentially, but it will ensure we have Chrome results uploaded to wpt.fyi 😅 