### PR TITLE
Don't run Stable channel Edge with experimental flag

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -670,7 +670,7 @@ class Opera(BrowserSetup):
 
 class Edge(ChromeAndEdgeSetup):
     name = "MicrosoftEdge"
-    browser_cls: ClassVar[Type[browser.ChromeChromiumBase]] = browser.Edge
+    browser_cls = browser.Edge
     webdriver_name = "msedgedriver"
 
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -448,9 +448,9 @@ class FirefoxAndroid(BrowserSetup):
             self._logcat.stop()
 
 
-class Chrome(BrowserSetup):
-    name = "chrome"
-    browser_cls: ClassVar[Type[browser.ChromeChromiumBase]] = browser.Chrome
+class ChromeAndEdgeSetup(BrowserSetup):
+    """Base class for Chrome and Edge."""
+    webdriver_name: ClassVar[str]  # e.g., "chromedriver", "msedgedriver"
     experimental_channels: ClassVar[Tuple[str, ...]] = ("dev", "canary")
 
     def setup_kwargs(self, kwargs):
@@ -485,7 +485,7 @@ class Chrome(BrowserSetup):
                     webdriver_binary = None
 
             if webdriver_binary is None:
-                install = self.prompt_install("chromedriver")
+                install = self.prompt_install(self.webdriver_name)
 
                 if install:
                     webdriver_binary = self.browser.install_webdriver(
@@ -499,16 +499,13 @@ class Chrome(BrowserSetup):
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
-                raise WptrunError("Unable to locate or install matching ChromeDriver binary")
-        if kwargs["headless"] is None and not kwargs["debug_test"]:
-            kwargs["headless"] = True
-            logger.info("Running in headless mode, pass --no-headless to disable")
+                raise WptrunError(f"Unable to locate or install matching {self.webdriver_name} binary")
         if browser_channel in self.experimental_channels:
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
             if kwargs["enable_experimental"] is None:
                 logger.info(
-                    "Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
+                    "Automatically turning on experimental features")
                 kwargs["enable_experimental"] = True
             if kwargs["enable_webtransport_h3"] is None:
                 # To start the WebTransport over HTTP/3 test server.
@@ -518,8 +515,21 @@ class Chrome(BrowserSetup):
             kwargs["enable_experimental"] = False
         if os.getenv("TASKCLUSTER_ROOT_URL"):
             # We are on Taskcluster, where our Docker container does not have
-            # enough capabilities to run Chrome with sandboxing. (gh-20133)
+            # enough capabilities to run the browser with sandboxing. (gh-20133)
             kwargs["binary_args"].append("--no-sandbox")
+
+
+class Chrome(ChromeAndEdgeSetup):
+    name = "chrome"
+    browser_cls: ClassVar[Type[browser.ChromeChromiumBase]] = browser.Chrome
+    webdriver_name = "chromedriver"
+
+    def setup_kwargs(self, kwargs):
+        super().setup_kwargs(kwargs)
+
+        if kwargs["headless"] is None and not kwargs["debug_test"]:
+            kwargs["headless"] = True
+            logger.info("Running in headless mode, pass --no-headless to disable")
 
 
 class HeadlessShell(BrowserSetup):
@@ -658,72 +668,10 @@ class Opera(BrowserSetup):
                 raise WptrunError("Unable to locate or install operadriver binary")
 
 
-class Edge(BrowserSetup):
+class Edge(ChromeAndEdgeSetup):
     name = "MicrosoftEdge"
-    browser_cls = browser.Edge
-    experimental_channels: ClassVar[Tuple[str, ...]] = ("dev", "canary")
-
-    def setup_kwargs(self, kwargs):
-        browser_channel = kwargs["browser_channel"]
-        if kwargs["binary"] is None:
-            binary = self.browser.find_binary(venv_path=self.venv.path, channel=browser_channel)
-            if binary:
-                kwargs["binary"] = binary
-            else:
-                raise WptrunError(f"Unable to locate {self.name.capitalize()} binary")
-
-        if kwargs["mojojs_path"]:
-            kwargs["enable_mojojs"] = True
-            logger.info("--mojojs-path is provided, enabling MojoJS")
-        else:
-            path = self.browser.install_mojojs(dest=self.venv.path,
-                                               browser_binary=kwargs["binary"])
-            if path:
-                kwargs["mojojs_path"] = path
-                kwargs["enable_mojojs"] = True
-                logger.info(f"MojoJS enabled automatically (mojojs_path: {path})")
-            else:
-                kwargs["enable_mojojs"] = False
-                logger.info("MojoJS is disabled for this run.")
-
-        if kwargs["webdriver_binary"] is None:
-            webdriver_binary = None
-            if not kwargs["install_webdriver"]:
-                webdriver_binary = self.browser.find_webdriver(self.venv.bin_path)
-                if webdriver_binary and not self.browser.webdriver_supports_browser(
-                        webdriver_binary, kwargs["binary"], browser_channel):
-                    webdriver_binary = None
-
-            if webdriver_binary is None:
-                install = self.prompt_install("msedgedriver")
-
-                if install:
-                    webdriver_binary = self.browser.install_webdriver(
-                        dest=self.venv.bin_path,
-                        channel=browser_channel,
-                        browser_binary=kwargs["binary"],
-                    )
-            else:
-                logger.info("Using webdriver binary %s" % webdriver_binary)
-
-            if webdriver_binary:
-                kwargs["webdriver_binary"] = webdriver_binary
-            else:
-                raise WptrunError("Unable to locate or install matching msedgedriver binary")
-        if browser_channel in self.experimental_channels:
-            # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
-            kwargs["webdriver_args"].append("--disable-build-check")
-            if kwargs["enable_experimental"] is None:
-                logger.info(
-                    "Automatically turning on experimental features for Microsoft Edge Dev/Canary")
-                kwargs["enable_experimental"] = True
-            if kwargs["enable_webtransport_h3"] is None:
-                # To start the WebTransport over HTTP/3 test server.
-                kwargs["enable_webtransport_h3"] = True
-        if os.getenv("TASKCLUSTER_ROOT_URL"):
-            # We are on Taskcluster, where our Docker container does not have
-            # enough capabilities to run Microsoft Edge with sandboxing. (gh-20133)
-            kwargs["binary_args"].append("--no-sandbox")
+    browser_cls: ClassVar[Type[browser.ChromeChromiumBase]] = browser.Edge
+    webdriver_name = "msedgedriver"
 
 
 class Safari(BrowserSetup):


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/52651 made changes to how Chrome's `--web-platform-experimental-features` flag gets set, which had the side-effect of causing Edge to always use this flag even in Stable channel runs.

This is because with https://github.com/web-platform-tests/wpt/pull/52651,  Chrome's [`executor_kwargs`](https://github.com/web-platform-tests/wpt/blob/f5447f6092e834d1df4b343e5f72866f7a63db74/tools/wptrunner/wptrunner/browsers/chrome.py#L58C1-L58C20), which is also used by Edge, requires `kwargs["enable_experimental"]` to have a value in order to not apply experimental flags by default.  The same change caused the value to be set in Chrome's [`setup_kwargs`](https://github.com/web-platform-tests/wpt/blob/b91489433531a902671f866762fedbd01b736534/tools/wpt/run.py#L516), but since that code is not shared for Edge, the missing value for Edge's `kwargs["enable_experimental"]` causes the experimental flag to be set.

Fix the issue by refactoring the Chrome and Edge `BrowserSetup` classes so that they both set `kwargs["enable_experimental"]`, and share other common logic to lower the likelihood of similar issues in the future.

While looking at this I also noticed a divergence in `--headless` behavior introduced in https://github.com/web-platform-tests/wpt/pull/44515. Filed #57221 to track that.

Closes #55905.