### PR TITLE
script: Reload the page when an incompatible encoding is detected during parsing

### DIFF
--- a/domparsing/DOMParser-parseFromString-encoding.html
+++ b/domparsing/DOMParser-parseFromString-encoding.html
@@ -10,7 +10,7 @@
 function assertEncoding(doc) {
   assert_equals(doc.charset, "UTF-8", "document.charset");
   assert_equals(doc.characterSet, "UTF-8", "document.characterSet");
-  assert_equals(doc.inputEncoding, "UTF-8", "document.characterSet");
+  assert_equals(doc.inputEncoding, "UTF-8", "document.inputEncoding");
 }
 
 setup(() => {

--- a/html/webappapis/dynamic-markup-insertion/html-unsafe-methods/Document-parseHTMLUnsafe-encoding.html
+++ b/html/webappapis/dynamic-markup-insertion/html-unsafe-methods/Document-parseHTMLUnsafe-encoding.html
@@ -11,7 +11,7 @@
 function assertEncoding(doc) {
   assert_equals(doc.charset, "UTF-8", "document.charset");
   assert_equals(doc.characterSet, "UTF-8", "document.characterSet");
-  assert_equals(doc.inputEncoding, "UTF-8", "document.characterSet");
+  assert_equals(doc.inputEncoding, "UTF-8", "document.inputEncoding");
 }
 
 setup(() => {


### PR DESCRIPTION
This continues https://github.com/servo/servo/pull/41376. With this change servo will properly parse `<meta charset`> and `<meta http-equiv="content-type">` tags and reload the page when appropriate.

Encoding hints encountered during dynamic markup insertion (such as `document.write`) or when the encoding does not matter (such as during `DOMParser.parseFromString`) are ignored.

@jdm I've added you as a co-author on the commit, since I used https://gist.github.com/jdm/1f08c1b8b3c33d3f5c44882a1b5eb822 which you posted earlier this year on zulip.

Companion PR for https://github.com/servo/html5ever/pull/702
Fixes https://github.com/servo/servo/issues/24898
Closes https://github.com/servo/servo/issues/6414
Reviewed in servo/servo#41430