### PR TITLE
Expect failure for `infrastructure/testdriver/bidi/subscription.html`

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/bidi/subscription.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/subscription.html.ini
@@ -1,3 +1,8 @@
 [subscription.html]
   expected:
     if product != "chrome": ERROR
+  [Assert testdriver can subscribe globally]
+    expected:
+      # TODO(https://github.com/web-platform-tests/wpt/issues/56985):
+      # Investigate root cause
+      if product == "chrome": FAIL


### PR DESCRIPTION
The subtest failure is consistently blocking infra PRs (#56985).