### PR TITLE
layout: Handle block-in-inline dependency on block constraints

### DIFF
--- a/css/css-flexbox/percentage-heights-021.html
+++ b/css/css-flexbox/percentage-heights-021.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: percentage in block-level inside inline inside flex item</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-stretch">
+<link rel="help" href="https://github.com/servo/servo/issues/41623">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="When the 2nd flex item is stretched to fill the flex line,
+  it needs to be laid out again, and the percentage should now resolve against 200px.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="display: flex">
+  <div style="height: 200px"></div>
+  <div style="background: red">
+    <span>
+      <div style="width: 200px; height: 100%; background: green"></div>
+    </span>
+  </div>
+</div>


### PR DESCRIPTION
When a block-level that depends on block constraints is inside an inline formatting context, then the entire layout of the IFC needs to be marked as depending on block constraints too.

Testing: Adding new test
Fixes: #<!-- nolink -->41623

Reviewed in servo/servo#41624