### PR TITLE
classifies "open-pseudo" web feature

### DIFF
--- a/css/selectors/WEB_FEATURES.yml
+++ b/css/selectors/WEB_FEATURES.yml
@@ -38,3 +38,6 @@ features:
   - hover-002.html
   - remove-hovered-element.html
   - focus-display-none-001.html
+- name: open-pseudo
+  files:
+  - open-pseudo.html

--- a/css/selectors/selectors-4/WEB_FEATURES.yml
+++ b/css/selectors/selectors-4/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: open-pseudo
+  files:
+  - details-open-pseudo-*

--- a/html/semantics/forms/the-select-element/customizable-select/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-select-element/customizable-select/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: open-pseudo
+  files:
+  - select-pseudo-open.html

--- a/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
+++ b/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
@@ -22,3 +22,6 @@ features:
   - modal-dialog-backdrop-opacity.html
   - modal-dialog-display-contents.html
   - modal-dialog-generated-content.html
+- name: open-pseudo
+  files:
+  - dialog-open-pseudo-invalidation.html


### PR DESCRIPTION
Web feature documentation: https://github.com/web-platform-dx/web-features/blob/main/features/open-pseudo.yml

(Noting that the [second commit](https://github.com/web-platform-tests/wpt/commit/b0be435ce3a6daecfb1ad5c08d480e7e4d88a1ae) here adds additional mappings to tests that directly reference the [spec](https://drafts.csswg.org/selectors-4/#open-state) associated with this feature, indicating that the open-pseudo is the primary focus of the test.)

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)