### PR TITLE
Support running Firefox under the Firefox Profiler

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import shutil
 from collections.abc import MutableMapping
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import json
 import os
@@ -19,7 +19,7 @@ import mozinfo
 import mozleak
 import mozversion
 try:
-    from mozgeckoprofiler import symbolicate_profile_json, view_gecko_profile
+    from mozgeckoprofiler import symbolicate_profile_json, view_gecko_profile  # type: ignore
 except ImportError:
     symbolicate_profile_json = None
     view_gecko_profile = None
@@ -356,7 +356,7 @@ def setup_leak_report(leak_check, profile, env):
 
 class FirefoxProfiler:
     def __init__(self, logger: StructuredLogger,
-                 mode: Optional[Literal["view"] | Literal["save"]],
+                 mode: Optional[Union[Literal["view"], Literal["save"]]],
                  path: Optional[str],
                  symbols_path: Optional[str]):
         self.logger = logger
@@ -376,7 +376,7 @@ class FirefoxProfiler:
             if self.path is not None:
                 path = self.path
             elif "MOZ_PROFILER_SHUTDOWN" in env:
-                path = Path(os.getenv("MOZ_PROFILER_SHUTDOWN"))
+                path = Path(env["MOZ_PROFILER_SHUTDOWN"])
             elif self.mode == "view":
                 path = Path(tempfile.mkdtemp())
                 self.cleanup = True

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -1,4 +1,7 @@
 # mypy: allow-untyped-defs
+import shutil
+from collections.abc import MutableMapping
+from typing import Literal, Optional
 
 import json
 import os
@@ -10,10 +13,17 @@ import tempfile
 import time
 from abc import ABCMeta, abstractmethod
 from http.client import HTTPConnection
+from pathlib import Path
 
 import mozinfo
 import mozleak
 import mozversion
+try:
+    from mozgeckoprofiler import symbolicate_profile_json, view_gecko_profile
+except ImportError:
+    symbolicate_profile_json = None
+    view_gecko_profile = None
+from mozlog.structuredlog import StructuredLogger
 from mozprocess import ProcessHandler
 from mozprofile import FirefoxProfile, Preferences
 from mozrunner import FirefoxRunner
@@ -124,7 +134,9 @@ def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs)
                       "headless": kwargs["headless"],
                       "allow_list_paths": kwargs["allow_list_paths"],
                       "gmp_path": kwargs["gmp_path"] if "gmp_path" in kwargs else None,
-                      "debug_test": kwargs["debug_test"]}
+                      "debug_test": kwargs["debug_test"],
+                      "firefox_profiler_mode": kwargs["firefox_profiler_mode"],
+                      "firefox_profiler_path": kwargs["firefox_profiler_path"]}
 
     if test_type == "wdspec":
         browser_kwargs["webdriver_binary"] = kwargs["webdriver_binary"]
@@ -194,6 +206,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     executor_kwargs["browser_version"] = run_info_data.get("browser_version")
     executor_kwargs["debug_test"] = kwargs["debug_test"]
     executor_kwargs["disable_fission"] = kwargs["disable_fission"]
+    executor_kwargs["firefox_profiler_mode"] = kwargs["firefox_profiler_mode"]
     return executor_kwargs
 
 
