### PR TITLE
Add test for the clear attribute presentational hints on BR elements

### DIFF
--- a/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints-ref.html
+++ b/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<div style="max-width: 100px; height: 100px; background: green;"></div>

--- a/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints.html
+++ b/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The clear attribute applies the clear CSS property.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3">
+<link rel=match href="./br-clear-presentational-hints-ref.html">
+<style>
+  body {
+    line-height: 0;
+  }
+  .test > div {
+    width: 25px;
+    height: 50px;
+    background: green;
+  }
+</style>
+<div style="max-width: 100px; display: flex; height: 100px; background: red;">
+  <div class="test">
+    <div style="float:right"></div>
+    <br clear="all">
+    <div></div>
+  </div>
+  <div class="test">
+    <div style="float:right"></div>
+    <br clear="both">
+    <div></div>
+  </div>
+  <div class="test">
+    <div style="float:right"></div>
+    <br clear="right">
+    <div></div>
+  </div>
+  <div class="test">
+    <div style="float:left"></div>
+    <br clear="left">
+    <div></div>
+  </div>
+</div>


### PR DESCRIPTION
This tests that these presentational hints from [the spec](https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3) are honored:
```css
br[clear=left i] { clear: left; }
br[clear=right i] { clear: right; }
br[clear=all i], br[clear=both i] { clear: both; }
```

Written as part of the [Ladybird](https://github.com/LadybirdBrowser/ladybird) project, should pass in all browsers.
Also, bonus example page where this behavior is used: https://archive.org/details/mspaint_xp_version