### PR TITLE
Use 20px Ahem in WPT span-with-overflowing-text-and-box-decorations.html

### DIFF
--- a/css/css-view-transitions/span-with-overflowing-text-and-box-decorations-ref.html
+++ b/css/css-view-transitions/span-with-overflowing-text-and-box-decorations-ref.html
@@ -14,7 +14,7 @@ span {
 
 body {
   background: pink;
-  font: 12px/1 Ahem;
+  font: 20px/1 Ahem;
 }
 </style>
 

--- a/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
+++ b/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
@@ -5,13 +5,12 @@
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="span-with-overflowing-text-and-box-decorations-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-4900">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
 <style>
 :root {
-  font: 12px/1 Ahem;
+  font: 20px/1 Ahem;
 }
 
 span {

--- a/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
+++ b/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
@@ -5,6 +5,7 @@
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="span-with-overflowing-text-and-box-decorations-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-4900">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>


### PR DESCRIPTION
This helps avoid the need to do layout/painting at fractional pixel-positions, and it aligns with the recommendation "A minimum computed font-size of 20px is suggested" from https://web-platform-tests.org/writing-tests/ahem.html#usage

This patch also removes the test's fuzzy allowance, since it should no longer be needed after this change.

Fixes https://github.com/web-platform-tests/interop/issues/1248