### PR TITLE
wdspec tests: Null "implicit wait" should not have timer

### DIFF
--- a/webdriver/tests/classic/find_element/find.py
+++ b/webdriver/tests/classic/find_element/find.py
@@ -121,8 +121,7 @@ def test_htmldocument(session, inline, using, value):
     assert_success(response)
 
 
-@pytest.mark.parametrize("value", [None, 1])
-def test_implicit_wait(session, inline, value):
+def test_implicit_wait(session, inline):
     session.url = inline("""
         <script>
             setTimeout(() => {
@@ -130,13 +129,27 @@ def test_implicit_wait(session, inline, value):
             }, 300);
         </script>
     """)
-    session.timeouts.implicit = value
+    session.timeouts.implicit = 1
 
     response = find_element(session, "css selector", "#delayed")
     value = assert_success(response)
 
     expected = session.execute_script("return document.getElementById('delayed')")
     assert_same_element(session, value, expected)
+
+
+def test_implicit_wait_none(session, inline):
+    session.url = inline("""
+        <script>
+            setTimeout(() => {
+                document.body.innerHTML = '<div id="delayed"></div>';
+            }, 300);
+        </script>
+    """)
+    session.timeouts.implicit = None
+
+    response = find_element(session, "css selector", "#delayed")
+    assert_error(response, "no such element")
 
 
 def test_implicit_wait_timeout(session, inline):

--- a/webdriver/tests/classic/find_element_from_element/find.py
+++ b/webdriver/tests/classic/find_element_from_element/find.py
@@ -179,8 +179,7 @@ def test_parent_of_document_node_errors(session, inline):
     assert_error(response, "invalid selector")
 
 
-@pytest.mark.parametrize("value", [None, 1])
-def test_implicit_wait(session, inline, value):
+def test_implicit_wait(session, inline):
     session.url = inline("""
         <div id="parent"></div>
         <script>
@@ -189,7 +188,7 @@ def test_implicit_wait(session, inline, value):
             }, 300);
         </script>
     """)
-    session.timeouts.implicit = value
+    session.timeouts.implicit = 1
 
     from_element = session.find.css("#parent", all=False)
     response = find_element(session, from_element.id, "css selector", "#delayed")
@@ -197,6 +196,22 @@ def test_implicit_wait(session, inline, value):
 
     expected = session.execute_script("return document.getElementById('delayed')")
     assert_same_element(session, value, expected)
+
+
+def test_implicit_wait_none(session, inline):
+    session.url = inline("""
+        <div id="parent"></div>
+        <script>
+            setTimeout(() => {
+                document.getElementById('parent').innerHTML = '<div id="delayed"></div>';
+            }, 300);
+        </script>
+    """)
+    session.timeouts.implicit = None
+
+    from_element = session.find.css("#parent", all=False)
+    response = find_element(session, from_element.id, "css selector", "#delayed")
+    assert_error(response, "no such element")
 
 
 def test_implicit_wait_timeout(session, inline):

--- a/webdriver/tests/classic/find_element_from_shadow_root/find.py
+++ b/webdriver/tests/classic/find_element_from_shadow_root/find.py
@@ -247,10 +247,9 @@ def test_find_element_in_nested_shadow_root(session, get_test_page, mode):
     assert element.text == expected_text
 
 
-@pytest.mark.parametrize("value", [None, 1])
-def test_implicit_wait_shadow_root(session, get_test_page, value):
+def test_implicit_wait_shadow_root(session, get_test_page):
     session.url = get_test_page()
-    session.timeouts.implicit = value
+    session.timeouts.implicit = 1
 
     session.execute_script("""
         setTimeout(() => {
@@ -269,6 +268,24 @@ def test_implicit_wait_shadow_root(session, get_test_page, value):
         return arguments[0].shadowRoot.getElementById('delayed')
     """, args=(session.find.css("custom-element", all=False),))
     assert_same_element(session, value, expected)
+
+
+def test_implicit_wait_none_shadow_root(session, get_test_page):
+    session.url = get_test_page()
+    session.timeouts.implicit = None
+
+    session.execute_script("""
+        setTimeout(() => {
+            const host = document.querySelector('custom-element');
+            const input = document.createElement('input');
+            input.id = 'delayed';
+            host.shadowRoot.appendChild(input);
+        }, 300);
+    """)
+
+    shadow_root = session.find.css("custom-element", all=False).shadow_root
+    response = find_element(session, shadow_root.id, "css selector", "#delayed")
+    assert_error(response, "no such element")
 
 
 def test_implicit_wait_timeout(session, get_test_page):

