### PR TITLE
Fixes the specified value serialization of calc() expressions in animation-range

### DIFF
--- a/css/css-animations/parsing/animation-range-shorthand.html
+++ b/css/css-animations/parsing/animation-range-shorthand.html
@@ -27,7 +27,7 @@ test_valid_value("animation-range", "exit-crossing 0% exit-crossing 100%",
 test_valid_value("animation-range", "cover 0% cover 100%", "cover");
 test_valid_value("animation-range", "contain 0% contain 100%", "contain");
 test_valid_value("animation-range",
-                 "entry calc(10% - 10%) entry calc(50% + 50%)", "entry");
+                 "entry calc(10% - 10%) entry calc(50% + 50%)", "entry calc(0%) entry calc(100%)");
 test_valid_value("animation-range", "cover 50%");
 test_valid_value("animation-range", "contain 50%");
 test_valid_value("animation-range", "entry 50%");


### PR DESCRIPTION
Previously, the test assumed that `animation-range: entry calc(0%) entry calc(100%)` could be simplified down to `animation-range: entry` for the specified value serialization, but CSS Value 4 requires calc() expressions to be not be simplified that far until the computed value.

See example 46 (https://drafts.csswg.org/css-values-4/#example-c3db2475) for more.