### PR TITLE
script: Set host for template content

### DIFF
--- a/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy.html
+++ b/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy.html
@@ -45,11 +45,10 @@ test(() => {
   assert_not_equals(new_doc, tmpl_doc);
 
   // Try moving tmpl.content to new_doc and check the results.
-  const tmplContentNodeDocument = tmpl.content.ownerDocument;
   const tmplContentAdoptResult = new_doc.adoptNode(tmpl.content);
   assert_equals(tmpl.content, tmplContentAdoptResult);
   assert_equals(tmpl.ownerDocument, document);
-  assert_equals(tmpl.content.ownerDocument, tmplContentNodeDocument);
+  assert_equals(tmpl.content.ownerDocument, new_doc);
 
   // Hierarchy checks at various combinations.
   assert_throws_dom('HierarchyRequestError', () => {


### PR DESCRIPTION
A template element should set the host of a DocumentFragment. However, it didn't have a host yet. That's because ShadowRoot declares a host attribute which returns Element, but its property is declared on DocumentFragment.

Therefore, define the host on DocumentFragment instead and use it in all relevant points for shadow roots. Then, update the pre-insert validity check to use the correct host-including variant of inclusive ancestors. Lastly, set the host of the template to wire it all up.

Reviewed in servo/servo#42276