### PR TITLE
Add tests for interactive element labels named by svg title elements

### DIFF
--- a/svg-aam/name/comp_host_language_label.html
+++ b/svg-aam/name/comp_host_language_label.html
@@ -31,6 +31,45 @@
 </svg>
 <br>
 
+<h2>Interactive Elements > SVG > title</h2>
+<a href="#" data-expectedlabel="circle label" data-testname="a > circle > title" class="ex">
+  <svg viewbox="0 0 300 100">
+    <title>circle label</title>
+    <circle cx="26" cy="26" r="25"></circle>
+  </svg>
+</a>
+<a href="#" data-expectedlabel="rect label" data-testname="a > rect > title" class="ex">
+  <svg viewbox="0 0 300 100">
+    <title>rect label</title>
+    <rect x="60" y="1" width="50" height="50"></rect>
+  </svg>
+</a>
+<a href="#" data-expectedlabel="polygon label" data-testname="a > polygon > title" class="ex">
+  <svg viewbox="0 0 300 100">
+    <title>polygon label</title>
+    <polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon>
+  </svg>
+</a>
+<button href="#" data-expectedlabel="circle label" data-testname="button > circle > title" class="ex">
+  <svg viewbox="0 0 300 100">
+    <title>circle label</title>
+    <circle cx="26" cy="26" r="25"></circle>
+  </svg>
+</button>
+<button href="#" data-expectedlabel="rect label" data-testname="button > rect > title" class="ex">
+  <svg viewbox="0 0 300 100">
+    <title>rect label</title>
+    <rect x="60" y="1" width="50" height="50"></rect>
+  </svg>
+</button>
+<button href="#" data-expectedlabel="polygon label" data-testname="button > polygon > title" class="ex">
+  <svg viewbox="0 0 300 100">
+    <title>polygon label</title>
+    <polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon>
+  </svg>
+</button>
+<br>
+
 
 <h2>SVG a[xlink:title][href]</h2>
 <svg viewbox="0 0 300 100">


### PR DESCRIPTION
close https://github.com/web-platform-tests/wpt/issues/52459

I added some test cases for interactive element labels named by svg title elements.

I'm not sure whether this test should be placed on the svg-aam directory or html-aam directory, so if we should place it on the html-aam directory, I'll fix it.