### PR TITLE
Digital Credentials: Fix user activation tests for early validation errors

### DIFF
--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -93,7 +93,6 @@
           requests: r
         },
       };
-      await test_driver.bless("user activation");
       await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
     }
   }, "navigator.credentials.create() API rejects if there are no credential request.");
@@ -237,7 +236,6 @@
 
     for (const badValue of throwingValues) {
       const options = makeCreateOptions({ data: badValue });
-
       await promise_rejects_js(
         t,
         TypeError,

--- a/digital-credentials/get.tentative.https.html
+++ b/digital-credentials/get.tentative.https.html
@@ -32,7 +32,6 @@
     const invalidData = [null, "", 123, true, false];
     for (const data of invalidData) {
       const options = makeGetOptions({ data });
-      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         TypeError,
@@ -105,7 +104,6 @@
           requests: r
         },
       };
-      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         TypeError,
@@ -245,7 +243,6 @@ promise_test(async t => {
 
   for (const badValue of throwingValues) {
     const options = makeGetOptions({ data: badValue });
-
     await promise_rejects_js(
       t,
       TypeError,

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -37,7 +37,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
-  }, "navigator.credentials.create() with empty requests and no user activation needed should reject with TypeError.");
+  }, "navigator.credentials.create() with empty protocol array and no user activation needed should reject with TypeError.");
 
   promise_test(async (t) => {
     await test_driver.bless();

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -12,26 +12,30 @@
   promise_test(async (t) => {
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should not be active",
     );
     const options = makeCreateOptions();
     await promise_rejects_dom(
       t,
       "NotAllowedError",
-      navigator.credentials.create(options)
+      navigator.credentials.create(options),
     );
   }, "navigator.credentials.create() calling the API without user activation should reject with NotAllowedError.");
 
   promise_test(async (t) => {
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should not be active",
     );
-    const options = makeCreateOptions({protocol: []});
-    await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
+    const options = makeCreateOptions({ protocol: [] });
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.create(options),
+    );
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should not be active",
     );
   }, "navigator.credentials.create() with empty requests and no user activation needed should reject with TypeError.");
 
@@ -39,7 +43,7 @@
     await test_driver.bless();
     assert_true(
       navigator.userActivation.isActive,
-      "User activation should be active after test_driver.bless()."
+      "User activation should be active after test_driver.bless().",
     );
     const abort = new AbortController();
     const options = makeCreateOptions({ signal: abort.signal });
@@ -48,7 +52,7 @@
     await promise_rejects_dom(t, "AbortError", promise);
     assert_true(
       navigator.userActivation.isActive,
-      "User activation should not be consumed on early abort with navigator.credentials.create()."
+      "User activation should not be consumed on early abort with navigator.credentials.create().",
     );
   }, "navigator.credentials.create() with early abort does not consume user activation.");
 
@@ -56,7 +60,7 @@
     await test_driver.bless();
     assert_true(
       navigator.userActivation.isActive,
-      "User activation should be active after test_driver.bless()."
+      "User activation should be active after test_driver.bless().",
     );
     const abort = new AbortController();
     const options = makeCreateOptions({ signal: abort.signal });
