### PR TITLE
Bump python dependencies to minimum required for Arm64 Windows

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -1,3 +1,4 @@
+import aioquic
 import asyncio
 import contextlib
 import logging
@@ -380,13 +381,14 @@ class WebTransportSession:
         """
         stream_id = self._http.create_webtransport_stream(
             session_id=self.session_id, is_unidirectional=False)
-        # TODO(bashi): Remove this workaround when aioquic supports receiving
-        # data on server-initiated bidirectional streams.
-        stream = self._http._get_or_create_stream(stream_id)
-        assert stream.frame_type is None
-        assert stream.session_id is None
-        stream.frame_type = FrameType.WEBTRANSPORT_STREAM
-        stream.session_id = self.session_id
+        if aioquic.__version__ <= "1.2.0":
+            # TODO(bashi): Remove this workaround when aioquic supports receiving
+            # data on server-initiated bidirectional streams.
+            stream = self._http._get_or_create_stream(stream_id)
+            assert stream.frame_type is None
+            assert stream.session_id is None
+            stream.frame_type = FrameType.WEBTRANSPORT_STREAM
+            stream.session_id = self.session_id
         return stream_id
 
     def send_stream_data(self,

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -1,4 +1,3 @@
-import aioquic
 import asyncio
 import contextlib
 import logging
@@ -12,13 +11,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
-from packaging.version import Version
-
 from aioquic.buffer import Buffer
 from aioquic.asyncio import QuicConnectionProtocol, serve
 from aioquic.asyncio.client import connect
 from aioquic.asyncio.protocol import QuicStreamAdapter
-from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, SettingsError
+from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, H3Stream, ProtocolError, SettingsError
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived
 from aioquic.quic.configuration import QuicConfiguration
 from aioquic.quic.connection import logger as quic_connection_logger
@@ -384,18 +381,18 @@ class WebTransportSession:
         stream_id = self._http.create_webtransport_stream(
             session_id=self.session_id, is_unidirectional=False)
         # TODO(bashi): Remove this workaround when aioquic supports receiving
-        # data on server-initiated bidirectional streams.
-        stream_cm = self._http._get_or_create_stream(stream_id)
-        if Version(aioquic.__version__) <= Version("1.2.0"):
-            # Older aioquic returns the stream directly rather than a context
-            # manager. The stream is freshly created here and not yet ended, so
-            # the seeded state persists for incoming client data.
-            stream_cm = contextlib.nullcontext(stream_cm)
-        with stream_cm as stream:
-            assert stream.frame_type is None
-            assert stream.session_id is None
-            stream.frame_type = FrameType.WEBTRANSPORT_STREAM
-            stream.session_id = self.session_id
+        # data on server-initiated bidirectional streams. The public API for
+        # accessing the stream object differs between aioquic versions, so seed
+        # the internal stream state directly. The stream is freshly created
+        # here, so the seeded state persists for incoming client data.
+        stream = self._http._stream.get(stream_id)
+        if stream is None:
+            stream = H3Stream(stream_id)
+            self._http._stream[stream_id] = stream
+        assert stream.frame_type is None
+        assert stream.session_id is None
+        stream.frame_type = FrameType.WEBTRANSPORT_STREAM
+        stream.session_id = self.session_id
         return stream_id
 
     def send_stream_data(self,

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
+from packaging.version import Version
+
 from aioquic.buffer import Buffer
 from aioquic.asyncio import QuicConnectionProtocol, serve
 from aioquic.asyncio.client import connect
@@ -381,10 +383,15 @@ class WebTransportSession:
         """
         stream_id = self._http.create_webtransport_stream(
             session_id=self.session_id, is_unidirectional=False)
-        if aioquic.__version__ <= "1.2.0":
-            # TODO(bashi): Remove this workaround when aioquic supports receiving
-            # data on server-initiated bidirectional streams.
-            stream = self._http._get_or_create_stream(stream_id)
+        # TODO(bashi): Remove this workaround when aioquic supports receiving
+        # data on server-initiated bidirectional streams.
+        stream_cm = self._http._get_or_create_stream(stream_id)
+        if Version(aioquic.__version__) <= Version("1.2.0"):
+            # Older aioquic returns the stream directly rather than a context
+            # manager. The stream is freshly created here and not yet ended, so
+            # the seeded state persists for incoming client data.
+            stream_cm = contextlib.nullcontext(stream_cm)
+        with stream_cm as stream:
             assert stream.frame_type is None
             assert stream.session_id is None
             stream.frame_type = FrameType.WEBTRANSPORT_STREAM

--- a/tools/webtransport/requirements.txt
+++ b/tools/webtransport/requirements.txt
@@ -1,1 +1,3 @@
-aioquic==1.2.0
+aioquic==1.3.0; python_version >= "3.10"
+aioquic==1.2.0; python_version < "3.10"
+cryptography==46

--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -10,4 +10,6 @@ pillow==12.1.1; python_version >= '3.10'
 requests==2.32.3
 types-requests==2.32.0.20241016
 urllib3==2.6.3
-aioquic==1.2.0
+aioquic==1.3.0; python_version >= "3.10"
+aioquic==1.2.0; python_version < "3.10"
+cryptography==46

--- a/tools/wptrunner/requirements_chromium.txt
+++ b/tools/wptrunner/requirements_chromium.txt
@@ -1,1 +1,3 @@
-aioquic==1.2.0
+aioquic==1.3.0; python_version >= "3.10"
+aioquic==1.2.0; python_version < "3.10"
+cryptography==46


### PR DESCRIPTION
GitHub only recently added Arm64 Windows runners, so only recent Python packages tend to have a Wheel for Arm64 Windows.

This change bumps the Python dependencies to version with Arm64 Wheels:
```
aioquic==1.3.0
cryptography==46
```

Testing: Ran Python locally on my Arm64 Windows device.
Contributes to fixing #<!-- nolink -->40611

Reviewed in servo/servo#42374