### PR TITLE
feat(manifest): Add initial tooling for Test262 test types [pt 1/5]

### DIFF
--- a/tools/manifest/commands.json
+++ b/tools/manifest/commands.json
@@ -4,7 +4,10 @@
     "script": "run",
     "parser": "create_parser",
     "help": "Update the MANIFEST.json file",
-    "virtualenv": false
+    "virtualenv": true,
+    "requirements": [
+      "requirements.txt"
+    ]
   },
   "manifest-download": {
     "path": "download.py",

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -198,6 +198,12 @@ class TestharnessTest(URLManifestItem):
         return rv
 
 
+class Test262Test(TestharnessTest):
+    __slots__ = ()
+
+    item_type = "test262"
+
+
 class RefTest(URLManifestItem):
     __slots__ = ("references",)
 

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -17,6 +17,7 @@ from .item import (ConformanceCheckerTest,
                    SpecItem,
                    SupportFile,
                    TestharnessTest,
+                   Test262Test,
                    VisualTest,
                    WebDriverSpecTest)
 from .log import get_logger
@@ -49,7 +50,8 @@ item_classes: Dict[Text, Type[ManifestItem]] = {"testharness": TestharnessTest,
                                                 "conformancechecker": ConformanceCheckerTest,
                                                 "visual": VisualTest,
                                                 "spec": SpecItem,
-                                                "support": SupportFile}
+                                                "support": SupportFile,
+                                                "test262": Test262Test}
 
 
 def compute_manifest_items(source_file: SourceFile) -> Optional[Tuple[Tuple[Text, ...], Text, Set[ManifestItem], Text]]:

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -24,10 +24,13 @@ from .item import (ConformanceCheckerTest,
                    RefTest,
                    SpecItem,
                    SupportFile,
+                   Test262Test,
                    TestharnessTest,
                    VisualTest,
                    WebDriverSpecTest)
 from .utils import cached_property
+
+from . import test262
 
 # Cannot do `from ..metadata.webfeatures.schema import WEB_FEATURES_YML_FILENAME`
 # because relative import beyond toplevel throws *ImportError*!
@@ -422,6 +425,12 @@ class SourceFile:
                 (self.type_flag == "print" or "print" in self.dir_path.split(os.path.sep)))
 
     @property
+    def name_is_test262(self) -> bool:
+        """Check if the file name matches the conditions for the file to be a
+        test262 file"""
+        return ("test262" in self.dir_path.split(os.path.sep) and self.ext == ".js")
+
+    @property
     def markup_type(self) -> Optional[Text]:
         """Return the type of markup contained in a file, based on its extension,
         or None if it doesn't contain markup"""
@@ -471,11 +480,29 @@ class SourceFile:
         return self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='pac']")
 
     @cached_property
+    def test262_test_record(self) -> Optional[Dict[Text, Any]]:
+        if self.name_is_test262:
+            with self.open() as f:
+                return test262.TestRecord.parse(f.read().decode('ISO-8859-1'), self.path)
+        else:
+            return None
+
+    @cached_property
     def script_metadata(self) -> Optional[List[Tuple[Text, Text]]]:
         if self.name_is_worker or self.name_is_multi_global or self.name_is_window or self.name_is_extension:
             regexp = js_meta_re
         elif self.name_is_webdriver:
             regexp = python_meta_re
+        elif self.name_is_test262:
+            if self.test262_test_record is None:
+                return None
+            paths = []
+            for filename in self.test262_test_record.get("includes", []):
+                if filename in ("assert.js", "sta.js"):
+                    paths.append(('script', "/third_party/test262/harness/%s" % filename))
+                else:
+                    paths.append(('script', "/resources/test262/%s" % filename))
+            return paths
         else:
             return None
 
@@ -917,6 +944,9 @@ class SourceFile:
         if self.name_is_window:
             return {TestharnessTest.item_type}
 
+        if self.name_is_test262:
+            return {Test262Test.item_type, SupportFile.item_type}
+
         if self.name_is_extension:
             return {TestharnessTest.item_type}
 
@@ -1099,6 +1129,38 @@ class SourceFile:
                 for variant in self.test_variants
             ]
             rv = TestharnessTest.item_type, tests
