### PR TITLE
layout: Handle zero-sized positioning areas when laying out a dimension for `background-repeat`

### DIFF
--- a/css/css-backgrounds/background-repeat-round-empty-crash.html
+++ b/css/css-backgrounds/background-repeat-round-empty-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42216">
+<style>
+  #span { background-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImb5Gm2hB0SlBCB0Uj); background-repeat: round round; border-right-style: solid; }
+</style>
+<span id="span"></span>


### PR DESCRIPTION
The specification says that the rounding of the tile size should only happen
when the positioning size is not zero. This change makes us follow the
specification in this case.

Testing: This PR adds a new WPT crash test.
Fixes: #<!-- nolink -->42216

Reviewed in servo/servo#42303