### PR TITLE
Support running specific binaries in Taskcluster CI

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -10,8 +10,8 @@ import subprocess
 import sys
 
 
-def get_browser_args(product, channel, artifact_path):
-    if product == "firefox":
+def get_browser_args(product, channel, artifact_path, wpt_args):
+    if product == "firefox" and not any(item.startswith("--install-browser") for item in wpt_args):
         local_binary = os.path.expanduser(os.path.join("~", "build", "firefox", "firefox"))
         if os.path.exists(local_binary):
             return ["--binary=%s" % local_binary]
@@ -85,7 +85,7 @@ def main(product, channel, commit_range, artifact_path, wpt_args):
     # Enable headless mode for WPE MiniBrowser and Servo because they do not work under Xvfb/X11 (needs Wayland)
     wpt_args.append("--headless" if product in ("wpewebkit_minibrowser", "servo") else "--no-headless")
 
-    wpt_args += get_browser_args(product, channel, artifact_path)
+    wpt_args += get_browser_args(product, channel, artifact_path, wpt_args)
 
     wpt_args.append(product)
 

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -84,11 +84,14 @@ def get_run_jobs(event):
 def get_commit_message(event: Mapping[str, Any]) -> Optional[str]:
     body = None
     if "commits" in event and event["commits"]:
+        logger.debug("Getting commit body from commits")
         body = event["commits"][0]["message"]
     elif "pull_request" in event:
+        logger.debug("Getting commit body from pull request")
         body = event["pull_request"]["body"]
     if body is not None:
         assert isinstance(body, str)
+    logger.info(f"Got commit body:\n{body}")
     return body
 
 
@@ -239,6 +242,7 @@ def build_full_command(event, task):
                 if m:
                     commit_args.append(m.group(1).strip())
             cmd_args["commit_args"] = " ".join(commit_args)
+            logger.debug(f"Got extra args {cmd_args['commit_args']} for {task['name']}")
 
     return ["/bin/bash",
             "--login",

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -83,9 +83,9 @@ def get_run_jobs(event):
 
 def get_commit_message(event: Mapping[str, Any]) -> Optional[str]:
     body = None
-    if "commits" in event and event["commits"]:
+    if "head_commit" in event:
         logger.debug("Getting commit body from commits")
-        body = event["commits"][0]["message"]
+        body = event["head_commit"]["message"]
     elif "pull_request" in event:
         logger.debug("Getting commit body from pull request")
         body = event["pull_request"]["body"]

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -428,7 +428,17 @@ def get_parser():
 
 
 def run(venv, **kwargs):
-    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+    if "TASKCLUSTER_PROXY_URL" in os.environ:
+        queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+    elif kwargs["dry_run"]:
+        if "event_path" not in kwargs:
+            logger.error("Missing --event-path for dry run")
+            return 1
+        queue = None
+    else:
+        logger.error("Missing --dry-run and TASKCLUSTER_PROXY_URL")
+        return 1
+
     event = get_event(queue, event_path=kwargs["event_path"])
 
     task_id_map = decide(event)

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+from typing import Optional
 
 import argparse
 import json
@@ -7,6 +8,7 @@ import os
 import re
 import subprocess
 from collections import OrderedDict
+from typing import Any, Mapping
 
 import taskcluster
 
@@ -79,13 +81,20 @@ def get_run_jobs(event):
     return all_jobs
 
 
-def get_extra_jobs(event):
+def get_commit_message(event: Mapping[str, Any]) -> Optional[str]:
     body = None
-    jobs = set()
     if "commits" in event and event["commits"]:
         body = event["commits"][0]["message"]
     elif "pull_request" in event:
         body = event["pull_request"]["body"]
+    if body is not None:
+        assert isinstance(body, str)
+    return body
+
+
+def get_extra_jobs(event):
+    jobs = set()
+    body = get_commit_message(event)
 
     if not body:
         return jobs
@@ -182,6 +191,7 @@ def build_full_command(event, task):
         "fetch_ref": fetch_ref,
         "task_cmd": task["command"],
         "install_str": "",
+        "commit_args": ""
     }
 
     options = task.get("options", {})
@@ -218,6 +228,18 @@ def build_full_command(event, task):
                              for item in install_packages)
         cmd_args["install_str"] = "\n".join("sudo %s;" % item for item in install_items)
 
