### PR TITLE
Map `long-animation-frames` web feature

### DIFF
--- a/interfaces/WEB_FEATURES.yml
+++ b/interfaces/WEB_FEATURES.yml
@@ -2,3 +2,6 @@ features:
 - name: barcode
   files:
   - shape-detection-api.idl
+- name: long-animation-frames
+  files:
+  - long-animation-frames.idl


### PR DESCRIPTION
> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

Feature: "Long animation frames"
Specification: https://github.com/web-platform-dx/web-features/blob/main/features/long-animation-frames.yml

No notable exclusions here. This feature is already covered in:
* [`long-animation-frame/WEB_FEATURES.yml`](https://github.com/web-platform-tests/wpt/blob/1012b6102284735222165dc1e38f9f437fdc7c3e/long-animation-frame/WEB_FEATURES.yml)