### PR TITLE
Avoid false positives

### DIFF
--- a/webdriver/tests/classic/execute_async_script/promise.py
+++ b/webdriver/tests/classic/execute_async_script/promise.py
@@ -95,6 +95,9 @@ def test_promise_all_reject(session):
 
 
 def test_await_promise_reject(session):
+    """The script in this subtest is designed to execute without exception in
+    implementations which interpret it as a function body rather than an async
+    function body."""
     response = execute_async_script(session, """
         let resolve = arguments[0];
         window.await = () => {};

--- a/webdriver/tests/classic/execute_async_script/promise.py
+++ b/webdriver/tests/classic/execute_async_script/promise.py
@@ -97,7 +97,8 @@ def test_promise_all_reject(session):
 def test_await_promise_reject(session):
     response = execute_async_script(session, """
         let resolve = arguments[0];
-        await Promise.reject(new Error('my error'));
+        window.await = () => {};
+        await(Promise.reject(new Error('my error')));
         resolve('foo');
         """)
     assert_error(response, "javascript error")

--- a/webdriver/tests/classic/execute_script/promise.py
+++ b/webdriver/tests/classic/execute_script/promise.py
@@ -83,7 +83,8 @@ def test_promise_all_reject(session):
 
 def test_await_promise_reject(session):
     response = execute_script(session, """
-        await Promise.reject(new Error('my error'));
+        window.await = () => {};
+        await(Promise.reject(new Error('my error')));
         return 'foo';
         """)
     assert_error(response, "javascript error")

--- a/webdriver/tests/classic/execute_script/promise.py
+++ b/webdriver/tests/classic/execute_script/promise.py
@@ -82,6 +82,11 @@ def test_promise_all_reject(session):
 
 
 def test_await_promise_reject(session):
+    """
+    The script in this subtest is designed to execute without exception in
+    implementations which interpret it as a function body rather than an async
+    function body.
+    """
     response = execute_script(session, """
         window.await = () => {};
         await(Promise.reject(new Error('my error')));


### PR DESCRIPTION
Author the input script to be interpretable as the body of both a traditional function and an async function. This ensures that the expected error is only produced in engines that interpret the `await` keyword as expected.