### PR TITLE
script: Do not consider a node an ancestor of itself in `Node::is_ancestor_of`

### DIFF
--- a/html/semantics/forms/the-select-element/select-add-optgroup-before-argument-is-select-crash.html
+++ b/html/semantics/forms/the-select-element/select-add-optgroup-before-argument-is-select-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/41080">
+<script>
+  const select = document.createElement("select");
+  const optgroup = document.createElement("optgroup");
+  select.options.add(optgroup, select);
+</script>


### PR DESCRIPTION
This change fixes a crash in options collections due to the fact that a
`<select>` element was being considered an ancestor of itself. This
regression likely introduced in #<!-- nolink -->40776.

This change also fills in the specification text for
`HTMLOptionCollect::Add`.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->41080.

Reviewed in servo/servo#42263