### PR TITLE
wpt: Fix syntax error in `pointerevent_touch-propagates-when-target-is-video_touch.html`

### DIFF
--- a/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
+++ b/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
@@ -40,7 +40,7 @@ promise_test(async t => {
       .setPointer("touchPointer")
       .pointerMove(xPosition, yPosition)
       .pointerDown()
-      .pointerMove(3, 3, video)
+      .pointerMove(3, 3, { origin: video } )
       .pointerUp()
       .send();
   });


### PR DESCRIPTION
The syntax is wrong. We cannot pass an Element as duration. Only Firefox [was passing this](https://wpt.fyi/results/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html?run_id=5098406608633856&run_id=5170937667518464&run_id=4715813002280960&run_id=5136051728547840),
which is a bug of geckodriver: 


Testing: Updated expectation of existing tests.
This blocks https://github.com/servo/servo/pull/42398, https://github.com/servo/servo/pull/42387.

Reviewed in servo/servo#42405