### PR TITLE
Nested @import and @namespace are syntax errors

### DIFF
--- a/css/cssom/CSSGroupingRule-insertRule.html
+++ b/css/cssom/CSSGroupingRule-insertRule.html
@@ -94,7 +94,7 @@
         var groupingRule = create(t);
         var first = groupingRule.cssRules[0].cssText;
 
-        assert_throws_dom('HierarchyRequestError', function() {
+        assert_throws_dom('SyntaxError', function() {
             groupingRule.insertRule('@import url("foo.css");', 0);
         });
 
@@ -106,7 +106,7 @@
         var groupingRule = create(t);
         var first = groupingRule.cssRules[0].cssText;
 
-        assert_throws_dom('HierarchyRequestError', function() {
+        assert_throws_dom('SyntaxError', function() {
             groupingRule.insertRule('@namespace url(http://www.w3.org/1999/xhtml);', 0);
         });
 


### PR DESCRIPTION
The updated tests in this PR were expecting a `HierarchyRequestError` from trying to insert `@import` and `@namespace` in a grouping rule (`@media`) at the top-level of a CSS style sheet.

I think a `SyntaxError` would be more appropriate because these rules are **invalid in this context**:

  > All [conditional group rules](https://drafts.csswg.org/css-conditional-3/#conditional-group-rule) are defined to take a [`<rule-list>`](https://drafts.csswg.org/css-syntax-3/#typedef-rule-list) in their block, and accept any rule that is normally allowed at the top-level of a stylesheet, **and not otherwise restricted.** (For example, an [@import](https://drafts.csswg.org/css-cascade-5/#at-ruledef-import) rule must appear at the actual beginning of a stylesheet, and so is not valid inside of another rule.)

https://drafts.csswg.org/css-conditional-3/#contents-of

  > Accompanying prose must define what is **valid and invalid in this context**.

https://drafts.csswg.org/css-syntax-3/#block-contents

  > 5. If `new rule` is a syntax error, [throw](http://heycam.github.io/webidl/#dfn-throw) a [SyntaxError](https://webidl.spec.whatwg.org/#syntaxerror) exception.
  > 6. If `new rule` cannot be inserted into `list` at the zero-indexed position `index` due to constraints specified by CSS, then [throw](http://heycam.github.io/webidl/#dfn-throw) a [HierarchyRequestError](https://webidl.spec.whatwg.org/#hierarchyrequesterror) exception.

https://drafts.csswg.org/cssom-1/#insert-a-css-rule