### PR TITLE
Annotate that a WebRTC test needs a long harness timeout.

### DIFF
--- a/webrtc-encoded-transform/script-transform.https.html
+++ b/webrtc-encoded-transform/script-transform.https.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src=/resources/testdriver.js></script>


### PR DESCRIPTION
The testcase script-transform.https.html has been observed on wpt.fyi to sometimes take more than 10 seconds in Firefox and more than 6 seconds in Edge, after a review of wpt.fyi test runs for a single day.

So, the default 10 second harness timeout seems like too strict of a cutoff. This patch annotates the test as needing a longer harness timeout.

Fixes https://github.com/web-platform-tests/interop/issues/1240