### PR TITLE
Bug 1990514: Disable bFPP for a few tests r?jgraham

### DIFF
--- a/webdriver/tests/classic/fullscreen_window/conftest.py
+++ b/webdriver/tests/classic/fullscreen_window/conftest.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+from tests.support.helpers import deep_update
+
+
+@pytest.fixture
+def default_capabilities(request):
+    """Firefox/Linux workaround to disable baseline FPP for fullscreen tests.
+
+    This is a hack for Firefox on Linux only. The maximize detection heuristic
+    compares window.outerWidth/Height to screen.availWidth/Height. With Firefox's
+    baseline fingerprinting protection (bFPP) enabled in Nightly,
+    screen.availWidth/Height are spoofed while window dimensions are not,
+    causing the heuristic to fail.
+    See https://bugzilla.mozilla.org/show_bug.cgi?id=1990514 for details.
+    """
+    capabilities = request.getfixturevalue("default_capabilities")
+
+    if sys.platform.startswith("linux"):
+        deep_update(
+            capabilities,
+            {
+                "moz:firefoxOptions": {
+                    "prefs": {
+                        "privacy.baselineFingerprintingProtection": False
+                    }
+                }
+            }
+        )
+
+    return capabilities

--- a/webdriver/tests/classic/maximize_window/conftest.py
+++ b/webdriver/tests/classic/maximize_window/conftest.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+from tests.support.helpers import deep_update
+
+
+@pytest.fixture
+def default_capabilities(request):
+    """Firefox/Linux workaround to disable baseline FPP for maximize tests.
+
+    This is a hack for Firefox on Linux only. The maximize detection heuristic
+    compares window.outerWidth/Height to screen.availWidth/Height. With Firefox's
+    baseline fingerprinting protection (bFPP) enabled in Nightly,
+    screen.availWidth/Height are spoofed while window dimensions are not,
+    causing the heuristic to fail.
+    See https://bugzilla.mozilla.org/show_bug.cgi?id=1990514 for details.
+    """
+    capabilities = request.getfixturevalue("default_capabilities")
+
+    if sys.platform.startswith("linux"):
+        deep_update(
+            capabilities,
+            {
+                "moz:firefoxOptions": {
+                    "prefs": {
+                        "privacy.baselineFingerprintingProtection": False
+                    }
+                }
+            }
+        )
+
+    return capabilities

--- a/webdriver/tests/classic/minimize_window/conftest.py
+++ b/webdriver/tests/classic/minimize_window/conftest.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+from tests.support.helpers import deep_update
+
+
+@pytest.fixture
+def default_capabilities(request):
+    """Firefox/Linux workaround to disable baseline FPP for minimize tests.
+
+    This is a hack for Firefox on Linux only. The maximize detection heuristic
+    compares window.outerWidth/Height to screen.availWidth/Height. With Firefox's
+    baseline fingerprinting protection (bFPP) enabled in Nightly,
+    screen.availWidth/Height are spoofed while window dimensions are not,
+    causing the heuristic to fail.
+    See https://bugzilla.mozilla.org/show_bug.cgi?id=1990514 for details.
+    """
+    capabilities = request.getfixturevalue("default_capabilities")
+
+    if sys.platform.startswith("linux"):
+        deep_update(
+            capabilities,
+            {
+                "moz:firefoxOptions": {
+                    "prefs": {
+                        "privacy.baselineFingerprintingProtection": False
+                    }
+                }
+            }
+        )
+
+    return capabilities

--- a/webdriver/tests/classic/set_window_rect/conftest.py
+++ b/webdriver/tests/classic/set_window_rect/conftest.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+from tests.support.helpers import deep_update
+
+
+@pytest.fixture
+def default_capabilities(request):
+    """Firefox workaround to disable baseline FPP for set_window_rect tests.
+
+    This is a hack for Firefox on Linux and Mac. The maximize detection heuristic
+    compares window.outerWidth/Height to screen.availWidth/Height. With Firefox's
+    baseline fingerprinting protection (bFPP) enabled in Nightly,
+    screen.availWidth/Height are spoofed while window dimensions are not,
+    causing the heuristic to fail.
+    See https://bugzilla.mozilla.org/show_bug.cgi?id=1990514 for details.
+    """
+    capabilities = request.getfixturevalue("default_capabilities")
+
+    if sys.platform.startswith("linux") or sys.platform == "darwin":
+        deep_update(
+            capabilities,
+            {
+                "moz:firefoxOptions": {
+                    "prefs": {
+                        "privacy.baselineFingerprintingProtection": False
+                    }
+                }
+            }
+        )
+
+    return capabilities


### PR DESCRIPTION
This is needed because there is a heuristic that detects if a window is maximized, and the fingerprinting protections break that heuristic when we lie about the user's available screen resolution.

Differential Revision: https://phabricator.services.mozilla.com/D277062