### PR TITLE
Use Ahem font and less text in inline-with-offset-from-containing-block.html

### DIFF
--- a/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
@@ -4,7 +4,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-
 <style>
   :root {
     scrollbar-width: none;

--- a/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
@@ -3,7 +3,7 @@
 <title>View transitions: inline with offset from containing block (ref)</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
   :root {
     scrollbar-width: none;

--- a/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
@@ -3,10 +3,12 @@
 <title>View transitions: inline with offset from containing block (ref)</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 
 <style>
   :root {
     scrollbar-width: none;
+    font: 20px/1 Ahem;
   }
   .outer {
     transform: scale3d(2, 2, 1);

--- a/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
@@ -24,7 +24,7 @@
 </style>
 
 <div class="outer">
-  <a class="inner">Some text</a>
+  <a class="inner">A B</a>
 </div>
 
 

--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -4,10 +4,11 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="inline-with-offset-from-containing-block-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="fuzzy" content="maxDifference=0-112; totalPixels=0-464">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   :root {
     scrollbar-width: none;

--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -4,7 +4,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="inline-with-offset-from-containing-block-ref.html">
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1633">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
@@ -43,7 +42,7 @@
 </style>
 
 <div class="outer">
-  <a class="inner">Some text</a>
+  <a class="inner">A B</a>
 </div>
 
 <script>

--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -8,7 +8,7 @@
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
   :root {
     scrollbar-width: none;

--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -4,12 +4,14 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="inline-with-offset-from-containing-block-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
 <style>
   :root {
     scrollbar-width: none;
+    font: 20px/1 Ahem;
   }
   .outer {
     transform: scale(2);


### PR DESCRIPTION
This test has a huge fuzzy annotation (which dates back to when it was first checked into WPT); that's because there's some text that may get rasterized before being scaled up, which may result in some blurry pixels.

Let's reduce the amount of text and switch to the Ahem font.  This means there will be fewer blurry pixels; and that lets us use a lower fuzzy tolerance, which makes the test stricter.

Fixes https://github.com/web-platform-tests/interop/issues/1249