### PR TITLE
script: Fix render blocking stylesheet load fire ordering

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
+++ b/html/semantics/document-metadata/the-link-element/link-style-error-limited-quirks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//" "">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <title>link: error events in limited quirks mode</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
While adding various spec comments to the parts of `#the-end` (which are scattered throughout the script crate), I stumbled upon the render blocking stylesheets implementation. There was a HTML PR to make clear when it should run and the corresponding WPT tests have been fixed.

Fixes #<!-- nolink -->22715
Reviewed in servo/servo#41973