### PR TITLE
indexeddb: implement connection queue

### DIFF
--- a/IndexedDB/idbfactory_open.any.js
+++ b/IndexedDB/idbfactory_open.any.js
@@ -194,15 +194,19 @@ function should_work(val, expected_version) {
     let name = format_value(val);
     let dbname = 'test-db-does-not-exist';
     async_test(function (t) {
+        console.log("Start")
         indexedDB.deleteDatabase(dbname);
         let rq = indexedDB.open(dbname, val);
         rq.onupgradeneeded = t.step_func(function () {
+            console.log("onupgradeneeded")
             let db = rq.result;
             assert_equals(db.version, expected_version, 'version');
             rq.transaction.abort();
+            console.log("onupgradeneeded done")
         });
         rq.onsuccess = t.unreached_func("open should fail");
         rq.onerror = t.step_func(function () {
+            console.log("Done")
             t.done()
         });
     }, "Calling open() with version argument " + name + " should not throw.");


### PR DESCRIPTION
Implement the connection queue concept from https://w3c.github.io/IndexedDB/#connection-queue

Testing: WPT tests.
Fixes: Part of https://github.com/servo/servo/issues/40983

Reviewed in servo/servo#41500