### PR TITLE
script: add force option for assign-slottables for a tree

### DIFF
--- a/shadow-dom/slot-reconciliation-at-node-removal.html
+++ b/shadow-dom/slot-reconciliation-at-node-removal.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>Shadow DOM: Slot reconciliation at node removal</title>
+<meta name="author" title="Hayato Ito" href="mailto:hayato@google.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/shadow-dom.js"></script>
+
+<div id="test_reconciliation_at_removal">
+  <div id="host">
+    <template data-mode="closed">
+      <div id="container">
+        <slot id="s1" name="foo"></slot>
+      </div>
+    </template>
+    <div id="content" slot="foo">This is some Text</div>
+  </div>
+</div>
+
+<script>
+test(() => {
+  let n = createTestTree(test_reconciliation_at_removal);
+  removeWhiteSpaceOnlyTextNodes(n.test_reconciliation_at_removal);
+  // Slot should have assigned nodes when it's in the shadow tree
+  assert_array_equals(n.s1.assignedNodes(), [n.content],
+                      'Slot should have assigned nodes before removal');
+
+  n.container.remove();
+  // Should be empty, the slot is not in the DOM tree anymore
+  assert_array_equals(n.s1.assignedNodes(), [],
+                      'Slot should have no assigned nodes after removal from shadow tree');
+}, 'Slot reconciliation: assignedNodes should be empty when slot is removed from shadow tree');
+</script>

--- a/shadow-dom/slot-reconciliation-at-node-removal.html
+++ b/shadow-dom/slot-reconciliation-at-node-removal.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Shadow DOM: Slot reconciliation at node removal</title>
-<meta name="author" title="Hayato Ito" href="mailto:hayato@google.com">
+<meta name="author" title="Ray Guo" href="mailto:rayguo17@gmail.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/shadow-dom.js"></script>


### PR DESCRIPTION
In the case of node removal, if the subtree of the removed node contains `<slot>` element, force traverse down to each `<slot>` element is needed to reset the assignment of the slottables that currently being assigned to the `<slot>` element. This changes add this force option to `assign_slottables_for_a_tree`, and only set true to node removal.

Testing: Should be covered by current WPT test, [try run](https://github.com/rayguo17/servo/actions/runs/21504337658)
Fixes https://github.com/servo/servo/issues/35188 
Fixes https://github.com/servo/servo/issues/42182

cc @TimvdLippe @simonwuelker @xiaochengh 
Reviewed in servo/servo#42250