### PR TITLE
classifies "host-context" web feature

### DIFF
--- a/css/css-scoping/WEB_FEATURES.yml
+++ b/css/css-scoping/WEB_FEATURES.yml
@@ -2,3 +2,7 @@ features:
 - name: has-slotted
   files:
   - has-slotted-*
+- name: host-context
+  files:
+  - host-context-*
+  - host-in-host-context-selector.html


### PR DESCRIPTION
Web Feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/host-context.yml

Notable exclusions from this mapping:
- `css/css-scoping/css-scoping-shadow-host-namespace.html` - Title is ":host, :host-context, and default `@namespace`" - tests both :host and :host-context with namespaces.
- `css/selectors/invalidation/host-context-pseudo-class-in-has.html` - primarily about :has()
- `css/selectors/invalidation/host-has-shadow-tree-element-*` - primarily about :has()
- `css/selectors/is-where-shadow.html` - primarily about :is() and :where()

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)