### PR TITLE
webdriver: Wait indefinitely with `None` timeout

### DIFF
--- a/webdriver/tests/classic/execute_async_script/promise.py
+++ b/webdriver/tests/classic/execute_async_script/promise.py
@@ -116,3 +116,33 @@ def test_promise_reject_timeout(session):
         resolve(promise);
         """)
     assert_error(response, "script timeout")
+
+
+def test_promise_resolve_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_async_script(session, """
+        let resolve = arguments[0];
+        let promise = new Promise(
+            (resolve) => setTimeout(
+                () => resolve('foobar'),
+                200
+            )
+        );
+        resolve(promise);
+        """)
+    assert_success(response, "foobar")
+
+
+def test_promise_reject_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_async_script(session, """
+        let resolve = arguments[0];
+        let promise = new Promise(
+            (resolve, reject) => setTimeout(
+                () => reject(new Error('my error')),
+                200
+            )
+        );
+        resolve(promise);
+        """)
+    assert_error(response, "javascript error")

--- a/webdriver/tests/classic/execute_script/promise.py
+++ b/webdriver/tests/classic/execute_script/promise.py
@@ -100,3 +100,29 @@ def test_promise_reject_timeout(session):
         );
         """)
     assert_error(response, "script timeout")
+
+
+def test_promise_resolve_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_script(session, """
+        return new Promise(
+            (resolve) => setTimeout(
+                () => resolve('foobar'),
+                200
+            )
+        );
+        """)
+    assert_success(response, "foobar")
+
+
+def test_promise_reject_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_script(session, """
+        return new Promise(
+            (resolve, reject) => setTimeout(
+                () => reject(new Error('my error')),
+                200
+            )
+        );
+        """)
+    assert_error(response, "javascript error")


### PR DESCRIPTION
So far for `None` [timeout](https://w3c.github.io/webdriver/#dfn-timeouts-configuration), we've treated it effectively as no wait which is wrong: https://github.com/web-platform-tests/wpt/pull/57332#issuecomment-3804242966.

This PR makes all `None` timeouts wait indefinitely. The funny part is, we somehow have only done it correctly for `pageload`: https://w3c.github.io/webdriver/#dfn-timeouts-configuration

Testing: We add test for script execution with `None` script timeout.
Reviewed in servo/servo#42184