### PR TITLE
Map `mask-type` and `mask-border` web-features

### DIFF
--- a/css/css-masking/animations/WEB_FEATURES.yml
+++ b/css/css-masking/animations/WEB_FEATURES.yml
@@ -10,3 +10,6 @@ features:
   files:
   - clip-*
   - "!clip-path-*"
+- name: mask-border
+  files:
+  - mask-border-*

--- a/css/css-masking/mask-svg-content/WEB_FEATURES.yml
+++ b/css/css-masking/mask-svg-content/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: mask-type
+  files:
+  - mask-type-*

--- a/css/css-masking/parsing/WEB_FEATURES.yml
+++ b/css/css-masking/parsing/WEB_FEATURES.yml
@@ -8,3 +8,6 @@ features:
   - mask-invalid.html
   - mask-position-*
   - mask-repeat-*
+- name: mask-type
+  files:
+  - mask-type-*


### PR DESCRIPTION
> Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

Feature: `mask-border`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/mask-border.yml

Notable exclusions

1. CSS zoom tests for `mask-border-width`
    - `css/css-viewport/zoom/mask-border-width.html`
2. `css/css-masking/inheritance.sub.html` - Tests inheritance of all masking properties, not specific to `mask-border` baseline support.

---

Feature: `mask-type`
Reference: https://github.com/web-platform-dx/web-features/blob/main/features/mask-type.yml

Notable exclusions

1. `mask-mode` interaction tests focusing on fallback behavior
    - `css/css-masking/mask-image/mask-mode-to-mask-type-svg.html`
    - `css/css-masking/mask-image/mask-mode-to-mask-type.html`