### PR TITLE
Test known commands with invalid commandfor targets

### DIFF
--- a/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -11,6 +11,7 @@
 <button id="invokerbutton" commandfor="invokee" command="--custom-command"></button>
 <input type="button" id="invalidbutton" commandfor="invokee" command="--custom-command">
 <form id="aform"></form>
+<svg id="svgInvokee"></svg>
 
 <script>
   aform.addEventListener('submit', (e) => (e.preventDefault()));
@@ -110,6 +111,18 @@
       invokerbutton.click();
       assert_equals(event, null, "event should not have fired");
     }, `setting custom command attribute to ${command} (no dash) did not dispatch an event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), {signal: t.get_signal()});
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command attribute to ${command} (no dash) did not dispatch an event with an svg target`);
   });
 
   test(function (t) {
@@ -206,15 +219,12 @@
   }, "event does NOT dispatch if button is form associated, with explicit type=reset");
 
   test(function (t) {
-    svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    svgInvokee.setAttribute("id", "svg-invokee");
     t.add_cleanup(resetState);
-    document.body.append(svgInvokee);
     assert_false(svgInvokee instanceof HTMLElement);
     assert_true(svgInvokee instanceof Element);
     let event = null;
-    svgInvokee.addEventListener("command", (e) => (event = e), { once: true });
-    invokerbutton.setAttribute("commandfor", "svg-invokee");
+    svgInvokee.addEventListener("command", (e) => (event = e), { once: true, signal: t.get_signal() });
+    invokerbutton.setAttribute("commandfor", "svgInvokee");
     invokerbutton.setAttribute("command", "--custom-command");
     assert_equals(invokerbutton.commandForElement, svgInvokee);
     invokerbutton.click();
@@ -222,5 +232,29 @@
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.source, invokerbutton, "event.invoker is set to right element");
     assert_equals(event.target, svgInvokee, "event.target is set to right element");
-  }, "event dispatches if invokee is non-HTML Element");
+  }, "event dispatches if invokee is non-HTML Element and command is custom");
+
+  // known commands with incompatible target
+  ["show-popover", "hide-popover", "toggle-popover", "show-modal", "close", "request-close"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.command = command;
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for invalid element`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for svg element`);
+  });
 </script>

--- a/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -235,7 +235,7 @@
   }, "event dispatches if invokee is non-HTML Element and command is custom");
 
   // known commands with incompatible target
-  ["show-popover", "hide-popover", "toggle-popover", "show-modal", "close", "request-close"].forEach((command) => {
+  ["show-modal", "close", "request-close"].forEach((command) => {
     test(function (t) {
       t.add_cleanup(resetState);
       let command_event_fired = false;
@@ -244,6 +244,30 @@
       invokerbutton.click();
       assert_false(command_event_fired, "command event fired");
     }, `setting command to ${command} did not dispatch an event for invalid element`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for svg element`);
+  });
+
+  // popover commands
+  ["show-popover", "hide-popover", "toggle-popover"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.command = command;
+      invokerbutton.click();
+      assert_true(command_event_fired, "command event fired");
+    }, `setting command to ${command} did dispatch an event for element without popover attribute`);
 
     test(function (t) {
       t.add_cleanup(resetState);

--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
@@ -28,9 +28,6 @@
     "foo-bar",
     "auto",
     "showmodal",
-    "show-popover",
-    "hide-popover",
-    "toggle-popover",
     "show-picker",
   ].forEach((action) => {
     test(function (t) {
@@ -73,6 +70,72 @@
       assert_true(invokee.matches(":modal"), "invokee :modal");
       assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open modal dialog does nothing`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      containedinvoker.setAttribute("command", action);
+      invokee.showModal();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      invokee.addEventListener(
+        "command",
+        (e) => {
+          containedinvoker.setAttribute("command", "");
+        },
+        { once: true },
+      );
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+    }, `invoking (as ${action}) on open modal while changing the attributer does nothing`);
+  });
+
+  // popover commands on dialog
+  [
+    "show-popover",
+    "hide-popover",
+    "toggle-popover",
+  ].forEach((action) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("command", action);
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      invokerbutton.click();
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on dialog fires event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      containedinvoker.setAttribute("command", action);
+      invokee.show();
+      assert_true(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on open dialog fires event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      containedinvoker.setAttribute("command", action);
+      invokee.showModal();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on open modal dialog fires event`);
 
     test(function (t) {
       t.add_cleanup(resetState);

--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
@@ -35,16 +35,21 @@
   ].forEach((action) => {
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.setAttribute("command", action);
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
       invokerbutton.click();
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on dialog does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       containedinvoker.setAttribute("command", action);
       invokee.show();
       assert_true(invokee.open, "invokee.open");
@@ -52,10 +57,13 @@
       containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open dialog does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       containedinvoker.setAttribute("command", action);
       invokee.showModal();
       assert_true(invokee.open, "invokee.open");
@@ -63,6 +71,7 @@
       containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open modal dialog does nothing`);
 
     test(function (t) {

--- a/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
@@ -26,19 +26,25 @@
   [null, "", "foo-bar", "showpopover", "show-modal", "show-picker", "open", "close"].forEach((command) => {
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.command = command;
       assert_false(invokee.matches(":popover-open"));
       invokerbutton.click();
       assert_false(invokee.matches(":popover-open"));
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${command}) on popover does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.command = command;
       invokee.showPopover();
       assert_true(invokee.matches(":popover-open"));
       invokerbutton.click();
       assert_true(invokee.matches(":popover-open"));
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${command}) on open popover does nothing`);
   });
 </script>


### PR DESCRIPTION
Previously browsers would sometimes fire command events when a known command value is targeted to an invalid element.