### PR TITLE
Revert "PointerEvent WPT: Assert .fromElement/.toElement attributes as optional"

### DIFF
--- a/pointerevents/pointerevent_attributes.html
+++ b/pointerevents/pointerevent_attributes.html
@@ -8,6 +8,11 @@
   <meta name="variant" content="?mouse-right">
   <meta name="variant" content="?pen-right">
   <meta name="variant" content="?touch">
+  <meta name="variant" content="?mouse-nonstandard">
+  <meta name="variant" content="?pen-nonstandard">
+  <meta name="variant" content="?mouse-right-nonstandard">
+  <meta name="variant" content="?pen-right-nonstandard">
+  <meta name="variant" content="?touch-nonstandard">
   <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
   <style>
     html {
@@ -90,6 +95,7 @@ const frameLoadedPromise = new Promise(resolve => {
     const queryStringFragments = location.search.substring(1).split('-');
     const pointerType = queryStringFragments[0];
     const button = queryStringFragments[1] === "right" ? "right" : undefined;
+    const standard = !(queryStringFragments[queryStringFragments.length - 1] === "nonstandard");
 
     const eventList = [
       'pointerover',
@@ -223,7 +229,7 @@ const frameLoadedPromise = new Promise(resolve => {
        verifyButtonAttributes(event);
        verifyPosition(event);
        assert_true(event.isPrimary, 'isPrimary attribute is true');
-       check_PointerEvent(event, testNamePrefix);
+       check_PointerEvent(event, testNamePrefix, standard);
     }
 
     function pointerPromise(test, testNamePrefix, type, target) {

--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -44,7 +44,7 @@ const ButtonsBitfield = {
 
 // Check for conformance to PointerEvent interface
 // https://w3c.github.io/pointerevents/#pointerevent-interface
-function check_PointerEvent(event, testNamePrefix) {
+function check_PointerEvent(event, testNamePrefix, standardAttrs = true) {
   if (testNamePrefix === undefined)
     testNamePrefix = "";
 
@@ -52,15 +52,17 @@ function check_PointerEvent(event, testNamePrefix) {
   var pointerTestName = (testNamePrefix ? testNamePrefix + ' ' : '')
     + (expectedPointerType == null ? event.pointerType : expectedPointerType) + ' ' + event.type;
 
-  if (expectedPointerType != null) {
-    test(function () {
-      assert_equals(event.pointerType, expectedPointerType);
-    }, pointerTestName + ".pointerType is correct.");
-  }
+  if (standardAttrs) {
+    if (expectedPointerType != null) {
+      test(function () {
+        assert_equals(event.pointerType, expectedPointerType);
+      }, pointerTestName + ".pointerType is correct.");
+    }
 
-  test(function () {
-    assert_true(event instanceof event.target.ownerDocument.defaultView.PointerEvent);
-  }, pointerTestName + " event is a PointerEvent event");
+    test(function () {
+      assert_true(event instanceof event.target.ownerDocument.defaultView.PointerEvent);
+    }, pointerTestName + " event is a PointerEvent event");
+  }
 
   // Check attributes for conformance to WebIDL (existence, type, being readable).
   var idl_type_check = {
@@ -71,74 +73,70 @@ function check_PointerEvent(event, testNamePrefix) {
     "object": function (v) { return typeof v === "object" }
   };
 
-
-  // Check optional attributes.
-  test(function () {
-    assert_implements_optional("fromElement" in event);
-    if (event.fromElement !== undefined) {
-      assert_equals(event.fromElement, null);
-    }
-  }, pointerTestName + ".fromElement value is null");
-  test(function () {
-    assert_implements_optional("toElement" in event);
-    if (event.toElement !== undefined) {
-      assert_equals(event.toElement, null);
-    }
-  }, pointerTestName + ".toElement value is null");
-
   // Check values for inherited attributes.
   // https://w3c.github.io/pointerevents/#attributes-and-default-actions
-  test(function () {
-    assert_equals(event.isTrusted, true);
-  }, pointerTestName + ".isTrusted value is true");
-  test(function () {
-    let expected = (event.type != 'pointerenter' && event.type != 'pointerleave');
-    assert_equals(event.composed, expected);
-  }, pointerTestName + ".composed value is valid");
-  test(function () {
-    let expected = (event.type != 'pointerenter' && event.type != 'pointerleave');
-    assert_equals(event.bubbles, expected);
-  }, pointerTestName + ".bubbles value is valid");
-  test(function () {
-    let cancelable_events = [
-      'pointerdown', 'pointermove', 'pointerup', 'pointerover', 'pointerout'
-    ];
-    assert_equals(event.cancelable, cancelable_events.includes(event.type));
-  }, pointerTestName + ".cancelable value is valid");
+  if (!standardAttrs) {
+    test(function () {
+      assert_implements_optional("fromElement" in event);
+      assert_equals(event.fromElement, null);
+    }, pointerTestName + ".fromElement value is null");
+    test(function () {
+      assert_implements_optional("toElement" in event);
+      assert_equals(event.toElement, null);
+    }, pointerTestName + ".toElement value is null");
+  } else {
+    test(function () {
+      assert_equals(event.isTrusted, true);
+    }, pointerTestName + ".isTrusted value is true");
+    test(function () {
+      let expected = (event.type != 'pointerenter' && event.type != 'pointerleave');
+      assert_equals(event.composed, expected);
+    }, pointerTestName + ".composed value is valid");
+    test(function () {
+      let expected = (event.type != 'pointerenter' && event.type != 'pointerleave');
+      assert_equals(event.bubbles, expected);
+    }, pointerTestName + ".bubbles value is valid");
+    test(function () {
+      let cancelable_events = [
+        'pointerdown', 'pointermove', 'pointerup', 'pointerover', 'pointerout'
+      ];
+      assert_equals(event.cancelable, cancelable_events.includes(event.type));
+    }, pointerTestName + ".cancelable value is valid");
 
-  // Check the pressure value.
-  // https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
-  test(function () {
-    assert_greater_than_equal(event.pressure, 0, "pressure is greater than or equal to 0");
-    assert_less_than_equal(event.pressure, 1, "pressure is less than or equal to 1");
+    // Check the pressure value.
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
+    test(function () {
+      assert_greater_than_equal(event.pressure, 0, "pressure is greater than or equal to 0");
+      assert_less_than_equal(event.pressure, 1, "pressure is less than or equal to 1");
 
-    if (event.buttons === 0) {
-      assert_equals(event.pressure, 0, "pressure is 0 with no buttons pressed");
-    } else {
-      assert_greater_than(event.pressure, 0, "pressure is greater than 0 with a button pressed");
-      if (event.pointerType === "mouse") {
-        assert_equals(event.pressure, 0.5, "pressure is 0.5 for mouse with a button pressed");
+      if (event.buttons === 0) {
+        assert_equals(event.pressure, 0, "pressure is 0 with no buttons pressed");
+      } else {
+        assert_greater_than(event.pressure, 0, "pressure is greater than 0 with a button pressed");
+        if (event.pointerType === "mouse") {
+          assert_equals(event.pressure, 0.5, "pressure is 0.5 for mouse with a button pressed");
+        }
       }
+    }, pointerTestName + ".pressure value is valid");
+
+    // Check mouse-specific properties.
+    if (event.pointerType === "mouse") {
+      test(function () {
+        assert_equals(event.width, 1, "width of mouse should be 1");
+        assert_equals(event.height, 1, "height of mouse should be 1");
+        assert_equals(event.tiltX, 0, event.type + ".tiltX is 0 for mouse");
+        assert_equals(event.tiltY, 0, event.type + ".tiltY is 0 for mouse");
+        assert_true(event.isPrimary, event.type + ".isPrimary is true for mouse");
+      }, pointerTestName + " properties for pointerType = mouse");
     }
-  }, pointerTestName + ".pressure value is valid");
 
-  // Check mouse-specific properties.
-  if (event.pointerType === "mouse") {
-    test(function () {
-      assert_equals(event.width, 1, "width of mouse should be 1");
-      assert_equals(event.height, 1, "height of mouse should be 1");
-      assert_equals(event.tiltX, 0, event.type + ".tiltX is 0 for mouse");
-      assert_equals(event.tiltY, 0, event.type + ".tiltY is 0 for mouse");
-      assert_true(event.isPrimary, event.type + ".isPrimary is true for mouse");
-    }, pointerTestName + " properties for pointerType = mouse");
-  }
-
-  // Check "pointerup" specific properties.
-  if (event.type == "pointerup") {
-    test(function () {
-      assert_equals(event.width, 1, "width of pointerup should be 1");
-      assert_equals(event.height, 1, "height of pointerup should be 1");
-    }, pointerTestName + " properties for pointerup");
+    // Check "pointerup" specific properties.
+    if (event.type == "pointerup") {
+      test(function () {
+        assert_equals(event.width, 1, "width of pointerup should be 1");
+        assert_equals(event.height, 1, "height of pointerup should be 1");
+      }, pointerTestName + " properties for pointerup");
+    }
   }
 }
 


### PR DESCRIPTION
Reverts web-platform-tests/wpt#57183

Unlike wpt.fyi the interop scoring script doesn't ignore `PRECONDITION_FAILED`, so this change ends up regressing the score of browsers that don't implement nonstandard extensions. We need to back it out and reconsider.