### PR TITLE
[wptrunner] Use more dataclass functionality for Product

### DIFF
--- a/tools/wptrunner/wptrunner/_default_if_sentinel.py
+++ b/tools/wptrunner/wptrunner/_default_if_sentinel.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import (
+    Generic,
+    cast,
+    overload,
+)
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
+else:
+    from typing_extensions import TypeVar
+
+
+_T = TypeVar("_T")
+_S = TypeVar("_S", default=None)
+
+
+class DefaultIfSentinel(Generic[_T, _S]):
+    """Descriptor that returns a default value, reverting to it when the sentinel is assigned.
+
+    ``DefaultIfSentinel[str]`` is a descriptor whose values are ``str`` and whose
+    sentinel is ``None``::
+
+        value: DefaultIfSentinel[str] = DefaultIfSentinel(default="hello")
+        # obj.value is "hello" by default, and assigning None resets to "hello"
+
+    ``DefaultIfSentinel[str, object]`` uses a dedicated sentinel object::
+
+        UNSET = object()
+        value: DefaultIfSentinel[str, object] = DefaultIfSentinel(
+            default="hello", sentinel=UNSET
+        )
+        # obj.value is "hello" by default, and assigning UNSET resets to "hello"
+
+    Type parameters:
+        _T: Type of values that can be assigned
+        _S: Type of the sentinel value (defaults to ``None``)
+
+    """
+
+    @overload
+    def __init__(
+        self: DefaultIfSentinel[_T, None], *, default: _T, sentinel: None = None
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self: DefaultIfSentinel[_T, None],
+        *,
+        default_factory: Callable[[], _T],
+        sentinel: None = None,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(self, *, default: _T, sentinel: _S) -> None:
+        ...
+
+    @overload
+    def __init__(self, *, default_factory: Callable[[], _T], sentinel: _S) -> None:
+        ...
+
+    def __init__(
+        self,
+        *,
+        default: _T | None = None,
+        default_factory: Callable[[], _T] | None = None,
+        sentinel: _S | None = None,
+    ) -> None:
+        if default_factory is not None:
+            self._default_factory = default_factory
+        else:
+            self._default_factory = cast("Callable[[], _T]", lambda: default)
+        self._sentinel = sentinel
+
+    def __set_name__(self, owner: type[object], name: str) -> None:
+        self._name = "_" + name
+
+    @overload
+    def __get__(self, inst: None, owner: type[object]) -> _T:
+        ...
+
+    @overload
+    def __get__(self, inst: object, owner: type[object] | None = None) -> _T:
+        ...
+
+    def __get__(self, inst: object | None, owner: type[object] | None = None) -> _T:
+        if inst is None:
+            return self._default_factory()
+
+        value = cast("_T", getattr(inst, self._name, self._sentinel))
+        if value is self._sentinel:
+            value = self._default_factory()
+            self.__set__(inst, value)
+        return value
+
+    def __set__(self, inst: object, value: _T | _S | Self) -> None:
+        # dataclasses.field(default=Descriptor()) causes __set__ to be called with Self
+        if value is self._sentinel or value is self:
+            object.__setattr__(inst, self._name, self._default_factory())
+        else:
+            object.__setattr__(inst, self._name, value)

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -9,10 +9,12 @@ from typing import (
     TypedDict,
 )
 
+from ._default_if_sentinel import DefaultIfSentinel
 from .browsers import product_list
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Mapping, Sequence
     from types import ModuleType
 
     from mozlog.structuredlog import StructuredLogger
@@ -22,11 +24,6 @@ if TYPE_CHECKING:
     from .environment import TestEnvironment
     from .executors.base import TestExecutor
     from .testloader import Subsuite
-
-    if sys.version_info >= (3, 9):
-        from collections.abc import Mapping, Sequence
-    else:
-        from typing import Mapping, Sequence
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -121,7 +118,7 @@ def default_run_info_extras(logger: StructuredLogger, **kwargs: Any) -> Mapping[
     return {}
 
 
-@dataclass
+@dataclass(frozen=True)
 class Product:
     name: str
     # Once we can rely on Python 3.10, we should add:
@@ -135,48 +132,21 @@ class Product:
     get_env_extras: EnvExtras
     get_timeout_multiplier: TimeoutMultiplier
     executor_classes: Mapping[str, type[TestExecutor]]
-    run_info_extras: RunInfoExtras
-    update_properties: tuple[Sequence[str], Mapping[str, Sequence[str]]]
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        browser_classes: Mapping[str | None, type[browsers_base.Browser]],
-        check_args: CheckArgs,
-        get_browser_kwargs: BrowserKwargs,
-        get_executor_kwargs: ExecutorKwargs,
-        env_options: Mapping[str, Any],
-        get_env_extras: EnvExtras,
-        get_timeout_multiplier: TimeoutMultiplier,
-        executor_classes: Mapping[str, type[TestExecutor]],
-        run_info_extras: None | RunInfoExtras = None,
-        update_properties: None | tuple[Sequence[str], Mapping[str, Sequence[str]]] = None,
-    ) -> None:
-        self.name = name
-        self._browser_cls = browser_classes
-        self.check_args = check_args
-        self.get_browser_kwargs = get_browser_kwargs
-        self.get_executor_kwargs = get_executor_kwargs
-        self.env_options = env_options
-        self.get_env_extras = get_env_extras
-        self.get_timeout_multiplier = get_timeout_multiplier
-        self.executor_classes = executor_classes
-
-        if run_info_extras is not None:
-            self.run_info_extras = run_info_extras
-        else:
-            self.run_info_extras = default_run_info_extras
-
-        if update_properties is not None:
-            self.update_properties = update_properties
-        else:
-            self.update_properties = (["product"], {})
+    run_info_extras: DefaultIfSentinel[
+        RunInfoExtras,
+    ] = DefaultIfSentinel(default=default_run_info_extras)
+    update_properties: DefaultIfSentinel[
+        tuple[
+            Sequence[str],
+            Mapping[str, Sequence[str]],
+        ],
+    ] = DefaultIfSentinel(default_factory=lambda: (["product"], {}))
 
     def get_browser_cls(self, test_type: str) -> type[browsers_base.Browser]:
-        if test_type in self._browser_cls:
-            return self._browser_cls[test_type]
-        return self._browser_cls[None]
+        cls = self.browser_classes.get(test_type)
+        if cls is not None:
+            return cls
+        return self.browser_classes[None]
 
     @staticmethod
     def _from_dunder_wptrunner(module: ModuleType) -> Product:

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
 import importlib
-import warnings
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     Protocol,
     TypedDict,
-    overload,
 )
 
 from .browsers import product_list