@@ -322,6 +335,7 @@ def get_environ(logger, binary, debug_info, headless, gmp_path, chaos_mode_flags
         env["MOZ_HEADLESS"] = "1"
     if not e10s:
         env["MOZ_FORCE_DISABLE_E10S"] = "1"
+
     return env
 
 
@@ -340,12 +354,81 @@ def setup_leak_report(leak_check, profile, env):
     return leak_report_file
 
 
+class FirefoxProfiler:
+    def __init__(self, logger: StructuredLogger,
+                 mode: Optional[Literal["view"] | Literal["save"]],
+                 path: Optional[str],
+                 symbols_path: Optional[str]):
+        self.logger = logger
+        self.mode = mode
+        self.path = Path(path) if path is not None and mode is not None else None
+        self.symbols_path = symbols_path
+        self.cleanup = False
+
+    def setup(self, env: MutableMapping[str, str]) -> None:
+        # If profiling options are enabled, turn on the gecko profiler by using the
+        # profiler environmental variables.
+        if self.mode is not None:
+            if self.mode != "save" and view_gecko_profile is None:
+                self.logger.error("--firefox-profiler=view specified but missing mozgeckoprofiler module, "
+                                  "unable to view profile data.")
+                return
+            if self.path is not None:
+                path = self.path
+            elif "MOZ_PROFILER_SHUTDOWN" in env:
+                path = Path(os.getenv("MOZ_PROFILER_SHUTDOWN"))
+            elif self.mode == "view":
+                path = Path(tempfile.mkdtemp())
+                self.cleanup = True
+            else:
+                self.logger.error("--firefox-profiler=save specified, but missing "
+                                  "--firefox-profiler-path or MOZ_UPLOAD_DIR, not "
+                                  "configuring the profiler.")
+                return
+
+            if path.suffix == "":
+                if not path.exists():
+                    path.mkdir(parents=True, exist_ok=True)
+                path = path / "profile_wpt.json"
+            elif not path.parent.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
+
+            self.path = path
+            env["MOZ_PROFILER_SHUTDOWN"] = str(path)
+            env["MOZ_PROFILER_STARTUP"] = "1"
+
+    def after_process_stop(self) -> None:
+        if self.path is not None:
+            self.logger.info("Shutdown performance profiling was enabled")
+
+            if not os.path.exists(self.path):
+                self.logger.error(f"Profile not created at path {self.path}")
+                self.path = None
+                return
+
+            self.logger.info(f"Profile saved locally to: {self.path}")
+
+            if symbolicate_profile_json is None:
+                self.logger.warning("--firefox-profiler=save specified but missing mozgeckoprofiler module, "
+                                    "unable to symbolificate profile data.")
+            else:
+                symbolicate_profile_json(self.path, self.symbols_path)
+                if self.mode == "view" and view_gecko_profile is not None:
+                    view_gecko_profile(self.path)
+
+            # Clean up the temporary file if it exists.
+            if self.cleanup:
+                shutil.rmtree(os.path.dirname(self.path))
+            self.path = None
+
+
 class FirefoxInstanceManager:
     __metaclass__ = ABCMeta
 
     def __init__(self, logger, binary, binary_args, profile_creator, debug_info,
                  chaos_mode_flags, headless,
-                 leak_check, stackfix_dir, symbols_path, gmp_path, asan, e10s):
+                 leak_check, stackfix_dir, symbols_path, gmp_path, asan, e10s,
+                 firefox_profiler_mode, firefox_profiler_path):
         """Object that manages starting and stopping instances of Firefox."""
         self.logger = logger
         self.binary = binary
@@ -360,6 +443,8 @@ class FirefoxInstanceManager:
         self.gmp_path = gmp_path
         self.asan = asan
         self.e10s = e10s
+        self.firefox_profiler_mode = firefox_profiler_mode
+        self.firefox_profiler_path = firefox_profiler_path
 
         self.previous = None
         self.current = None
@@ -407,13 +492,19 @@ class FirefoxInstanceManager:
                                           args,
                                           self.debug_info)
 
