### PR TITLE
Annotate that a WebRTC test needs a long harness timeout.

### DIFF
--- a/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html
+++ b/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src=/resources/testdriver.js></script>


### PR DESCRIPTION
The testcase RTCRtpScriptTransform-encoded-transform.https.html has been observed on wpt.fyi to take more than 10 seconds in at least Firefox and Chrome (and 2-3 seconds on Safari, which is close enough to 10 that it might overshoot in rare cases under system load).

So, let's annotate it to avoid imposing a strict 10-second time limit.

Fixes https://github.com/web-platform-tests/interop/issues/1240