### PR TITLE
webdriver: Fix outdated timeouts test and remove redundant check

### DIFF
--- a/webdriver/tests/classic/new_session/support/create.py
+++ b/webdriver/tests/classic/new_session/support/create.py
@@ -83,7 +83,6 @@ invalid_data = [
         {"page load": 10},
         {" pageLoad": 10},
         {"pageLoad ": 10},
-        {"pageLoad": None},
         {"pageLoad": False},
         {"pageLoad": []},
         {"pageLoad": "10"},

--- a/webdriver/tests/classic/new_session/timeouts.py
+++ b/webdriver/tests/classic/new_session/timeouts.py
@@ -20,7 +20,7 @@ def test_timeouts(new_session, add_browser_capabilities, key, value):
     value = assert_success(response)
     assert value["capabilities"]["timeouts"] == timeouts
 
-@pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -11])
+@pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -1])
 @pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
 def test_invalid_timeouts(new_session, add_browser_capabilities, key, value):
     timeouts = {key: value}

--- a/webdriver/tests/classic/new_session/timeouts.py
+++ b/webdriver/tests/classic/new_session/timeouts.py
@@ -22,7 +22,20 @@ def test_timeouts(new_session, add_browser_capabilities, key, value):
 
 @pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -1])
 @pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
-def test_invalid_timeouts(new_session, add_browser_capabilities, key, value):
+def test_invalid_timeouts_value(new_session, add_browser_capabilities, key, value):
+    timeouts = {key: value}
+
+    response, _ = new_session({
+        "capabilities": {
+            "alwaysMatch": add_browser_capabilities({"timeouts": timeouts})
+        }
+    })
+
+    assert_error(response, "invalid argument")
+
+@pytest.mark.parametrize("value", ["foo", False, [], {}])
+@pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
+def test_invalid_timeouts_type(new_session, add_browser_capabilities, key, value):
     timeouts = {key: value}
 
     response, _ = new_session({

--- a/webdriver/tests/classic/new_session/timeouts.py
+++ b/webdriver/tests/classic/new_session/timeouts.py
@@ -20,11 +20,15 @@ def test_timeouts(new_session, add_browser_capabilities, key, value):
     value = assert_success(response)
     assert value["capabilities"]["timeouts"] == timeouts
 
-@pytest.mark.parametrize("timeouts", [
-    {"implicit": None, "pageLoad": MAX_SAFE_INTEGER + 2,"script": 30000},
-    {"implicit": MAX_SAFE_INTEGER + 2, "pageLoad": None,"script": 30000},
-    {"implicit": None, "pageLoad": None,"script": MAX_SAFE_INTEGER + 2}
-])
-def test_invalid_timeouts(new_session, add_browser_capabilities, timeouts):
-    response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({"timeouts": timeouts})}})
+@pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -11])
+@pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
+def test_invalid_timeouts(new_session, add_browser_capabilities, key, value):
+    timeouts = {key: value}
+
+    response, _ = new_session({
+        "capabilities": {
+            "alwaysMatch": add_browser_capabilities({"timeouts": timeouts})
+        }
+    })
+
     assert_error(response, "invalid argument")

--- a/webdriver/tests/classic/new_session/timeouts.py
+++ b/webdriver/tests/classic/new_session/timeouts.py
@@ -12,13 +12,10 @@ def test_default_values(session):
     assert timeouts["script"] == 30000
 
 
-@pytest.mark.parametrize("timeouts", [
-    {"implicit": 444, "pageLoad": 300000,"script": 30000},
-    {"implicit": 0, "pageLoad": None,"script": 30000},
-    {"implicit": None, "pageLoad": 300000,"script": 444},
-    {"implicit": 0, "pageLoad": 300000,"script": None},
-])
-def test_timeouts(new_session, add_browser_capabilities, timeouts):
+@pytest.mark.parametrize("value", [None, 0, 3000])
+@pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
+def test_timeouts(new_session, add_browser_capabilities, key, value):
+    timeouts = {key: value}
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({"timeouts": timeouts})}})
     value = assert_success(response)
     assert value["capabilities"]["timeouts"] == timeouts

--- a/webdriver/tests/classic/new_session/timeouts.py
+++ b/webdriver/tests/classic/new_session/timeouts.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.support.asserts import assert_success, assert_error
 
+MAX_SAFE_INTEGER = 2**53 - 1
 
 def test_default_values(session):
     timeouts = session.capabilities["timeouts"]
@@ -13,8 +14,8 @@ def test_default_values(session):
 
 @pytest.mark.parametrize("timeouts", [
     {"implicit": 444, "pageLoad": 300000,"script": 30000},
-    {"implicit": 0, "pageLoad": 444,"script": 30000},
-    {"implicit": 0, "pageLoad": 300000,"script": 444},
+    {"implicit": 0, "pageLoad": None,"script": 30000},
+    {"implicit": None, "pageLoad": 300000,"script": 444},
     {"implicit": 0, "pageLoad": 300000,"script": None},
 ])
 def test_timeouts(new_session, add_browser_capabilities, timeouts):
@@ -23,9 +24,9 @@ def test_timeouts(new_session, add_browser_capabilities, timeouts):
     assert value["capabilities"]["timeouts"] == timeouts
 
 @pytest.mark.parametrize("timeouts", [
-    {"implicit": None, "pageLoad": 300000,"script": 30000},
-    {"implicit": 0, "pageLoad": None,"script": 30000},
-    {"implicit": None, "pageLoad": None,"script": None}
+    {"implicit": None, "pageLoad": MAX_SAFE_INTEGER + 2,"script": 30000},
+    {"implicit": MAX_SAFE_INTEGER + 2, "pageLoad": None,"script": 30000},
+    {"implicit": None, "pageLoad": None,"script": MAX_SAFE_INTEGER + 2}
 ])
 def test_invalid_timeouts(new_session, add_browser_capabilities, timeouts):
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({"timeouts": timeouts})}})


### PR DESCRIPTION
Initially the attempt is to validate params according to spec. But it turns out validation is already done at [webdriver crate](https://hg-edge.mozilla.org/mozilla-central/file/tip/testing/webdriver/src/capabilities.rs#l368) so I reverted the change.

But Chrome/Firefox are not compliant with spec: https://wpt.fyi/results/webdriver/tests/classic/new_session/timeouts.py?label=experimental&label=master&aligned. They only allow `script timeouts` to be `None` but not `pageLoad` and `implicit`, which is how the test is currently written.

Testing: Updated the test to be compliant with spec. New failures are because it is validated at [webdriver crate](https://hg-edge.mozilla.org/mozilla-central/file/tip/testing/webdriver/src/capabilities.rs#l377).

Reviewed in servo/servo#41631