+        firefox_profiler = FirefoxProfiler(self.logger,
+                                           self.firefox_profiler_mode,
+                                           self.firefox_profiler_path,
+                                           self.symbols_path)
+        firefox_profiler.setup(env)
         leak_report_file = setup_leak_report(self.leak_check, profile, env)
         output_handler = FirefoxOutputHandler(self.logger,
                                               cmd,
                                               stackfix_dir=self.stackfix_dir,
                                               symbols_path=self.symbols_path,
                                               asan=self.asan,
-                                              leak_report_file=leak_report_file)
+                                              leak_report_file=leak_report_file,
+                                              firefox_profiler=firefox_profiler)
         runner = FirefoxRunner(profile=profile,
                                binary=cmd[0],
                                cmdargs=cmd[1:],
@@ -551,7 +642,7 @@ class BrowserInstance:
 
 class FirefoxOutputHandler(OutputHandler):
     def __init__(self, logger, command, symbols_path=None, stackfix_dir=None, asan=False,
-                 leak_report_file=None):
+                 leak_report_file=None, firefox_profiler=None):
         """Filter for handling Firefox process output.
 
         This receives Firefox process output in the __call__ function, does
@@ -575,6 +666,7 @@ class FirefoxOutputHandler(OutputHandler):
             self.stack_fixer = None
         self.asan = asan
         self.leak_report_file = leak_report_file
+        self.firefox_profiler = firefox_profiler
 
         # These are filled in after configure_handlers() is called
         self.lsan_handler = None
@@ -632,6 +724,9 @@ class FirefoxOutputHandler(OutputHandler):
             # Fallback for older versions of mozleak, or if we didn't shutdown cleanly
             if os.path.exists(self.leak_report_file):
                 os.unlink(self.leak_report_file)
+
+        if self.firefox_profiler:
+            self.firefox_profiler.after_process_stop()
 
     def __call__(self, line):
         """Write a line of output from the firefox process to the log"""
@@ -854,7 +949,8 @@ class FirefoxBrowser(Browser):
                  asan=False, chaos_mode_flags=None, config=None,
                  browser_channel="nightly", headless=None, preload_browser=False,
                  specialpowers_path=None, debug_test=False, allow_list_paths=None,
-                 gmp_path=None, **kwargs):
+                 gmp_path=None, firefox_profiler_mode=None, firefox_profiler_path=None,
+                 **kwargs):
         super().__init__(logger, **kwargs)
 
         if timeout_multiplier:
@@ -902,7 +998,9 @@ class FirefoxBrowser(Browser):
                                                      symbols_path,
                                                      gmp_path,
                                                      asan,
-                                                     e10s)
+                                                     e10s,
+                                                     firefox_profiler_mode,
+                                                     firefox_profiler_path)
 
     def settings(self, test):
         self._settings = {"check_leaks": self.leak_check and not test.leaks,

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -11,14 +11,31 @@ import sys
 import threading
 import traceback
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, ClassVar, Optional, Union, Tuple, Type
+from typing import (Any,
+                    Callable,
+                    ClassVar,
+                    List,
+                    Mapping,
+                    Optional,
+                    Union,
+                    Set,
+                    Tuple,
+                    Type,
+                    TYPE_CHECKING)
 from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from mozdebug import DebuggerInfo
+from mozlog.structuredlog import StructuredLogger
 
 from . import pytestrunner
 from .actions import actions
 from .asyncactions import async_actions
 from .protocol import Protocol, WdspecProtocol
+from ..wpttest import Result, SubtestResult, Test
 
+if TYPE_CHECKING:
+    from ..browsers.base import ExecutorBrowser
+    from ..testrunner import TestRunner
 
 here = os.path.dirname(__file__)
 
@@ -54,7 +71,7 @@ def executor_kwargs(test_type, test_environment, run_info_data, subsuite, **kwar
     return executor_kwargs
 
 
-def strip_server(url):
+def strip_server(url: str) -> str:
     """Remove the scheme and netloc from a url, leaving only the path and any query
     or fragment.
 
@@ -68,7 +85,7 @@ def strip_server(url):
     return urlunsplit(url_parts)
 
 
-def server_url(server_config, protocol, subdomain=False):
+def server_url(server_config: Mapping[str, Any], protocol: str, subdomain:bool = False) -> str:
     scheme = "https" if protocol == "h2" else protocol
     host = server_config["browser_host"]
     if subdomain:
