### PR TITLE
Stop comparing font-family in select listbox UA style test

### DIFF
--- a/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative.html
+++ b/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative.html
@@ -94,7 +94,6 @@ select {
     'font-style',
     'font-weight',
     'font-size',
-    'font-family',
     'writing-mode',
     'scrollbar-width',
     'overflow',


### PR DESCRIPTION
`<select multiple>` can render as a native listbox widget and may use platform UI fonts rather than document fonts.

As a result, the computed font-family for form controls can vary across user agents and execution environments.

This change removes font-family from the set of compared properties to make the test more portable.