### PR TITLE
maps "service-workers" web feature

### DIFF
--- a/service-workers/WEB_FEATURES.yml
+++ b/service-workers/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: service-workers
+  files:
+  - '*'

--- a/service-workers/cache-storage/WEB_FEATURES.yml
+++ b/service-workers/cache-storage/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: service-workers
+  files: '**'

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/WEB_FEATURES.yml
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/WEB_FEATURES.yml
@@ -1,4 +1,10 @@
 features:
+- name: service-workers
+  files:
+  - '*'
+  # Keep exclusions synced with mappings below
+  - '!isSecureContext*'
 - name: is-secure-context
   files:
+  # Keep in sync with `service-workers` mapping above
   - isSecureContext*

--- a/service-workers/service-worker/WEB_FEATURES.yml
+++ b/service-workers/service-worker/WEB_FEATURES.yml
@@ -1,5 +1,12 @@
 features:
+- name: service-workers
+  files:
+  - '*'
+  # Keep exclusions in sync with mappings below
+  - '!registration-script-module.https.html'
+  - '!update-registration-with-type.https.html'
 - name: js-modules-service-workers
   files:
+  # Keep in sync with `service-workers` mapping above
   - registration-script-module.https.html
   - update-registration-with-type.https.html

--- a/service-workers/service-worker/multi-globals/WEB_FEATURES.yml
+++ b/service-workers/service-worker/multi-globals/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: service-workers
+  files: '**'

--- a/service-workers/service-worker/navigation-preload/WEB_FEATURES.yml
+++ b/service-workers/service-worker/navigation-preload/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: service-workers
+  files: '**'

--- a/service-workers/service-worker/tentative/WEB_FEATURES.yml
+++ b/service-workers/service-worker/tentative/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: service-workers
+  files: '**'


### PR DESCRIPTION
Web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/service-workers.yml

This essentially maps everything in the [`service-workers/` directory](https://github.com/web-platform-tests/wpt/tree/master/service-workers) to the "service-workers" web feature, while excluding already mapped features ("js-modules-service-workers" & "is-secure-context")

---
As of 2025-12-05, https://github.com/web-platform-tests/wpt-pr-bot/pull/268. To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)