+
+        elif self.name_is_test262:
+            if self.test262_test_record is None:
+                rv = "support", [
+                    SupportFile(
+                        self.tests_root,
+                        self.rel_path
+                    )]
+            else:
+                suffix = ".test262"
+                if "module" in self.test262_test_record:
+                    suffix += "-module"
+                elif "onlyStrict" in self.test262_test_record:
+                    # Modules are always strict mode, so only append strict for
+                    # non-module tests.
+                    suffix += ".strict"
+                suffix += ".html"
+                test_url = replace_end(self.rel_url, ".js", suffix)
+                tests = [
+                    Test262Test(
+                        self.tests_root,
+                        self.rel_path,
+                        self.url_base,
+                        test_url + variant,
+                        timeout=self.timeout,
+                        pac=self.pac,
+                        testdriver_features=self.testdriver_features,
+                        script_metadata=self.script_metadata
+                    )
+                    for variant in self.test_variants
+                ]
+                rv = Test262Test.item_type, tests
 
         elif self.content_is_css_manual and not self.name_is_reference:
             rv = ManualTest.item_type, [

--- a/tools/manifest/test262.py
+++ b/tools/manifest/test262.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from dataclasses import dataclass
 from logging import Logger
-from typing import Optional, Text, Tuple
+from typing import Dict, List, Optional, Text, Tuple
 
 import re
 
@@ -19,8 +19,8 @@ _STRIP_CONTROL_CHARS = re.compile(r'[\x7f-\x9f]')
 @dataclass
 class TestRecord:
     test: str
-    includes: Optional[list[str]] = None
-    negative: Optional[dict[str, str]] = None
+    includes: Optional[List[Text]] = None
+    negative: Optional[Dict[Text, Text]] = None
     is_only_strict: bool = False
     is_module: bool = False
 

--- a/tools/manifest/test262.py
+++ b/tools/manifest/test262.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from dataclasses import dataclass
 from logging import Logger
-from typing import Optional, Text, Tuple, Any
+from typing import Optional, Text, Tuple
 
 import re
 
@@ -20,7 +20,7 @@ _STRIP_CONTROL_CHARS = re.compile(r'[\x7f-\x9f]')
 class TestRecord:
     test: str
     includes: Optional[list[str]] = None
-    negative: Optional[dict[str, Any]] = None
+    negative: Optional[dict[str, str]] = None
     is_only_strict: bool = False
     is_module: bool = False
 

--- a/tools/manifest/test262.py
+++ b/tools/manifest/test262.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
-from typing import Dict, Optional, Text, Tuple, Any, Callable
+from dataclasses import dataclass
+from logging import Logger
+from typing import Optional, Text, Tuple, Any
 
 import re
 
@@ -13,50 +15,59 @@ _YAML_PATTERN = re.compile(r"/\*---(.*)---\*/" + _BLANK_LINES, re.DOTALL)
 _STRIP_CONTROL_CHARS = re.compile(r'[\x7f-\x9f]')
 
 
+
+@dataclass
 class TestRecord:
-    @staticmethod
-    def _yaml_attr_parser(test_record: Dict[Text, Any], attrs: Text, name: Text, onerror: Callable[[Text], Any]) -> None:
-        import yaml
-        parsed = yaml.safe_load(re.sub(_STRIP_CONTROL_CHARS, ' ', attrs))
-        if parsed is None:
-            onerror("Failed to parse yaml in name %s" % name)
-            return
+    test: str
+    includes: Optional[list[str]] = None
+    negative: Optional[dict[str, Any]] = None
+    is_only_strict: bool = False
+    is_module: bool = False
 
-        for key in parsed:
-            value = parsed[key]
-            if key == "info":
-                key = "commentary"
-            test_record[key] = value
+def _yaml_attr_parser(logger: Logger, test_record: TestRecord, attrs: Text, name: Text) -> None:
+    import yaml
+    parsed = yaml.safe_load(re.sub(_STRIP_CONTROL_CHARS, ' ', attrs))
+    if parsed is None:
+        logger.error("Failed to parse yaml in name %s" % name)
+        return
 
-        if 'flags' in test_record:
-            for flag in test_record['flags']:
-                test_record[flag] = ""
+    for key, value in parsed.items():
+        if key == "negative":
+            test_record.negative = value
+        elif key == "flags":
+            if isinstance(value, list):
+                for flag in value:
+                    if flag == "onlyStrict":
+                        test_record.is_only_strict = True
+                    elif flag == "module":
+                        test_record.is_module = True
+        elif key == "includes":
+            test_record.includes = value
 
-    @staticmethod
-    def _find_attrs(src: Text) -> Tuple[Optional[Text], Optional[Text]]:
-        match = _YAML_PATTERN.search(src)
-        if not match:
-            return (None, None)
 
-        return (match.group(0), match.group(1).strip())
+def _find_attrs(src: Text) -> Tuple[Optional[Text], Optional[Text]]:
+    match = _YAML_PATTERN.search(src)
+    if not match:
+        return (None, None)
 
-    @staticmethod
-    def parse(src: Text, name: Text, onerror: Callable[[Text], Any] = print) -> Optional[Dict[Text, Any]]:
-        if name.endswith('_FIXTURE.js'):
-            return None
+    return (match.group(0), match.group(1).strip())
 
-        # Find the YAML frontmatter.
-        (frontmatter, attrs) = TestRecord._find_attrs(src)
 
-        # YAML frontmatter is required for all tests.
-        if frontmatter is None:
-            onerror("Missing frontmatter: %s" % name)
-            return None
+def parse(logger: Logger, src: Text, name: Text) -> Optional[TestRecord]:
+    if name.endswith('_FIXTURE.js'):
+        return None
 
-        test_record: Dict[Text, Any] = {}
-        test_record['test'] = src
+    # Find the YAML frontmatter.
+    (frontmatter, attrs) = _find_attrs(src)
 
-        if attrs:
-            TestRecord._yaml_attr_parser(test_record, attrs, name, onerror)
+    # YAML frontmatter is required for all tests.
+    if frontmatter is None:
+        logger.error("Missing frontmatter: %s" % name)
+        return None
 
-        return test_record
+    test_record = TestRecord(test = src)
+
+    if attrs:
+        _yaml_attr_parser(logger, test_record, attrs, name)
+
+    return test_record

--- a/tools/manifest/test262.py
+++ b/tools/manifest/test262.py
@@ -1,0 +1,62 @@
+from __future__ import print_function
+
+from typing import Dict, Optional, Text, Tuple, Any, Callable
+
+import re
+
+# Matches trailing whitespace and any following blank lines.
+_BLANK_LINES = r"([ \t]*[\r\n]{1,2})*"
+
+# Matches the YAML frontmatter block.
+_YAML_PATTERN = re.compile(r"/\*---(.*)---\*/" + _BLANK_LINES, re.DOTALL)
+
+_STRIP_CONTROL_CHARS = re.compile(r'[\x7f-\x9f]')
+
+
+class TestRecord:
+    @staticmethod
+    def _yaml_attr_parser(test_record: Dict[Text, Any], attrs: Text, name: Text, onerror: Callable[[Text], Any]) -> None:
+        import yaml
+        parsed = yaml.safe_load(re.sub(_STRIP_CONTROL_CHARS, ' ', attrs))
+        if parsed is None:
+            onerror("Failed to parse yaml in name %s" % name)
+            return
+
+        for key in parsed:
+            value = parsed[key]
+            if key == "info":
+                key = "commentary"
+            test_record[key] = value
+
+        if 'flags' in test_record:
+            for flag in test_record['flags']:
+                test_record[flag] = ""
+
+    @staticmethod
+    def _find_attrs(src: Text) -> Tuple[Optional[Text], Optional[Text]]:
+        match = _YAML_PATTERN.search(src)
+        if not match:
+            return (None, None)
+
+        return (match.group(0), match.group(1).strip())
+
+    @staticmethod
+    def parse(src: Text, name: Text, onerror: Callable[[Text], Any] = print) -> Optional[Dict[Text, Any]]:
+        if name.endswith('_FIXTURE.js'):
+            return None
+
+        # Find the YAML frontmatter.
+        (frontmatter, attrs) = TestRecord._find_attrs(src)
+
+        # YAML frontmatter is required for all tests.
+        if frontmatter is None:
+            onerror("Missing frontmatter: %s" % name)
+            return None
+
+        test_record: Dict[Text, Any] = {}
+        test_record['test'] = src
+
+        if attrs:
+            TestRecord._yaml_attr_parser(test_record, attrs, name, onerror)
+
+        return test_record

--- a/tools/manifest/test262.py
+++ b/tools/manifest/test262.py
@@ -48,9 +48,9 @@ def _yaml_attr_parser(logger: Logger, test_record: TestRecord, attrs: Text, name
 def _find_attrs(src: Text) -> Tuple[Optional[Text], Optional[Text]]:
     match = _YAML_PATTERN.search(src)
     if not match:
-        return (None, None)
+        return None, None
 
-    return (match.group(0), match.group(1).strip())
+    return match.group(0), match.group(1).strip()
 
 
 def parse(logger: Logger, src: Text, name: Text) -> Optional[TestRecord]:
@@ -58,7 +58,7 @@ def parse(logger: Logger, src: Text, name: Text) -> Optional[TestRecord]:
         return None
 
     # Find the YAML frontmatter.
-    (frontmatter, attrs) = _find_attrs(src)
+    frontmatter, attrs = _find_attrs(src)
 
     # YAML frontmatter is required for all tests.
     if frontmatter is None:

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -1013,3 +1013,40 @@ def test_html_testdriver_features(features):
 
     s = create("html/test.html", contents=contents)
     assert s.testdriver_features == features
+
+@pytest.mark.parametrize("rel_path, is_test262", [
+    ("test262/test.js", True),
+    ("other/test.js", False),
+])
+def test_name_is_test262(rel_path, is_test262):
+    tests_root = "/tmp"
+    url_base = "/"
+    sf = SourceFile(tests_root, rel_path, url_base)
+    assert sf.name_is_test262 == is_test262
+
+def test_test262_test_record():
+    contents = b"""/*---
+description: A simple test
+---*/"""
+    sf = create("test262/test.js", contents=contents)
+    record = sf.test262_test_record
+    assert record is not None
+    assert record["description"] == "A simple test"
+
+@pytest.mark.parametrize("rel_path, contents, expected_url", [
+    ("test262/test.js",
+     b"/*---\ndescription: A simple test\n---*/",
+     "/test262/test.test262.html"),
+    ("test262/module.js",
+     b"/*---\ndescription: A module test\nflags: [module]\n---*/",
+     "/test262/module.test262-module.html"),
+    ("test262/strict.js",
+     b"/*---\ndescription: A strict mode test\nflags: [onlyStrict]\n---*/",
+     "/test262/strict.test262.strict.html"),
+])
+def test_manifest_items_test262(rel_path, contents, expected_url):
+    sf = create(rel_path, contents=contents)
+    item_type, items = sf.manifest_items()
+    assert item_type == "test262"
+    assert len(items) == 1
+    assert items[0].url == expected_url

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -1031,7 +1031,6 @@ description: A simple test
     sf = create("test262/test.js", contents=contents)
     record = sf.test262_test_record
     assert record is not None
-    assert record["description"] == "A simple test"
 
 @pytest.mark.parametrize("rel_path, contents, expected_url", [
     ("test262/test.js",

--- a/tools/manifest/tests/test_test262.py
+++ b/tools/manifest/tests/test_test262.py
@@ -21,7 +21,7 @@ description: A simple test
 features: [Test262]
 ---*/
 assert.sameValue(1, 1);
-""")
+""", includes=None, negative=None, is_module=False, is_only_strict=False)
     ),
     (
         "no_frontmatter.js",
@@ -50,7 +50,7 @@ description: Test with module flag
 flags: [raw, module]
 ---*/
 assert.sameValue(1, 1);
-""", is_module=True)
+""", includes=None, negative=None, is_module=True, is_only_strict=False)
     ),
     (
         "flags-onlyStrict.js",
@@ -65,7 +65,7 @@ description: Test with onlyStrict flag
 flags: [raw, onlyStrict]
 ---*/
 assert.sameValue(1, 1);
-""", is_only_strict=True)
+""", includes=None, negative=None, is_module=False, is_only_strict=True)
     ),
     (
         "negative.js",
@@ -84,7 +84,7 @@ negative:
   type: TypeError
 ---*/
 throw new TypeError();
-""", negative={"phase": "runtime", "type": "TypeError"})
+""", includes=None, negative={"phase": "runtime", "type": "TypeError"}, is_module=False, is_only_strict=False)
     ),
     (
         "includes.js",
@@ -99,7 +99,7 @@ description: Test with includes
 includes: [assert.js, sta.js]
 ---*/
 assert.sameValue(1, 1);
-""", includes=["assert.js", "sta.js"])
+""", includes=["assert.js", "sta.js"], negative=None, is_module=False, is_only_strict=False)
     ),
 ])
 def test_test262_parser(name, src, expected_record):

