### PR TITLE
Map "SVG" to web-features

### DIFF
--- a/css/css-sizing/WEB_FEATURES.yml
+++ b/css/css-sizing/WEB_FEATURES.yml
@@ -61,3 +61,6 @@ features:
 - name: width-height
   files:
   - percentage-height-replaced-content-in-auto-cb.html
+- name: svg
+  files:
+  - svg-intrinsic-size-*

--- a/svg/coordinate-systems/WEB_FEATURES.yml
+++ b/svg/coordinate-systems/WEB_FEATURES.yml
@@ -1,0 +1,8 @@
+features:
+- name: svg
+  files:
+  - abspos.html
+  - out-of-flow-svg-root.html
+  - outer-svg-intrinsic-size-001.html
+  - outer-svg-intrinsic-size-002.html
+  - viewBox-*

--- a/svg/extensibility/interfaces/WEB_FEATURES.yml
+++ b/svg/extensibility/interfaces/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg
+  files:
+  - foreignObject-graphics.svg

--- a/svg/import/WEB_FEATURES.yml
+++ b/svg/import/WEB_FEATURES.yml
@@ -1,4 +1,17 @@
 features:
+- name: svg
+  files:
+  - "*"
+  # Exclude tests mapped to `svg-filters`. Keep in sync with `svg-filters` mapping below
+  - "!filters-*"
+
+  # Exclude tests mapped to `opacity-svg`. Keep in sync with `opacity-svg` mapping below
+  - "!painting-fill-05-b-manual.svg"
+  - "!painting-stroke-08-t-manual.svg"
+
+  # Exclude tests mapped to `pointer-events`. Keep in sync with `pointer-events` mapping below
+  - "!animate-interact-pevents-*"
+  - "!interact-pevents-*"
 - name: svg-filters
   files:
   - "filters-*"

--- a/svg/painting/WEB_FEATURES.yml
+++ b/svg/painting/WEB_FEATURES.yml
@@ -1,0 +1,5 @@
+features:
+- name: svg
+  files:
+  - currentColor-*
+  - svg-percent-stroke-width-viewbox-update.html

--- a/svg/painting/reftests/WEB_FEATURES.yml
+++ b/svg/painting/reftests/WEB_FEATURES.yml
@@ -8,3 +8,6 @@ features:
 - name: text-shadow
   files:
   - text-shadow-*
+- name: svg
+  files:
+  - marker-path-*

--- a/svg/path/bearing/WEB_FEATURES.yml
+++ b/svg/path/bearing/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: svg
+  files: "**"

--- a/svg/render/WEB_FEATURES.yml
+++ b/svg/render/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg
+  files:
+  - "*"

--- a/svg/shapes/WEB_FEATURES.yml
+++ b/svg/shapes/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg
+  files:
+  - "*"

--- a/svg/shapes/reftests/WEB_FEATURES.yml
+++ b/svg/shapes/reftests/WEB_FEATURES.yml
@@ -2,3 +2,7 @@ features:
 - name: svg-filters
   files:
   - polygon-with-filtered-marker.html
+- name: svg
+  files:
+  - "*"
+  - "!polygon-with-filtered-marker.html"

--- a/svg/struct/WEB_FEATURES.yml
+++ b/svg/struct/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: svg
+  files:
+  - "*"

--- a/svg/struct/reftests/WEB_FEATURES.yml
+++ b/svg/struct/reftests/WEB_FEATURES.yml
@@ -2,3 +2,9 @@ features:
 - name: target
   files:
   - "use-external-resource-target-pseudo-*"
+- name: svg
+  files:
+  - currentScale*
+  - gradient-in-symbol.svg
+  - inner-svg-*
+  - outer-svg-transform.svg

--- a/svg/types/scripted/WEB_FEATURES.yml
+++ b/svg/types/scripted/WEB_FEATURES.yml
@@ -6,3 +6,11 @@ features:
   files:
   - SVGAnimatedEnumeration-SVGFilterElement.html
   - SVGAnimatedEnumeration-SVGFEColorMatrixElement.html
+- name: svg
+  files:
+  - SVGGraphicsElement*
+  - SVGLength-*
+  - SVGLengthList-*
+  - SVGMatrix-tentative.html
+  - SVGPathElement.getTotalLength-01.html
+  - SVGRect.html


### PR DESCRIPTION
Hello, reviewers! As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/).

@foolip @jcscottiii To identify "core" SVG tests, I:

- started with the spec reference metadata, limiting to those tests that link to the "TR" spec for SVG, SVG1.1, and SVG2
- included adjacent tests that don't reference and particular specification
- avoided tests that overlap with advanced CSS features
- included tests that appear to be testing APIs explicitly referenced by [the `svg` web-features `compat_features` key](https://github.com/web-platform-dx/web-features/blob/8279e451315cbe7b5e70ed7eea7cb30ce1f46c5b/features/svg.yml#L8).

