### PR TITLE
Use Ahem font in WPT old-content-is-inline.html

### DIFF
--- a/css/css-view-transitions/old-content-is-inline-ref.html
+++ b/css/css-view-transitions/old-content-is-inline-ref.html
@@ -2,9 +2,14 @@
 <title>View transitions: Old content is an inline element (ref)</title>
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
+<link rel="stylesheet" href="/fonts/ahem.css">
 
 <style>
-:root { background-color: rebeccapurple; }
+:root {
+  background-color: rebeccapurple;
+  font: 20px/1 Ahem;
+}
+
 body { margin: 0; }
 
 .container {
@@ -31,7 +36,7 @@ body { margin: 0; }
 
 .inline {
   background-color: limegreen;
-  color: rgba(0, 0, 0, 0);
+  color: blue;
 }
 
 .transitioned .inline {
@@ -49,20 +54,20 @@ body { margin: 0; }
 </style>
 
 <div class="container start">
-  <span>FILLER FILLER</span>
-  <span id="start" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="start" class="inline">INL INL</span>
   <p>START STATE</p>
 </div>
 
 <div class="container end transitioned">
-  <span>FILLER FILLER</span>
-  <span id="end" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="end" class="inline">INL INL</span>
   <p>END STATE</p>
 </div>
 
 <div id="dummyEndInline">
-  <span style="opacity:0">FILLER FILLER</span>
-  <span class="inline">INLINE INLINE INLINE INLINE</span>
+  <span style="opacity:0">FILL FILL</span>
+  <span class="inline">INL INL</span>
 </div>
 <script>
   let endWidth = document.getElementById('end').getBoundingClientRect().width;

--- a/css/css-view-transitions/old-content-is-inline.html
+++ b/css/css-view-transitions/old-content-is-inline.html
@@ -4,11 +4,15 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="old-content-is-inline-ref.html">
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-500">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <script src="/common/reftest-wait.js"></script>
 
 <style>
-body { margin : 0; }
+body {
+  margin : 0;
+  font: 20px/1 Ahem;
+}
+
 .container {
   position: absolute;
   left: 100px;
@@ -35,8 +39,7 @@ body { margin : 0; }
 
 .inline {
   background-color: limegreen;
-  /* allow small pixel diff in text */
-  color: rgba(0, 0, 0, 0);
+  color: blue;
 }
 
 .start .inline {
@@ -105,8 +108,8 @@ This subtree will be held at the animation start to test the old content's
 starting position.
 -->
 <div class="container start">
-  <span>FILLER FILLER</span>
-  <span id="start" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="start" class="inline">INL INL</span>
   <p>START STATE</p>
 </div>
 
@@ -115,8 +118,8 @@ This subtree will be held at the animation end to test the old content's
 ending position.
 -->
 <div class="container end">
-  <span>FILLER FILLER</span>
-  <span id="end" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="end" class="inline">INL INL</span>
   <p>END STATE</p>
 </div>
 


### PR DESCRIPTION
This testcase is only valid (i.e. it only actually matches its reference case) if the text doesn't linewrap.  So it needs to specify a specific font in order to have some guarantees that linewrapping won't happen.

Hence, this patch switches to the Ahem font, and reduces the length of the strings so that they're short enough to fit on a single line in that font.

This patch also removes the styling that was making the text transparent, and makes the text blue instead; with the Ahem font, we're not at as much risk of fuzzy failures from subtle antialiasing differences.

Fixes https://github.com/web-platform-tests/interop/issues/1250