### PR TITLE
layout: Fix WebRender hit test item's offset

### DIFF
--- a/css/css-overflow/overflow-auto-scrolling-with-margin-and-transform.html
+++ b/css/css-overflow/overflow-auto-scrolling-with-margin-and-transform.html
@@ -1,6 +1,6 @@
 <!doctype html>
-<title>Should be able to interactively scroll an overflow: auto element with a margin</title>
-<link rel="help" href="https://github.com/servo/servo/pull/41707">
+<title>Should be able to interactively scroll an overflow: auto element with a margin and transform</title>
+<link rel="help" href="https://github.com/servo/servo/pull/42005">
 <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -18,6 +18,7 @@
   background-color: red;
   overflow: auto;
   scrollbar-width: none;
+  transform: translate(-300%, -300%);
 }
 #item {
   position: relative;
@@ -47,5 +48,5 @@
     let [horizontal_delta, vertical_delta] = await scroll_delta_promise;
     assert_equals(horizontal_delta, 50, "Element scrolled horizontally");
     assert_equals(vertical_delta, 50, "Element scrolled vertically");
-  }, "Margins should not interfere with interactive scrolling of a scroll container");
+  }, "Margin and transform should not interfere with interactive scrolling of a scroll container");
 </script>


### PR DESCRIPTION
PR #<!-- nolink -->41707 changed so that the hit test item is being offset by the containing block of the fragment, but this is not exactly correct since WebRender process the the coordinates of the items based on the nearest reference frame parent. Therefore, the previous fix would fail whenever a reference frame is defined for a descendant scroll container.

Testing: Testdriver WPT
Reviewed in servo/servo#42005