+    commit_args_name = task.get("commit-args-name")
+    if commit_args_name:
+        body = get_commit_message(event)
+        if body:
+            regexp = re.compile(r"\s*" + commit_args_name + r":(.*)$")
+            commit_args = []
+            for line in body.splitlines():
+                m = regexp.match(line)
+                if m:
+                    commit_args.append(m.group(1).strip())
+            cmd_args["commit_args"] = " ".join(commit_args)
+
     return ["/bin/bash",
             "--login",
             "-xc",
@@ -227,7 +249,7 @@ def build_full_command(event, task):
   %(fetch_ref)s;
 %(install_str)s
 cd web-platform-tests;
-./wpt tc-run %(options_str)s -- %(task_cmd)s;
+./wpt tc-run %(options_str)s -- %(task_cmd)s %(commit_args)s;
 """ % cmd_args]
 
 

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-from typing import Optional
 
 import argparse
 import json
@@ -8,11 +7,12 @@ import os
 import re
 import subprocess
 from collections import OrderedDict
-from typing import Any, Mapping
+from typing import Any, List, Mapping, MutableMapping, Optional, Tuple, Set
 
 import taskcluster
 
 from . import taskgraph
+from tools.wpt import virtualenv
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -21,8 +21,12 @@ here = os.path.abspath(os.path.dirname(__file__))
 logging.basicConfig()
 logger = logging.getLogger()
 
+Event = Mapping[str, Any]
+Task = Mapping[str, Any]
+TcTask = Mapping[str, Any]
 
-def get_triggers(event):
+
+def get_triggers(event: Event) -> Tuple[bool, Optional[str]]:
     # Set some variables that we use to get the commits on the current branch
     ref_prefix = "refs/heads/"
     is_pr = "pull_request" in event
@@ -35,7 +39,7 @@ def get_triggers(event):
     return is_pr, branch
 
 
-def fetch_event_data(queue):
+def fetch_event_data(queue: taskcluster.Queue) -> Optional[str]:
     try:
         task_id = os.environ["TASK_ID"]
     except KeyError:
@@ -45,10 +49,11 @@ def fetch_event_data(queue):
 
     task_data = queue.task(task_id)
 
-    return task_data.get("extra", {}).get("github_event")
+    event: str = task_data.get("extra", {}).get("github_event")
+    return event
 
 
-def filter_triggers(event, all_tasks):
+def filter_triggers(event: Event, all_tasks: Mapping[str, Task]) -> MutableMapping[str, Task]:
     is_pr, branch = get_triggers(event)
     triggered = OrderedDict()
     for name, task in all_tasks.items():
@@ -64,7 +69,7 @@ def filter_triggers(event, all_tasks):
     return triggered
 
 
-def get_run_jobs(event):
+def get_run_jobs(event: Event) -> Set[str]:
     from tools.ci import jobs
     revish = "%s..%s" % (event["pull_request"]["base"]["sha"]
                          if "pull_request" in event
@@ -73,9 +78,9 @@ def get_run_jobs(event):
                          if "pull_request" in event
                          else event["after"])
     logger.info("Looking for changes in range %s" % revish)
-    paths = jobs.get_paths(revish=revish)
+    paths: Set[str] = jobs.get_paths(revish=revish)  # type: ignore
     logger.info("Found changes in paths:%s" % "\n".join(paths))
-    path_jobs = jobs.get_jobs(paths)
+    path_jobs: Set[str] = jobs.get_jobs(paths)  # type: ignore
     all_jobs = path_jobs | get_extra_jobs(event)
     logger.info("Including jobs:\n * %s" % "\n * ".join(all_jobs))
     return all_jobs
@@ -95,8 +100,8 @@ def get_commit_message(event: Mapping[str, Any]) -> Optional[str]:
     return body
 
 
-def get_extra_jobs(event):
-    jobs = set()
+def get_extra_jobs(event: Event) -> Set[str]:
+    jobs: Set[str] = set()
     body = get_commit_message(event)
 
     if not body:
@@ -114,7 +119,7 @@ def get_extra_jobs(event):
     return jobs
 
 
-def filter_excluded_users(tasks, event):
+def filter_excluded_users(tasks: MutableMapping[str, Task], event: Event) -> None:
     # Some users' pull requests are excluded from tasks,
     # such as pull requests from automated exports.
     try:
@@ -139,7 +144,7 @@ def filter_excluded_users(tasks, event):
         )
 
 
-def filter_schedule_if(event, tasks):
+def filter_schedule_if(event: Event, tasks: Mapping[str, Task]) -> MutableMapping[str, Task]:
     scheduled = OrderedDict()
     run_jobs = None
     for name, task in tasks.items():
@@ -155,11 +160,11 @@ def filter_schedule_if(event, tasks):
     return scheduled
 
 
-def get_fetch_rev(event):
+def get_fetch_rev(event: Event) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     is_pr, _ = get_triggers(event)
     if is_pr:
         # Try to get the actual rev so that all non-decision tasks are pinned to that
-        rv = ["refs/pull/%s/merge" % event["pull_request"]["number"]]
+        refs: List[Optional[str]] = ["refs/pull/%s/merge" % event["pull_request"]["number"]]
         # For every PR GitHub maintains a 'head' branch with commits from the
         # PR, and a 'merge' branch containing a merge commit between the base
         # branch and the PR.
@@ -177,8 +182,8 @@ def get_fetch_rev(event):
                     logger.error("Failed to get commit for %s" % ref)
                 else:
                     sha = output.decode("utf-8").split()[0]
-            rv.append(sha)
-        rv = tuple(rv)
+            refs.append(sha)
+        rv = tuple(refs)
     else:
         # For a branch push we have a ref and a head but no merge SHA
         rv = (event["ref"], event["after"], None)
@@ -186,7 +191,7 @@ def get_fetch_rev(event):
     return rv
 
 
-def build_full_command(event, task):
+def build_full_command(event: Event, task: Task) -> List[str]:
     fetch_ref, head_sha, merge_sha = get_fetch_rev(event)
     cmd_args = {
         "task_name": task["name"],
@@ -257,15 +262,19 @@ cd web-platform-tests;
 """ % cmd_args]
 
 
