### PR TITLE
Shorten the text in new-content-is-inline.html

### DIFF
--- a/css/css-view-transitions/new-content-is-inline-ref.html
+++ b/css/css-view-transitions/new-content-is-inline-ref.html
@@ -2,7 +2,7 @@
 <title>View transitions: New content is an inline element (ref)</title>
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
 
 <style>
 :root {
@@ -37,7 +37,7 @@ body { margin: 0; }
 .inline {
   opacity: 0;
   background-color: coral;
-  color: rgba(0, 0, 0, 0);
+  color: blue;
 }
 
 .transitioned .inline {
@@ -56,20 +56,20 @@ body { margin: 0; }
 </style>
 
 <div class="container start">
-  <span>FILLER FILLER</span>
-  <span id="start" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="start" class="inline">INL INL</span>
   <p style="margin-top: 50px">START STATE</p>
 </div>
 
 <div class="container end transitioned">
-  <span>FILLER FILLER</span>
-  <span id="end" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="end" class="inline">INL INL</span>
   <p>END STATE</p>
 </div>
 
 <div id="dummyStartInline" class="transitioned">
-  <span style="opacity:0">FILLER FILLER</span>
-  <span class="inline">INLINE INLINE INLINE INLINE</span>
+  <span style="opacity:0">FILL FILL</span>
+  <span class="inline">INL INL</span>
 </div>
 <script>
   let endWidth = document.getElementById('end').getBoundingClientRect().width;

--- a/css/css-view-transitions/new-content-is-inline.html
+++ b/css/css-view-transitions/new-content-is-inline.html
@@ -4,8 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="new-content-is-inline-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1000">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <script src="/common/reftest-wait.js"></script>
 
 <style>
@@ -40,8 +39,7 @@ body {
 
 .inline {
   background-color: limegreen;
-  /* allow small pixel diff in text */
-  color: rgba(0, 0, 0, 0);
+  color: blue;
 }
 
 .start .inline {
@@ -110,8 +108,8 @@ This subtree will be held at the animation start to test the old content's
 starting position.
 -->
 <div class="container start">
-  <span>FILLER FILLER</span>
-  <span id="start" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="start" class="inline">INL INL</span>
   <p style="margin-top: 50px">START STATE</p>
 </div>
 
@@ -120,8 +118,8 @@ This subtree will be held at the animation end to test the old content's
 ending position.
 -->
 <div class="container end">
-  <span>FILLER FILLER</span>
-  <span id="end" class="inline">INLINE INLINE INLINE INLINE</span>
+  <span>FILL FILL</span>
+  <span id="end" class="inline">INL INL</span>
   <p>END STATE</p>
 </div>
 


### PR DESCRIPTION
This patch shortens the text ("FILLER" -> "FILL" and "INLINE..." -> "INL INL")

Shorter text is nice because it avoids the need to linewrap, which:
* brings the test into alignment with its neighbor "old-content-is-inline.html"
* restores the test to the no-linewrapping state that it was in before the Ahem font-family was added to it.
* removes the need for a fuzzy annotation (removed in this patch)

This patch also includes a few other small cleanups for consistency with changes that I recently made to its neighbor "old-content-is-inline.html":
* I'm making some text blue instead of transparent. (The test was only transparent to avoid subpixel positioning differences, which stopped being a problem once the test started using Ahem.)
* I'm simplifying the ahem.css link-tag.

Fixes https://github.com/web-platform-tests/interop/issues/1252