@@ -66,7 +70,7 @@
     await promise_rejects_dom(t, "AbortError", promise);
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should be consumed after navigator.credentials.create()."
+      "User activation should be consumed after navigator.credentials.create().",
     );
   }, "navigator.credentials.create() with late abort consumes user activation.");
 </script>

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -25,23 +25,40 @@
   promise_test(async (t) => {
     const options = makeCreateOptions({protocol: []});
     await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
-  }, "navigator.credentials.create() with empty requests should reject with TypeError (no user activation needed).");
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active"
+    );
+  }, "navigator.credentials.create() with empty requests and no user activation needed should reject with TypeError.");
+
+  promise_test(async (t) => {
+    const options = makeCreateOptions();
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      navigator.credentials.create(options)
+    );
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active"
+    );
+  }, "navigator.credentials.create() calling the API without user activation should reject with NotAllowedError.");
 
   promise_test(async (t) => {
     await test_driver.bless();
-    const abort = new AbortController();
-    const options = makeCreateOptions({ signal: abort.signal });
     assert_true(
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."
     );
+    const abort = new AbortController();
+    const options = makeCreateOptions({ signal: abort.signal });
 
     const createPromise = navigator.credentials.create(options);
     abort.abort();
     await promise_rejects_dom(t, "AbortError", createPromise);
-    assert_false(
+    assert_true(
       navigator.userActivation.isActive,
-      "User activation should be consumed after navigator.credentials.create()."
+      "User activation should not be consumed on early abort with navigator.credentials.create()."
     );
   }, "navigator.credentials.create() consumes user activation.");
 </script>

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -23,6 +23,10 @@
   }, "navigator.credentials.create() calling the API without user activation should reject with NotAllowedError.");
 
   promise_test(async (t) => {
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active"
+    );
     const options = makeCreateOptions({protocol: []});
     await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
     assert_false(
@@ -32,17 +36,21 @@
   }, "navigator.credentials.create() with empty requests and no user activation needed should reject with TypeError.");
 
   promise_test(async (t) => {
-    const options = makeCreateOptions();
-    await promise_rejects_dom(
-      t,
-      "NotAllowedError",
-      navigator.credentials.create(options)
-    );
-    assert_false(
+    await test_driver.bless();
+    assert_true(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should be active after test_driver.bless()."
     );
-  }, "navigator.credentials.create() calling the API without user activation should reject with NotAllowedError.");
+    const abort = new AbortController();
+    const options = makeCreateOptions({ signal: abort.signal });
+    abort.abort();
+    const createPromise = navigator.credentials.create(options);
+    await promise_rejects_dom(t, "AbortError", createPromise);
+    assert_true(
+      navigator.userActivation.isActive,
+      "User activation should not be consumed on early abort with navigator.credentials.create()."
+    );
+  }, "navigator.credentials.create() with early abort does not consume user activation.");
 
   promise_test(async (t) => {
     await test_driver.bless();
@@ -56,9 +64,9 @@
     const createPromise = navigator.credentials.create(options);
     abort.abort();
     await promise_rejects_dom(t, "AbortError", createPromise);
-    assert_true(
+    assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be consumed on early abort with navigator.credentials.create()."
+      "User activation should be consumed after navigator.credentials.create()."
     );
-  }, "navigator.credentials.create() consumes user activation.");
+  }, "navigator.credentials.create() with late abort consumes user activation.");
 </script>

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -44,8 +44,8 @@
     const abort = new AbortController();
     const options = makeCreateOptions({ signal: abort.signal });
     abort.abort();
-    const createPromise = navigator.credentials.create(options);
-    await promise_rejects_dom(t, "AbortError", createPromise);
+    const promise = navigator.credentials.create(options);
+    await promise_rejects_dom(t, "AbortError", promise);
     assert_true(
       navigator.userActivation.isActive,
       "User activation should not be consumed on early abort with navigator.credentials.create()."
@@ -61,9 +61,9 @@
     const abort = new AbortController();
     const options = makeCreateOptions({ signal: abort.signal });
 
-    const createPromise = navigator.credentials.create(options);
+    const promise = navigator.credentials.create(options);
     abort.abort();
-    await promise_rejects_dom(t, "AbortError", createPromise);
+    await promise_rejects_dom(t, "AbortError", promise);
     assert_false(
       navigator.userActivation.isActive,
       "User activation should be consumed after navigator.credentials.create()."

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>Digital Credential API: create() user activation tests.</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.js" type="module"></script>
+<body></body>
+<script type="module">
+  import { makeCreateOptions } from "./support/helper.js";
+
+  promise_test(async (t) => {
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active"
+    );
+    const options = makeCreateOptions();
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      navigator.credentials.create(options)
+    );
+  }, "navigator.credentials.create() calling the API without user activation should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    const options = makeCreateOptions({protocol: []});
+    await promise_rejects_js(t, TypeError, navigator.credentials.create(options));
+  }, "navigator.credentials.create() with empty requests should reject with TypeError (no user activation needed).");
+
+  promise_test(async (t) => {
+    await test_driver.bless();
+    const abort = new AbortController();
+    const options = makeCreateOptions({ signal: abort.signal });
+    assert_true(
+      navigator.userActivation.isActive,
+      "User activation should be active after test_driver.bless()."
+    );
+
+    const createPromise = navigator.credentials.create(options);
+    abort.abort();
+    await promise_rejects_dom(t, "AbortError", createPromise);
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should be consumed after navigator.credentials.create()."
+    );
+  }, "navigator.credentials.create() consumes user activation.");
+</script>

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -44,8 +44,8 @@
     const abort = new AbortController();
     const options = makeGetOptions({ signal: abort.signal });
     abort.abort();
