### PR TITLE
script: Fix handling of invalid fetch responses for link stylesheets

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
+++ b/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//" "">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <title>link: error events in limited quirks mode</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Regardless of the `Ok` status, we should always create a
stylesheet. However, the determining of the load/error event
is based on whether it has parsed actual content or not.

It also realigns some of the spec text to now only do it for link
elements, since for styles we shouldn't be checking the result of
the content type.

Part of #<!-- nolink -->22715
Reviewed in servo/servo#42037