### PR TITLE
Fix per-element allow list handling.

### DIFF
--- a/sanitizer-api/sanitizer-parseHTML.tentative.html
+++ b/sanitizer-api/sanitizer-parseHTML.tentative.html
@@ -113,6 +113,28 @@ TypeError
 |   <body>
 |     <br>
 
+#data
+<p onclick="alert(document.cookie)">Click handler!</p>
+#config
+{"elements": [{ "name":"p", "attributes":["onclick"] }, "html", "body"], "attributes":[]}
+#document
+#document
+| <html>
+|   <body>
+|     <p>
+|      "Click handler!"
+
+#data
+<p onclick="alert(document.cookie)">Click handler!</p>
+#config
+{"elements": [{ "name":"p", "attributes":["onclick"] }, "html", "body"]}
+#document
+#document
+| <html>
+|   <body>
+|     <p>
+|      "Click handler!"
+
 </script>
 <script id="unsafe" type="html5lib-testcases">
 #data


### PR DESCRIPTION
RemoveAttribute doesn't remove per-element allow list attributes (when there's also a global allow list). This is per (old) spec, but the spec has been fixed.

Add CHECKs for Sanitizer's primary security guarantee, to make sure similar issues will not result in an unsafe user experience.

Spec: https://github.com/WICG/sanitizer-api/pull/369
Bug: 477643913, 479513763
Change-Id: I60a103f3fea6ad01f2090a13400e1d51941bea11
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7516493
Reviewed-by: Mike West <mkwst@chromium.org>
Commit-Queue: Daniel Vogelheim <vogelheim@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1579985}