### PR TITLE
Map `overscroll-behavior` web-feature

### DIFF
--- a/css/css-overscroll-behavior/WEB_FEATURES.yml
+++ b/css/css-overscroll-behavior/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: overscroll-behavior
+  files: "**"


### PR DESCRIPTION
> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

Feature: `overscroll-behavior`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/overscroll-behavior.yml Notable exclusions

1. `css/css-overflow/overflow-body-propagation-005.html`
   - Primary focus: Overflow propagation rules (does body overflow propagate to viewport?)
   - Uses `overscroll-behavior` only to verify it doesn't interfere with standard propagation.

2. `dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior.html`
   - Primary focus: `scrollend` event
   - Uses `overscroll-behavior` as test context.