### PR TITLE
Fix hashchange only queue when fragment actually changes

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/hashchange-same-fragment-does-not-fire.html
+++ b/html/browsers/browsing-the-web/history-traversal/hashchange-same-fragment-does-not-fire.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>hashchange is not fired when setting the same fragment</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+promise_test(async t => {
+  t.add_cleanup(() => history.replaceState(null, "", location.pathname + location.search));
+
+  const first = new Promise(resolve => addEventListener("hashchange", resolve, { once: true }));
+  location.hash = "#foo";
+  await first;
+
+  const secondHashchange = new Promise(resolve => {
+    addEventListener("hashchange", () => resolve("fired"), { once: true });
+  });
+  const timeout = new Promise(resolve => t.step_timeout(() => resolve("timeout"), 100));
+
+  location.hash = "#foo";
+
+  const result = await Promise.race([secondHashchange, timeout]);
+  assert_equals(result, "timeout", "hashchange must not fire when fragment does not change");
+}, "Setting the same location.hash twice must not fire hashchange the second time");
+</script>


### PR DESCRIPTION
Fix hashchange only queue when fragment actually changes

Testing: tested it manually for now. 
Fixes: #<!-- nolink -->41304

Reviewed in servo/servo#41325