### PR TITLE
script: Consume in-memory streams when requested by JS.

### DIFF
--- a/wasm/webapi/instantiateStreaming.any.js
+++ b/wasm/webapi/instantiateStreaming.any.js
@@ -12,7 +12,9 @@ for (const [name, fn] of instanceTestFactory) {
   promise_test(async () => {
     const { buffer, args, exports, verify } = fn();
     const response = new Response(buffer, { "headers": { "Content-Type": "application/wasm" } });
+      console.log("about to instantiate");
     const result = await WebAssembly.instantiateStreaming(response, ...args);
+      console.log("done");
     assert_WebAssemblyInstantiatedSource(result, exports);
     verify(result.instance);
   }, name);


### PR DESCRIPTION
When streams are created with their entire content in memory and no other mechanism to push chunks, any attempts to stream them into the WASM compiler will silently do nothing. These changes push the content of such streams into the JS engine's stream consumer.

Testing: Lots of tests no longer time out.
Fixes: #<!-- nolink -->41790

Reviewed in servo/servo#41792