### PR TITLE
[ai LanguageModel] Update RegExp for image and audio content assertions

### DIFF
--- a/ai/language-model/language-model-prompt-multimodal.tentative.https.window.js
+++ b/ai/language-model/language-model-prompt-multimodal.tentative.https.window.js
@@ -6,7 +6,8 @@
 
 'use strict';
 
-const kPrompt = 'describe this';
+const kImagePrompt = 'describe this';
+const kAudioPrompt = 'transcribe this';
 const kValidImagePath = '/images/computer.jpg';
 const kValidAudioPath = '/media/speech.wav';
 const kValidSVGImagePath = '/images/pattern.svg';
@@ -34,7 +35,7 @@ promise_test(async t => {
   // TODO(crbug.com/409615288): Expect a TypeError according to the spec.
   return promise_rejects_dom(
       t, 'SyntaxError',
-      session.prompt(messageWithContent(kPrompt, 'text', newImage)));
+      session.prompt(messageWithContent(kImagePrompt, 'text', newImage)));
 }, 'Prompt with type:"text" and image content should reject');
 
 promise_test(async t => {
@@ -58,14 +59,14 @@ promise_test(async (t) => {
   const session = await createLanguageModel();
   return promise_rejects_dom(
       t, 'NotSupportedError',
-      session.prompt(messageWithContent(kPrompt, 'image', newImage)));
+      session.prompt(messageWithContent(kImagePrompt, 'image', newImage)));
 }, 'Prompt image without `image` expectedInput');
 
 promise_test(async () => {
   const blob = await (await fetch(kValidImagePath)).blob();
   const options = {
     expectedInputs: [{type: 'image'}],
-    initialPrompts: messageWithContent(kPrompt, 'image', blob)
+    initialPrompts: messageWithContent(kImagePrompt, 'image', blob)
   };
   await ensureLanguageModel(options);
   const session = await LanguageModel.create(options);
@@ -82,7 +83,7 @@ promise_test(async () => {
   const blob = await (await fetch(kValidImagePath)).blob();
   const session = await createLanguageModel(kImageOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', blob));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', blob));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with Blob image content');
 
@@ -92,7 +93,7 @@ promise_test(async () => {
   const bitmap = await createImageBitmap(blob);
   const session = await createLanguageModel(kImageOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', bitmap));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', bitmap));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ImageBitmap image content');
 
@@ -103,7 +104,7 @@ promise_test(async () => {
   const frame = new VideoFrame(bitmap, {timestamp: 1});
   const session = await createLanguageModel(kImageOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', frame));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', frame));
   frame.close();  // Avoid JS garbage collection warning.
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with VideoFrame image content');
@@ -116,7 +117,7 @@ promise_test(async () => {
   context.fillRect(10, 10, 200, 200);
   const session = await createLanguageModel(kImageOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', canvas));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', canvas));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with OffscreenCanvas image content');
 
@@ -124,7 +125,7 @@ promise_test(async () => {
   await ensureLanguageModel(kImageOptions);
   const session = await createLanguageModel(kImageOptions);
   const result = await session.prompt(
-      messageWithContent(kPrompt, 'image', new ImageData(256, 256)));
+      messageWithContent(kImagePrompt, 'image', new ImageData(256, 256)));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ImageData image content');
 
@@ -134,7 +135,7 @@ promise_test(async () => {
   newImage.src = kValidImagePath;
   const session = await createLanguageModel(kImageOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', newImage));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', newImage));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLImageElement image content');
 
@@ -145,7 +146,7 @@ promise_test(async () => {
   canvas.height = 768;
   const session = await createLanguageModel(kImageOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', canvas));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', canvas));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLCanvasElement image content');
 
@@ -154,7 +155,7 @@ promise_test(async () => {
   const imageData = await fetch(kValidImagePath);
   const session = await createLanguageModel(kImageOptions);
   const result = await session.prompt(
-      messageWithContent(kPrompt, 'image', await imageData.arrayBuffer()));
+      messageWithContent(kImagePrompt, 'image', await imageData.arrayBuffer()));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ArrayBuffer image content');
 
@@ -163,7 +164,7 @@ promise_test(async () => {
   const imageData = await fetch(kValidImagePath);
   const session = await createLanguageModel(kImageOptions);
   const result = await session.prompt(messageWithContent(
-      kPrompt, 'image', new DataView(await imageData.arrayBuffer())));
+      kImagePrompt, 'image', new DataView(await imageData.arrayBuffer())));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ArrayBufferView image content');
 
@@ -179,14 +180,14 @@ promise_test(async (t) => {
   imageView.set(bufferView);
 
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'image', imageView));
+      await session.prompt(messageWithContent(kImagePrompt, 'image', imageView));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 
   // Offset causes 56 bytes of blank data, resulting in a decoding error.
   await promise_rejects_dom(
       t, 'InvalidStateError',
       session.prompt(messageWithContent(
-          kPrompt, 'image',
+          kImagePrompt, 'image',
           new Uint8Array(newBufferArray, 200, buffer.byteLength))));
 }, 'Prompt with ArrayBufferView image content with an offset.');
 
@@ -198,7 +199,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(
-        kPrompt, 'image', newImage));
+        kImagePrompt, 'image', newImage));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLImageElement image content (with SVG)');
 
@@ -223,7 +224,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(
-        kPrompt, 'image', svgImage));
+        kImagePrompt, 'image', svgImage));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with SVGImageElement image content');
 
@@ -238,7 +239,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(
-        kPrompt, 'image', video));
+        kImagePrompt, 'image', video));
   assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLVideoElement image content');
 
