### PR TITLE
Add variants to exclude event timing targetSelector from Interop 2025

### DIFF
--- a/event-timing/idlharness.any.js
+++ b/event-timing/idlharness.any.js
@@ -1,4 +1,7 @@
+// META: variant=?exclude=targetSelector
+// META: variant=?include=targetSelector
 // META: global=window,worker
+// META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 


### PR DESCRIPTION
This is related to: https://github.com/web-platform-tests/interop/issues/1233
Corresponding WPT metadata change: https://github.com/web-platform-tests/wpt-metadata/pull/8377