### PR TITLE
Add fuzz annotation to WPT fragmented-at-start-ignored.html.

### DIFF
--- a/css/css-view-transitions/fragmented-at-start-ignored.html
+++ b/css/css-view-transitions/fragmented-at-start-ignored.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="fragmented-at-start-ignored-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9200">
 
 <script src="/common/reftest-wait.js"></script>
 <style>


### PR DESCRIPTION
This test occasionally renders with an imperceptible mismatch (maxDifference of 1) in the blue area at the bottom-left of the test. This patch is just annotating that.