### PR TITLE
[css-color] Factor out calc(sign(cqw)) tests into their own test file.

### DIFF
--- a/css/css-color/parsing/color-computed-contrast-color-function.html
+++ b/css/css-color/parsing/color-computed-contrast-color-function.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-<html>
-<head>
 <meta charset="utf-8">
 <title>Test CSS Color Module 5 contrast-color() computed value</title>
 <link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
@@ -8,18 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<style>
-  #container {
-    container-type: inline-size;
-    width: 10px;
-    color: pink;
-  }
-</style>
-</head>
-<body>
-<div id="container">
-  <div id="target"></div>
-</div>
+<div id="target"></div>
 <script>
 
 // NOTE: As the algorithm for determining constrast is not defined, all computed values can validly be either `rgb(0, 0, 0)` or `rgb(255, 255, 255)`.
@@ -44,8 +31,5 @@ test_computed_value("background-color", "contrast-color(contrast-color(pink))", 
 test_computed_value("background-color", "contrast-color(currentcolor)", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
 
 // Test color using calc().
-test_computed_value("background-color", "contrast-color(color(srgb calc(1 + (sign(20cqw - 10px) * 1)) calc(1 + (sign(20cqw - 10px) * 1)) calc(1 + (sign(20cqw - 10px) * 1))))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
-
+test_computed_value("background-color", "contrast-color(color(srgb calc(1 + 1 / 1) calc(1 + 1 / 1) calc(1 + 1 / 1)))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
 </script>
-</body>
-</html>

--- a/css/css-color/parsing/color-valid-contrast-color-function.html
+++ b/css/css-color/parsing/color-valid-contrast-color-function.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-<html>
-<head>
 <meta charset="utf-8">
 <title>Test CSS Color Module 5 contrast-color() parsing valid values</title>
 <link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
@@ -15,8 +13,6 @@
     color: pink;
   }
 </style>
-</head>
-<body>
 <div id="container">
   <div id="target"></div>
 </div>
@@ -42,8 +38,8 @@ test_valid_value("background-color", "contrast-color(contrast-color(pink))");
 test_valid_value("background-color", "contrast-color(currentcolor)");
 
 // Test color using calc().
-test_valid_value("background-color", "contrast-color(color(srgb calc(0.5) calc(1 + (sign(20cqw - 10px) * 0.5)) 1 / .5))", "contrast-color(color(srgb calc(0.5) calc(1 + (0.5 * sign(20cqw - 10px))) 1 / 0.5))");
-
+test_valid_value("background-color", "contrast-color(color(srgb calc(0.5) calc(1 + 1 / 1) 1 / .5))", [
+  "contrast-color(color(srgb calc(0.5) calc(2) 1 / 0.5))",
+  "contrast-color(color(srgb 0.5 2 1 / 0.5))"
+]);
 </script>
-</body>
-</html>

--- a/css/css-color/parsing/contrast-color-function-calc-container.html
+++ b/css/css-color/parsing/contrast-color-function-calc-container.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test CSS Color Module 5 contrast-color() computed value with calc() and container units</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#contrast-color">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#serializing-color-function-values">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+    color: pink;
+  }
+</style>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+// NOTE: As the algorithm for determining constrast is not defined, all computed values can validly be either `rgb(0, 0, 0)` or `rgb(255, 255, 255)`.
+test_computed_value("background-color", `contrast-color(color(srgb calc(1 + (sign(20cqw - 10px) * 1)) calc(1 + (sign(20cqw - 10px) * 1)) calc(1 + (sign(20cqw - 10px) * 1))))`, ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+test_valid_value("background-color", "contrast-color(color(srgb calc(0.5) calc(1 + (sign(20cqw - 10px) * 0.5)) 1 / .5))", "contrast-color(color(srgb calc(0.5) calc(1 + (0.5 * sign(20cqw - 10px))) 1 / 0.5))");
+</script>


### PR DESCRIPTION
The modified contrast-color tests are proposed to be in interop 2026, but these subtests rely on an unrelated feature not implemented by all engines (being able to use lengths inside calc() where numbers are expected).

Add some basic numeric calc tests, and move the cqw ones to a separate test file.