### PR TITLE
Allow space for classic scrollbars

### DIFF
--- a/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
+++ b/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
@@ -10,7 +10,6 @@
 
 .scroller {
   width: 100px;
-  height: 100px;
   overflow: auto;
   position: relative;
 }


### PR DESCRIPTION
A definite height on the .scroller causes the test to fail with classic scrollbars. (When the horizontal scrollbar is visible, the content overflows causing the vertical scrollbar to appear as well.)