### PR TITLE
Add line-height to position-area-inline-container.html and its -abs variant

### DIFF
--- a/css/css-anchor-position/position-area-abs-inline-container.html
+++ b/css/css-anchor-position/position-area-abs-inline-container.html
@@ -7,6 +7,7 @@
   #in-flow {
     font-family: Ahem;
     font-size: 100px;
+    line-height: 1;
     color: orange;
   }
   #inline-container {

--- a/css/css-anchor-position/position-area-inline-container.html
+++ b/css/css-anchor-position/position-area-inline-container.html
@@ -7,6 +7,7 @@
   #in-flow {
     font-family: Ahem;
     font-size: 100px;
+    line-height: 1;
     color: orange;
   }
   #inline-container {


### PR DESCRIPTION
This test specified the Ahem font but forgot to include a line-height, which inadvertently depend on `line-height:normal` behavior (which varies between browsers).

Tests with Ahem should always specify a line-height, per guidelines at https://web-platform-tests.org/writing-tests/ahem.html ("An explicit (i.e., not normal) line-height should also always be used")

This commit adds `line-height:1` to align with that guideline.

Fixes https://github.com/web-platform-tests/interop/issues/1237