### PR TITLE
script: Use correct creation_url for workers

### DIFF
--- a/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report.html
+++ b/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  let finalURL = "/content-security-policy/reporting-api/support/dedicatedworker-report-url.sub.js";
+  promise_test(async () => {
+    await fetch_tests_from_worker(new Worker(finalURL));
+  });
+
+  promise_test(async () => {
+    let redirectedURL = "/fetch/api/resources/redirect.py?location=" +
+                  encodeURIComponent(finalURL) + "&test-name=' (with redirect)'";
+    await fetch_tests_from_worker(new Worker(redirectedURL));
+  });
+</script>

--- a/content-security-policy/reporting-api/support/dedicatedworker-report-url.sub.js
+++ b/content-security-policy/reporting-api/support/dedicatedworker-report-url.sub.js
@@ -1,0 +1,16 @@
+importScripts("{{location[server]}}/resources/testharness.js");
+
+async_test(function(t) {
+  const observer = new ReportingObserver(t.step_func_done((reports) => {
+    const url = new URL(reports[0].url);
+    // Remove any query parameters which are not relevant for the comparison of the eventual URL with redirects
+    url.search = '';
+    assert_equals(url.href, "{{location[server]}}/content-security-policy/reporting-api/support/dedicatedworker-report-url.sub.js");
+  }));
+  observer.observe();
+
+  const url = new URL("{{location[server]}}/content-security-policy/support/ping.js").toString();
+  promise_rejects_js(t, TypeError, fetch(url), "Fetch request should be rejected");
+}, "URL in report should point to worker where violation occurs{{GET[test-name]}}");
+
+done();

--- a/content-security-policy/reporting-api/support/dedicatedworker-report-url.sub.js.sub.headers
+++ b/content-security-policy/reporting-api/support/dedicatedworker-report-url.sub.js.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Set-Cookie: reporting-api-works-on-frame-src={{$id:uuid()}}; Path=/content-security-policy/reporting-api
+Reporting-Endpoints: csp-group="https://{{host}}:{{ports[https][0]}}/reporting/resources/report.py?op=put&reportID={{uuid()}}"
+Content-Security-Policy: connect-src 'none'; report-to csp-group


### PR DESCRIPTION
Instead of the creation URL of the containing global,
it should instead use the URL of the current worker.

Despite the referrer specification stating that we
should use the creation URL, instead browsers use
the current URL. A new WPT test is added to cover that
which we currently fail because of incorrect
serialization of query parameters of a URL. But the
actual redirect and all work now.
Reviewed in servo/servo#41458