### PR TITLE
Delete mappings for display:run-in

### DIFF
--- a/css/css-display/run-in/WEB_FEATURES.yml
+++ b/css/css-display/run-in/WEB_FEATURES.yml
@@ -1,7 +1,0 @@
-features:
-- name: text-align
-  files:
-  - text-align-applies-to-004.xht
-- name: line-height
-  files:
-  - line-height-applies-to-011.xht


### PR DESCRIPTION
https://caniuse.com/run-in isn't supported in any current browser, so any failures in this directory are going to be noise for other features.