@@ -96,20 +113,23 @@ class TestharnessResultConverter:
         assert result_url == test.url, (f"Got results from {result_url}, expected {test.url}")
         harness_result = test.make_result(self.harness_codes[status], message, extra=extra, stack=stack)
         return (harness_result,
-                [test.make_subtest_result(st_name, self.test_codes[st_status], st_message, st_stack)
+                [test.make_subtest_result(name=st_name,
+                                          status=self.test_codes[st_status],
+                                          message=st_message,
+                                          stack=st_stack)
                  for st_name, st_status, st_message, st_stack in subtest_results])
 
 
 testharness_result_converter = TestharnessResultConverter()
 
 
-def hash_screenshots(screenshots):
+def hash_screenshots(screenshots: List[str]) -> List[str]:
     """Computes the sha1 checksum of a list of base64-encoded screenshots."""
     return [hashlib.sha1(base64.b64decode(screenshot)).hexdigest()
             for screenshot in screenshots]
 
 
-def _ensure_hash_in_reftest_screenshots(extra):
+def _ensure_hash_in_reftest_screenshots(extra: Mapping[str, Any]) -> None:
     """Make sure reftest_screenshots have hashes.
 
     Marionette internal reftest runner does not produce hashes.
@@ -125,7 +145,7 @@ def _ensure_hash_in_reftest_screenshots(extra):
             item["hash"] = hash_screenshots([item["screenshot"]])[0]
 
 
-def get_pages(ranges_value, total_pages):
+def get_pages(ranges_value: List[List[Optional[int]]], total_pages: int) -> Set[int]:
     """Get a set of page numbers to include in a print reftest.
 
     :param ranges_value: Parsed page ranges as a list e.g. [[1,2], [4], [6,None]]
@@ -147,6 +167,8 @@ def get_pages(ranges_value, total_pages):
         if range_limits[1] is None:
             range_limits[1] = total_pages
 
+        assert isinstance(range_limits[0], int)
+        assert isinstance(range_limits[1], int)
         if range_limits[0] > total_pages:
             continue
         rv |= set(range(range_limits[0], range_limits[1] + 1))
@@ -172,7 +194,7 @@ def pytest_result_converter(self, test, data):
     harness_result = test.make_result(*harness_data)
     subtest_results = [test.make_subtest_result(*item) for item in subtest_data]
 
-    return (harness_result, subtest_results)
+    return harness_result, subtest_results
 
 
 def crashtest_result_converter(self, test, result):
@@ -263,6 +285,7 @@ class TestExecutor:
     __metaclass__ = ABCMeta
 
     test_type: ClassVar[str]
+    protocol_cls: ClassVar[Type[Protocol]]
     # convert_result is a class variable set to a callable converter
     # (e.g. reftest_result_converter) converting from an instance of
     # URLManifestItem (e.g. RefTest) + type-dependent results object +
@@ -277,10 +300,16 @@ class TestExecutor:
     extra_timeout = 5  # seconds
 
 
-    def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 debug_info=None, subsuite=None, **kwargs):
+    def __init__(self,
+                 logger: StructuredLogger,
+                 browser: "ExecutorBrowser",
+                 server_config: Mapping[str, Any],
+                 timeout_multiplier: int = 1,
+                 debug_info: Optional[DebuggerInfo] = None,
+                 subsuite: Optional[str] = None,
+                 **kwargs: Any):
         self.logger = logger
-        self.runner = None
+        self.runner: Optional["TestRunner"] = None
         self.browser = browser
         self.server_config = server_config
         self.timeout_multiplier = timeout_multiplier
@@ -288,9 +317,9 @@ class TestExecutor:
         self.subsuite = subsuite
         self.last_environment = {"protocol": "http",
                                  "prefs": {}}
-        self.protocol = None  # This must be set in subclasses
+        self.protocol: Optional[Protocol] = None  # This must be set in subclasses
 