--- a/tools/manifest/tests/test_test262.py
+++ b/tools/manifest/tests/test_test262.py
@@ -1,0 +1,75 @@
+# mypy: allow-untyped-defs
+
+import pytest
+
+from tools.manifest.test262 import TestRecord
+
+@pytest.mark.parametrize("name, src, expected_record", [
+    (
+        "test.js",
+        """/*---
+description: A simple test
+features: [Test262]
+---*/
+assert.sameValue(1, 1);
+""",
+        {"description": "A simple test", "features": ["Test262"]}
+    ),
+    (
+        "no_frontmatter.js",
+        """assert.sameValue(1, 1);""",
+        None
+    ),
+    (
+        "test_FIXTURE.js",
+        """/*---
+description: A fixture file
+---*/
+assert.sameValue(1, 1);
+""",
+        None
+    ),
+    (
+        "flags.js",
+        """/*---
+description: Test with flags
+flags: [raw, module]
+---*/
+assert.sameValue(1, 1);
+""",
+        {"flags": ["raw", "module"]}
+    ),
+    (
+        "negative.js",
+        """/*---
+description: Negative test
+negative:
+  phase: runtime
+  type: TypeError
+---*/
+throw new TypeError();
+""",
+        {"negative": {"phase": "runtime", "type": "TypeError"}}
+    ),
+    (
+        "includes.js",
+        """/*---
+description: Test with includes
+includes: [assert.js, sta.js]
+---*/
+assert.sameValue(1, 1);
+""",
+        {"includes": ["assert.js", "sta.js"]}
+    ),
+])
+def test_test262_parser(name, src, expected_record):
+    record = TestRecord.parse(src, name)
+
+    if expected_record is None:
+        assert record is None
+    else:
+        assert record is not None
+        for key, value in expected_record.items():
+            assert key in record
+            assert record[key] == value
+        assert record["test"] == src

