### PR TITLE
script: Clear layout data on shadow root during `attachShadow`

### DIFF
--- a/html/interaction/focus/focus-after-attach-shadow-crash.html
+++ b/html/interaction/focus/focus-after-attach-shadow-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/42215">
+<style>
+  #outer { overflow: hidden; }
+</style>
+<div id="outer"><span id="inner" tabindex="1">hello</span></div>
+<script>
+  window.addEventListener("load", _ => {
+    document.body.attachShadow({mode: "open"});
+    inner.focus();
+  });
+</script>


### PR DESCRIPTION
When a node has `attachShadow()` successfully called on it, its
descendants are no longer in the flat tree. This change makes it so that
the layout data of these descendants is cleared during `attachShadow()`
so that the node is no longer considered to have a layout box.

Testing: This change includes a new WPT crash test.
Fixes: #<!-- nolink -->42215.

Reviewed in servo/servo#42237