### PR TITLE
script: Remove named window proxy map entry when destroying nested browsing context

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -225,7 +225,7 @@ class TimedRunner:
                             sys._current_frames()[executor.ident]))
                     self.result = False, ("EXTERNAL-TIMEOUT", message)
                 else:
-                    self.logger.info("Browser not responding, setting status to CRASH")
+                    self.logger.info("Browser not responding, setting status to CRASH (!!)")
                     self.result = False, ("CRASH", None)
         elif self.result[1] is None:
             # We didn't get any data back from the test, so check if the


### PR DESCRIPTION
Leaving the entries sitting around both unnecessarily increases memory usage and breaks code that looks up window proxies by name and reuses names for iframes within the same page.

Testing: TBD
Fixes: #<!-- nolink -->15258

Reviewed in servo/servo#42344