### PR TITLE
HTML: style load event not fired for DOM mutations while the element …

### DIFF
--- a/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing.xhtml
+++ b/html/semantics/document-metadata/the-style-element/style-load-mutate-while-parsing.xhtml
@@ -1,0 +1,25 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>The 'load' event on the style element should not fire for mutations while it's on the stack of open elements</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <style>
+   body { background-color: transparent; }
+
+   <script>
+   window.t = async_test((t) => {
+     window.style = document.querySelector('style');
+     style.onload = t.unreached_func('load event fired for mutation');
+     style.append('body { color: inherit; }');
+   });
+   </script>
+
+   <script>
+   style.onload = t.step_func(() => {
+     t.done();
+   });
+   </script>
+  </style>
+ </head>
+ <body/>
+</html>


### PR DESCRIPTION
…is still parsed

See https://github.com/whatwg/html/pull/12090