### PR TITLE
tests: Enable paint-timing tests

### DIFF
--- a/paint-timing/fcp-only/fcp-document-opacity-image.html
+++ b/paint-timing/fcp-only/fcp-document-opacity-image.html
@@ -31,6 +31,7 @@ const change_opacity = () => {
 
 promise_test(async t => {
   assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+  assert_implements(window.LargestContentfulPaint, "Largest Contentful Paint isn't supported.");
   await load_image();
   await assertNoFirstContentfulPaint(t);
   change_opacity();

--- a/paint-timing/fcp-only/fcp-document-opacity-text.html
+++ b/paint-timing/fcp-only/fcp-document-opacity-text.html
@@ -23,6 +23,7 @@ const change_opacity = () => {
 
 promise_test(async t => {
   assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+  assert_implements(window.LargestContentfulPaint, "Largest Contentful Paint isn't supported.");
   await assertNoFirstContentfulPaint(t);
   change_opacity();
   await waitForAnimationFrames(3);


### PR DESCRIPTION
We have a implementation of PaintTiming , so we should run the tests associated with them.

Testing: New tests enabled.
Reviewed in servo/servo#42025