### PR TITLE
script: Consolidate global initialization for fetch requests

### DIFF
--- a/beacon/resources/beacon.py
+++ b/beacon/resources/beacon.py
@@ -72,7 +72,7 @@ def main(request, response):
                 payload = request.body
 
             payload_parts = list(filter(None, payload.split(b":")))
-            if len(payload_parts) > 0:
+            if len(payload_parts) > 1:
                 payload_size = int(payload_parts[0])
 
                 # Confirm the payload size sent matches with the number of


### PR DESCRIPTION
Rather than having each callside specifying the relevant
information from the GlobalScope, do this via a trait instead.
This would have saved us quite a bit of test debugging
since we would often forget to set relevant information
from the global context for a request.

Now, in the future when we need additional information from
the globalscope for a request, we only need to update this
method to make that happen.

Previously it would also sometimes use `document`, but
calling the relevant information on either `document` or
`globalscope` doesn't matter, since the `globalscope`
defers to the value from the `document` anyways.
Reviewed in servo/servo#41663