### PR TITLE
Map "Description list" to web-features

### DIFF
--- a/html/semantics/grouping-content/the-dd-element/WEB_FEATURES.yml
+++ b/html/semantics/grouping-content/the-dd-element/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: description-list
+  files: "**"

--- a/html/semantics/grouping-content/the-dl-element/WEB_FEATURES.yml
+++ b/html/semantics/grouping-content/the-dl-element/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: description-list
+  files: "**"

--- a/html/semantics/grouping-content/the-dt-element/WEB_FEATURES.yml
+++ b/html/semantics/grouping-content/the-dt-element/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: description-list
+  files: "**"


### PR DESCRIPTION
Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

### Matching test files for <a href="https://webstatus.dev/features/description-list">Description list</a>

<details>
  <summary><code>./html/semantics/grouping-content/the-dl-element</code></summary>


- [x] [html/semantics/grouping-content/the-dl-element/grouping-dl.html](https://github.com/web-platform-tests/wpt/blob/master//html/semantics/grouping-content/the-dl-element/grouping-dl.html)

</details><details>
  <summary><code>./html/semantics/grouping-content/the-dd-element</code></summary>


- [x] [html/semantics/grouping-content/the-dd-element/grouping-dd.html](https://github.com/web-platform-tests/wpt/blob/master//html/semantics/grouping-content/the-dd-element/grouping-dd.html)

</details><details>
  <summary><code>./html/semantics/grouping-content/the-dt-element</code></summary>


- [x] [html/semantics/grouping-content/the-dt-element/grouping-dt.html](https://github.com/web-platform-tests/wpt/blob/master//html/semantics/grouping-content/the-dt-element/grouping-dt.html)

</details>
