### PR TITLE
classifies `nth-child` and `nth-of-type` web features

### DIFF
--- a/css/selectors/WEB_FEATURES.yml
+++ b/css/selectors/WEB_FEATURES.yml
@@ -32,6 +32,12 @@ features:
 - name: nth-child-of
   files:
   - nth-child-of-*
+- name: nth-of-type
+  files:
+  - first-of-type.html
+  - last-of-type.html
+  - only-of-type.html
+  - nth-of-type-namespace.html
 - name: user-pseudos
   files:
   - user-invalid.html

--- a/css/selectors/WEB_FEATURES.yml
+++ b/css/selectors/WEB_FEATURES.yml
@@ -32,6 +32,11 @@ features:
 - name: nth-child-of
   files:
   - nth-child-of-*
+  - nth-child-and-nth-last-child.html
+  - nth-child-specificity-*
+  - nth-last-child-of-*
+  - nth-last-child-specificity-*
+  - nth-last-child-invalid.html
 - name: nth-of-type
   files:
   - first-of-type.html

--- a/css/selectors/WEB_FEATURES.yml
+++ b/css/selectors/WEB_FEATURES.yml
@@ -22,6 +22,13 @@ features:
 - name: not
   files:
   - not-*
+- name: nth-child
+  files:
+  - first-child.html
+  - last-child.html
+  - only-child.html
+  - nth-child-spurious-brace-crash.html
+  - child-indexed-no-parent.html
 - name: nth-child-of
   files:
   - nth-child-of-*

--- a/css/selectors/invalidation/WEB_FEATURES.yml
+++ b/css/selectors/invalidation/WEB_FEATURES.yml
@@ -21,6 +21,14 @@ features:
 - name: nth-child-of
   files:
   - nth-child-of-*
+  - nth-child-when-*
+  - nth-child-whole-subtree.html
+  - nth-child-containing-ancestor.html
+  - negated-nth-child-when-*
+  - nth-last-child-of-*
+  - nth-last-child-when-*
+  - nth-last-child-containing-ancestor.html
+  - negated-nth-last-child-when-*
 - name: nth-of-type
   files:
   - 'negated-*-of-type*'

--- a/css/selectors/invalidation/WEB_FEATURES.yml
+++ b/css/selectors/invalidation/WEB_FEATURES.yml
@@ -21,6 +21,9 @@ features:
 - name: nth-child-of
   files:
   - nth-child-of-*
+- name: nth-of-type
+  files:
+  - 'negated-*-of-type*'
 - name: user-pseudos
   files:
   - user-valid-user-invalid.html

--- a/css/selectors/invalidation/WEB_FEATURES.yml
+++ b/css/selectors/invalidation/WEB_FEATURES.yml
@@ -14,6 +14,10 @@ features:
 - name: not
   files:
   - not-*
+- name: nth-child
+  files:
+  - first-child-last-child.html
+  - nth-child-in-shadow-root.html
 - name: nth-child-of
   files:
   - nth-child-of-*


### PR DESCRIPTION
I batched web feature classification of [`nth-child`](https://github.com/web-platform-dx/web-features/blob/main/features/nth-child.yml) and [`nth-of-type`](https://github.com/web-platform-dx/web-features/blob/main/features/nth-of-type.yml) to minimize future merge conflicts. 

As I was classifying, I also found likely additional mappings for the [related `nth-child-of` feature](https://github.com/web-platform-dx/web-features/blob/main/features/nth-child-of.yml). Those changes are all in this commit. Happy to revert that or move to a different PR if it adds too much scope to this PR!

One notable exclusion here is [child-indexed-pseudo-class.html](https://github.com/bocoup/wpt/blob/web-features-nth-child/css/selectors/child-indexed-pseudo-class.html) from any mapping (tests both `nth-child` and `nth-of-type`). 

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)