### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=306448

### DIFF
--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-ref.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-ref.html
@@ -69,7 +69,7 @@ subgrid.extent {
   <item>1</item>
   <item>2</item>
   <item>3</item>
-  <subgrid style="grid: none / none">
+  <subgrid>
     <item>4a</item>
     <item>4b</item>
     <item>4c</item>

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
@@ -67,15 +67,15 @@ subgrid.extent {
 <!-- auto-placed subgrid inhibits subgridding when parent is doing grid-lanes layout ... -->
 
 <grid class="rows">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <subgrid>
-    <item>4a</item>
-    <item>4b</item>
-    <item>4c</item>
+  <item style="height: 24px;">1</item>
+  <item style="height: 40px;">2</item>
+  <item style="height: 40px;">3</item>
+  <subgrid style="height: calc(30px + 4px + 20px);">
+    <item style="height: 13px;">4a</item>
+    <item style="height: 29px;">4b</item>
+    <item style="height: 19px;">4c</item>
   </subgrid>
-  <item>5</item>
+  <item style="height: 30px;">5</item>
 </grid>
 
 </body></html>


### PR DESCRIPTION
WebKit export from bug: [\[grid-lanes\] Fix grid-lanes-subgrid-002a test to match cross-browser rendering behavior](https://bugs.webkit.org/show_bug.cgi?id=306448)