-    def setup(self, runner, protocol=None):
+    def setup(self, runner: "TestRunner", protocol: Optional[Protocol] = None) -> None:
         """Run steps needed before tests can be started e.g. connecting to
         browser instance
 
@@ -303,23 +332,25 @@ class TestExecutor:
         elif self.protocol is not None:
             self.protocol.setup(runner)
 
-    def teardown(self):
+    def teardown(self) -> None:
         """Run cleanup steps after tests have finished"""
         if self.protocol is not None:
             self.protocol.teardown()
 
-    def reset(self):
+    def reset(self) -> None:
         """Re-initialize internal state to facilitate repeated test execution
         as implemented by the `--rerun` command-line argument."""
         pass
 
-    def before_test(self, test):
+    def before_test(self, test: Test) -> None:
+        assert self.protocol is not None
         self.protocol.before_test(test)
 
-    def after_test(self, test, result, subtest_results):
+    def after_test(self, test: Test, result: Result, subtest_results: List[SubtestResult]) -> None:
+        assert self.protocol is not None
         self.protocol.after_test(test, result, subtest_results)
 
-    def run_test(self, test):
+    def run_test(self, test: Test) -> None:
         """Run a particular test.
 
         :param test: The test to run"""
@@ -332,7 +363,7 @@ class TestExecutor:
             exception_string = traceback.format_exc()
             message = f"Exception in TestExecutor.run:\n{exception_string}"
             self.logger.warning(message)
-            result = self.result_from_exception(test, e, exception_string)
+            result, subtest_results = self.result_from_exception(test, e, exception_string)
 
         self.after_test(test, result, subtest_results)
         # log result of parent test
@@ -341,27 +372,31 @@ class TestExecutor:
 
         self.last_environment = test.environment
 
+        assert self.runner is not None
         self.runner.send_message("test_ended", test, (result, subtest_results))
 
-    def server_url(self, protocol, subdomain=False):
+    def server_url(self, protocol: str, subdomain:bool = False) -> str:
         return server_url(self.server_config, protocol, subdomain)
 
-    def test_url(self, test):
+    def test_url(self, test: Test) -> str:
         return urljoin(self.server_url(test.environment["protocol"],
                                        test.subdomain), test.url)
 
     @abstractmethod
-    def do_test(self, test):
+    def do_test(self, test: Test) -> Tuple[Result, List[SubtestResult]]:
         """Test-type and protocol specific implementation of running a
         specific test.
 
         :param test: The test to run."""
         pass
 
-    def on_environment_change(self, new_environment):
+    def on_environment_change(self, new_environment: Mapping[str, Any]) -> None:
         pass
 
-    def result_from_exception(self, test, e, exception_string):
+    def result_from_exception(self,
+                              test: Test,
+                              e: Exception,
+                              exception_string: str) -> Tuple[Result, List[SubtestResult]]:
         if hasattr(e, "status") and e.status in test.result_cls.statuses:
             status = e.status
         else:
@@ -372,8 +407,12 @@ class TestExecutor:
         message += exception_string
         return test.make_result(status, message), []
 
-    def wait(self):
-        return self.protocol.base.wait()
+    def wait(self) -> bool:
+        assert self.protocol is not None
+        assert hasattr(self.protocol, "base")
+        re_run = self.protocol.base.wait()
+        assert isinstance(re_run, bool)
+        return re_run
 
 
 class TestharnessExecutor(TestExecutor):
@@ -853,7 +892,11 @@ class CallbackHandler:
 
         return False, None
 
-    def _send_message(self, cmd_id, message_type, status, message=None):
+    def _send_message(self,
+                      cmd_id: str,
+                      message_type: str,
+                      status: str,
+                      message: Optional[str] = None) -> None:
         self.protocol.testdriver.send_message(cmd_id, message_type, status, message=message)
 
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1358,15 +1358,15 @@ class WebDriverRefTestExecutor(RefTestExecutor):
             self.protocol.webdriver.window.position = (2, 2)
         self.protocol.webdriver.window.size = (800 + width_offset, 600 + height_offset)
 
-        result = self.implementation.run_test(test)
+        result, subtest_results = self.convert_result(self.implementation.run_test(test))
 
         if (leak_part := getattr(self.protocol, "leak", None)) and (counters := leak_part.check()):
-            result.setdefault("extra", {})["leak_counters"] = counters
+            result.extra["leak_counters"] = counters
 
-        if self.debug_test and result["status"] in ["PASS", "FAIL", "ERROR"] and "extra" in result:
+        if self.debug_test and result.status in ["PASS", "FAIL", "ERROR"] and result.extra:
             self.protocol.debug.load_reftest_analyzer(test, result)
 
-        return self.convert_result(test, result)
+        return result, subtest_results
 
     def screenshot(self, test, viewport_size, dpi, page_ranges):
         # https://github.com/web-platform-tests/wpt/issues/7135

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -99,6 +99,12 @@ class Protocol:
         for cls in self.implements:
             getattr(self, cls.name).teardown()
 
+    def before_test(self, test):
+        pass
+
+    def after_test(self, test, result, sbutest_results):
+        pass
+
 
 class ProtocolPart:
     """Base class  for all ProtocolParts.
@@ -957,6 +963,21 @@ class LeakProtocolPart(ProtocolPart):
         return None
 
 
