### PR TITLE
Add test for overconstrained sticky with rtl

### DIFF
--- a/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
+++ b/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>position:overconstrained sticky elements with rtl direction</title>
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that the left is adjusted when the sticky element is overconstrained and the direction of the containing block is rtl" />
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+.scroller {
+  width: 100px;
+  height: 100px;
+  overflow: auto;
+  position: relative;
+}
+.container {
+  display: flex;
+  position: relative;
+  width: 600px;
+  direction: rtl;
+}
+.padding {
+  width: 200px;
+  height: 100px;
+  flex: none;
+}
+.sticky {
+  position: sticky;
+  background: green;
+  left: 0;
+  right: 0;
+  width: 200px;
+  height: 100px;
+  flex: none;
+  direction: ltr;
+}
+</style>
+
+<body>
+  <div class="scroller">
+    <div class="container">
+      <div class="padding"></div>
+      <div class="sticky"></div>
+      <div class="padding"></div>
+    </div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 0;
+  assert_equals(element.offsetLeft, 0);
+}, 'start of scroll container');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 180;
+    assert_equals(element.offsetLeft, 80);
+}, 'right before the in-flow position of the sticky box');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 220;
+    assert_equals(element.offsetLeft, 120);
+}, 'right after the in-flow position the sticky box');
+
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 500;
+  assert_equals(element.offsetLeft, 400);
+}, 'end of scroll container');
+</script>


### PR DESCRIPTION
Adding a test for overconstrained sticky when the writing mode of the containing block is rtl.

When the direction of the containing block is rtl the _left edge_ inset of the sticky view rectangle should be adjusted, as it is the effective end-edge inset.

> If this results in a [sticky view rectangle](https://www.w3.org/TR/css-position-3/#sticky-view-rectangle) size in any axis less than the size of the [border box](https://www.w3.org/TR/css-box-4/#border-box) of the sticky box in that axis, then the effective [end](https://www.w3.org/TR/css-writing-modes-4/#end)-edge inset in the affected axis is reduced (possibly becoming negative) to bring the sticky view rectangle’s size up to the size of the border box in that axis (where end is interpreted relative to the [writing mode](https://www.w3.org/TR/css-writing-modes-4/#writing-mode) of the [containing block](https://www.w3.org/TR/css-display-4/#containing-block)).

https://www.w3.org/TR/css-position-3/#sticky-pos