-    const createPromise = navigator.credentials.get(options);
-    await promise_rejects_dom(t, "AbortError", createPromise);
+    const promise = navigator.credentials.get(options);
+    await promise_rejects_dom(t, "AbortError", promise);
     assert_true(
       navigator.userActivation.isActive,
       "User activation should not be consumed on early abort with navigator.credentials.get()."
@@ -61,9 +61,9 @@
     const abort = new AbortController();
     const options = makeGetOptions({ signal: abort.signal });
 
-    const createPromise = navigator.credentials.get(options);
+    const promise = navigator.credentials.get(options);
     abort.abort();
-    await promise_rejects_dom(t, "AbortError", createPromise);
+    await promise_rejects_dom(t, "AbortError", promise);
     assert_false(
       navigator.userActivation.isActive,
       "User activation should be consumed after navigator.credentials.get()."

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -12,26 +12,26 @@
   promise_test(async (t) => {
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should not be active",
     );
     const options = makeGetOptions();
     await promise_rejects_dom(
       t,
       "NotAllowedError",
-      navigator.credentials.get(options)
+      navigator.credentials.get(options),
     );
   }, "navigator.credentials.get() calling the API without user activation should reject with NotAllowedError.");
 
   promise_test(async (t) => {
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should not be active",
     );
-    const options = makeGetOptions({protocol: []});
+    const options = makeGetOptions({ protocol: [] });
     await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should not be active"
+      "User activation should not be active",
     );
   }, "navigator.credentials.get() with empty requests and no user activation needed should reject with TypeError.");
 
@@ -39,7 +39,7 @@
     await test_driver.bless();
     assert_true(
       navigator.userActivation.isActive,
-      "User activation should be active after test_driver.bless()."
+      "User activation should be active after test_driver.bless().",
     );
     const abort = new AbortController();
     const options = makeGetOptions({ signal: abort.signal });
@@ -48,7 +48,7 @@
     await promise_rejects_dom(t, "AbortError", promise);
     assert_true(
       navigator.userActivation.isActive,
-      "User activation should not be consumed on early abort with navigator.credentials.get()."
+      "User activation should not be consumed on early abort with navigator.credentials.get().",
     );
   }, "navigator.credentials.get() with early abort does not consume user activation.");
 
@@ -56,7 +56,7 @@
     await test_driver.bless();
     assert_true(
       navigator.userActivation.isActive,
-      "User activation should be active after test_driver.bless()."
+      "User activation should be active after test_driver.bless().",
     );
     const abort = new AbortController();
     const options = makeGetOptions({ signal: abort.signal });
