### PR TITLE
Map more color-scheme tests to web-features

### DIFF
--- a/css/css-color-adjust/animation/WEB_FEATURES.yml
+++ b/css/css-color-adjust/animation/WEB_FEATURES.yml
@@ -2,6 +2,6 @@ features:
 - name: color-scheme
   files:
   - color-scheme-*
-- name: print-color-adjust
+- name: forced-colors
   files:
-  - print-color-adjust.html
+  - forced-color-adjust-*

--- a/html/semantics/document-metadata/the-meta-element/color-scheme/WEB_FEATURES.yml
+++ b/html/semantics/document-metadata/the-meta-element/color-scheme/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: color-scheme
+  files: "**"


### PR DESCRIPTION
The `<meta>` tag is in scope of the feature:
https://github.com/web-platform-dx/web-features/blob/main/features/color-scheme.yml

These tests were missed in https://github.com/web-platform-tests/wpt/pull/45888

Drive-by map one forced-colors tests that was in the same directory.
