### PR TITLE
net: Keep track of size of keep-alive records

### DIFF
--- a/beacon/resources/beacon.py
+++ b/beacon/resources/beacon.py
@@ -72,7 +72,7 @@ def main(request, response):
                 payload = request.body
 
             payload_parts = list(filter(None, payload.split(b":")))
-            if len(payload_parts) > 0:
+            if len(payload_parts) > 1:
                 payload_size = int(payload_parts[0])
 
                 # Confirm the payload size sent matches with the number of


### PR DESCRIPTION
These keep-alive records live on the `CoreResourceManager` since the vec
of records must be modified by the fetch thread. The script thread sometimes
requires this information as well, which is why it can send a message to
obtain the total size.

The keep-alive records must be tracked per global. That's why all code needs
to specify the `pipeline_id`. Requests optionally have this field, which is why
the code expects it to be present. The relevant information is added to the
navigator request to ensure it can compute it.

Fixes #<!-- nolink -->41230 
Reviewed in servo/servo#41457