### PR TITLE
script: Fix fetch-later length and quota computation

### DIFF
--- a/fetch/fetch-later/quota/accumulated-oversized-payload.https.window.js
+++ b/fetch/fetch-later/quota/accumulated-oversized-payload.https.window.js
@@ -37,15 +37,21 @@ test(
 
       // Makes the 2nd call (POST) to the same reporting origin that sends
       // max bytes, which should be rejected.
-      assert_throws_quotaexceedederror(() => {
-        fetchLater(requestUrl, {
-          method: 'POST',
-          signal: controller.signal,
-          body: makeBeaconData(generatePayload(quota), dataType),
-          // Required, as the size of referrer also take up quota.
-          referrer: '',
-        });
-      }, null, null);
+      assert_throws_quotaexceedederror(
+        () => {
+          fetchLater(requestUrl, {
+            method: 'POST',
+            signal: controller.signal,
+            body: makeBeaconData(generatePayload(quota), dataType),
+            // Required, as the size of referrer also take up quota.
+            referrer: '',
+          });
+        },
+        // Either no information should be provided, or it should exactly
+        // be the expected values
+        (requested) => [QUOTA_PER_ORIGIN, null].includes(requested),
+        (remaining) => [halfQuota - 1, null].includes(remaining)
+      );
 
       // Makes the 3rd call (GET) to the same reporting origin, where its
       // request size is len(requestUrl) + headers, which should be accepted.


### PR DESCRIPTION
The specification isn't complete here and thus we
were missing WPT coverage. Spec will be updated.

Also, we are correctly throwing the QuotaExceededError with relevant information, while Chrome sets both
fields to `null`. Therefore, the test now allows for both (since providing relevant information is good for the developer and recommended in the spec [1]).

[1]: https://webidl.spec.whatwg.org/#ref-for-quotaexceedederror%E2%91%A2

Reviewed in servo/servo#41665