### PR TITLE
layout: Support `content: <image>` on non-pseudo-elements

### DIFF
--- a/css/css-content/element-replacement-dynamic.html
+++ b/css/css-content/element-replacement-dynamic.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <title>The content CSS attribute can replace an element's contents dynamically</title>
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
 <link rel="match" href="element-replacement-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
-<meta name="assert" content"This test checks that the CSS content propertly can replace a normal element's contents when changed dynamically" />
+<meta name="assert" content="This test checks that the CSS content propertly can replace a normal element's contents when changed dynamically" />
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
 
 <style>
 #target {
@@ -18,7 +22,8 @@
 <div id="target">This text should not be visible</div>
 
 <script>
-const target = document.getElementById("target");
-getComputedStyle(target).width;
-target.className = "replaced";
+waitForAtLeastOneFrame().then(() => {
+  document.getElementById("target").className = "replaced";
+  takeScreenshot();
+});
 </script>

--- a/css/css-content/element-replacement-root-canvas-bg-from-body.html
+++ b/css/css-content/element-replacement-root-canvas-bg-from-body.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>When content CSS attribute can replace a document's root, the HTML body element's background does not become the canvas background</title>
+<link rel="match" href="element-replacement-root-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#body-background" />
+<meta name="assert" content="When the content CSS attribute replaces a document's root, its contents do not create boxes, so the HTML body element's background can't affect the canvas background." />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+}
+body {
+  background-color: aquamarine;
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/css/css-content/element-replacement-root-canvas-bg-ref.html
+++ b/css/css-content/element-replacement-root-canvas-bg-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Reference for the content CSS attribute can replace a document's root</title>
+
+<style>
+:root {
+    background-color: aquamarine;
+}
+body {
+  margin: 0;
+}
+</style>
+
+<img src="resources/rect.svg" />

--- a/css/css-content/element-replacement-root-canvas-bg.html
+++ b/css/css-content/element-replacement-root-canvas-bg.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>When content CSS attribute can replace a document's root, its canvas still becomes the canvas background</title>
+<link rel="match" href="element-replacement-root-canvas-bg-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#root-background" />
+<meta name="assert" content="When the content CSS attribute replaces a document's root, it does not affect the fact that the root's background becomes the canvas background" />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+  background-color: aquamarine;
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/css/css-content/element-replacement-root-ref.html
+++ b/css/css-content/element-replacement-root-ref.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Reference for the content CSS attribute can replace a document's root</title>
+
+<style>
+body {
+  margin: 0;
+}
+</style>
+
+<img src="resources/rect.svg" />

--- a/css/css-content/element-replacement-root.html
+++ b/css/css-content/element-replacement-root.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>The content CSS attribute can replace a document's root</title>
+<link rel="match" href="element-replacement-root-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<meta name="assert" content="This test checks that the CSS content propertly can replace the contents of a document's root" />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+}
+</style>
+
+<p>This text should not be visible</p>


### PR DESCRIPTION
Per CSS-CONTENT-3, one of the possible values of the `content` CSS property is `<content-replacement>`, which evaluates to a single `<image>`. This value is also allowed on regular elements, not just on pseudo-elements, and it will make the element into a replaced element representing the given image, discarding its contents.

This patch implements this in `traverse_element`: if the `display` value is not `none` or `contents`, we first check whether the `contents` property should make the element replaced, and if it shouldn't, then we check whether the element itself is replaced or a widget.

Per the spec, an invalid image must be treated as representing a transparent black image with zero natural width and height – in particular, it must not show a broken image icon. We added the method `ReplacedContents::zero_sized_invalid_image` to implement this.

This patch adds support for image URL references, but not for color gradients, which are treated as invalid images. The reason for this is that currently Servo does not support gradients in `ReplacedContentKind`. This is left as a follow-up change.

Testing: Some of the existing `css/css-content/element-replacement*` WPT tests now pass with this patch. We also added some new ones dealing with replacing the document root.

Fixes: #<!-- nolink -->41479
Reviewed in servo/servo#41480