### PR TITLE
Update fetch-later quota expectations

### DIFF
--- a/fetch/fetch-later/quota/max-payload.https.window.js
+++ b/fetch/fetch-later/quota/max-payload.https.window.js
@@ -25,6 +25,7 @@ promise_test(async _ => {
         activateAfter: 0,
         method: 'POST',
         bodySize: getRemainingQuota(QUOTA_PER_ORIGIN, requestUrl, headers),
+        referrer: '',
       },
       {
         targetUrl: requestUrl,
@@ -39,11 +40,12 @@ test(_ => {
 
   assert_throws_quotaexceedederror(() => {
     fetchLater(requestUrl, {
-          activateAfter: 0,
-          method: 'POST',
-          body: generatePayload(
-              getRemainingQuota(QUOTA_PER_ORIGIN, requestUrl, headers) + 1,
-              dataType),
-        });
-  }, null, null);
+      activateAfter: 0,
+      method: 'POST',
+      body: generatePayload(
+          getRemainingQuota(QUOTA_PER_ORIGIN, requestUrl, headers) + 1,
+          dataType),
+      referrer: '',
+    });
+  }, QUOTA_PER_ORIGIN + 1, QUOTA_PER_ORIGIN);
 }, `fetchLater() rejects max+1 payload in a POST request body of ${dataType}.`);

--- a/fetch/fetch-later/quota/multiple-origins.https.window.js
+++ b/fetch/fetch-later/quota/multiple-origins.https.window.js
@@ -9,8 +9,10 @@ const {HTTPS_ORIGIN, HTTPS_NOTSAMESITE_ORIGIN} = get_host_info();
 for (const dataType in BeaconDataType) {
   // Tests multiple request reporting origins within same document.
   test(
-      () => {
+      (t) => {
         const controller = new AbortController();
+        // Release quota taken by the pending requests for subsequent tests.
+        t.add_cleanup(() => controller.abort());
 
         // Makes the 1st call (POST) that sends max/2+1 quota to `HTTPS_ORIGIN`.
         fetchLater(`${HTTPS_ORIGIN}/`, {
@@ -34,9 +36,6 @@ for (const dataType in BeaconDataType) {
           method: 'GET',
           signal: controller.signal,
         });
-
-        // Release quota taken by the pending requests for subsequent tests.
-        controller.abort();
       },
       `fetchLater() has per-request-origin quota for its POST body of ${
           dataType}.`);

--- a/fetch/fetch-later/quota/oversized-payload.https.window.js
+++ b/fetch/fetch-later/quota/oversized-payload.https.window.js
@@ -16,8 +16,12 @@ for (const dataType in BeaconDataType) {
         method: 'POST',
         body: makeBeaconData(
             generatePayload(OVERSIZED_REQUEST_BODY_SIZE), dataType),
+        referrer: '',
       });
-    }, null, null);
+      // It is difficult to compute the exact requested length, as that depends on
+      // the datatype. Instead, it should always be more than `OVERSIZED_REQUEST_BODY_SIZE`
+      // since we count url and referrer as well
+    }, (requested) => requested > OVERSIZED_REQUEST_BODY_SIZE, QUOTA_PER_ORIGIN);
   }, `fetchLater() does not accept payload[size=${
           OVERSIZED_REQUEST_BODY_SIZE}] exceeding per-origin quota in a POST request body of ${
           dataType}.`);


### PR DESCRIPTION
Follows the spec updates per whatwg/fetch#1903
It now expects the explicit requested and quota
fields.

Unfortunately that is sometimes difficult to
determine, since it depends on a couple of things
such as data type and internal structure. Therefore, where we know exactly the result we hardcode the
value. For those where it is less determinate, we
use a function to compute at least an upper-/lowerbound.
Reviewed in servo/servo#41776