### PR TITLE
cssom-view: add arg validation checks for shadowRoot.elementsFromPoint

### DIFF
--- a/css/cssom-view/elementsFromPoint-shadowroot.html
+++ b/css/cssom-view/elementsFromPoint-shadowroot.html
@@ -63,6 +63,9 @@ var y12 = centerY(box12);
 var x22 = centerX(box22);
 var y22 = centerY(box22);
 
+shouldThrow('shadowRoot.elementsFromPoint()');
+shouldThrow('shadowRoot.elementsFromPoint(0)');
+
 var root3 = blockHost.attachShadow({mode: 'closed'});
 root3.appendChild(document.createTextNode('text1'));
 var root4 = inlineBlockHost.attachShadow({mode: 'closed'});


### PR DESCRIPTION
This adds missing argument validation checks for shadowRoot.elementsFromPoint.