### PR TITLE
Implement pending preload responses with futures

### DIFF
--- a/preload/preload-resource-match.https.html
+++ b/preload/preload-resource-match.https.html
@@ -103,7 +103,7 @@ const loaders = {
     },
     fetch: async (href, attr, t) => {
         const options = {mode: attr.crossOrigin ? 'cors' : 'no-cors',
-             credentials: !attr.crossOrigin || attr.crossOrigin === 'anonymous' ? 'omit' : 'include'}
+             credentials: attr.crossOrigin === 'anonymous' ? 'same-origin' : 'include'}
 
         const response = await fetch(href, options)
         await response.text();


### PR DESCRIPTION
This implements waiting for pending preloads, where the preload request
is still fetching the result when the second "real" request is started. It is
implemented by storing responses in the `SharedPreloadedResources`
which is communicated via `PreloadId` send to the `CoreResourceManager`.

Part of #<!-- nolink -->35035

Reviewed in servo/servo#40059