### PR TITLE
Clear connection timing when service-worker response is passed to resource timing.

### DIFF
--- a/service-workers/service-worker/next-hop-protocol.https.html
+++ b/service-workers/service-worker/next-hop-protocol.https.html
@@ -31,9 +31,9 @@ async function runTest(t, base_url, expected_protocol) {
   assert_equals(await getNextHopProtocol(frame, `${base_url}?ignore`),
                 expected_protocol, 'nextHopProtocol is set on fallback');
   assert_equals(await getNextHopProtocol(frame, `${base_url}`),
-                expected_protocol, 'nextHopProtocol is set on pass-through');
+                '', 'nextHopProtocol is not set on pass-through');
   assert_equals(await getNextHopProtocol(frame, `${base_url}?cache`),
-                expected_protocol, 'nextHopProtocol is set on cached response');
+                '', 'nextHopProtocol is not set on cached response');
 }
 
 promise_test(async (t) => {

--- a/service-workers/service-worker/resource-timing-cross-origin.https.html
+++ b/service-workers/service-worker/resource-timing-cross-origin.https.html
@@ -30,10 +30,12 @@ function test_sw_resource_timing({ mode }) {
       assert_equals(entry.connectStart, 0, 'connectStart should be 0 in cross-origin request.');
       assert_equals(entry.connectEnd, 0, 'connectEnd should be 0 in cross-origin request.');
       assert_equals(entry.responseStart, 0, 'responseStart should be 0 in cross-origin request.');
+      assert_greater_than(entry.responseStart, entry.fetchStart, 'responseStart is specific to service-workers.');
       assert_equals(entry.secureConnectionStart, 0, 'secureConnectionStart should be 0 in cross-origin request.');
       assert_equals(entry.decodedBodySize, 0, 'decodedBodySize should be 0 in cross-origin request.');
       assert_equals(entry.encodedBodySize, 0, 'encodedBodySize should be 0 in cross-origin request.');
       assert_equals(entry.transferSize, 0, 'transferSize should be 0 in cross-origin request.');
+      assert_equals(entry.nextHopProtocol, "", 'nextHopProtocol should be 0 in cross-origin request.');
       frame.remove();
       await registration.unregister();
   }, `Test that timing allow check fails when service worker changes origin from same to cross origin (${mode}).`);


### PR DESCRIPTION
By spec, this information is part of the fetch rather than the response, and the connection info for a response passed from a service worker is not the connection info of the client's fetch.

Bug: 477180001
Change-Id: I98145f0976eb8d301a21c20e3c7892a96edd9274
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7516608
Commit-Queue: Noam Rosenthal <nrosenthal@google.com>
Reviewed-by: Yoav Weiss (@Shopify) <yoavweiss@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1578031}