### PR TITLE
Map `notifications-apps` web-feature

### DIFF
--- a/notifications/WEB_FEATURES.yml
+++ b/notifications/WEB_FEATURES.yml
@@ -1,3 +1,14 @@
 features:
 - name: notifications
-  files: "**"
+  files:
+  - "*"
+  - "!fetch-url-resolve.https.window.js"
+  - "!getnotifications-across-processes.https.window.js"
+  - "!registration-association.https.window.js"
+  - "!shownotification*"
+- name: notifications-apps
+  files:
+  - fetch-url-resolve.https.window.js
+  - getnotifications-across-processes.https.window.js
+  - registration-association.https.window.js
+  - "shownotification*"


### PR DESCRIPTION
> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

Feature: notifications-apps
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/notifications-apps.yml

Note that `notifications` does correctly map to all of these but I opted to take an approach of mapping tests to the more specific/constrained feature when appropriate, in this case that more constrained feature is `notifications-apps`.

Notable exclusions

1. `fenced-frame/notification.https.html` - Primary focus: Fenced Frame restrictions on notifications