### PR TITLE
Digital Credentials: abort does not break later requests

### DIFF
--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -84,4 +84,33 @@
     iframe.remove();
     await p;
   }, "Promise rejects with DOMException when the document becomes non-fully active");
+
+  promise_test(async (t) => {
+    const iframe = await createIframe();
+    t.add_cleanup(() => iframe.remove());
+    const DOMExceptionCtor = iframe.contentWindow.DOMException;
+
+    for (let i = 0; i < 10; ++i) {
+      await test_driver.bless("User activation", null, iframe.contentWindow);
+      await iframe.focus();
+
+      const controller = new iframe.contentWindow.AbortController();
+      const p = iframe.contentWindow.navigator.credentials.get(
+        makeGetOptions({ signal: controller.signal })
+      );
+
+      controller.abort(new Error(`Aborted iteration ${i}`));
+
+      try {
+        await p;
+        assert_unreached("navigator.credentials.get() unexpectedly resolved");
+      } catch (e) {
+        assert_not_equals(
+          e.name,
+          "InvalidStateError",
+          `Iteration ${i}: should not fail with InvalidStateError`
+        );
+      }
+    }
+}, "Aborted Digital Credentials requests do not leave a subsequent request stuck in an invalid state.");
 </script>

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -88,7 +88,6 @@
   promise_test(async (t) => {
     const iframe = await createIframe();
     t.add_cleanup(() => iframe.remove());
-    const DOMExceptionCtor = iframe.contentWindow.DOMException;
 
     for (let i = 0; i < 10; ++i) {
       await test_driver.bless("User activation", null, iframe.contentWindow);

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -111,5 +111,5 @@
         );
       }
     }
-}, "Aborted Digital Credentials requests do not leave a subsequent request stuck in an invalid state.");
+}, "Aborted Digital Credentials requests do not leave a subsequent request stuck in an invalid state");
 </script>

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -99,16 +99,17 @@
         makeGetOptions({ signal: controller.signal })
       );
 
-      controller.abort(new Error(`Aborted iteration ${i}`));
+      const abortReason = new Error(`Aborted iteration ${i}`);
+      controller.abort(abortReason);
 
       try {
         await p;
         assert_unreached("navigator.credentials.get() unexpectedly resolved");
       } catch (e) {
-        assert_not_equals(
-          e.name,
-          "InvalidStateError",
-          `Iteration ${i}: should not fail with InvalidStateError`
+        assert_equals(
+          e,
+          abortReason,
+          `Iteration ${i}: should reject with the exact abort reason`
         );
       }
     }

--- a/digital-credentials/non-fully-active.https.html
+++ b/digital-credentials/non-fully-active.https.html
@@ -87,12 +87,11 @@
 
   promise_test(async (t) => {
     const iframe = await createIframe();
+    iframe.focus();
     t.add_cleanup(() => iframe.remove());
 
     for (let i = 0; i < 10; ++i) {
       await test_driver.bless("User activation", null, iframe.contentWindow);
-      await iframe.focus();
-
       const controller = new iframe.contentWindow.AbortController();
       const p = iframe.contentWindow.navigator.credentials.get(
         makeGetOptions({ signal: controller.signal })


### PR DESCRIPTION
Add test ensuring aborted Digital Credentials requests don’t leave invalid state.