### PR TITLE
layout: Stop splitting inline boxes when they contain block-levels

### DIFF
--- a/css/cssom-view/getClientRects-inline-with-block-child.html
+++ b/css/cssom-view/getClientRects-inline-with-block-child.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-element-getclientrects">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<section>
+  <span id="target">
+    <div style="height: 50px"></div>
+  </span>
+</section>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function assert_rect_equals(actual, expected, description) {
+  assert_equals(actual.x, expected.x, description + " - x");
+  assert_equals(actual.y, expected.y, description + " - y");
+  assert_equals(actual.width, expected.width, description + " - width");
+  assert_equals(actual.height, expected.height, description + " - height");
+}
+test(() => {
+  const target = document.getElementById("target");
+  const rects = target.getClientRects();
+  // TODO: check that it's exactly 3 fragments.
+  assert_greater_than_equal(rects.length, 2, "At least 2 fragments");
+  assert_rect_equals(
+    rects[0],
+    {x: 8, y: 8, width: 0, height: 0},
+    "First rect",
+  );
+  assert_rect_equals(
+    rects[rects.length - 1],
+    {x: 8, y: 58, width: 0, height: 0},
+    "Last rect",
+  );
+});
+</script>


### PR DESCRIPTION
We now follow the same approach as Blink: sequences of block-levels in an inline formatting context get wrapped in an anonymous block, which is treated as a line item. Inline ancestors are no longer split.

This means that inline elements will now generate a single inline box, and the box tree makes more sense in general. This will help for incremental layout.

This also means that block-level elements will now be properly affected by effects like opacity of filters set on inline ancestors.

Recently, WebKit has done some similar work, but without the anonymous blocks. We might also consider removing them in the future.

Google's explainer: https://docs.google.com/document/d/15kgdIHhb9EVNup6Ir5NWwJxpzY5GH0ED7Ld3iMW3HlA/

Testing: Several tests are now passing
Fixes: #<!-- nolink -->39813

Reviewed in servo/servo#41492