### PR TITLE
Properly implement flex formatting context style repair

### DIFF
--- a/css/css-display/display-flex-inside-parent-ref.html
+++ b/css/css-display/display-flex-inside-parent-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Test: display: flex inside a parent container</title>
+    <link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-items">
+    <style type="text/css">
+        .overide.current {
+            color: #d8232a
+        }
+
+        .current {
+            display: flex;
+            background: #f4f6f9;
+            color: #008000
+        }
+    </style>
+</head>
+
+<body>
+    <h1>CSS Test: display: flex inside a parent container</h1>
+    <p>Test passes if A is in red color</p>
+    <div class="overide current">A</div>
+</body>
+</html>

--- a/css/css-display/display-flex-inside-parent.html
+++ b/css/css-display/display-flex-inside-parent.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: display: flex inside a parent container</title>
+  <link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-items">
+  <link rel="match" href="display-flex-inside-parent-ref.html">
+  <script src="/common/reftest-wait.js"></script>
+
+  <style type="text/css">
+    .overide.current {
+      color: #d8232a
+    }
+
+    .current {
+      display: flex;
+      background: #f4f6f9;
+      color: #008000
+    }
+  </style>
+</head>
+
+<body>
+  <h1>CSS Test: display: flex inside a parent container</h1>
+  <p>Test passes if A is in red color</p>
+  <div class=" current">A</div>
+  <script>
+    function runTest() {
+      const text = document.getElementsByClassName("current");
+      text[0].className = "overide current";
+    }
+    onload = () => runTest();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This repairs the style of children of FlexContainer. 

Reference: https://www.w3.org/TR/css-flexbox-1/#flex-items
Last line of Example 2

<img width="967" height="84" alt="Screenshot from 2026-01-16 14-49-49" src="https://github.com/user-attachments/assets/ef25c017-2eb3-4f47-aee7-be0e04f02412" />


Testing: `wpt/tests/css/css-display/display-flex-inside-parent.html`
Fixes: #<!-- nolink -->41947

Reviewed in servo/servo#41928