### PR TITLE
Avoid timeout in scroll animation test

### DIFF
--- a/scroll-animations/scroll-timelines/updating-the-finished-state.html
+++ b/scroll-animations/scroll-timelines/updating-the-finished-state.html
@@ -485,13 +485,17 @@ async_test(t => {
 
   animation.play();
 
-  animation.onfinish = event => {
+  animation.onfinish = async event => {
     scroller.scrollTop = 0;
-    window.requestAnimationFrame(function() {
-      window.requestAnimationFrame(function() {
-        scroller.scrollTop = maxScroll;
-      });
-    });
+
+    // Wait for two animation frames - this is because the onfinish callback
+    // is executing within step 3 of the update animations and send events
+    // procedure: "perform a microtask checkpoint" so only waiting one frame
+    // would not have run the "update animations and send events" procedure
+    // with scrollTop set to 0.
+    await waitForAnimationFrames(2);
+
+    scroller.scrollTop = maxScroll;
     animation.onfinish = event => {
       t.done();
     };
@@ -506,15 +510,21 @@ async_test(t => {
 
   animation.play();
 
-  animation.onfinish = event => {
+  animation.onfinish = async event => {
     scroller.scrollTop = 0;
-    window.requestAnimationFrame(function() {
-      animation.play();
-      scroller.scrollTop = maxScroll;
-      animation.onfinish = event => {
-        t.done();
-      };
-    });
+
+    // Wait for two animation frames - this is because the onfinish callback
+    // is executing within step 3 of the update animations and send events
+    // procedure: "perform a microtask checkpoint" so only waiting one frame
+    // would not have run the "update animations and send events" procedure
+    // with scrollTop set to 0.
+    await waitForAnimationFrames(2);
+
+    animation.play();
+    scroller.scrollTop = maxScroll;
+    animation.onfinish = event => {
+      t.done();
+    };
   };
   scroller.scrollTop = maxScroll;
 }, 'Animation finish event is fired again after replaying from start');


### PR DESCRIPTION
As with the test above we are required to wait for two animation frames to pass, this is because the onfinish callback is executing within step 3 of the [update animations and send events](https://www.w3.org/TR/web-animations-1/#update-animations-and-send-events) procedure: "perform a microtask checkpoint" and thus the callback passed to the first `requestAnimationFrame` will execute within the same iteration of the [update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering) procedure (i.e. before we have a chance to run the [update animations and send events](https://www.w3.org/TR/web-animations-1/#update-animations-and-send-events) procedure with scrollTop set to 0).