### PR TITLE
layout: Suppress soft wrap opportunities between NU/AL/AI/ID characters to respect `word-break: keep-all`

### DIFF
--- a/css/css-text/word-break/reference/word-break-keep-all-011-ref.html
+++ b/css/css-text/word-break/reference/word-break-keep-all-011-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test reference</title>
+<link rel="author" title="Richard Tjokroutomo" href="mailto:richard.tjokro2@gmail.com">
+
+<style>
+p {
+  width: min-content;
+  border: 1px solid #000000;
+  overflow: visible;
+  white-space: nowrap;
+}
+</style>
+
+</style>
+<div>
+<h2>word-break: normal:</h2>
+<p>中文<br>english<br>中文<br>english<br>中文<br>english<br>中文<br>english<br>中文<br>english</p>
+
+<h2>word-break: keep-all:</h2>
+<p>中文english中文english中文english中文english中文english</p>
+
+<h2>word-break: keep-all (w/ whitespace):</h2>
+<p>中文english中文english<br>中文english中文english中文english</p>
+
+<h2>word-break: keep-all (w/ whitespace & Chinese comma):</h2>
+<p>中文english中文english<br>中文english中文，<br>english中文english</p>
+</div>

--- a/css/css-text/word-break/word-break-keep-all-011.html
+++ b/css/css-text/word-break/word-break-keep-all-011.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text Test: word-break: keep-all should suppress linebreak for NU/AL/AI/ID characters</title>
+<link rel="author" title="Richard Tjokroutomo" href="mailto:richard.tjokro2@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-text/#valdef-word-break-keep-all">
+<link rel="match" href="reference/word-break-keep-all-011-ref.html">
+<meta name="assert" content="
+  When word-break: keep-all, the text should only linebreak on whitespace & Chinese comma.
+">
+
+<style>
+p {
+  width: min-content;
+  border: 1px solid #000000;
+}
+
+.normal {
+  word-break: normal;
+}
+
+.keep-all {
+  word-break: keep-all;
+}
+
+</style>
+<div>
+<h2>word-break: normal:</h2>
+<p class="normal">中文english中文english中文english中文english中文english</p>
+
+<h2>word-break: keep-all:</h2>
+<p class="keep-all">中文english中文english中文english中文english中文english</p>
+
+<h2>word-break: keep-all (w/ whitespace):</h2>
+<p class="keep-all">中文english中文english 中文english中文english中文english</p>
+
+<h2>word-break: keep-all (w/ whitespace & Chinese comma):</h2>
+<p class="keep-all">中文english中文english 中文english中文，english中文english</p>
+</div>


### PR DESCRIPTION
This change modifies `LineBreaker` to properly handle `word-break: keep-all` by adjusting the arguments passed to  `icu_segmenter::LineSegmenter`.

- [CSS specification](https://drafts.csswg.org/css-text/#valdef-word-break-keep-all)
- Stylo PR : servo/stylo#289

Testing: Created a WPT test for this change, specifically: `tests/wpt/tests/css/css-text/word-break/word-break-keep-all-011.html`.
Fixes: #<!-- nolink -->42047
Reviewed in servo/servo#42088