-def get_owner(event):
+def get_owner(event: Event) -> str:
     if "pusher" in event:
-        pusher = event.get("pusher", {}).get("email", "")
+        pusher: str = event.get("pusher", {}).get("email", "")
         if pusher and "@" in pusher:
             return pusher
     return "web-platform-tests@users.noreply.github.com"
 
 
-def create_tc_task(event, task, taskgroup_id, depends_on_ids, env_extra=None):
+def create_tc_task(event: Event,
+                   task: Task,
+                   taskgroup_id: str,
+                   depends_on_ids: List[str],
+                   env_extra: Optional[Mapping[str, str]] = None) -> Tuple[str, TcTask]:
     command = build_full_command(event, task)
     task_id = taskcluster.slugId()
     task_data = {
@@ -308,7 +317,8 @@ def create_tc_task(event, task, taskgroup_id, depends_on_ids, env_extra=None):
     return task_id, task_data
 
 
-def get_artifact_data(artifact, task_id_map):
+def get_artifact_data(artifact: Mapping[str, Any],
+                      task_id_map: Mapping[str, Tuple[str, Mapping[str, Any]]]) -> Mapping[str, Any]:
     task_id, data = task_id_map[artifact["task"]]
     return {
         "task": task_id,
@@ -318,12 +328,13 @@ def get_artifact_data(artifact, task_id_map):
     }
 
 
-def build_task_graph(event, all_tasks, tasks):
-    task_id_map = OrderedDict()
+def build_task_graph(event: Event,
+                     all_tasks: Mapping[str, Task], tasks: Mapping[str, Task]) -> Mapping[str, Tuple[str, TcTask]]:
+    task_id_map: MutableMapping[str, Tuple[str, TcTask]] = OrderedDict()
     taskgroup_id = os.environ.get("TASK_ID", taskcluster.slugId())
     sink_task_depends_on = []
 
-    def add_task(task_name, task):
+    def add_task(task_name: str, task: Task) -> None:
         depends_on_ids = []
         if "depends-on" in task:
             for depends_name in task["depends-on"]:
@@ -358,7 +369,7 @@ def build_task_graph(event, all_tasks, tasks):
     # To work around this we declare a sink task that depends on all the other
     # tasks completing, and checks if they have succeeded. We can then
     # make the sink task the sole required task for pull requests.
-    sink_task = tasks.get("sink-task")
+    sink_task = {**tasks.get("sink-task", {})}
     if sink_task:
         logger.info("Scheduling sink-task")
         sink_task["command"] += " {}".format(" ".join(sink_task_depends_on))
@@ -370,8 +381,8 @@ def build_task_graph(event, all_tasks, tasks):
     return task_id_map
 
 
-def create_tasks(queue, task_id_map):
-    for (task_id, task_data) in task_id_map.values():
+def create_tasks(queue: taskcluster.Queue, task_id_map: Mapping[str, Tuple[str, TcTask]]) -> None:
+    for task_id, task_data in task_id_map.values():
         try:
             queue.createTask(task_id, task_data)
         except Exception:
@@ -379,11 +390,11 @@ def create_tasks(queue, task_id_map):
             raise
 
 
-def get_event(queue, event_path):
+def get_event(queue: Optional[taskcluster.Queue], event_path: Optional[str]) -> Event:
     if event_path is not None:
         try:
             with open(event_path) as f:
-                event_str = f.read()
+                event_str: Optional[str] = f.read()
         except OSError:
             logger.error("Missing event file at path %s" % event_path)
             raise
@@ -391,17 +402,18 @@ def get_event(queue, event_path):
         event_str = os.environ["TASK_EVENT"]
     else:
         event_str = fetch_event_data(queue)
-    if not event_str:
+    if event_str is None:
         raise ValueError("Can't find GitHub event definition; for local testing pass --event-path")
     try:
-        return json.loads(event_str)
+        event: Event = json.loads(event_str)
+        return event
     except ValueError:
         logger.error("Event was not valid JSON")
         raise
 
 
-def decide(event):
-    all_tasks = taskgraph.load_tasks_from_path(os.path.join(here, "tasks", "test.yml"))
+def decide(event: Event) -> Mapping[str, Tuple[str, TcTask]]:
+    all_tasks = taskgraph.load_tasks_from_path(os.path.join(here, "tasks", "test.yml"))  # type: ignore
 
     triggered_tasks = filter_triggers(event, all_tasks)
     scheduled_tasks = filter_schedule_if(event, triggered_tasks)
@@ -415,7 +427,7 @@ def decide(event):
     return task_id_map
 
 
-def get_parser():
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event-path",
                         help="Path to file containing serialized GitHub event")
