### PR TITLE
layout: Add a query for getting the effective overflow of an element and use it in `script`

### DIFF
--- a/intersection-observer/animating.html
+++ b/intersection-observer/animating.html
@@ -18,8 +18,8 @@ pre, #log {
 }
 @keyframes slideup {
   0% { transform: translateY(0) }
-  30% { transform: translateY(0) }
-  31% { transform: translateY(-2000px) }
+  50% { transform: translateY(0) }
+  51% { transform: translateY(-2000px) }
   100% { transform: translateY(-2000px) }
 }
 </style>
@@ -40,10 +40,10 @@ promise_test(t => {
         }
       });
     });
-    target.style.animation = "3s linear slideup";
+    target.style.animation = "4s linear slideup";
     setTimeout(() => {
-      reject("Did not get a not-intersecting notification within 2 seconds.");
-    }, 2000);
+      reject("Did not get a not-intersecting notification within 3 seconds.");
+    }, 3000);
     target.addEventListener("animationend", evt => {
       reject("animationend event fired before not-intersecting notification.");
     });

--- a/intersection-observer/root-is-table-with-overflow-scroll.html
+++ b/intersection-observer/root-is-table-with-overflow-scroll.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<title>IntersectionObserver observing table with border and overflow scroll</title>
+<link rel="author" href="mailto:steven.novaryo@gmail.com" title="Steven Novaryo">
+<link rel="help" href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-root-intersection-rectangle">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#global-style-overrides">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+
+<style>
+  #root {
+    box-sizing: border-box;
+    overflow: scroll;
+    border: 50px solid black;
+    will-change: transform;
+  }
+  #target {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    position: absolute;
+    top: 300px;
+    left: 300px;
+    background-color: green;
+  }
+</style>
+<table id="root">
+  <tr>
+    <td>
+      <span id="target"></span>
+    </td>
+  </tr>
+</table>
+<script>
+var entries = [];
+var rootRect = root.getBoundingClientRect();
+
+runTestCycle(function() {
+  assert_true(!!target, "target exists");
+  var observer = new IntersectionObserver(function(changes) {
+    entries = entries.concat(changes)
+  }, { root: root });
+  observer.observe(target);
+  entries = entries.concat(observer.takeRecords());
+  assert_equals(entries.length, 0, "No initial notifications.");
+  runTestCycle(step0, "First rAF.");
+}, "IntersectionObserver observing an element inside a root table.");
+
+function step0() {
+  // To reduce the inconsistencies of the layout within different UAs we are calculating the offset dynamically.
+  var targetRect = target.getBoundingClientRect();
+  target.style.top = `${300 - (targetRect.top - rootRect.bottom + 50)}px`;
+  target.style.left = `${300 - (targetRect.left - rootRect.right + 50)}px`;
+  runTestCycle(step1, "Moving the target to the right bottom corner of the table.");
+  checkLastEntry(entries, 0, [
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    0, 0, 0, 0,
+    rootRect.left, rootRect.right, rootRect.top, rootRect.bottom,
+    false
+  ]);
+}
+
+function step1() {
+  var targetRect = target.getBoundingClientRect();
+  checkLastEntry(entries, 1, [
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    rootRect.left, rootRect.right, rootRect.top, rootRect.bottom,
+    true
+  ]);
+}
+
+</script>


### PR DESCRIPTION
In layout calculation within script, Instead of relying on the computed values for overflow, query the overflow from layout for its used value to accurately reflect whether an element establish a scroll container. This query will be used for `IntersectionObserver` as well.

Testing: There are new `IntersectionObserver` WPT failures:
- `intersection-observer/isIntersecting-change-events.html`
- `intersection-observer/containing-block.html`

The failures are more than likely a false positive because intersection observation steps wasn't supposed to trigger a reflow, but it was before. It could be caused by the implementation of `IntersectionObserver` in major UAs being a little bit different from the spec in the calculation of `threshold` and `isIntersecting`  .
Reviewed in servo/servo#42251