### PR TITLE
Add null check to aria-utils checking for expected values are provided

### DIFF
--- a/wai-aria/scripts/aria-utils.js
+++ b/wai-aria/scripts/aria-utils.js
@@ -44,6 +44,9 @@ const AriaUtils = {
       throw `Selector passed in verifyRolesBySelector("${selector}") should match at least one element.`;
     }
     for (const el of els) {
+      if (!el.hasAttribute("data-expectedrole")) {
+        throw `Element should have attribute 'data-expectedrole'. Element: ${el.outerHTML}`;
+      }
       let role = el.getAttribute("data-expectedrole");
       let testName = el.getAttribute("data-testname") || role; // data-testname optional if role is unique per test file
       if (typeof roleTestNamePrefix !== "undefined") {
@@ -136,6 +139,9 @@ const AriaUtils = {
       throw `Selector passed in verifyLabelsBySelector("${selector}") should match at least one element.`;
     }
     for (const el of els) {
+      if (!el.hasAttribute("data-expectedlabel")) {
+        throw `Element should have attribute 'data-expectedlabel'. Element: ${el.outerHTML}`;
+      }
       let label = el.getAttribute("data-expectedlabel");
       let testName = el.getAttribute("data-testname") || label; // data-testname optional if label is unique per test file
       if (typeof labelTestNamePrefix !== "undefined") {


### PR DESCRIPTION
This change simply adds some null checks to ensure that the test author specified expectation attributes, and if they did not, fails in such a way that the author could quickly fix.

Original, reverted PR: #49485
**Difference from original**: This change uses "hasAttribute" to ensure that this doesn't get triggered when attributes exist but contain empty strings. This came from [a comment on the original PR](https://github.com/web-platform-tests/wpt/pull/49485#issuecomment-2725840533).

Closes https://github.com/web-platform-tests/interop-accessibility/issues/74