@@ -427,11 +439,14 @@ def get_parser():
     return parser
 
 
-def run(venv, **kwargs):
+def run(venv: virtualenv.Virtualenv,
+        event_path: Optional[str] = None,
+        dry_run: Optional[bool] = None,
+        tasks_path: Optional[str] = None) -> Optional[int]:
     if "TASKCLUSTER_PROXY_URL" in os.environ:
         queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
-    elif kwargs["dry_run"]:
-        if "event_path" not in kwargs:
+    elif dry_run:
+        if event_path is None:
             logger.error("Missing --event-path for dry run")
             return 1
         queue = None
@@ -439,16 +454,17 @@ def run(venv, **kwargs):
         logger.error("Missing --dry-run and TASKCLUSTER_PROXY_URL")
         return 1
 
-    event = get_event(queue, event_path=kwargs["event_path"])
+    event = get_event(queue, event_path)
 
     task_id_map = decide(event)
 
     try:
-        if not kwargs["dry_run"]:
+        if not dry_run:
             create_tasks(queue, task_id_map)
         else:
             print(json.dumps(task_id_map, indent=2))
     finally:
-        if kwargs["tasks_path"]:
-            with open(kwargs["tasks_path"], "w") as f:
+        if tasks_path is not None:
+            with open(tasks_path, "w") as f:
                 json.dump(task_id_map, f, indent=2)
+    return None

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -54,6 +54,7 @@ components:
       browser:
         - ${vars.browser}
       channel: ${vars.channel}
+    commit-args-name: wpt-args
     command: >-
       ./tools/ci/taskcluster-run.py
       ${vars.browser}

--- a/tools/ci/tc/tests/test_decision.py
+++ b/tools/ci/tc/tests/test_decision.py
@@ -36,7 +36,7 @@ def test_filter_schedule_if(run_jobs, tasks, expected):
     ("", set()),
     ("tc-jobs:foo\ntc-jobs:bar", {"foo"})])
 @pytest.mark.parametrize("event", [
-    {"commits": [{"message": "<message>"}]},
+    {"head_commit": {"message": "<message>"}},
     {"pull_request": {"body": "<message>"}}
 ])
 def test_extra_jobs_pr(msg, expected, event):

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -136,6 +136,37 @@ def test_verify_payload():
                 raise e
 
 