@@ -66,7 +66,7 @@
     await promise_rejects_dom(t, "AbortError", promise);
     assert_false(
       navigator.userActivation.isActive,
-      "User activation should be consumed after navigator.credentials.get()."
+      "User activation should be consumed after navigator.credentials.get().",
     );
   }, "navigator.credentials.get() with late abort consumes user activation.");
 </script>

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -33,7 +33,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
-  }, "navigator.credentials.get() with empty requests and no user activation needed should reject with TypeError.");
+  }, "navigator.credentials.get() with empty protocol array and no user activation needed should reject with TypeError.")
 
   promise_test(async (t) => {
     await test_driver.bless();

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Digital Credential API: get() consumes user activation.</title>
+<title>Digital Credential API: get() user activation tests.</title>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
@@ -7,7 +7,7 @@
 <script src="support/helper.js" type="module"></script>
 <body></body>
 <script type="module">
-  import { makeGetOptions, makeCreateOptions } from "./support/helper.js";
+  import { makeGetOptions } from "./support/helper.js";
 
   promise_test(async (t) => {
     assert_false(
@@ -21,6 +21,11 @@
       navigator.credentials.get(options)
     );
   }, "navigator.credentials.get() calling the API without user activation should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    const options = makeGetOptions({protocol: []});
+    await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+  }, "navigator.credentials.get() with empty requests should reject with TypeError (no user activation needed).");
 
   promise_test(async (t) => {
     await test_driver.bless();
@@ -39,35 +44,4 @@
       "User activation should be consumed after navigator.credentials.get()."
     );
   }, "navigator.credentials.get() consumes user activation.");
-
-  promise_test(async (t) => {
-    assert_false(
-      navigator.userActivation.isActive,
-      "User activation should not be active"
-    );
-    const options = makeCreateOptions();
-    await promise_rejects_dom(
-      t,
-      "NotAllowedError",
-      navigator.credentials.create(options)
-    );
-  }, "navigator.credentials.create() calling the API without user activation should reject with NotAllowedError.");
-
-  promise_test(async (t) => {
-    await test_driver.bless();
-    const abort = new AbortController();
-    const options = makeCreateOptions({ signal: abort.signal });
-    assert_true(
-      navigator.userActivation.isActive,
-      "User activation should be active after test_driver.bless()."
-    );
-
-    const createPromise = navigator.credentials.create(options);
-    abort.abort();
-    await promise_rejects_dom(t, "AbortError", createPromise);
-    assert_false(
-      navigator.userActivation.isActive,
-      "User activation should be consumed after navigator.credentials.create()."
-    );
-  }, "navigator.credentials.create() consumes user activation.");
 </script>

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -23,25 +23,50 @@
   }, "navigator.credentials.get() calling the API without user activation should reject with NotAllowedError.");
 
   promise_test(async (t) => {
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active"
+    );
     const options = makeGetOptions({protocol: []});
     await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
-  }, "navigator.credentials.get() with empty requests should reject with TypeError (no user activation needed).");
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active"
+    );
+  }, "navigator.credentials.get() with empty requests and no user activation needed should reject with TypeError.");
 
   promise_test(async (t) => {
     await test_driver.bless();
-    const abort = new AbortController();
-    const options = makeGetOptions({ signal: abort.signal });
     assert_true(
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."
     );
-
-    const getPromise = navigator.credentials.get(options);
+    const abort = new AbortController();
+    const options = makeGetOptions({ signal: abort.signal });
     abort.abort();
-    await promise_rejects_dom(t, "AbortError", getPromise);
+    const createPromise = navigator.credentials.get(options);
+    await promise_rejects_dom(t, "AbortError", createPromise);
+    assert_true(
+      navigator.userActivation.isActive,
+      "User activation should not be consumed on early abort with navigator.credentials.get()."
+    );
+  }, "navigator.credentials.get() with early abort does not consume user activation.");
+
+  promise_test(async (t) => {
+    await test_driver.bless();
+    assert_true(
+      navigator.userActivation.isActive,
+      "User activation should be active after test_driver.bless()."
+    );
+    const abort = new AbortController();
+    const options = makeGetOptions({ signal: abort.signal });
+
+    const createPromise = navigator.credentials.get(options);
+    abort.abort();
+    await promise_rejects_dom(t, "AbortError", createPromise);
     assert_false(
       navigator.userActivation.isActive,
       "User activation should be consumed after navigator.credentials.get()."
     );
-  }, "navigator.credentials.get() consumes user activation.");
+  }, "navigator.credentials.get() with late abort consumes user activation.");
 </script>


### PR DESCRIPTION
Validation errors (TypeError) no longer consume user activation since validation now happens before user activation checking.

Spec change: https://github.com/w3c-fedid/digital-credentials/pull/418