### PR TITLE
Origin API: correct typos

### DIFF
--- a/html/browsers/origin/api/origin-from-string.any.js
+++ b/html/browsers/origin/api/origin-from-string.any.js
@@ -20,5 +20,5 @@ for (const tuple of urls.tuple) {
     const origin = Origin.from(tuple);
     assert_true(!!origin);
     assert_false(origin.opaque, "Origin should not be opaque.");
-  }, `Origin.from(${JSON.stringify(tuple)}) is an opaque origin.`);
+  }, `Origin.from(${JSON.stringify(tuple)}) is a tuple origin.`);
 }

--- a/html/browsers/origin/api/origin-from-url.any.js
+++ b/html/browsers/origin/api/origin-from-url.any.js
@@ -20,5 +20,5 @@ for (const tuple of urls.tuple) {
     const origin = Origin.from(new URL(tuple));
     assert_true(!!origin);
     assert_false(origin.opaque, "Origin should not be opaque.");
-  }, `Origin.from(${JSON.stringify(tuple)}) is an opaque origin.`);
+  }, `Origin.from(${JSON.stringify(tuple)}) is a tuple origin.`);
 }


### PR DESCRIPTION
I noticed this when running the new tests in WebKit as we were failing `file:///` for being a tuple, but then the old results suggested `file:///` was opaque. Clearly both cannot be true.

cc @shannonbooth 