### PR TITLE
X-Frame-Options: don't strip 0x0B or 0x0C

### DIFF
--- a/x-frame-options/get-decode-split.html
+++ b/x-frame-options/get-decode-split.html
@@ -20,4 +20,16 @@ xfo_simple_tests({
   sameOriginAllowed: false,
   crossOriginAllowed: false
 });
+
+xfo_simple_tests({
+  headerValue: `\x0BDENY`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `\x0CDENY`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
 </script>


### PR DESCRIPTION
Per the specification only tabs and spaces are supposed to be trimmed.