### PR TITLE
Add infra tests for navigation (and "navigation") during reftest execution

### DIFF
--- a/infrastructure/expected-fail/reftest-with-push-cross-document-navigation.html
+++ b/infrastructure/expected-fail/reftest-with-push-cross-document-navigation.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Reftests should error after push cross-document navigation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationType">
+<link rel="match" href="resources/reftest-navigation-destination.html">
+<script src="/common/reftest-wait.js"></script>
+<p>Reftests should error after a navigation (initial page)</p>
+<script>
+  onload = () => {
+    location.href = "resources/reftest-navigation-destination.html";
+  };
+</script>
+</html>

--- a/infrastructure/expected-fail/reftest-with-push-same-document-navigation.html
+++ b/infrastructure/expected-fail/reftest-with-push-same-document-navigation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Reftests should error after push same-document navigation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationType">
+<link rel="match" href="resources/reftest-navigation-destination.html">
+<script src="/common/reftest-wait.js"></script>
+<p>Reftests should error after a navigation (initial page)</p>
+<script>
+  let destinationHash = null;
+
+  onhashchange = () => {
+    if (location.hash === destinationHash) {
+      document.querySelector("p").textContent = "Reftests should error after a navigation";
+      takeScreenshot();
+    }
+  };
+
+  onload = () => {
+    destinationHash = "#" + encodeURI(String(Date.now()) + String(Math.random()));
+    location.href = destinationHash;
+  };
+</script>
+</html>

--- a/infrastructure/expected-fail/reftest-with-reload-navigation.html
+++ b/infrastructure/expected-fail/reftest-with-reload-navigation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Reftests should error after reload navigation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationType">
+<link rel="match" href="resources/reftest-navigation-destination.html">
+<script src="/common/reftest-wait.js"></script>
+<p>Reftests should error after a navigation (initial page)</p>
+<script>
+  onload = () => {
+    if (sessionStorage.getItem("reloaded")) {
+      sessionStorage.removeItem("reloaded");
+      document.querySelector("p").textContent = "Reftests should error after a navigation";
+      takeScreenshot();
+    } else {
+      sessionStorage.setItem("reloaded", "true");
+      location.reload();
+    }
+  };
+</script>
+</html>

--- a/infrastructure/expected-fail/reftest-with-replace-cross-document-navigation.html
+++ b/infrastructure/expected-fail/reftest-with-replace-cross-document-navigation.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Reftests should error after replace cross-document navigation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationType">
+<link rel="match" href="resources/reftest-navigation-destination.html">
+<script src="/common/reftest-wait.js"></script>
+<p>Reftests should error after a navigation (initial page)</p>
+<script>
+  onload = () => {
+    location.replace("resources/reftest-navigation-destination.html");
+  };
+</script>
+</html>

--- a/infrastructure/expected-fail/reftest-with-replace-same-document-navigation.html
+++ b/infrastructure/expected-fail/reftest-with-replace-same-document-navigation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Reftests should error after replace same-document navigation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationType">
+<link rel="match" href="resources/reftest-navigation-destination.html">
+<script src="/common/reftest-wait.js"></script>
+<p>Reftests should error after a navigation (initial page)</p>
+<script>
+  let destinationHash = null;
+
+  onhashchange = () => {
+    if (location.hash === destinationHash) {
+      document.querySelector("p").textContent = "Reftests should error after a navigation";
+      takeScreenshot();
+    }
+  };
+
+  onload = () => {
+    destinationHash = "#" + encodeURI(String(Date.now()) + String(Math.random()));
+    location.replace(destinationHash);
+  };
+</script>
+</html>

--- a/infrastructure/expected-fail/resources/reftest-navigation-destination.html
+++ b/infrastructure/expected-fail/resources/reftest-navigation-destination.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<script src="/common/reftest-wait.js"></script>
+<p>Reftests should error after a navigation</p>
+<script>
+  onload = () => takeScreenshot();
+</script>
+</html>


### PR DESCRIPTION
Related: https://github.com/w3c/webdriver/issues/1708 (because this is really about undefined WebDriver behaviour) and https://github.com/web-platform-tests/wpt/issues/48825 and https://github.com/web-platform-tests/interop/issues/1110

These cover both actual navigation and fragment "navigation".

Based on local testing:

Test | Chrome | Firefox (external) | Firefox (internal) | Safari
-- | -- | -- | -- | --
/infrastructure/expected-fail/reftest-with-push-cross-document-navigation.html | PASS | ERROR | TIMEOUT | ERROR
/infrastructure/expected-fail/reftest-with-push-same-document-navigation.html | PASS | PASS | TIMEOUT | PASS
/infrastructure/expected-fail/reftest-with-reload-navigation.html | PASS | ERROR | PASS | ERROR
/infrastructure/expected-fail/reftest-with-replace-cross-document-navigation.html | PASS | ERROR | TIMEOUT | ERROR
/infrastructure/expected-fail/reftest-with-replace-same-document-navigation.html | PASS | PASS | TIMEOUT | PASS

Notably, even the fragment "navigation" cases (reftest-with-push-same-document-navigation.html and reftest-with-replace-same-document-navigation.html), which don't involve any actual navigation, fail in Firefox with its default internal reftest runner.

The Firefox (external reftest runner) and Safari behaviour are aligned, at least.

Chrome I've very occasionally seen failures with, which suggests there's at least something racy going on there.

(Marking this as a draft for now, as we gotta figure out what we want the expectations to be!)