### PR TITLE
Add onerror handlers to XHR header value tests

### DIFF
--- a/fetch/api/headers/header-values-normalize.any.js
+++ b/fetch/api/headers/header-values-normalize.any.js
@@ -49,6 +49,7 @@ for(let i = 0; i < 0x21; i++) {
           assert_equals(xhr.getResponseHeader("x-request-val2"), expectedVal2)
           assert_equals(xhr.getResponseHeader("x-request-val3"), expectedVal3)
         })
+        xhr.onerror = t.unreached_func("XHR should not fail")
         xhr.send()
       }
     }, "XMLHttpRequest with value " + encodeURI(val))

--- a/fetch/api/headers/header-values.any.js
+++ b/fetch/api/headers/header-values.any.js
@@ -46,6 +46,7 @@ if (!self.GLOBAL.isWorker()) {
         assert_equals(xhr.getResponseHeader("x-request-val" + i), val)
       })
     })
+    xhr.onerror = t.unreached_func("XHR should not fail")
     xhr.send()
   }, "XMLHttpRequest with all valid values")
 }


### PR DESCRIPTION
These tests were missing error handlers, causing them to hang until timeout if the XHR request fails for any reason (e.g., network error). Adding onerror handlers ensures the tests fail fast in error scenarios.

---

(Further background: due to https://github.com/nodejs/node/issues/61582, jsdom has started failing these tests as timeouts; I'd rather have them fail quickly.)