### PR TITLE
classifies image-maps web feature

### DIFF
--- a/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/WEB_FEATURES.yml
+++ b/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: image-maps
+  files:
+  - mouse-cursor-imagemap.html

--- a/html/semantics/embedded-content/image-maps/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/image-maps/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: image-maps
+  files: '**'

--- a/html/semantics/embedded-content/the-area-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-area-element/WEB_FEATURES.yml
@@ -1,4 +1,10 @@
 features:
-  - name: download
-    files:
-      - 'area-download-click.html'
+- name: image-maps
+  files:
+  - '*'
+  # Keep exclusions synced with mappings below
+  - '!area-download-click.html'
+- name: download
+  files:
+  # Keep in sync with `image-maps` mapping
+  - 'area-download-click.html'

--- a/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
@@ -18,3 +18,6 @@ features:
   - responsive-image-select-print.html
   - update-the-source-set.html
   - null-image-source.html
+- name: image-maps
+  files:
+  - usemap-casing.html

--- a/html/semantics/embedded-content/the-img-element/ismap/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/ismap/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: image-maps
+  files: '**'

--- a/uievents/mouse/WEB_FEATURES.yml
+++ b/uievents/mouse/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: image-maps
+  files:
+  - mouse_boundary_events_on_image_map.html


### PR DESCRIPTION
Web feature docs for `image-maps`: https://github.com/web-platform-dx/web-features/blob/main/features/image-maps.yml

---
As of 2025-12-05, https://github.com/web-platform-tests/wpt-pr-bot/pull/268. To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)