### PR TITLE
Add a test for container-query parent and slotted child host styles

### DIFF
--- a/css/css-conditional/container-queries/container-for-shadow-dom.html
+++ b/css/css-conditional/container-queries/container-for-shadow-dom.html
@@ -367,6 +367,28 @@
   <div id="pseudo-2"></div>
 </div>
 
+<div id="named-host-to-slotted">
+  <template shadowrootmode="open">
+    <style>
+      :host {
+        container: --host-container / inline-size;
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <div id="host-slotted-named">
+    <template shadowrootmode="open">
+      <style>
+        @container --host-container (width >= 0) {
+          :host {
+            color: green;
+          }
+        }
+      </style>
+    </template>
+  </div>
+</div>
+
 <script>
   setup(() => {
     assert_implements_size_container_queries();
@@ -481,4 +503,9 @@
     const target = document.querySelector("#pseudo-2");
     assert_equals(getComputedStyle(target, "::before").color, green);
   }, "Search flat tree anchestors of the originating element of ::before");
+
+  test(() => {
+    const target = document.querySelector("#host-slotted-named");
+    assert_equals(getComputedStyle(target).color, green);
+  }, "Parent container name and style on :host, with query set on slotted child's :host");
 </script>

--- a/css/css-conditional/container-queries/style-container-for-shadow-dom.html
+++ b/css/css-conditional/container-queries/style-container-for-shadow-dom.html
@@ -188,6 +188,29 @@
   </div>
 </div>
 
+<div id="named-host-to-slotted">
+  <template shadowrootmode="open">
+    <style>
+      :host {
+        --foo: baz;
+        container-name: --host-container;
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <div id="host-slotted-named">
+    <template shadowrootmode="open">
+      <style>
+        @container --host-container style(--foo: baz) {
+          :host {
+            color: green;
+          }
+        }
+      </style>
+    </template>
+  </div>
+</div>
+
 <script>
   setup(() => {
     assert_implements_style_container_queries();
@@ -256,5 +279,10 @@
     const t12 = document.querySelector("#inner-scope-host-part > div").shadowRoot.querySelector("#t12");
     assert_equals(getComputedStyle(t12).color, green);
   }, "A :host::part rule matching a container in the shadow tree");
+
+  test(() => {
+    const target = document.querySelector("#host-slotted-named");
+    assert_equals(getComputedStyle(target).color, green);
+  }, "Parent container name and style on :host, with query set on slotted child's :host");
 
 </script>


### PR DESCRIPTION
This edge case currently fails in WebKit but passes in Chromium / FF

@lilles , it seems like this was a recent update in Chromium, as this fails in 143 but passes in 145; wasn't sure if you already had a test written for Chromium that you were going to sync or not. 