### PR TITLE
Navigation API: navigation.back() inside of onnavigate should reject

### DIFF
--- a/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html
+++ b/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script>
+promise_test(async t => {
+  let w = window.open("/common/blank.html");
+  await new Promise(resolve => w.onload = resolve);
+
+  await test_driver.bless("navigate", async function() {
+    w.navigation.navigate("resources/navigate-during-onnavigate-should-reject-helper.html");
+  });
+
+  await new Promise(resolve => onmessage = resolve);
+  w.postMessage("start", "*");
+  await new Promise(resolve => onmessage = resolve);
+  w.close();
+}, "Test that await navigation.back().finished during onnavigate should reject");
+</script>

--- a/navigation-api/navigate-event/resources/navigate-during-onnavigate-should-reject-helper.html
+++ b/navigation-api/navigate-event/resources/navigate-during-onnavigate-should-reject-helper.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<head>
+<script>
+onload = () => {
+  opener.postMessage("load", "*");
+};
+
+onmessage = () => {
+  runTest();
+}
+
+async function runTest() {
+  await navigation.navigate("#1").finished;
+  navigation.onnavigate = async () => {
+    await navigation.back().finished.catch(() => {
+      opener.postMessage("done", "*");
+    })
+  }
+
+  history.back();
+}
+</script>
+</head>


### PR DESCRIPTION
Chrome seem to already have this behavior, gecko does not at time of writing, that instead hangs forever.