### PR TITLE
Remove stale fuzzy annotation from WPT new-content-is-inline.html

### DIFF
--- a/css/css-view-transitions/new-content-is-inline.html
+++ b/css/css-view-transitions/new-content-is-inline.html
@@ -5,7 +5,7 @@
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="new-content-is-inline-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1000">
+<meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-607">
 <script src="/common/reftest-wait.js"></script>
 
 <style>


### PR DESCRIPTION
This test has an extremely permissive fuzzy annotation which predated its switch to the Ahem font.

Now that it's rendered with Ahem, it shouldn't need this fuzzy annotation anymore.  Let's remove it.