### PR TITLE
base: When normalizing `RopeIndex` ensure it does not intersect a character

### DIFF
--- a/html/semantics/forms/the-textarea-element/textarea-selection-range-intersects-character-crash.html
+++ b/html/semantics/forms/the-textarea-element/textarea-selection-range-intersects-character-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>A selection range that intersects a character should not cause a crash</title>
+<link rel="help" href="https://github.com/servo/servo/issues/42217">
+
+<textarea id="textarea">A</textarea>
+<script>
+  textarea.setSelectionRange(1, 1);
+  textarea.defaultValue = String.fromCodePoint(301146);
+  textarea.selectionStart;
+</script>


### PR DESCRIPTION
When doing operations on `RopeIndex` that need to make slices of lines,
this change makes it so that the resulting index does not intersect a
character. This is important because Rust will panic if you attempt to
slice a string that way.

Testing: This change adds a WPT crash test and a `Rope` unit test.
Fixes: #<!-- nolink -->42217.

Reviewed in servo/servo#42240