### PR TITLE
[`LanguageModel` tests]: Update error message for aborted `create()` operation

### DIFF
--- a/ai/resources/util.js
+++ b/ai/resources/util.js
@@ -88,7 +88,7 @@ async function testCreateMonitorWithAbortAt(
 
       if (hadEvent) {
         assert_unreached(
-            'This should never be reached since LanguageDetector.create() was aborted.');
+            'This should never be reached since the create() operation was aborted.');
         return;
       }
 


### PR DESCRIPTION
This helper method is being used by more tests than those of `LanguageDetector`, for example, [by `LanguageModel`](https://github.com/web-platform-tests/wpt/blob/9bd4d659822e4f1b71ad4b039786cfbadbd3dd44/ai/language-model/language-model-create.tentative.https.window.js#L37).