### PR TITLE
wpt: Parse `run_log` as `url_or_path`

### DIFF
--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -769,7 +769,7 @@ def create_parser_metadata_update(product_choices=None):
     parser.add_argument("--extra-property", action="append", default=[],
                         help="Extra property from run_info.json to use in metadata update.")
     # TODO: Should make this required iff run=logfile
-    parser.add_argument("run_log", nargs="*", type=abs_path,
+    parser.add_argument("run_log", nargs="*", type=url_or_path,
                         help="Log file from run of tests")
     commandline.add_logging_group(parser)
     return parser


### PR DESCRIPTION
Currently, we parse it as https://github.com/servo/servo/blob/c6f2fc2eb596cd2cd581179113bbceda301c4c93/tests/wpt/tests/tools/wptrunner/wptrunner/wptcommandline.py#L17-L18. This appends CWD to the front even if we pass a URL.

Fixes: https://github.com/servo/servo/issues/41728

Reviewed in servo/servo#41729