### PR TITLE
script: Fix handling changes to relevant attributes for stylesheets

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
+++ b/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42259">
+<link id="link" rel="stylesheet" href="data:text/css,div { background-color: green !important; }">
+<script>
+  link.type = "text/css";
+  link.type = "text/css";
+</script>

--- a/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
+++ b/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  p {
+    color: green;
+  }
+</style>
+<p>This text should be green on a white background

--- a/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
+++ b/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Removing href should remove previously applied styles</title>
+<link rel=match href=stylesheet-change-href-ref.html>
+<style>
+p {
+  color: green;
+}
+</style>
+<script>
+  function removeHref() {
+    var elem = document.getElementById('stylesheet');
+    elem.removeAttribute('href');
+    elem.onload = null;
+  }
+</script>
+<link id=stylesheet rel=stylesheet href="resources/bad.css" onload="removeHref()">
+<p>This text should be green on a white background


### PR DESCRIPTION
We weren't removing stylesheets when we should be doing so. This most notably happens when the stylesheet no longer has a href or its "rel" changes.

The crash is also fixed, since the issue was that we were passing the value of the attribute that was changed as if it were an href. However, if we set the type attribute, then that's not the href.

To fix that, we now retrieve the href inside the method so we always have the correct value.

Fixes #<!-- nolink -->42259

Reviewed in servo/servo#42273