### PR TITLE
Updating `var()` tests for unitless lengths

### DIFF
--- a/svg/styling/css-var-on-length-attributes-02.svg
+++ b/svg/styling/css-var-on-length-attributes-02.svg
@@ -1,7 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Usage of css var() on svg width and height attributes (units not specified)</title>
   <html:link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com"/>
-  <html:link rel="match" href="../embedded/reference/green-rect-100x100.svg"/>
+  <link rel="help" href="https://github.com/web-platform-tests/wpt/pull/56390#issuecomment-3669058046">
+  <html:link rel="match" href="about:blank"/>
   <style>
     rect {
       --length: 100;

--- a/svg/styling/css-var-on-length-attributes-02.svg
+++ b/svg/styling/css-var-on-length-attributes-02.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Usage of css var() on svg width and height attributes (units not specified)</title>
   <html:link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com"/>
-  <link rel="help" href="https://github.com/web-platform-tests/wpt/pull/56390#issuecomment-3669058046">
+  <html:link rel="help" href="https://github.com/web-platform-tests/wpt/pull/56390#issuecomment-3669058046"/>
   <html:link rel="match" href="about:blank"/>
   <style>
     rect {

--- a/svg/styling/css-var-on-length-attributes-04.svg
+++ b/svg/styling/css-var-on-length-attributes-04.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Usage of css var() with default fallback on svg width and height attributes (units not specified)</title>
   <html:link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com"/>
-  <html:link rel="match" href="../embedded/reference/green-rect-100x100.svg"/>
+  <link rel="help" href="https://github.com/web-platform-tests/wpt/pull/56390#issuecomment-3669058046">
+  <html:link rel="match" href="about:blank"/>
   <rect width="var(--length,100)" height="var(--length,100)" fill="green"/>
 </svg>

--- a/svg/styling/css-var-on-length-attributes-04.svg
+++ b/svg/styling/css-var-on-length-attributes-04.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Usage of css var() with default fallback on svg width and height attributes (units not specified)</title>
   <html:link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com"/>
-  <link rel="help" href="https://github.com/web-platform-tests/wpt/pull/56390#issuecomment-3669058046">
+  <html:link rel="help" href="https://github.com/web-platform-tests/wpt/pull/56390#issuecomment-3669058046"/>
   <html:link rel="match" href="about:blank"/>
   <rect width="var(--length,100)" height="var(--length,100)" fill="green"/>
 </svg>


### PR DESCRIPTION
This update aligns the expectations for the following WPTs:

- [css-var-on-length-attributes-02.svg](https://wpt.fyi/results/svg/styling/css-var-on-length-attributes-02.svg?label=master&label=experimental&aligned&q=css-var-on-length-attributes-02.svg)
- [css-var-on-length-attributes-04.svg](https://wpt.fyi/results/svg/styling/css-var-on-length-attributes-04.svg?label=master&label=experimental&aligned&q=css-var-on-length-attributes-04.svg)

These tests currently check whether **unitless lengths (e.g., 10)** are allowed when using `var()` in SVG length attributes. Based on the resolution in [Clarify whether var() (custom properties) are allowed in SVG presentation attributes, and how they are](parsed/resolvedhttps://github.com/w3c/svgwg/issues/1031) and the related discussion in PR https://github.com/web-platform-tests/wpt/pull/56390, the expectations should be updated to **blank rendering**.

**Rationale**

- CSS custom property substitution (`var()`) occurs during the CSS cascade stage, which does not handle unitless values.
- Introducing SVG-specific quirks for unitless lengths would break consistency with CSS behavior.
- Therefore, `var(`) with unitless lengths in SVG attributes should not resolve successfully, resulting in no rendering.