### PR TITLE
maps "outlines" and "cursor" web features 

### DIFF
--- a/css/CSS2/ui/WEB_FEATURES.yml
+++ b/css/CSS2/ui/WEB_FEATURES.yml
@@ -7,3 +7,6 @@ features:
   - outline-width-*
   - outline-style-*
   - outline-color-*
+- name: cursor
+  files:
+  - "cursor-*"

--- a/css/CSS2/ui/WEB_FEATURES.yml
+++ b/css/CSS2/ui/WEB_FEATURES.yml
@@ -2,3 +2,8 @@ features:
 - name: system-color
   files:
   - "system-colors-*"
+- name: outlines
+  files:
+  - outline-width-*
+  - outline-style-*
+  - outline-color-*

--- a/css/css-ui/WEB_FEATURES.yml
+++ b/css/css-ui/WEB_FEATURES.yml
@@ -38,6 +38,12 @@ features:
   files:
   - caret-color-*
   - caret-eol-*
+- name: cursor
+  files:
+  - canvas-cursor-*
+  - cgrsor-*
+  - cursor-*
+  - select-cursor-*
 - name: cross-fade
   files:
   - cursor-image-016-manual.html

--- a/css/css-ui/WEB_FEATURES.yml
+++ b/css/css-ui/WEB_FEATURES.yml
@@ -13,9 +13,21 @@ features:
   files:
   - interactivity-*
   - inert-attribute-overriding.html
+- name: outlines
+  files:
+  - outline-width-*
+  - outline-style-*
+  - outline-color-*
+  - outline-offset-*
+  - outline-auto-width-*
 - name: outline
   files:
   - outline-*
+  - "!outline-width-*"
+  - "!outline-style-*"
+  - "!outline-color-*"
+  - "!outline-offset-*"
+  - "!outline-auto-width-*"
 - name: resize
   files:
   - resize-*

--- a/css/css-ui/WEB_FEATURES.yml
+++ b/css/css-ui/WEB_FEATURES.yml
@@ -13,21 +13,23 @@ features:
   files:
   - interactivity-*
   - inert-attribute-overriding.html
-- name: outlines
-  files:
-  - outline-width-*
-  - outline-style-*
-  - outline-color-*
-  - outline-offset-*
-  - outline-auto-width-*
 - name: outline
   files:
   - outline-*
+  # Keep exclusions synced with `outlines` mapping below
   - "!outline-width-*"
   - "!outline-style-*"
   - "!outline-color-*"
   - "!outline-offset-*"
   - "!outline-auto-width-*"
+- name: outlines
+  files:
+  # Keep mappings synced with `outline` mapping above
+  - outline-width-*
+  - outline-style-*
+  - outline-color-*
+  - outline-offset-*
+  - outline-auto-width-*
 - name: resize
   files:
   - resize-*

--- a/css/css-ui/animation/WEB_FEATURES.yml
+++ b/css/css-ui/animation/WEB_FEATURES.yml
@@ -10,3 +10,6 @@ features:
   - outline-width-*
   - outline-color-*
   - outline-offset-*
+- name: cursor
+  files:
+  - cursor-*

--- a/css/css-ui/animation/WEB_FEATURES.yml
+++ b/css/css-ui/animation/WEB_FEATURES.yml
@@ -5,3 +5,8 @@ features:
 - name: caret-color
   files:
   - caret-color-*
+- name: outlines
+  files:
+  - outline-width-*
+  - outline-color-*
+  - outline-offset-*

--- a/css/css-ui/parsing/WEB_FEATURES.yml
+++ b/css/css-ui/parsing/WEB_FEATURES.yml
@@ -20,3 +20,6 @@ features:
   - outline-style-*
   - outline-color-*
   - outline-offset-*
+- name: cursor
+  files:
+  - cursor-*

--- a/css/css-ui/parsing/WEB_FEATURES.yml
+++ b/css/css-ui/parsing/WEB_FEATURES.yml
@@ -14,3 +14,9 @@ features:
 - name: box-sizing
   files:
   - box-sizing-*
+- name: outlines
+  files:
+  - outline-width-*
+  - outline-style-*
+  - outline-color-*
+  - outline-offset-*


### PR DESCRIPTION
To reduce merge conflicts, I combined two open PRs for the `outlines` and `cursor` web features here, so this supersedes #56787 and #56619. (Original PR notes are included in the commits.)

cc @foolip @jcscottiii 

