### PR TITLE
Map `online` web-feature

### DIFF
--- a/html/browsers/offline/browser-state/WEB_FEATURES.yml
+++ b/html/browsers/offline/browser-state/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: online
+  files: "**"

--- a/workers/WEB_FEATURES.yml
+++ b/workers/WEB_FEATURES.yml
@@ -12,6 +12,9 @@ features:
   files:
   - WorkerNavigator_userAgentData.http.html
   - WorkerNavigator_userAgentData.https.html
+- name: online
+  files:
+  - WorkerNavigator_onLine.htm
 - name: postmessage
   files:
   - Worker-postMessage-happens-in-parallel.https.html

--- a/workers/interfaces/WorkerUtils/navigator/WEB_FEATURES.yml
+++ b/workers/interfaces/WorkerUtils/navigator/WEB_FEATURES.yml
@@ -1,4 +1,7 @@
 features:
+- name: online
+  files:
+  - 006.html
 - name: user-agent-sniffing
   files:
   - 005.html

--- a/workers/non-automated/WEB_FEATURES.yml
+++ b/workers/non-automated/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: online
+  files:
+  - navigator-onLine.html


### PR DESCRIPTION
> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

Feature: `online`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/online.yml

Notable exclusions

1. WebIDL bindings test
    - `webidl/ecmascript-binding/global-object-implicit-this-value.any.js`: Tests implicit `this` value for global object members, using `ononline` as an example property.
2. Worker global scope tests
    - `workers/constructors/Worker/DedicatedWorkerGlobalScope-members.worker.js`: Tests existence of global scope members generally.