### PR TITLE
Fix Shift_JIS href encoding tests to test href, not form

### DIFF
--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-han.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-han.html
@@ -55,6 +55,6 @@ function normalizeStr(str) {
   return str;
 }
 </script>
-<script src="../../resources/encode-form-common.js"></script>
+<script src="../../resources/encode-href-common.js"></script>
 </body>
 </html>

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-hangul.html
@@ -45,6 +45,6 @@ function normalizeStr(str) {
   return str;
 }
 </script>
-<script src="../../resources/encode-form-common.js"></script>
+<script src="../../resources/encode-href-common.js"></script>
 </body>
 </html>

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-misc.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-misc.html
@@ -37,6 +37,6 @@ function normalizeStr(str) {
   return str;
 }
 </script>
-<script src="../../resources/encode-form-common.js"></script>
+<script src="../../resources/encode-href-common.js"></script>
 </body>
 </html>

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href.html
@@ -37,7 +37,7 @@ function expect(result, codepoint) {
   return "%" + result.replace(/ /g, "%");
 }
 </script>
-<script src="../../resources/encode-form-common.js"></script>
+<script src="../../resources/encode-href-common.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
These were previously duplicating their sibling tests sjis-encode-form-*.html. Now they properly test href encoding.