### PR TITLE
script: Start a performance timeline entry for iframe documents

### DIFF
--- a/performance-timeline/timing-entries-iframe.html
+++ b/performance-timeline/timing-entries-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -9,32 +9,17 @@
   <body>
     <script>
       function load() {
-        setTimeout(function () {
-
-          console.log('Performance entries: ', JSON.stringify(performance.getEntries()));
-
-          promise_test(async function (t) {
-            let resources = performance.getEntriesByType('resource')
-            let has_resource = false
-            for ({ initiatorType, name } of resources) {
-              console.log('Name resource: ', name)
-              if (initiatorType == 'iframe') {
-                has_resource = true
-              }
+        promise_test(async function (t) {
+          let resources = performance.getEntriesByType("resource");
+          let has_resource = false;
+          for ({ initiatorType, name } of resources) {
+            console.log("Name resource: ", name);
+            if (initiatorType == "iframe") {
+              has_resource = true;
             }
-            assert_true(has_resource, 'iframe resource entry found')
-
-            let navigations = performance.getEntriesByType('navigation')
-            let has_navigation = false
-            for (const { name } of navigations) {
-              console.log('Name navigation: ', name)
-              if (name.endsWith('t.html')) {
-                has_navigation = true
-              }
-            }
-            assert_true(has_navigation, 'iframe navigation entry found')
-          }, 'Testing timing entries for iframe documents')
-        }, 0)
+          }
+          assert_true(has_resource, "iframe resource entry found");
+        }, "Testing timing entries for iframe documents");
       }
     </script>
     <iframe onload="load()" src="t.html"></iframe>

--- a/performance-timeline/timing-entries-iframe.html
+++ b/performance-timeline/timing-entries-iframe.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>testing timing entries for iframe documents</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      function load() {
+        setTimeout(function () {
+
+          console.log('Performance entries: ', JSON.stringify(performance.getEntries()));
+
+          promise_test(async function (t) {
+            let resources = performance.getEntriesByType('resource')
+            let has_resource = false
+            for ({ initiatorType, name } of resources) {
+              console.log('Name resource: ', name)
+              if (initiatorType == 'iframe') {
+                has_resource = true
+              }
+            }
+            assert_true(has_resource, 'iframe resource entry found')
+
+            let navigations = performance.getEntriesByType('navigation')
+            let has_navigation = false
+            for (const { name } of navigations) {
+              console.log('Name navigation: ', name)
+              if (name.endsWith('t.html')) {
+                has_navigation = true
+              }
+            }
+            assert_true(has_navigation, 'iframe navigation entry found')
+          }, 'Testing timing entries for iframe documents')
+        }, 0)
+      }
+    </script>
+    <iframe onload="load()" src="t.html"></iframe>
+  </body>
+</html>

--- a/performance-timeline/timing-entries-iframe.html
+++ b/performance-timeline/timing-entries-iframe.html
@@ -13,7 +13,6 @@
           let resources = performance.getEntriesByType("resource");
           let has_resource = false;
           for ({ initiatorType, name } of resources) {
-            console.log("Name resource: ", name);
             if (initiatorType == "iframe") {
               has_resource = true;
             }


### PR DESCRIPTION
Added resource timing that was missing for an iframe document.

Testing: Added
Fixes: https://github.com/servo/servo/issues/41666

Reviewed in servo/servo#42270