@@ -252,14 +253,14 @@ promise_test(async (t) => {
   const session = await createLanguageModel();
   return promise_rejects_dom(
       t, 'NotSupportedError',
-      session.prompt(messageWithContent(kPrompt, 'audio', blob)));
+      session.prompt(messageWithContent(kImagePrompt, 'audio', blob)));
 }, 'Prompt audio without `audio` expectedInput');
 
 promise_test(async () => {
   const blob = await (await fetch(kValidAudioPath)).blob();
   const options = {
     expectedInputs: [{type: 'audio'}],
-    initialPrompts: messageWithContent(kPrompt, 'audio', blob)
+    initialPrompts: messageWithContent(kAudioPrompt, 'audio', blob)
   };
   await ensureLanguageModel(options);
   const session = await LanguageModel.create(options);
@@ -276,7 +277,7 @@ promise_test(async () => {
   const blob = await (await fetch(kValidAudioPath)).blob();
   const session = await createLanguageModel(kAudioOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'audio', blob));
+      await session.prompt(messageWithContent(kAudioPrompt, 'audio', blob));
   assert_regexp_match(result, /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Prompt with Blob audio content');
 
@@ -287,7 +288,7 @@ promise_test(async (t) => {
   // TODO(crbug.com/409615288): Expect a TypeError according to the spec.
   return promise_rejects_dom(
       t, 'DataError',
-      session.prompt(messageWithContent(kPrompt, 'audio', blob)));
+      session.prompt(messageWithContent(kImagePrompt, 'audio', blob)));
 }, 'Prompt audio with blob containing invalid audio data.');
 
 promise_test(async () => {
@@ -297,7 +298,7 @@ promise_test(async () => {
   const buffer = await audioCtx.decodeAudioData(await audio_data.arrayBuffer());
   const session = await createLanguageModel(kAudioOptions);
   const result =
-      await session.prompt(messageWithContent(kPrompt, 'audio', buffer));
+      await session.prompt(messageWithContent(kAudioPrompt, 'audio', buffer));
   assert_regexp_match(result, /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Prompt with AudioBuffer');
 
@@ -306,6 +307,6 @@ promise_test(async () => {
   const audio_data = await fetch(kValidAudioPath);
   const session = await createLanguageModel(kAudioOptions);
   const result = await session.prompt(
-      messageWithContent(kPrompt, 'audio', await audio_data.arrayBuffer()));
+      messageWithContent(kAudioPrompt, 'audio', await audio_data.arrayBuffer()));
   assert_regexp_match(result, /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Prompt with BufferSource - ArrayBuffer');

--- a/ai/language-model/language-model-prompt-multimodal.tentative.https.window.js
+++ b/ai/language-model/language-model-prompt-multimodal.tentative.https.window.js
@@ -74,7 +74,7 @@ promise_test(async () => {
   assert_equals(session.inputUsage, tokenLength);
   assert_regexp_match(
       await session.prompt([{role: 'system', content: ''}]),
-      /<image>/);
+      /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Test Image initialPrompt');
 
 promise_test(async () => {
@@ -83,7 +83,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', blob));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with Blob image content');
 
 promise_test(async () => {
@@ -93,7 +93,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', bitmap));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ImageBitmap image content');
 
 promise_test(async () => {
@@ -105,7 +105,7 @@ promise_test(async () => {
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', frame));
   frame.close();  // Avoid JS garbage collection warning.
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with VideoFrame image content');
 
 promise_test(async () => {
@@ -117,7 +117,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', canvas));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with OffscreenCanvas image content');
 
 promise_test(async () => {
@@ -125,7 +125,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result = await session.prompt(
       messageWithContent(kPrompt, 'image', new ImageData(256, 256)));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ImageData image content');
 
 promise_test(async () => {
@@ -135,7 +135,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', newImage));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLImageElement image content');
 
 promise_test(async () => {
@@ -146,7 +146,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', canvas));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLCanvasElement image content');
 
 promise_test(async () => {
@@ -155,7 +155,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result = await session.prompt(
       messageWithContent(kPrompt, 'image', await imageData.arrayBuffer()));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ArrayBuffer image content');
 
 promise_test(async () => {
@@ -164,7 +164,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kImageOptions);
   const result = await session.prompt(messageWithContent(
       kPrompt, 'image', new DataView(await imageData.arrayBuffer())));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with ArrayBufferView image content');
 
 promise_test(async (t) => {
@@ -180,7 +180,7 @@ promise_test(async (t) => {
 
   const result =
       await session.prompt(messageWithContent(kPrompt, 'image', imageView));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 
   // Offset causes 56 bytes of blank data, resulting in a decoding error.
   await promise_rejects_dom(
@@ -199,7 +199,7 @@ promise_test(async () => {
   const result =
       await session.prompt(messageWithContent(
         kPrompt, 'image', newImage));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLImageElement image content (with SVG)');
 
 
@@ -224,7 +224,7 @@ promise_test(async () => {
   const result =
       await session.prompt(messageWithContent(
         kPrompt, 'image', svgImage));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with SVGImageElement image content');
 
 promise_test(async () => {
@@ -239,7 +239,7 @@ promise_test(async () => {
   const result =
       await session.prompt(messageWithContent(
         kPrompt, 'image', video));
-  assert_regexp_match(result, /<image>/);
+  assert_regexp_match(result, /image|picture|photo/i /* Expect the model to describe the file like "This {image, picture, photo}…". */);
 }, 'Prompt with HTMLVideoElement image content');
 
 /*****************************************
@@ -268,7 +268,7 @@ promise_test(async () => {
   assert_equals(session.inputUsage, tokenLength);
   assert_regexp_match(
       await session.prompt([{role: 'system', content: ''}]),
-      /<audio>/);
+      /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Test Audio initialPrompt');
 
 promise_test(async () => {
@@ -277,7 +277,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kAudioOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'audio', blob));
-  assert_regexp_match(result, /<audio>/);
+  assert_regexp_match(result, /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Prompt with Blob audio content');
 
 promise_test(async (t) => {
@@ -298,7 +298,7 @@ promise_test(async () => {
   const session = await createLanguageModel(kAudioOptions);
   const result =
       await session.prompt(messageWithContent(kPrompt, 'audio', buffer));
-  assert_regexp_match(result, /<audio>/);
+  assert_regexp_match(result, /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Prompt with AudioBuffer');
 
 promise_test(async () => {
@@ -307,5 +307,5 @@ promise_test(async () => {
   const session = await createLanguageModel(kAudioOptions);
   const result = await session.prompt(
       messageWithContent(kPrompt, 'audio', await audio_data.arrayBuffer()));
-  assert_regexp_match(result, /<audio>/);
+  assert_regexp_match(result, /sentence/i /* Expect the model to transcribe the audio of "This is a sentence in a single segment". */);
 }, 'Prompt with BufferSource - ArrayBuffer');


### PR DESCRIPTION
The previous values assumed brackets `<` and `>` which didn't occur in the output.

CC: @foolip 

Fixes #57291