### PR TITLE
Add webExtension `runtime.getVersion()` test

### DIFF
--- a/web-extensions/resources/runtime/background.js
+++ b/web-extensions/resources/runtime/background.js
@@ -26,5 +26,16 @@ browser.test.runTests([
         browser.test.assertEq(typeof platformInfo, "object")
         browser.test.assertEq(typeof platformInfo.os, "string")
         browser.test.assertEq(typeof platformInfo.arch, "string")
+    },
+    async function browserRuntimeGetVersion() {
+        const version = browser.runtime.getVersion()
+        browser.test.assertEq(typeof version, "string")
+        // Implementations are free on how they interpret the version number.
+        // However, they need to be consistent in APIs (like the management API).
+        browser.test.assertTrue(version === "1.01" || version === "1.1")
+        if (browser.management && browser.management.getSelf) {
+            const extensionInfo = await browser.management.getSelf()
+            browser.test.assertEq(version, extensionInfo.version)
+        }
     }
 ])

--- a/web-extensions/resources/runtime/manifest.json
+++ b/web-extensions/resources/runtime/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "BrowserRuntimeTestExtension",
     "description": "browser.runtime test extension",
-    "version": "1.0",
+    "version": "1.01",
     "background": {
         "scripts": [ "background.js" ],
         "service_worker": "background.js",


### PR DESCRIPTION
@oliverdunk made sure to also consider the different interpretation of the version by Chromium as discussed in https://github.com/w3c/webextensions/issues/878. The check also compares the version from `management.getSelf()` with `runtime.getVersion()` as intended by Chromium.

@kiaraarose since this is very early in the wpt process for webExtensions, we should consider switching to semicolons and double space as that seems to be most common for js in wpt tests.

@zombie FYI