### PR TITLE
Add 2ms overshoot to mainThreadBusy to account for timer precision rounding

### DIFF
--- a/event-timing/resources/event-timing-test-utils.js
+++ b/event-timing/resources/event-timing-test-utils.js
@@ -1,5 +1,14 @@
 function mainThreadBusy(ms) {
-  const target = performance.now() + ms;
+  // Add 2ms to ensure we block for *at least* the requested amount of time,
+  // even in the face of two forms of timer imprecision:
+  //
+  // (1) Firefox rounds performance.now() to 1ms for privacy protection against
+  // timing attacks (e.g., Spectre), which can cause the loop to exit up to 1ms
+  // early when timestamps round unfavorably.
+  // (2) Firefox also introduces "jitter" randomness to web-exposed timestamps,
+  // an anti-fingerprinting protection that may make performance.now() lie by
+  // up to 1ms (while still increasing monotonically).
+  const target = performance.now() + ms + 2;
   while (performance.now() < target);
 }
 


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/1247

Firefox rounds performance.now() to 1ms for privacy protection against timing attacks (e.g., Spectre), which can cause the busy-wait loop to exit up to 1ms early when timestamps round unfavorably. Additionally, Firefox introduces "jitter" randomness to web-exposed timestamps as an anti-fingerprinting protection, which may make performance.now() lie by up to 1ms (while still increasing monotonically).

Adding 2ms ensures the loop blocks for at least the requested amount of time, accounting for both forms of timer imprecision (up to 1ms each).

This fixes intermittent timeouts in event-timing/duration-with-target-low.html and other tests that rely on mainThreadBusy.

This is reviewed by @dholbert in [Phabricator](https://phabricator.services.mozilla.com/D280227)