### PR TITLE
maps "flexbox-gap" web feature

### DIFF
--- a/css/css-flexbox/WEB_FEATURES.yml
+++ b/css/css-flexbox/WEB_FEATURES.yml
@@ -1,7 +1,6 @@
 features:
 - name: flexbox
   files: "**"
-# TODO: map *gap* to flexbox-gap. This is currently not possible without the
-# tests being associated with both flexbox and flexbox-gap. All but one of the
-# *gap* tests are passing in all browsers, so lumping them in with flexbox is
-# relatively harmless.
+- name: flexbox-gap
+  files:
+  - "*gap*"


### PR DESCRIPTION
Web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/flexbox-gap.yml

@foolip I follow the guidance in the original TODO here and kept some overlapping mappings here, but if you think we should an exclusion pattern (as we've done elsewhere), let me know and I can update!

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)