### PR TITLE
[ai LanguageModel] Make RegExp case insensitive in prompt assertions

### DIFF
--- a/ai/language-model/language-model-prompt.tentative.https.window.js
+++ b/ai/language-model/language-model-prompt.tentative.https.window.js
@@ -24,10 +24,10 @@ promise_test(async (t) => {
 promise_test(async (t) => {
   await ensureLanguageModel();
   const session = await createLanguageModel();
-  assert_regexp_match(await session.prompt('shorthand'), /shorthand/);
+  assert_regexp_match(await session.prompt('shorthand'), /shorthand/i);
   assert_regexp_match(
       await session.prompt([{role: 'system', content: 'shorthand'}]),
-      /shorthand/);
+      /shorthand/i);
 }, 'Check Shorthand');
 
 promise_test(async () => {
@@ -42,7 +42,7 @@ promise_test(async () => {
   assert_equals(session.inputUsage, tokenLength);
   assert_regexp_match(
       await session.prompt([{role: 'system', content: ''}]),
-      /regurgitation/);
+      /regurgitation/i);
 }, 'Test that initialPrompt counts towards session inputUsage');
 
 promise_test(async () => {


### PR DESCRIPTION
The model responds sometimes uppercase, sometimes lowercase

CC: @foolip 