### PR TITLE
Map "Ink" to web-features

### DIFF
--- a/delegated-ink/WEB_FEATURES.yml
+++ b/delegated-ink/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: ink
+  files: "**"


### PR DESCRIPTION
Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

### Matching test files for <a href="https://webstatus.dev/features/ink">Ink</a>

<details>
  <summary><code>./delegated-ink</code></summary>


- [x] [delegated-ink/delete-presentation-area.html](https://github.com/web-platform-tests/wpt/blob/master//delegated-ink/delete-presentation-area.html)
- [x] [delegated-ink/exception-thrown-bad-color.tentative.html](https://github.com/web-platform-tests/wpt/blob/master//delegated-ink/exception-thrown-bad-color.tentative.html)
- [x] [delegated-ink/exception-thrown-diameter-less-than-or-equal-to-0.tentative.html](https://github.com/web-platform-tests/wpt/blob/master//delegated-ink/exception-thrown-diameter-less-than-or-equal-to-0.tentative.html)
- [x] [delegated-ink/exception-thrown-untrusted-event.tentative.window.js](https://github.com/web-platform-tests/wpt/blob/master//delegated-ink/exception-thrown-untrusted-event.tentative.window.js)
- [x] [delegated-ink/requestPresenter-returns-valid-promise.tentative.window.js](https://github.com/web-platform-tests/wpt/blob/master//delegated-ink/requestPresenter-returns-valid-promise.tentative.window.js)

</details>
