### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=304494

### DIFF
--- a/mathml/presentation-markup/operators/embellished-op-4-1.html
+++ b/mathml/presentation-markup/operators/embellished-op-4-1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-108" />
     <title>embellished operators 4-1: some non-space-like children</title>
     <link rel="match" href="embellished-op-4-1-ref.html"/>
     <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=21479"/>

--- a/mathml/presentation-markup/operators/embellished-op-4-2.html
+++ b/mathml/presentation-markup/operators/embellished-op-4-2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-57" />
     <title>embellished operators 4-2: some non-space-like children</title>
     <link rel="match" href="embellished-op-4-2-ref.html"/>
     <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=21479"/>

--- a/mathml/presentation-markup/operators/embellished-op-4-3.html
+++ b/mathml/presentation-markup/operators/embellished-op-4-3.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-57" />
     <title>embellished operators 4-3: some non-space-like children</title>
     <link rel="match" href="embellished-op-4-3-ref.html"/>
     <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=21479"/>


### PR DESCRIPTION
WebKit export from bug: [\[subpixel\] MathOperator::paint should snap paint location to device pixel](https://bugs.webkit.org/show_bug.cgi?id=304494)