--- a/tools/wpt/requirements.txt
+++ b/tools/wpt/requirements.txt
@@ -1,2 +1,4 @@
 requests==2.32.3
 types-requests==2.32.0.20241016
+pyyaml==6.0.1
+types-pyyaml==6.0.12.20241230


### PR DESCRIPTION
This commit introduces the foundational infrastructure for the WPT manifest to recognize and process Test262 tests. This is the first step towards the goal of running the entire Test262 suite within the WPT infrastructure, as outlined in the approved RFC.

The core of this change is a new `TestRecord` parser in `test262.py` which is responsible for extracting the YAML frontmatter from Test262 `.js` files (similar to how [test262](https://github.com/tc39/test262/blob/main/tools/packaging/parseTestRecord.py) does it using monkeyYaml). This metadata is then used by the manifest generation process to correctly identify and classify the tests.

Key changes included in this commit:
- A new `tools/manifest/test262.py` module containing the YAML frontmatter parser.
- A corresponding `Test262Test` manifest item type defined in `tools/manifest/item.py` to represent these tests.
- Updates to `tools/manifest/sourcefile.py` to identify Test262 files by their directory path (`/test262/`) and invoke the new parser.
- The addition of `pyyaml` as a project dependency to handle the YAML parsing to tools/wpt/requirements.txt
  - **Note to reviewers:**  PyYaml is lazily loaded. This is to prevent the modification of too many commands.json files. This may not be preferred since WPT does not do that often but open to other options. Please check failing checks for commits on the original PR for how I kept trying to track down the next commands.json file to fix.
- New unit tests for the parser and the manifest generation logic for Test262 files.

This work is part of the effort to add Test262 support as laid out in the RFC: https://github.com/web-platform-tests/rfcs/pull/229

This commit is the first in a series of smaller PRs split from the larger, original implementation in https://github.com/web-platform-tests/wpt/pull/55997. Subsequent PRs will add the server-side logic to serve the tests and the wptrunner integration to execute them.