### PR TITLE
classifies q-unit and rem web features

### DIFF
--- a/css/css-values/WEB_FEATURES.yml
+++ b/css/css-values/WEB_FEATURES.yml
@@ -46,6 +46,7 @@ features:
   files:
   - round-function.html
   - round-mod-rem-*
+  - rem-length-degrees-crash.html
 - name: trig-functions
   files:
   - acos-asin-atan-atan2-*
@@ -86,3 +87,7 @@ features:
 - name: q-unit
   files:
   - q-unit-*
+- name: rem
+  files:
+  - rem-unit-*
+  - rem-root-*

--- a/css/css-values/WEB_FEATURES.yml
+++ b/css/css-values/WEB_FEATURES.yml
@@ -83,3 +83,6 @@ features:
 - name: border-radius
   files:
   - getComputedStyle-border-radius-*
+- name: q-unit
+  files:
+  - q-unit-*


### PR DESCRIPTION
I batch classified [`q-unit`](https://github.com/web-platform-dx/web-features/blob/main/features/q-unit.yml) and [`rem`](https://github.com/web-platform-dx/web-features/blob/main/features/rem.yml) in this PR since they're small and both touch the same file!

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)