-from .deprecated import deprecated
 
 if TYPE_CHECKING:
     import sys
@@ -124,12 +121,12 @@ def default_run_info_extras(logger: StructuredLogger, **kwargs: Any) -> Mapping[
     return {}
 
 
-_legacy_product_msg = "Use Product.from_product_name(name) instead of Product(config, name)"
-
-
 @dataclass
 class Product:
     name: str
+    # Once we can rely on Python 3.10, we should add:
+    # _: KW_ONLY
+    # This matches __init__ below.
     browser_classes: Mapping[str | None, type[browsers_base.Browser]]
     check_args: CheckArgs
     get_browser_kwargs: BrowserKwargs
@@ -141,19 +138,6 @@ class Product:
     run_info_extras: RunInfoExtras
     update_properties: tuple[Sequence[str], Mapping[str, Sequence[str]]]
 
-    @overload
-    @deprecated(_legacy_product_msg, category=None)
-    def __init__(
-        self,
-        config: object,
-        legacy_name: str,
-        /,
-        *,
-        _do_not_use_allow_legacy_name_call: bool = False,
-    ) -> None:
-        ...
-
-    @overload
     def __init__(
         self,
         name: str,
@@ -169,76 +153,6 @@ class Product:
         run_info_extras: None | RunInfoExtras = None,
         update_properties: None | tuple[Sequence[str], Mapping[str, Sequence[str]]] = None,
     ) -> None:
-        ...
-
-    def __init__(
-        self,
-        name: object,
-        _legacy_name: None | str = None,
-        *,
-        browser_classes: None | Mapping[str | None, type[browsers_base.Browser]] = None,
-        check_args: None | CheckArgs = None,
-        get_browser_kwargs: None | BrowserKwargs = None,
-        get_executor_kwargs: None | ExecutorKwargs = None,
-        env_options: None | Mapping[str, Any] = None,
-        get_env_extras: None | EnvExtras = None,
-        get_timeout_multiplier: None | TimeoutMultiplier = None,
-        executor_classes: None | Mapping[str, type[TestExecutor]] = None,
-        run_info_extras: None | RunInfoExtras = None,
-        update_properties: None | tuple[Sequence[str], Mapping[str, Sequence[str]]] = None,
-        _do_not_use_allow_legacy_name_call: bool = False,
-    ) -> None:
-        if _legacy_name is None:
-            assert isinstance(name, str)
-        else:
-            if not _do_not_use_allow_legacy_name_call:
-                warnings.warn(_legacy_product_msg, category=DeprecationWarning, stacklevel=2)
-
-            module = _product_module(_legacy_name)
-            data: WptrunnerModuleDict = module.__wptrunner__
-
-            name = data["product"]
-            if name != _legacy_name:
-                msg = f"Product {_legacy_name!r} calls itself {name!r}, which differs"
-                raise ValueError(msg)
-            browser_classes = (
-                {None: getattr(module, data["browser"])}
-                if isinstance(data["browser"], str)
-                else {
-                    key: getattr(module, value)
-                    for key, value in data["browser"].items()
-                }
-            )
-            check_args = getattr(module, data["check_args"])
-            get_browser_kwargs = getattr(module, data["browser_kwargs"])
-            get_executor_kwargs = getattr(module, data["executor_kwargs"])
-            env_options = getattr(module, data["env_options"])()
-            get_env_extras = getattr(module, data["env_extras"])
-            get_timeout_multiplier = getattr(module, data["timeout_multiplier"])
-            executor_classes = {
-                test_type: getattr(module, cls_name)
-                for test_type, cls_name in data["executor"].items()
-            }
-            run_info_extras = (
-                getattr(module, data["run_info_extras"])
-                if "run_info_extras" in data
-                else None
-            )
-            update_properties = (
-                getattr(module, data["update_properties"])()
-                if "update_properties" in data
-                else None
-            )
-
-        assert browser_classes is not None
-        assert check_args is not None
-        assert get_browser_kwargs is not None
-        assert get_executor_kwargs is not None
-        assert env_options is not None
-        assert get_env_extras is not None
-        assert get_timeout_multiplier is not None
-        assert executor_classes is not None
-
         self.name = name
         self._browser_cls = browser_classes
         self.check_args = check_args
@@ -259,11 +173,64 @@ class Product:
         else:
             self.update_properties = (["product"], {})
 
-    @classmethod
-    def from_product_name(cls, name: str) -> Product:
-        return cls(None, name, _do_not_use_allow_legacy_name_call=True)
-
     def get_browser_cls(self, test_type: str) -> type[browsers_base.Browser]:
         if test_type in self._browser_cls:
             return self._browser_cls[test_type]
         return self._browser_cls[None]
+
+    @staticmethod
+    def _from_dunder_wptrunner(module: ModuleType) -> Product:
+        data: WptrunnerModuleDict = module.__wptrunner__
+
+        name = data["product"]
+        browser_classes: Mapping[str | None, type[browsers_base.Browser]] = (
+            {None: getattr(module, data["browser"])}
+            if isinstance(data["browser"], str)
+            else {
+                key: getattr(module, value)
+                for key, value in data["browser"].items()
+            }
+        )
+        check_args = getattr(module, data["check_args"])
+        get_browser_kwargs = getattr(module, data["browser_kwargs"])
+        get_executor_kwargs = getattr(module, data["executor_kwargs"])
+        env_options = getattr(module, data["env_options"])()
+        get_env_extras = getattr(module, data["env_extras"])
+        get_timeout_multiplier = getattr(module, data["timeout_multiplier"])
+        executor_classes = {
+            test_type: getattr(module, cls_name)
+            for test_type, cls_name in data["executor"].items()
+        }
+        run_info_extras = (
+            getattr(module, data["run_info_extras"])
+            if "run_info_extras" in data
+            else None
+        )
+        update_properties = (
+            getattr(module, data["update_properties"])()
+            if "update_properties" in data
+            else None
+        )
+
+        return Product(
+            name=name,
+            browser_classes=browser_classes,
+            check_args=check_args,
+            get_browser_kwargs=get_browser_kwargs,
+            get_executor_kwargs=get_executor_kwargs,
+            env_options=env_options,
+            get_env_extras=get_env_extras,
+            get_timeout_multiplier=get_timeout_multiplier,
+            executor_classes=executor_classes,
+            run_info_extras=run_info_extras,
+            update_properties=update_properties,
+        )
+
+    @staticmethod
+    def from_product_name(name: str) -> Product:
+        module = _product_module(name)
+        product = Product._from_dunder_wptrunner(module)
+        if name != product.name:
+            msg = f"Product {name!r} calls itself {product.name!r}, which differs"
+            raise ValueError(msg)
+        return product

--- a/tools/wptrunner/wptrunner/tests/test_default_if_sentinel.py
+++ b/tools/wptrunner/wptrunner/tests/test_default_if_sentinel.py
@@ -1,0 +1,146 @@
+import dataclasses
+import itertools
+
+import pytest
+
+from .._default_if_sentinel import DefaultIfSentinel
+
+
+def test_descriptor_with_default() -> None:
+    class A:
+        x = DefaultIfSentinel(default="default")
+
+    o = A()
+    assert o.x == "default"
+
+    o.x = "changed"
+    assert o.x == "changed"
+
+    o.x = None
+    assert o.x == "default"
+
+
+def test_descriptor_with_default_factory() -> None:
+    class A:
+        x = DefaultIfSentinel(default_factory=lambda: "default")
+
+    o = A()
+    assert o.x == "default"
+
+    o.x = "changed"
+    assert o.x == "changed"
+
+    o.x = None
+    assert o.x == "default"
+
+
+@pytest.mark.parametrize(
+    "sentinel_value,assigned_value",
+    list(
+        itertools.product(
+            [
+                None,
+                object(),
+                "SENTINEL",
+                [],
+            ],
+            repeat=2,
+        )
+    ),
+)
+def test_descriptor_sentinel_handling(
+    sentinel_value: object, assigned_value: object
+) -> None:
+    class TestClass:
+        value = DefaultIfSentinel(default="default", sentinel=sentinel_value)
+
+    obj = TestClass()
+    obj.value = assigned_value
+
+    if assigned_value is sentinel_value:
+        assert obj.value == "default"
+    else:
+        assert obj.value is assigned_value
+
+
+def test_descriptor_identity_not_equality() -> None:
+    sentinel_list: list[int] = []
+
+    class TestClass:
+        value = DefaultIfSentinel(default_factory=lambda: [1], sentinel=sentinel_list)
+
+    obj = TestClass()
+    obj.value = sentinel_list
+    assert obj.value is not sentinel_list
+    assert obj.value == [1]
+
+    different_list: list[int] = []
+    obj.value = different_list
+    assert obj.value is different_list
+
+
+def test_descriptor_list_same_instance() -> None:
+    class A:
+        value: DefaultIfSentinel[list[int]] = DefaultIfSentinel(default_factory=list)
+
+    obj = A()
+    first = obj.value
+    second = obj.value
+    assert first is second
+
+
+def test_descriptor_list_isolation_between_instances() -> None:
+    class A:
+        value: DefaultIfSentinel[list[int]] = DefaultIfSentinel(default_factory=list)
+
+    obj1 = A()
+    obj2 = A()
+    assert obj1.value == []
+    assert obj2.value == []
+    assert obj1.value is not obj2.value
+
+
+def test_descriptor_list_different_instance_from_class() -> None:
+    class A:
+        value: DefaultIfSentinel[list[int]] = DefaultIfSentinel(default_factory=list)
+
+    first = A.value
+    second = A.value
+    assert first == []
+    assert second == []
+    assert first is not second
+
+    A.value.append(1)
+    obj = A()
+    A.value.append(2)
+
+    assert obj.value == []
+    assert obj.value is not first
+    assert obj.value is not second
+
+
+def test_descriptor_dataclasses_field() -> None:
+    @dataclasses.dataclass
+    class TestClass:
+        value: "DefaultIfSentinel[str]" = dataclasses.field(
+            default=DefaultIfSentinel(default="default"),
+            repr=False,
+        )
+
+    obj = TestClass()
+    assert obj.value == "default"
+
+
+def test_descriptor_dataclasses_frozen() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class TestClass:
+        value: "DefaultIfSentinel[str]" = DefaultIfSentinel(default="default")
+
+    obj1 = TestClass()
+    assert obj1.value == "default"
+
+    obj2 = TestClass("changed")
+    assert obj2.value == "changed"
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        obj1.value = "changed"  # type: ignore[misc]

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -40,16 +40,6 @@ def test_load_all_products(product):
             pass
 
 
-@all_products("product")
-def test_load_all_products_deprecated(product):
-    """test every product causes a DeprecationWarning"""
-    with pytest.deprecated_call(match=r"Use Product\.from_product_name"):
-        try:
-            products.Product({}, product)
-        except ImportError:
-            pass
-
-
 @active_products("product", marks={
     "sauce": pytest.mark.skip("needs env extras kwargs"),
 })

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -65,3 +65,48 @@ def test_server_start_config(product):
             else:
                 assert config["server_host"] == config["browser_host"]
             assert isinstance(config["bind_address"], bool)
+
+
+def test_default_if_none_descriptor_with_none() -> None:
+    """Test that _DefaultIfNone descriptor converts None to default"""
+    product = products.Product(
+        name="test",
+        browser_classes={None: mock.MagicMock()},
+        check_args=mock.MagicMock(),
+        get_browser_kwargs=mock.MagicMock(),
+        get_executor_kwargs=mock.MagicMock(),
+        env_options={},
+        get_env_extras=mock.MagicMock(),
+        get_timeout_multiplier=mock.MagicMock(),
+        executor_classes={},
+        run_info_extras=None,  # This would fail without the descriptor
+        update_properties=None,  # This would fail without the descriptor
+    )
+
+    assert product.run_info_extras is products.default_run_info_extras
+    assert product.update_properties == (["product"], {})
+
+
+def test_default_if_none_descriptor_with_provided_values() -> None:
+    """Test that _DefaultIfNone descriptor preserves provided values"""
+    def custom_run_info_extras(logger, **kwargs):
+        return {"custom": "value"}
+
+    custom_update_properties = (["custom"], {"prop": ["value"]})
+
+    product = products.Product(
+        name="test",
+        browser_classes={None: mock.MagicMock()},
+        check_args=mock.MagicMock(),
+        get_browser_kwargs=mock.MagicMock(),
+        get_executor_kwargs=mock.MagicMock(),
+        env_options={},
+        get_env_extras=mock.MagicMock(),
+        get_timeout_multiplier=mock.MagicMock(),
+        executor_classes={},
+        run_info_extras=custom_run_info_extras,
+        update_properties=custom_update_properties,
+    )
+
+    assert product.run_info_extras is custom_run_info_extras
+    assert product.update_properties is custom_update_properties


### PR DESCRIPTION
By moving the dataclass to a base class we can simply call the dataclass generated `__init__` on the superclass, rather than having to do it all manually.

All of the logic is now within dataclass; all the `Product` subclass does is maintain support for the deprecated constructor, and provides the `from_product_name` method.