+def update_event_commit_args(event):
+    event["pull_request"]["body"] += "\ntest-args: --test1\ntest-args:--test2=value\nother-args:--other"
+
+
+@pytest.mark.parametrize("event_path,event_update,task,expected", [
+    ("pr_event.json", None, {"name": "test-task", "command": "test"},"""
+~/start.sh   https://github.com/web-platform-tests/wpt.git   fetch_ref;
+
+cd web-platform-tests;
+./wpt tc-run --ref=fetch_ref --no-hosts -- test ;
+"""),
+    ("pr_event.json",
+     update_event_commit_args,
+     {"name": "test-task", "command": "test", "commit-args-name": "test-args"},"""
+~/start.sh   https://github.com/web-platform-tests/wpt.git   fetch_ref;
+
+cd web-platform-tests;
+./wpt tc-run --ref=fetch_ref --no-hosts -- test --test1 --test2=value;
+""")
+])
+def test_command(event_path, event_update, task, expected):
+    with mock.patch("tools.ci.tc.decision.get_fetch_rev", return_value=("fetch_ref", None, None)):
+        with open(data_path(event_path), encoding="utf8") as event_file:
+            event = json.load(event_file)
+            if event_update is not None:
+                event_update(event)
+            command = decision.build_full_command(event, task)
+            full_expected = ['/bin/bash', '--login', '-xc', expected]
+            assert command == full_expected
+
+
 @pytest.mark.parametrize("event_path,is_pr,files_changed,expected", [
     ("master_push_event.json", False, None,
      ['download-firefox-nightly',

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -141,23 +141,25 @@ class Browser:
 
         return output_path
 
-    def download(self, dest=None, channel=None, rename=None):
+    def download(self, dest=None, channel=None, rename=None, url=None):
         """Download a package or installer for the browser
         :param dest: Directory in which to put the dowloaded package
         :param channel: Browser channel to download
         :param rename: Optional name for the downloaded package; the original
                        extension is preserved.
+        :param url: Optional URL to download the browser from
         :return: The path to the downloaded package/installer
         """
         raise NotImplementedError
 
-    def install(self, dest=None, channel=None):
+    def install(self, dest=None, channel=None, url=None):
         """Download and install the browser.
 
         This method usually calls download().
 
         :param dest: Directory in which to install the browser
         :param channel: Browser channel to install
+        :param url: Optional URL to download the browser from
         :return: The path to the installed browser
         """
         raise NotImplementedError
@@ -459,33 +461,34 @@ class Firefox(Browser):
 
         return "%s%s" % (self.platform, bits)
 
-    def download(self, dest=None, channel="nightly", rename=None):
-        product = {
-            "nightly": "firefox-nightly-latest-ssl",
-            "beta": "firefox-beta-latest-ssl",
-            "stable": "firefox-latest-ssl"
-        }
+    def download(self, dest=None, channel="nightly", rename=None, url=None):
+        if url is None:
+            product = {
+                "nightly": "firefox-nightly-latest-ssl",
+                "beta": "firefox-beta-latest-ssl",
+                "stable": "firefox-latest-ssl"
+            }
 
-        os_builds = {
-            ("linux", "x86"): "linux",
-            ("linux", "x86_64"): "linux64",
-            ("win", "x86"): "win",
-            ("win", "AMD64"): "win64",
-            ("macos", "x86_64"): "osx",
-            ("macos", "arm64"): "osx",
-        }
-        os_key = (self.platform, uname[4])
+            os_builds = {
+                ("linux", "x86"): "linux",
+                ("linux", "x86_64"): "linux64",
+                ("win", "x86"): "win",
+                ("win", "AMD64"): "win64",
+                ("macos", "x86_64"): "osx",
+                ("macos", "arm64"): "osx",
+            }
+            os_key = (self.platform, uname[4])
 
-        dest = self._get_browser_download_dir(dest, channel)
+            dest = self._get_browser_download_dir(dest, channel)
 
-        if channel not in product:
-            raise ValueError("Unrecognised release channel: %s" % channel)
+            if channel not in product:
+                raise ValueError("Unrecognised release channel: %s" % channel)
 
-        if os_key not in os_builds:
-            raise ValueError("Unsupported platform: %s %s" % os_key)
+            if os_key not in os_builds:
+                raise ValueError("Unsupported platform: %s %s" % os_key)
 
-        url = "https://download.mozilla.org/?product=%s&os=%s&lang=en-US" % (product[channel],
-                                                                             os_builds[os_key])
+            url = "https://download.mozilla.org/?product=%s&os=%s&lang=en-US" % (product[channel],
+                                                                                 os_builds[os_key])
         self.logger.info("Downloading Firefox from %s" % url)
         resp = get(url)
 
@@ -501,7 +504,7 @@ class Firefox(Browser):
 
         return installer_path
 
-    def install(self, dest=None, channel="nightly"):
+    def install(self, dest=None, channel="nightly", url=None):
         """Install Firefox."""
         import mozinstall
 
@@ -509,7 +512,7 @@ class Firefox(Browser):
 
         filename = os.path.basename(dest)
 
-        installer_path = self.download(dest, channel)
+        installer_path = self.download(dest, channel, rename=None, url=url)
 
         try:
             mozinstall.install(installer_path, dest)
@@ -685,19 +688,22 @@ class FirefoxAndroid(Browser):
         self.apk_path = None
         self._fx_browser = Firefox(self.logger)
 
-    def download(self, dest=None, channel=None, rename=None):
-        if dest is None:
-            dest = os.pwd
+    def download(self, dest=None, channel=None, rename=None, url=None):
+        if url is None:
+            if dest is None:
+                dest = os.pwd
 
-        branches = {
-            "stable": "mozilla-release",
-            "beta": "mozilla-beta",
-        }
-        branch = branches.get(channel, "mozilla-central")
+            branches = {
+                "stable": "mozilla-release",
+                "beta": "mozilla-beta",
+            }
+            branch = branches.get(channel, "mozilla-central")
 
-        resp = get_taskcluster_artifact(
-            f"gecko.v2.{branch}.shippable.latest.mobile.android-x86_64-opt",
-            "public/build/geckoview-test_runner.apk")
+            resp = get_taskcluster_artifact(
+                f"gecko.v2.{branch}.shippable.latest.mobile.android-x86_64-opt",
+                "public/build/geckoview-test_runner.apk")
+        else:
+            resp = get(url)
 
         filename = "geckoview-test_runner.apk"
         if rename:
@@ -709,8 +715,8 @@ class FirefoxAndroid(Browser):
 
         return self.apk_path
 
-    def install(self, dest=None, channel=None):
-        return self.download(dest, channel)
+    def install(self, dest=None, channel=None, url=None):
+        return self.download(dest, channel, url)
 
     def install_prefs(self, binary, dest=None, channel=None):
         return FirefoxAndroidPrefs(self.logger).install_prefs(binary, dest, channel)
@@ -1008,7 +1014,9 @@ class Chromium(ChromeChromiumBase):
 
         return self._build_snapshots_url(revision, filename)
 
-    def download(self, dest=None, channel=None, rename=None, version=None, revision=None):
+    def download(self, dest=None, channel=None, rename=None, version=None, revision=None, url=None):
+        if url is not None:
+            raise ValueError("--install-browser-url not supported")
         dest = self._get_browser_download_dir(dest, channel)
 
         filename = f"{self._chromium_package_name}.zip"
@@ -1036,7 +1044,9 @@ class Chromium(ChromeChromiumBase):
     def find_binary(self, venv_path=None, channel=None):
         return self._find_binary_in_directory(self._get_browser_binary_dir(venv_path, channel))
 
-    def install(self, dest=None, channel=None, version=None, revision=None):
+    def install(self, dest=None, channel=None, version=None, revision=None, url=None):
+        if url is not None:
+            raise ValueError("--install-browser-url not supported")
         dest = self._get_browser_binary_dir(dest, channel)
         installer_path = self.download(dest, channel, version=version, revision=revision)
         with open(installer_path, "rb") as f:
@@ -1334,10 +1344,13 @@ class Chrome(ChromeChromiumBase):
         with open(os.path.join(dest, CHROMEDRIVER_SAVED_DOWNLOAD_FILE), "w") as f:
             f.write(url)
 
-    def download(self, dest=None, channel="canary", rename=None, version=None):
+    def download(self, dest=None, channel="canary", rename=None, version=None, url=None):
         """Download Chrome for Testing. For more information,
         see: https://github.com/GoogleChromeLabs/chrome-for-testing
         """
+        if url is not None:
+            raise ValueError("--install-browser-url not supported")
+
         dest = self._get_browser_binary_dir(None, channel)
         filename = f"{self._chrome_package_name}.zip"
 
@@ -1408,7 +1421,9 @@ class Chrome(ChromeChromiumBase):
         self.logger.warning("Unable to find the browser binary.")
         return None
 
-    def install(self, dest=None, channel=None, version=None):
+    def install(self, dest=None, channel=None, version=None, url=None):
+        if url is not None:
+            raise ValueError("--install-browser-url not supported")
         dest = self._get_browser_binary_dir(dest, channel)
         installer_path = self.download(dest=dest, channel=channel, version=version)
         with open(installer_path, "rb") as f:
@@ -1552,7 +1567,7 @@ class HeadlessShell(ChromeChromiumBase):
     product = "headless_shell"
     requirements = None
 
-    def download(self, dest=None, channel=None, rename=None):
+    def download(self, dest=None, channel=None, rename=None, url=None):
         # TODO(crbug.com/344669542): Download binaries via CfT.
         raise NotImplementedError
 
@@ -1794,7 +1809,7 @@ class Edge(Browser):
             self.logger.info(f"Removing existing MSEdgeDriver binary: {existing_driver_notes_path}")
             rmtree(existing_driver_notes_path)
 
-    def download(self, dest=None, channel=None, rename=None):
+    def download(self, dest=None, channel=None, rename=None, url=None):
         raise NotImplementedError
 
     def install_mojojs(self, dest, browser_binary):
@@ -2164,7 +2179,7 @@ class Safari(Browser):
 
         return dest_path
 
-    def download(self, dest=None, channel="preview", rename=None, system_version=None):
+    def download(self, dest=None, channel="preview", rename=None, system_version=None, url=None):
         if channel != "preview":
             raise ValueError(f"can only install 'preview', not '{channel}'")
 
@@ -2176,7 +2191,7 @@ class Safari(Browser):
             image_path = self._download_image(stp_downloads, tmpdir, system_version)
             return self._download_extract(image_path, dest, rename)
 
-    def install(self, dest=None, channel=None):
+    def install(self, dest=None, channel=None, url=None):
         # We can't do this because stable/beta releases are system components and STP
         # requires admin permissions to install.
         raise NotImplementedError
@@ -2241,25 +2256,31 @@ class Servo(Browser):
         artifact = f"{filename}{extension}"
         return get(f"https://download.servo.org/nightly/{platform}/{artifact}")
 
-    def download(self, dest=None, channel="nightly", rename=None):
+    def download(self, dest=None, channel="nightly", rename=None, url=None):
         if dest is None:
             dest = os.pwd
 
-        resp = self._get(dest, channel)
+        if url is None:
+            resp = self._get(channel)
+        else:
+            resp = get(url)
         _, default_filename, extension, _ = self.platform_components()
 
         filename = rename if rename is not None else default_filename
         with open(os.path.join(dest, "%s%s" % (filename, extension,)), "w") as f:
             f.write(resp.content)
 
-    def install(self, dest=None, channel="nightly"):
+    def install(self, dest=None, channel="nightly", url=None):
         """Install latest Browser Engine."""
         if dest is None:
             dest = os.pwd
 
         _, _, _, decompress = self.platform_components()
 
-        resp = self._get(channel)
+        if url is None:
+            resp = self._get(channel)
+        else:
+            resp = get(url)
         decompress(resp.raw, dest=dest)
         path = which("servoshell", path=os.path.join(dest, "servo"))
         st = os.stat(path)
@@ -2296,6 +2317,7 @@ class WebKit(Browser):
 
     product = "webkit"
     requirements = None
+
 
 class Ladybird(Browser):
     product = "ladybird"
@@ -2381,8 +2403,11 @@ class WebKitTestRunner(Browser):
         }
 
     def download(
-        self, dest=None, channel="main", rename=None, version=None, revision=None
+        self, dest=None, channel="main", rename=None, version=None, revision=None, url=None
     ):
+        if url is not None:
+            raise ValueError("--install-browser-url not supported")
+
         if platform.system() == "Darwin":
             meta = self._download_metadata_apple_port(channel)
         else:
@@ -2403,9 +2428,9 @@ class WebKitTestRunner(Browser):
 
         return output_path
 
-    def install(self, dest=None, channel="main"):
+    def install(self, dest=None, channel="main", url=None):
         dest = self._get_browser_binary_dir(dest, channel)
-        installer_path = self.download(dest=dest, channel=channel)
+        installer_path = self.download(dest=dest, channel=channel, url=url)
         self.logger.info(f"Extracting to {dest}")
         with open(installer_path, "rb") as f:
             unzip(f, dest)
@@ -2444,7 +2469,9 @@ class WebKitGlibBaseMiniBrowser(WebKit):
                 raise NotImplementedError('subclass "%s" should define class variable "%s"' % (self.__class__.__name__, required_class_var))
         return super().__init__(*args, **kwargs)
 
-    def download(self, dest=None, channel=None, rename=None):
+    def download(self, dest=None, channel=None, rename=None, url=None):
+        if url is not None:
+            raise ValueError("--install-browser-url not supported")
         base_download_dir = self.BASE_DOWNLOAD_URI + platform.machine() + "/release/" + channel + "/MiniBrowser/"
         try:
             response = get(base_download_dir + "LAST-IS")
@@ -2475,9 +2502,9 @@ class WebKitGlibBaseMiniBrowser(WebKit):
             raise RuntimeError("The %s MiniBrowser bundle at %s has incorrect SHA256 hash." % (self.PORT_PRETTY_NAME, bundle_file_path))
         return bundle_file_path
 
-    def install(self, dest=None, channel=None, prompt=True):
+    def install(self, dest=None, channel=None, url=None):
         dest = self._get_browser_binary_dir(dest, channel)
-        bundle_path = self.download(dest, channel)
+        bundle_path = self.download(dest, channel, url)
         bundle_uncompress_directory = os.path.join(dest, self.product)
 
         # Clean it from previous runs

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -262,10 +262,18 @@ class FirefoxPrefs:
         # directory listings. So we have to hardcode in all the files we need. In particular
         # for each profile we are currently just downloading the user.js file and ignoring the
         # extensions/ directory, which is currently unused.
-        ref = self.get_git_ref(version, channel, rev)
-        self.logger.info(f"Getting profile data from git ref {ref}")
+        refs = self.get_git_refs(version, channel, rev)
+        for ref in refs:
+            try:
+                profiles_bytes = get_file_github("mozilla-firefox/firefox", ref, "testing/profiles/profiles.json")
+            except requests.exceptions.HTTPError:
+                self.logger.debug(f"Failed to download ref {ref}")
+            else:
+                self.logger.info(f"Getting profile data from git ref {ref}")
+                break
+        else:
+            raise ValueError(f"Failed to download prefs, tried git refs: {' '.join(refs)}")
         file_data = {}
-        profiles_bytes = get_file_github("mozilla-firefox/firefox", ref, "testing/profiles/profiles.json")
         profiles = json.loads(profiles_bytes)
         file_data["profiles.json"] = profiles_bytes
         for subdir in profiles["web-platform-tests"]:
@@ -353,19 +361,22 @@ class FirefoxPrefs:
             tags.append(tag)
         return tags
 
-    def get_git_ref(self, version: Optional[str], channel: str, rev: Optional[str]) -> str:
+    def get_git_refs(self, version: Optional[str], channel: str, rev: Optional[str]) -> List[str]:
         if rev is not None:
-            return rev
+            return [rev]
 
         ref_prefix = "FIREFOX_"
         ref_re = None
         tags = []
+        default = None
 
         if channel == "stable":
             if version:
-                return "FIREFOX_%s_RELEASE" % version.replace(".", "_")
+                return ["FIREFOX_%s_RELEASE" % version.replace(".", "_"), "release"]
+            default = "release"
             ref_re = re.compile(r"FIREFOX_(\d+)_(\d+)(?:_(\d+))?_RELEASE")
         elif channel == "beta":
+            default = "beta"
             if version:
                 ref_prefix = "FIREFOX_%s" % version.replace(".", "_")
                 if "b" not in version:
@@ -375,9 +386,10 @@ class FirefoxPrefs:
             else:
                 ref_re = re.compile(r"FIREFOX_(\d+)_(\d+)b(\d+)_(?:BUILD(\d+)|RELEASE)")
         else:
-            return "main"
+            return ["main"]
 
         assert ref_re is not None
+        assert default is not None
 
         for tag in self.get_git_tags(ref_prefix):
             m = ref_re.match(tag)
@@ -388,8 +400,8 @@ class FirefoxPrefs:
                 order[-1] = sys.maxsize
             tags.append((tuple(order), tag))
         if not tags:
-            raise ValueError(f"No tag found for version {version} channel {channel}")
-        return max(tags)[1]
+            self.logger.warning(f"No tag found for version {version} channel {channel}")
+        return [max(tags)[1], default]
 
 
 class FirefoxAndroidPrefs(FirefoxPrefs):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -55,6 +55,9 @@ def create_parser():
     parser.add_argument("--install-webdriver", action="store_true",
                         help="Install WebDriver from the release channel specified by --channel "
                         "(or the nightly channel by default).")
+    parser.add_argument("--install-browser-url", action="store", default=None,
+                        help="URL to download the browser from"
+                        "(or the nightly channel by default).")
     parser.add_argument("--logcat-dir",
                         help="Directory to write Android logcat files to")
     parser._add_container_actions(wptcommandline.create_parser())
@@ -236,9 +239,9 @@ class BrowserSetup:
             elif resp == "n":
                 return False
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         if self.prompt_install(self.name):
-            return self.browser.install(self.venv.path, channel)
+            return self.browser.install(self.venv.path, channel=channel, url=url)
 
     def requirements(self):
         if self.browser.requirements:
@@ -695,7 +698,7 @@ class Safari(BrowserSetup):
     name = "safari"
     browser_cls = browser.Safari
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         raise NotImplementedError
 
     def setup_kwargs(self, kwargs):
@@ -712,7 +715,7 @@ class Sauce(BrowserSetup):
     name = "sauce"
     browser_cls = browser.Sauce
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         raise NotImplementedError
 
     def setup_kwargs(self, kwargs):
@@ -727,9 +730,9 @@ class Servo(BrowserSetup):
     name = "servo"
     browser_cls = browser.Servo
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         if self.prompt_install(self.name):
-            return self.browser.install(self.venv.path)
+            return self.browser.install(self.venv.path, url=url)
 
     def setup_kwargs(self, kwargs):
         if kwargs["binary"] is None:
@@ -759,9 +762,9 @@ class WebKitTestRunner(BrowserSetup):
     name = "wktr"
     browser_cls = browser.WebKitTestRunner
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         if self.prompt_install(self.name):
-            return self.browser.install(self.venv.path, channel=channel)
+            return self.browser.install(self.venv.path, channel=channel, url=url)
 
     def setup_kwargs(self, kwargs):
         if kwargs["binary"] is None:
@@ -775,9 +778,9 @@ class WebKitTestRunner(BrowserSetup):
 class WebKitGlibBaseMiniBrowser(BrowserSetup):
     """ Base class for WebKitGTKMiniBrowser and WPEWebKitMiniBrowser """
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         if self.prompt_install(self.name):
-            return self.browser.install(self.venv.path, channel, self.prompt)
+            return self.browser.install(self.venv.path, channel, url=url)
 
     def setup_kwargs(self, kwargs):
         if kwargs["binary"] is None:
@@ -816,7 +819,7 @@ class Epiphany(BrowserSetup):
     name = "epiphany"
     browser_cls = browser.Epiphany
 
-    def install(self, channel=None):
+    def install(self, channel=None, url=None):
         raise NotImplementedError
 
     def setup_kwargs(self, kwargs):
@@ -934,6 +937,9 @@ def setup_wptrunner(venv, **kwargs):
         kwargs["test_list"] += test_list
         kwargs["default_exclude"] = True
 
+    if kwargs["install_browser_url"] and not kwargs["install_browser"]:
+        kwargs["install_browser"] = True
+
     if kwargs["install_browser"] and not kwargs["channel"]:
         logger.info("--install-browser is given but --channel is not set, default to nightly channel")
         kwargs["channel"] = "nightly"
@@ -952,7 +958,8 @@ def setup_wptrunner(venv, **kwargs):
 
     if kwargs["install_browser"]:
         logger.info("Installing browser")
-        kwargs["binary"] = setup_cls.install(channel=kwargs["browser_channel"])
+        kwargs["binary"] = setup_cls.install(channel=kwargs["browser_channel"],
+                                             url=kwargs["install_browser_url"])
 
     setup_cls.setup(kwargs)
 


### PR DESCRIPTION
Sometimes it's useful to be able to run specific binaries e.g. local development builds.

To support this, we have several changes:
* An `--install-browser-url` argument to `wpt run` which (for some browsers) causes the browser to be downloaded from that specific URL rather than the normal browser distribution URL.
* The ability to put `wpt-args: [args]` in a commit message, and have those arguments applied to the wpt jobs in a push. This allows pushing to a `triggers/` branch with a commit message containing the `--install-browser-url` argument, and having that run in CI.