--- a/webdriver/tests/classic/find_elements/find.py
+++ b/webdriver/tests/classic/find_elements/find.py
@@ -141,8 +141,7 @@ def test_htmldocument(session, inline, using, value):
     assert len(value) == 1
 
 
-@pytest.mark.parametrize("value", [None, 1])
-def test_implicit_wait(session, inline, value):
+def test_implicit_wait(session, inline):
     session.url = inline(
         """
         <script>
@@ -152,7 +151,7 @@ def test_implicit_wait(session, inline, value):
         </script>
     """
     )
-    session.timeouts.implicit = value
+    session.timeouts.implicit = 1
 
     response = find_elements(session, "css selector", "#delayed")
     value = assert_success(response)
@@ -161,6 +160,24 @@ def test_implicit_wait(session, inline, value):
 
     element = WebElement.from_json(value[0], session)
     assert_same_element(session, element, expected)
+
+
+def test_implicit_wait_none(session, inline):
+    session.url = inline(
+        """
+        <script>
+            setTimeout(() => {
+                document.body.innerHTML = '<div id="delayed"></div>';
+            }, 300);
+        </script>
+    """
+    )
+    session.timeouts.implicit = None
+
+    response = find_elements(session, "css selector", "#delayed")
+    elements = assert_success(response)
+
+    assert len(elements) == 0
 
 
 def test_implicit_wait_timeout(session, inline):

--- a/webdriver/tests/classic/find_elements_from_element/find.py
+++ b/webdriver/tests/classic/find_elements_from_element/find.py
@@ -199,8 +199,7 @@ def test_parent_of_document_node_errors(session, inline):
     assert_error(response, "invalid selector")
 
 
-@pytest.mark.parametrize("value", [None, 1])
-def test_implicit_wait(session, inline, value):
+def test_implicit_wait(session, inline):
     session.url = inline(
         """
         <div id="parent"></div>
@@ -211,7 +210,7 @@ def test_implicit_wait(session, inline, value):
         </script>
     """
     )
-    session.timeouts.implicit = value
+    session.timeouts.implicit = 1
 
     from_element = session.find.css("#parent", all=False)
     response = find_elements(session, from_element.id, "css selector", "#delayed")
@@ -221,6 +220,27 @@ def test_implicit_wait(session, inline, value):
 
     element = WebElement.from_json(value[0], session)
     assert_same_element(session, element, expected)
+
+
+def test_implicit_wait_none(session, inline):
+    session.url = inline(
+        """
+        <div id="parent"></div>
+        <script>
+            setTimeout(() => {
+                document.getElementById('parent').innerHTML = '<div id="delayed"></div>';
+            }, 300);
+        </script>
+    """
+    )
+    session.timeouts.implicit = None
+
+    from_element = session.find.css("#parent", all=False)
+    response = find_elements(session, from_element.id, "css selector", "#delayed")
+
+    elements = assert_success(response)
+
+    assert len(elements) == 0
 
 
 def test_implicit_wait_timeout(session, inline):

--- a/webdriver/tests/classic/find_elements_from_shadow_root/find.py
+++ b/webdriver/tests/classic/find_elements_from_shadow_root/find.py
@@ -260,10 +260,9 @@ def test_find_elements_in_nested_shadow_root(
     assert element.text == expected_text
 
 
-@pytest.mark.parametrize("value", [None, 1])
-def test_implicit_wait_shadow_root(session, get_test_page, value):
+def test_implicit_wait_shadow_root(session, get_test_page):
     session.url = get_test_page()
-    session.timeouts.implicit = value
+    session.timeouts.implicit = 1
 
     session.execute_script(
         """
@@ -291,6 +290,28 @@ def test_implicit_wait_shadow_root(session, get_test_page, value):
 
     element = WebElement.from_json(value[0], session)
     assert_same_element(session, element, expected)
+
+
+def test_implicit_wait_none_shadow_root(session, get_test_page):
+    session.url = get_test_page()
+    session.timeouts.implicit = None
+
+    session.execute_script(
+        """
+        setTimeout(() => {
+            const host = document.querySelector('custom-element');
+            const input = document.createElement('input');
+            input.id = 'delayed';
+            host.shadowRoot.appendChild(input);
+        }, 300);
+    """
+    )
+
+    shadow_root = session.find.css("custom-element", all=False).shadow_root
+    response = find_elements(session, shadow_root.id, "css selector", "#delayed")
+
+    elements = assert_success(response)
+    assert len(elements) == 0
 
 
 def test_implicit_wait_timeout(session, get_test_page):


### PR DESCRIPTION
When implicit wait is `None`, we should not wait at all: https://github.com/web-platform-tests/wpt/pull/57151#discussion_r2727033236

See step 5 of https://w3c.github.io/webdriver/#dfn-find
Reviewed in servo/servo#42158