### PR TITLE
storage: Scope `WebStorage` quota per storage type instead of per origin total

### DIFF
--- a/webstorage/storage_local_quota_independent_from_session.window.js
+++ b/webstorage/storage_local_quota_independent_from_session.window.js
@@ -1,0 +1,43 @@
+test(t => {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    var key = "name";
+    var val = "x".repeat(4 * 1024);
+
+    t.add_cleanup(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    let indexBefore = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            localStorage.setItem("" + key + indexBefore, "" + val + indexBefore);
+            indexBefore++;
+        }
+    }, null, null);
+
+    localStorage.clear();
+
+    let indexLocal = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            sessionStorage.setItem("" + key + indexLocal, "" + val + indexLocal);
+            indexLocal++;
+        }
+    }, null, null);
+
+    let indexAfter = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            localStorage.setItem("" + key + indexAfter, "" + val + indexAfter);
+            indexAfter++;
+        }
+    }, null, null);
+
+    assert_greater_than_equal(
+        indexAfter,
+        Math.floor(indexBefore / 2)
+    );
+}, "localStorage retains comparable quota after sessionStorage exhaustion");

--- a/webstorage/storage_session_quota_independent_from_local.window.js
+++ b/webstorage/storage_session_quota_independent_from_local.window.js
@@ -1,0 +1,43 @@
+test(t => {
+    sessionStorage.clear();
+    localStorage.clear();
+
+    var key = "name";
+    var val = "x".repeat(4 * 1024);
+
+    t.add_cleanup(() => {
+        sessionStorage.clear();
+        localStorage.clear();
+    });
+
+    let indexBefore = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            sessionStorage.setItem("" + key + indexBefore, "" + val + indexBefore);
+            indexBefore++;
+        }
+    }, null, null);
+
+    sessionStorage.clear();
+
+    let indexLocal = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            localStorage.setItem("" + key + indexLocal, "" + val + indexLocal);
+            indexLocal++;
+        }
+    }, null, null);
+
+    let indexAfter = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            sessionStorage.setItem("" + key + indexAfter, "" + val + indexAfter);
+            indexAfter++;
+        }
+    }, null, null);
+
+    assert_greater_than_equal(
+        indexAfter,
+        Math.floor(indexBefore / 2)
+    );
+}, "sessionStorage retains comparable quota after localStorage exhaustion");


### PR DESCRIPTION
Change quota accounting for `WebStorage` so that usage is tracked per storage
type instead of combining `localStorage` and `sessionStorage` into a single per
origin total.

The previous implementation summed the sizes of both storage types and applied
a shared quota limit. This could cause a write to `sessionStorage` to fail due
to data stored in `localStorage` (and vice-versa), and also resulted in origin
descriptors being created even when only one storage type was in use.

This behavior is not consistent with other browsers, where quota is enforced
independently for each storage mechanism.

Testing: Existing unit and WPT tests continue to pass, a new WPT test has been
added

Reviewed in servo/servo#41531