### PR TITLE
script: More thoroughly convert between UTF-16 and UTF-8 offsets in text inputs

### DIFF
--- a/html/semantics/forms/textfieldselection/textarea-setRangeText-utf16-code-unit-crash.html
+++ b/html/semantics/forms/textfieldselection/textarea-setRangeText-utf16-code-unit-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>setRangeText: Should not crash when setting text range intersects UTF-16 code units</title>
+<link rel="help" href="https://github.com/servo/servo/issues/36719">
+<script>
+  textarea = document.createElement("textarea");
+  textarea.defaultValue = String.fromCodePoint(806453);
+  textarea.setRangeText("", 0, 1);
+</script>


### PR DESCRIPTION
DOM APIs for interacting with selection and text in text inputs
`<input type=text>` and `<textarea>` all accept offsets and lengths in
UTF-16 code units. Servo was not converting all of these offsets into
UTF-8 code units. This change makes it so that this conversion is done
more thoroughly and makes it clear when the code is dealing with UTF-8
offsets and UTF-16 offsets.

Helper functions are added for doing this conversion in both directions
as it is necessary. In addition, a `char` iterator is added for
`TextInput` as it is useful for doing this conversion. It will be used
more completely in the future when a `Rope` data structure is extracted
from `TextInput`.

Finally, specification text is added to all of the DOM implementation
touched here.

Testing: This change includes a new WPT crash test as well as a series of unit
tests to verify conversion between UTF-8 and UTF-16 offsets.
Fixes #<!-- nolink -->36719.
Fixes #<!-- nolink -->20028.
Fixes #<!-- nolink -->39184.

Reviewed in servo/servo#41588