### PR TITLE
script: Include font-variation-settings on `parse_font_face_descriptors`

### DIFF
--- a/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
+++ b/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Testing that variationSettings is persisted in the FontFace object</title>
+  <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#propdef-font-variation-settings" />
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <script>
+    const face = new FontFace(
+      "wght",
+      'local("Ahem"), url("/fonts/Ahem.ttf")',
+      { variationSettings: "'wght' 850" }
+    );
+
+    test(() => {
+      assert_equals(face.variationSettings, "\"wght\" 850");
+    }, "Test FontFace variationSettings property");
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Implementation for parsing the font-variation-settings and including them in the fontface rule-set, currently they are discarded and annotated with a TODO
Related: https://github.com/servo/servo/issues/41591

Testing: Tests are included for the changes to be implemented, as suggested they currently fail and thats the starting point.

Reviewed in servo/servo#41968