### PR TITLE
script: Do not assume that every textual `<input>` is a focusable area

### DIFF
--- a/html/semantics/forms/the-input-element/disabled-attempt-focus-crash.html
+++ b/html/semantics/forms/the-input-element/disabled-attempt-focus-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<title>Clicking in a disabled input type=text field should not cause a crash</title>
+<link rel="help" href="https://github.com/servo/servo/issues/42074">
+<head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+<input id=target type=text value="text" disabled>
+
+<script>
+    async function test() {
+      await new test_driver.Actions()
+        .pointerMove(5, 5, { origin: target })
+        .pointerDown()
+        .pointerUp()
+        .send();
+    }
+    test();
+</script>
+
+</html>


### PR DESCRIPTION
An input text might not be a focusable area if it is disabled. In this
case return `None` from `find_focusable_shadow_host_if_necessary` which
causes no focus to occur.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

Testing: This change includes a test.
Fixes: #<!-- nolink -->42074.

Reviewed in servo/servo#42078