### PR TITLE
Add tests for DOCTYPE system identifier empty vs missing distinction

### DIFF
--- a/html/syntax/parsing/doctype-system-identifier-distinction.html
+++ b/html/syntax/parsing/doctype-system-identifier-distinction.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>DOCTYPE system identifier: empty string treated as missing</title>
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode"
+/>
+<link rel="help" href="https://github.com/whatwg/html/issues/12023" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  // Tests that an empty string system identifier is treated the same as a missing
+  // system identifier for quirks mode determination.
+  // See https://github.com/whatwg/html/issues/12023
+  //
+  // The important distinction that must be preserved:
+  // - missing system ID → quirks mode (BackCompat)
+  // - empty system ID → quirks mode (BackCompat) [same as missing]
+  // - non-empty system ID → limited-quirks mode (CSS1Compat) [different from missing]
+
+  const testCases = [
+    // HTML 4.01 Frameset - empty system ID (treated same as missing)
+    {
+      file: "support/doctype-system-id-empty-frameset.html",
+      expected: "BackCompat",
+      description:
+        'DOCTYPE with "-//W3C//DTD HTML 4.01 Frameset//" and empty system ID triggers quirks mode',
+    },
+    // HTML 4.01 Frameset - missing system ID
+    {
+      file: "support/doctype-system-id-missing-frameset.html",
+      expected: "BackCompat",
+      description:
+        'DOCTYPE with "-//W3C//DTD HTML 4.01 Frameset//" and missing system ID triggers quirks mode',
+    },
+    // HTML 4.01 Frameset - non-empty system ID (must remain different!)
+    {
+      file: "support/doctype-system-id-nonempty-frameset.html",
+      expected: "CSS1Compat",
+      description:
+        'DOCTYPE with "-//W3C//DTD HTML 4.01 Frameset//" and non-empty system ID triggers limited-quirks mode',
+    },
+    // HTML 4.01 Transitional - empty system ID (treated same as missing)
+    {
+      file: "support/doctype-system-id-empty-transitional.html",
+      expected: "BackCompat",
+      description:
+        'DOCTYPE with "-//W3C//DTD HTML 4.01 Transitional//" and empty system ID triggers quirks mode',
+    },
+    // HTML 4.01 Transitional - missing system ID
+    {
+      file: "support/doctype-system-id-missing-transitional.html",
+      expected: "BackCompat",
+      description:
+        'DOCTYPE with "-//W3C//DTD HTML 4.01 Transitional//" and missing system ID triggers quirks mode',
+    },
+    // HTML 4.01 Transitional - non-empty system ID (must remain different!)
+    {
+      file: "support/doctype-system-id-nonempty-transitional.html",
+      expected: "CSS1Compat",
+      description:
+        'DOCTYPE with "-//W3C//DTD HTML 4.01 Transitional//" and non-empty system ID triggers limited-quirks mode',
+    },
+  ];
+
+  for (const testCase of testCases) {
+    async_test((t) => {
+      const iframe = document.createElement("iframe");
+      iframe.onload = t.step_func_done(() => {
+        assert_equals(
+          iframe.contentDocument.compatMode,
+          testCase.expected,
+          `compatMode should be ${testCase.expected}`
+        );
+        iframe.remove();
+      });
+      iframe.src = testCase.file;
+      document.body.appendChild(iframe);
+    }, testCase.description);
+  }
+</script>

--- a/html/syntax/parsing/support/doctype-system-id-empty-frameset.html
+++ b/html/syntax/parsing/support/doctype-system-id-empty-frameset.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//" "">
+<meta charset="utf-8" />
+<title>DOCTYPE with empty system identifier (Frameset)</title>

--- a/html/syntax/parsing/support/doctype-system-id-empty-transitional.html
+++ b/html/syntax/parsing/support/doctype-system-id-empty-transitional.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//" "">
+<meta charset="utf-8">
+<title>DOCTYPE with empty system identifier (Transitional)</title>
+

--- a/html/syntax/parsing/support/doctype-system-id-missing-frameset.html
+++ b/html/syntax/parsing/support/doctype-system-id-missing-frameset.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//">
+<meta charset="utf-8">
+<title>DOCTYPE with missing system identifier (Frameset)</title>
+

--- a/html/syntax/parsing/support/doctype-system-id-missing-transitional.html
+++ b/html/syntax/parsing/support/doctype-system-id-missing-transitional.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//">
+<meta charset="utf-8">
+<title>DOCTYPE with missing system identifier (Transitional)</title>
+

--- a/html/syntax/parsing/support/doctype-system-id-nonempty-frameset.html
+++ b/html/syntax/parsing/support/doctype-system-id-nonempty-frameset.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//" "http://www.w3.org/TR/html4/frameset.dtd">
+<meta charset="utf-8">
+<title>DOCTYPE with non-empty system identifier (Frameset)</title>
+

--- a/html/syntax/parsing/support/doctype-system-id-nonempty-transitional.html
+++ b/html/syntax/parsing/support/doctype-system-id-nonempty-transitional.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//" "http://www.w3.org/TR/html4/loose.dtd">
+<meta charset="utf-8">
+<title>DOCTYPE with non-empty system identifier (Transitional)</title>
+


### PR DESCRIPTION
This PR adds tests to verify the behavior of DOCTYPE system identifier handling for quirks mode determination.

## Related Issue

- https://github.com/whatwg/html/issues/12023

## Summary

The HTML spec currently distinguishes between a **missing** system identifier and an **empty string** (`""`) system identifier. However, Chromium and WebKit treat both cases identically (as quirks mode triggers).

## Test Cases

| DOCTYPE Public ID | System ID | Expected `compatMode` |
|-------------------|-----------|----------------------|
| `-//W3C//DTD HTML 4.01 Frameset//` | `""` (empty) | `BackCompat` |
| `-//W3C//DTD HTML 4.01 Frameset//` | missing | `BackCompat` |
| `-//W3C//DTD HTML 4.01 Frameset//` | non-empty | `CSS1Compat` |
| `-//W3C//DTD HTML 4.01 Transitional//` | `""` (empty) | `BackCompat` |
| `-//W3C//DTD HTML 4.01 Transitional//` | missing | `BackCompat` |
| `-//W3C//DTD HTML 4.01 Transitional//` | non-empty | `CSS1Compat` |

## Expected Results

| Browser | Result |
|---------|--------|
| Chrome | ✅ 6/6 PASS |
| Safari | ✅ 6/6 PASS |
| Firefox | 4/6 PASS, 2 FAIL (empty cases fail - follows current spec) |

## Test Results Screenshots

### Chrome
<img width="1301" height="689" alt="image" src="https://github.com/user-attachments/assets/44825d4b-ee2e-495a-8d21-3b08051ade23" />

### Safari
<img width="1006" height="815" alt="image" src="https://github.com/user-attachments/assets/b47dfc1d-1467-4510-8940-61a82c980b83" />

### Firefox
<img width="1225" height="683" alt="image" src="https://github.com/user-attachments/assets/2d11f28d-55ae-4780-b70d-9e98693c7495" />


## Files Added

- `html/syntax/parsing/doctype-system-identifier-distinction.html` - Main test file
- `html/syntax/parsing/support/doctype-system-id-empty-frameset.html`
- `html/syntax/parsing/support/doctype-system-id-empty-transitional.html`
- `html/syntax/parsing/support/doctype-system-id-missing-frameset.html`
- `html/syntax/parsing/support/doctype-system-id-missing-transitional.html`
- `html/syntax/parsing/support/doctype-system-id-nonempty-frameset.html`
- `html/syntax/parsing/support/doctype-system-id-nonempty-transitional.html`