+class ProfilerProtocolPart(ProtocolPart):
+    """Protocol part for controlling a browser profiler."""
+    __metaclass__ = ABCMeta
+
+    name = "profiler"
+
+    @abstractmethod
+    def record_profile(self) -> None:
+        ...
+
+    @abstractmethod
+    def add_marker(self, name: str, options: Mapping[str, Any], text: str) -> None:
+        ...
+
+
 class CoverageProtocolPart(ProtocolPart):
     """Protocol part for collecting per-test coverage data."""
     __metaclass__ = ABCMeta
@@ -1147,7 +1168,7 @@ class DebugProtocolPart(ProtocolPart):
         debug_test_logger.add_handler(mozlog.handlers.StreamHandler(output, formatter=mozlog.formatters.TbplFormatter()))
         debug_test_logger.test_start(test.id)
         # Always use PASS as the expected value so we get output even for expected failures
-        debug_test_logger.test_end(test.id, result["status"], "PASS", extra=result.get("extra"))
+        debug_test_logger.test_end(test.id, result.status, "PASS", extra=result.extra)
 
         self.parent.base.load(urljoin(self.parent.executor.server_url("https"),
                               "/common/third_party/reftest-analyzer.xhtml#log=%s" %

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -181,7 +181,7 @@ class TestRunner:
         rerun = self.executor.wait()
         self.send_message("wait_finished", rerun)
 
-    def send_message(self, command, *args):
+    def send_message(self, command: str, *args: Any) -> None:
         self.result_queue.put((command, args))
 
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -147,17 +147,20 @@ class TestRunner:
                     "reset": self.reset,
                     "stop": self.stop,
                     "wait": self.wait}
-        while True:
-            command, args = self.command_queue.get()
-            try:
-                rv = commands[command](*args)
-            except Exception:
-                self.send_message("error",
-                                  "Error running command %s with arguments %r:\n%s" %
-                                  (command, args, traceback.format_exc()))
-            else:
-                if rv is Stop:
-                    break
+        try:
+            while True:
+                command, args = self.command_queue.get()
+                try:
+                    rv = commands[command](*args)
+                except Exception:
+                    self.send_message("error",
+                                      "Error running command %s with arguments %r:\n%s" %
+                                      (command, args, traceback.format_exc()))
+                else:
+                    if rv is Stop:
+                        break
+        finally:
+            self.teardown()
 
     def stop(self):
         return Stop
@@ -953,10 +956,8 @@ class TestRunnerManager(threading.Thread):
             # former can gracefully tear down the protocol (e.g., closing an
             # active WebDriver session).
             self._ensure_runner_stopped()
-            # TODO(web-platform-tests/wpt#48030): Consider removing the
-            # `stop(force=...)` argument.
             if self.browser:
-                self.browser.stop(force=True)
+                self.browser.stop()
         except (OSError, PermissionError):
             self.logger.error("Failed to stop either the runner or the browser process",
                               exc_info=True)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -344,6 +344,14 @@ scheme host and port.""")
                              help="Enable chaos mode with the specified feature flag "
                              "(see http://searchfox.org/mozilla-central/source/mfbt/ChaosMode.h for "
                              "details). If no value is supplied, all features are activated")
+    gecko_group.add_argument("--firefox-profiler", action="store", choices=["save", "view"],
+                             default=None, dest="firefox_profiler_mode",
+                             help="Run the Firefox Profiler and get a performance profile of the "
+                             "tests. This is useful to find performance issues, and also "
+                             "to see what exactly the test is doing. To get profiler options run"
+                             "firefox with the environment variable `MOZ_PROFILER_HELP=1`")
+    gecko_group.add_argument("--firefox-profiler-path", action="store_true", default=os.environ.get("MOZ_UPLOAD_DIR"),
+                             help="Path to save Firefox profile to")
 
     gecko_view_group = parser.add_argument_group("GeckoView-specific")
     gecko_view_group.add_argument("--setenv", dest="env", action="append", default=[],


### PR DESCRIPTION
This adds two new wptrunner arguments, `--firefox-profiler-mode=[save|view]` to enable the profiler and `--firefox-profiler-path` to specify the path to save the resulting profiles to.