### PR TITLE
webdriver: Implement pointerCancel for touch chain

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -210,6 +210,12 @@ class ActionSequence:
         self._pointer_action("pointerUp", button=button)
         return self
 
+    def pointer_cancel(self):
+        """Queue a pointerCancel action.
+        """
+        self._pointer_action("pointerCancel")
+        return self
+
     def pointer_down(
         self,
         button=0,

--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -74,7 +74,7 @@ def test_touch_pointer_cancel(session, test_actions_pointer_page, touch_chain):
 
     assert results['touchstart']
     assert results["touchcancel"]
-    assert not results["touchend"]
+    assert results["touchend"]
     assert not results["click"]
 
 

--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -12,6 +12,7 @@ from tests.classic.perform_actions.support.mouse import (
 from tests.classic.perform_actions.support.refine import get_events
 
 from . import assert_pointer_events, record_pointer_events
+import time
 
 
 def test_null_response_value(session, touch_chain):
@@ -63,8 +64,12 @@ def test_touch_pointer_cancel(session, test_actions_pointer_page, touch_chain):
     touch_chain.pointer_move(0, 0, origin=pointerArea) \
         .pointer_down() \
         .pointer_cancel() \
+        .pointer_up() \
         .perform()
 
+    # Use delay to allow potential
+    # simulated click to spin (which should not if pointerCancel works)
+    time.sleep(1)
     results = session.execute_script("return window.events;")
 
     assert results['touchstart']


### PR DESCRIPTION
Testing: Adding a new function `pointer_cancel` in test infrastructure and two touch chain subtests for [pointerCancel](https://w3c.github.io/webdriver/#dfn-dispatch-a-pointercancel-action).


Reviewed in servo/servo#41937