### PR TITLE
[WebCryptoAPI] Add tests for argument read order

### DIFF
--- a/WebCryptoAPI/digest/cshake.tentative.https.any.js
+++ b/WebCryptoAPI/digest/cshake.tentative.https.any.js
@@ -180,7 +180,7 @@ Object.keys(digestedData).forEach(function (alg) {
             .digest({
               get name() {
                 // Alter the buffer back while calling digest
-                buffer[0] = ~buffer[0];
+                buffer[0] = sourceData[size][0];
                 return alg;
               },
               length

--- a/WebCryptoAPI/digest/cshake.tentative.https.any.js
+++ b/WebCryptoAPI/digest/cshake.tentative.https.any.js
@@ -171,26 +171,42 @@ Object.keys(digestedData).forEach(function (alg) {
           });
       }, alg + ' with ' + length + ' bit output and ' + size + ' source data');
 
-      promise_test(function (test) {
-        var buffer = new Uint8Array(sourceData[size]);
-        return crypto.subtle
-          .digest({ name: alg, length: length }, buffer)
-          .then(function (result) {
-            // Alter the buffer after calling digest
-            if (buffer.length > 0) {
+      if (sourceData[size].length > 0) {
+        promise_test(function (test) {
+          var buffer = new Uint8Array(sourceData[size]);
+          // Alter the buffer before calling digest
+          buffer[0] = ~buffer[0];
+          return crypto.subtle
+            .digest({
+              get name() {
+                // Alter the buffer back while calling digest
+                buffer[0] = ~buffer[0];
+                return alg;
+              },
+              length
+            }, buffer)
+            .then(function (result) {
+              assert_true(
+                equalBuffers(result, digestedData[alg][length][size]),
+                'digest matches expected'
+              );
+            });
+        }, alg + ' with ' + length + ' bit output and ' + size + ' source data and altered buffer during call');
+
+        promise_test(function (test) {
+          var buffer = new Uint8Array(sourceData[size]);
+          return crypto.subtle
+            .digest({ name: alg, length: length }, buffer)
+            .then(function (result) {
+              // Alter the buffer after calling digest
               buffer[0] = ~buffer[0];
-            }
-            assert_true(
-              equalBuffers(result, digestedData[alg][length][size]),
-              'digest matches expected'
-            );
-          });
-      }, alg +
-        ' with ' +
-        length +
-        ' bit output and ' +
-        size +
-        ' source data and altered buffer after call');
+              assert_true(
+                equalBuffers(result, digestedData[alg][length][size]),
+                'digest matches expected'
+              );
+            });
+        }, alg + ' with ' + length + ' bit output and ' + size + ' source data and altered buffer after call');
+      }
     });
   });
 });

--- a/WebCryptoAPI/digest/digest.https.any.js
+++ b/WebCryptoAPI/digest/digest.https.any.js
@@ -89,7 +89,7 @@
                     copiedBuffer[0] = 255 - copiedBuffer[0];
                     var promise = subtle.digest({
                         get name() {
-                            copiedBuffer[0] = 255 - copiedBuffer[0];
+                            copiedBuffer[0] = sourceData[size][0];
                             return upCase;
                         }
                     }, copiedBuffer)

--- a/WebCryptoAPI/digest/digest.https.any.js
+++ b/WebCryptoAPI/digest/digest.https.any.js
@@ -83,19 +83,37 @@
                 return promise;
             }, mixedCase + " with " + size + " source data");
 
-            promise_test(function(test) {
-                var copiedBuffer = copyBuffer(sourceData[size]);
-                var promise = subtle.digest({name: upCase}, copiedBuffer)
-                .then(function(result) {
-                    assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
-                }, function(err) {
-                    assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
-                });
+            if (sourceData[size].length > 0) {
+                promise_test(function(test) {
+                    var copiedBuffer = copyBuffer(sourceData[size]);
+                    copiedBuffer[0] = 255 - copiedBuffer[0];
+                    var promise = subtle.digest({
+                        get name() {
+                            copiedBuffer[0] = 255 - copiedBuffer[0];
+                            return upCase;
+                        }
+                    }, copiedBuffer)
+                    .then(function(result) {
+                        assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
+                    }, function(err) {
+                        assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
+                    });
+                    return promise;
+                }, upCase + " with " + size + " source data and altered buffer during call");
 
-                copiedBuffer[0] = 255 - copiedBuffer;
-                return promise;
-            }, upCase + " with " + size + " source data and altered buffer after call");
+                promise_test(function(test) {
+                    var copiedBuffer = copyBuffer(sourceData[size]);
+                    var promise = subtle.digest({name: upCase}, copiedBuffer)
+                    .then(function(result) {
+                        assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
+                    }, function(err) {
+                        assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
+                    });
 
+                    copiedBuffer[0] = 255 - copiedBuffer[0];
+                    return promise;
+                }, upCase + " with " + size + " source data and altered buffer after call");
+            }
         });
     });
 

--- a/WebCryptoAPI/digest/sha3.tentative.https.any.js
+++ b/WebCryptoAPI/digest/sha3.tentative.https.any.js
@@ -109,19 +109,39 @@ Object.keys(sourceData).forEach(function (size) {
         });
     }, alg + ' with ' + size + ' source data');
 
-    promise_test(function (test) {
-      var buffer = new Uint8Array(sourceData[size]);
-      return crypto.subtle.digest(alg, buffer).then(function (result) {
-        // Alter the buffer after calling digest
-        if (buffer.length > 0) {
+    if (sourceData[size].length > 0) {
+      promise_test(function (test) {
+        var buffer = new Uint8Array(sourceData[size]);
+        // Alter the buffer before calling digest
+        buffer[0] = ~buffer[0];
+        return crypto.subtle
+          .digest({
+            get name() {
+              // Alter the buffer back while calling digest
+              buffer[0] = ~buffer[0];
+              return alg;
+            }
+          }, buffer)
+          .then(function (result) {
+            assert_true(
+              equalBuffers(result, digestedData[alg][size]),
+              'digest matches expected'
+            );
+          });
+      }, alg + ' with ' + size + ' source data and altered buffer during call');
+
+      promise_test(function (test) {
+        var buffer = new Uint8Array(sourceData[size]);
+        return crypto.subtle.digest(alg, buffer).then(function (result) {
+          // Alter the buffer after calling digest
           buffer[0] = ~buffer[0];
-        }
-        assert_true(
-          equalBuffers(result, digestedData[alg][size]),
-          'digest matches expected'
-        );
-      });
-    }, alg + ' with ' + size + ' source data and altered buffer after call');
+          assert_true(
+            equalBuffers(result, digestedData[alg][size]),
+            'digest matches expected'
+          );
+        });
+      }, alg + ' with ' + size + ' source data and altered buffer after call');
+    }
   });
 });
 

--- a/WebCryptoAPI/digest/sha3.tentative.https.any.js
+++ b/WebCryptoAPI/digest/sha3.tentative.https.any.js
@@ -118,7 +118,7 @@ Object.keys(sourceData).forEach(function (size) {
           .digest({
             get name() {
               // Alter the buffer back while calling digest
-              buffer[0] = ~buffer[0];
+              buffer[0] = sourceData[size][0];
               return alg;
             }
           }, buffer)

--- a/WebCryptoAPI/encrypt_decrypt/aes.js
+++ b/WebCryptoAPI/encrypt_decrypt/aes.js
@@ -35,6 +35,38 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Check for successful encryption even if the buffer is changed while calling encrypt.
+    passingVectors.forEach(function(vector) {
+        var plaintext = copyBuffer(vector.plaintext);
+        plaintext[0] = 255 - plaintext[0];
+        var promise = importVectorKey(vector, ["encrypt", "decrypt"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var operation = subtle.encrypt({
+                    ...vector.algorithm,
+                    get name() {
+                        plaintext[0] = 255 - plaintext[0];
+                        return vector.algorithm.name;
+                    }
+                }, vector.key, plaintext)
+                .then(function(result) {
+                    assert_true(equalBuffers(result, vector.result), "Should return expected result");
+                }, function(err) {
+                    assert_unreached("encrypt error for test " + vector.name + ": " + err.message);
+                });
+                return operation;
+            }, vector.name + " with altered plaintext during call");
+        }, function(err) {
+            // We need a failed test if the importVectorKey operation fails, so
+            // we know we never tested encryption
+            promise_test(function(test) {
+                assert_unreached("importKey failed for " + vector.name);
+            }, "importKey step: " + vector.name + " with altered plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful encryption even if the buffer is changed after calling encrypt.
     passingVectors.forEach(function(vector) {
         var plaintext = copyBuffer(vector.plaintext);
@@ -49,13 +81,13 @@ function run_test() {
                 });
                 plaintext[0] = 255 - plaintext[0];
                 return operation;
-            }, vector.name + " with altered plaintext");
+            }, vector.name + " with altered plaintext after call");
         }, function(err) {
             // We need a failed test if the importVectorKey operation fails, so
             // we know we never tested encryption
             promise_test(function(test) {
                 assert_unreached("importKey failed for " + vector.name);
-            }, "importKey step: " + vector.name + " with altered plaintext");
+            }, "importKey step: " + vector.name + " with altered plaintext after call");
         });
 
         all_promises.push(promise);
@@ -84,7 +116,39 @@ function run_test() {
         all_promises.push(promise);
     });
 
-    // Check for successful decryption even if ciphertext is altered.
+    // Check for successful decryption even if ciphertext is altered while calling encrypt.
+    passingVectors.forEach(function(vector) {
+        var ciphertext = copyBuffer(vector.result);
+        ciphertext[0] = 255 - ciphertext[0];
+        var promise = importVectorKey(vector, ["encrypt", "decrypt"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var operation = subtle.decrypt({
+                    ...vector.algorithm,
+                    get name() {
+                        ciphertext[0] = 255 - ciphertext[0];
+                        return vector.algorithm.name;
+                    }
+                }, vector.key, ciphertext)
+                .then(function(result) {
+                    assert_true(equalBuffers(result, vector.plaintext), "Should return expected result");
+                }, function(err) {
+                    assert_unreached("decrypt error for test " + vector.name + ": " + err.message);
+                });
+                return operation;
+            }, vector.name + " decryption with altered ciphertext during call");
+        }, function(err) {
+            // We need a failed test if the importVectorKey operation fails, so
+            // we know we never tested encryption
+            promise_test(function(test) {
+                assert_unreached("importKey failed for " + vector.name);
+            }, "importKey step for decryption: " + vector.name + " with altered ciphertext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful decryption even if ciphertext is altered after calling encrypt.
     passingVectors.forEach(function(vector) {
         var ciphertext = copyBuffer(vector.result);
         var promise = importVectorKey(vector, ["encrypt", "decrypt"])
@@ -98,13 +162,13 @@ function run_test() {
                 });
                 ciphertext[0] = 255 - ciphertext[0];
                 return operation;
-            }, vector.name + " decryption with altered ciphertext");
+            }, vector.name + " decryption with altered ciphertext after call");
         }, function(err) {
             // We need a failed test if the importVectorKey operation fails, so
             // we know we never tested encryption
             promise_test(function(test) {
                 assert_unreached("importKey failed for " + vector.name);
-            }, "importKey step for decryption: " + vector.name + " with altered ciphertext");
+            }, "importKey step for decryption: " + vector.name + " with altered ciphertext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/encrypt_decrypt/aes.js
+++ b/WebCryptoAPI/encrypt_decrypt/aes.js
@@ -45,7 +45,7 @@ function run_test() {
                 var operation = subtle.encrypt({
                     ...vector.algorithm,
                     get name() {
-                        plaintext[0] = 255 - plaintext[0];
+                        plaintext[0] = vector.plaintext[0];
                         return vector.algorithm.name;
                     }
                 }, vector.key, plaintext)
@@ -126,7 +126,7 @@ function run_test() {
                 var operation = subtle.decrypt({
                     ...vector.algorithm,
                     get name() {
-                        ciphertext[0] = 255 - ciphertext[0];
+                        ciphertext[0] = vector.result[0];
                         return vector.algorithm.name;
                     }
                 }, vector.key, ciphertext)

--- a/WebCryptoAPI/encrypt_decrypt/rsa.js
+++ b/WebCryptoAPI/encrypt_decrypt/rsa.js
@@ -40,6 +40,44 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test decryption with an altered buffer during call
+    passingVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["encrypt"], ["decrypt"])
+        .then(function(vectors) {
+            // Get a one byte longer plaintext to encrypt
+            if (!("ciphertext" in vector)) {
+                return;
+            }
+
+            promise_test(function(test) {
+                var ciphertext = copyBuffer(vector.ciphertext);
+                ciphertext[0] = 255 - ciphertext[0];
+                var operation = subtle.decrypt({
+                    ...vector.algorithm,
+                    get name() {
+                        ciphertext[0] = 255 - ciphertext[0];
+                        return vector.algorithm.name;
+                    }
+                }, vector.privateKey, ciphertext)
+                .then(function(plaintext) {
+                    assert_true(equalBuffers(plaintext, vector.plaintext, "Decryption works"));
+                }, function(err) {
+                    assert_unreached("Decryption should not throw error " + vector.name + ": " + err.message + "'");
+                });
+                return operation;
+            }, vector.name + " decryption with altered ciphertext during call");
+
+        }, function(err) {
+            // We need a failed test if the importVectorKey operation fails, so
+            // we know we never tested encryption
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " decryption with altered ciphertext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Test decryption with an altered buffer
     passingVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["encrypt"], ["decrypt"])
@@ -59,14 +97,14 @@ function run_test() {
                 });
                 ciphertext[0] = 255 - ciphertext[0];
                 return operation;
-            }, vector.name + " decryption with altered ciphertext");
+            }, vector.name + " decryption with altered ciphertext after call");
 
         }, function(err) {
             // We need a failed test if the importVectorKey operation fails, so
             // we know we never tested encryption
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
-            }, "importVectorKeys step: " + vector.name + " decryption with altered ciphertext");
+            }, "importVectorKeys step: " + vector.name + " decryption with altered ciphertext after call");
         });
 
         all_promises.push(promise);
@@ -125,6 +163,57 @@ function run_test() {
     });
 
 
+    // Check for successful encryption even if plaintext is altered during call.
+    passingVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["encrypt"], ["decrypt"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                plaintext[0] = 255 - plaintext[0];
+                var operation = subtle.encrypt({
+                    ...vector.algorithm,
+                    get name() {
+                        plaintext[0] = 255 - plaintext[0];
+                        return vector.algorithm.name;
+                    }
+                }, vector.publicKey, plaintext)
+                .then(function(ciphertext) {
+                    assert_equals(ciphertext.byteLength * 8, vector.privateKey.algorithm.modulusLength, "Ciphertext length matches modulus length");
+                    // Can we get the original plaintext back via decrypt?
+                    return subtle.decrypt(vector.algorithm, vector.privateKey, ciphertext)
+                    .then(function(result) {
+                        assert_true(equalBuffers(result, vector.plaintext), "Round trip returns original plaintext");
+                        return ciphertext;
+                    }, function(err) {
+                        assert_unreached("decrypt error for test " + vector.name + ": " + err.message + "'");
+                    });
+                })
+                .then(function(priorCiphertext) {
+                    // Will a second encrypt give us different ciphertext, as it should?
+                    return subtle.encrypt(vector.algorithm, vector.publicKey, vector.plaintext)
+                    .then(function(ciphertext) {
+                        assert_false(equalBuffers(priorCiphertext, ciphertext), "Two encrypts give different results")
+                    }, function(err) {
+                        assert_unreached("second time encrypt error for test " + vector.name + ": '" + err.message + "'");
+                    });
+                }, function(err) {
+                    assert_unreached("decrypt error for test " + vector.name + ": '" + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with altered plaintext during call");
+
+        }, function(err) {
+            // We need a failed test if the importVectorKey operation fails, so
+            // we know we never tested encryption
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful encryption even if plaintext is altered after call.
     passingVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["encrypt"], ["decrypt"])
@@ -157,14 +246,14 @@ function run_test() {
 
                 plaintext[0] = 255 - plaintext[0];
                 return operation;
-            }, vector.name + " with altered plaintext");
+            }, vector.name + " with altered plaintext after call");
 
         }, function(err) {
             // We need a failed test if the importVectorKey operation fails, so
             // we know we never tested encryption
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
-            }, "importVectorKeys step: " + vector.name + " with altered plaintext");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/encrypt_decrypt/rsa.js
+++ b/WebCryptoAPI/encrypt_decrypt/rsa.js
@@ -55,7 +55,7 @@ function run_test() {
                 var operation = subtle.decrypt({
                     ...vector.algorithm,
                     get name() {
-                        ciphertext[0] = 255 - ciphertext[0];
+                        ciphertext[0] = vector.ciphertext[0];
                         return vector.algorithm.name;
                     }
                 }, vector.privateKey, ciphertext)
@@ -173,7 +173,7 @@ function run_test() {
                 var operation = subtle.encrypt({
                     ...vector.algorithm,
                     get name() {
-                        plaintext[0] = 255 - plaintext[0];
+                        plaintext[0] = vector.plaintext[0];
                         return vector.algorithm.name;
                     }
                 }, vector.publicKey, plaintext)

--- a/WebCryptoAPI/sign_verify/ecdsa.js
+++ b/WebCryptoAPI/sign_verify/ecdsa.js
@@ -39,6 +39,38 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with an altered buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                signature[0] = 255 - signature[0];
+                var algorithm = {
+                    hash: vector.hashName,
+                    get name() {
+                        signature[0] = 255 - signature[0];
+                        return vector.algorithmName;
+                    }
+                };
+                var operation = subtle.verify(algorithm, vector.publicKey, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with altered signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with altered signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Test verification with an altered buffer after call
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify"], ["sign"])
@@ -60,6 +92,38 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " verification with altered signature after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful verification even if plaintext is altered during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                plaintext[0] = 255 - plaintext[0];
+                var algorithm = {
+                    hash: vector.hashName,
+                    get name() {
+                        plaintext[0] = 255 - plaintext[0];
+                        return vector.algorithmName;
+                    }
+                };
+                var operation = subtle.verify(algorithm, vector.publicKey, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with altered plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext during call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/sign_verify/ecdsa.js
+++ b/WebCryptoAPI/sign_verify/ecdsa.js
@@ -49,7 +49,7 @@ function run_test() {
                 var algorithm = {
                     hash: vector.hashName,
                     get name() {
-                        signature[0] = 255 - signature[0];
+                        signature[0] = vector.signature[0];
                         return vector.algorithmName;
                     }
                 };
@@ -107,7 +107,7 @@ function run_test() {
                 var algorithm = {
                     hash: vector.hashName,
                     get name() {
-                        plaintext[0] = 255 - plaintext[0];
+                        plaintext[0] = vector.plaintext[0];
                         return vector.algorithmName;
                     }
                 };

--- a/WebCryptoAPI/sign_verify/eddsa.js
+++ b/WebCryptoAPI/sign_verify/eddsa.js
@@ -33,7 +33,7 @@ function run_test(algorithmName) {
               signature[0] = 255 - signature[0];
               isVerified = await subtle.verify({
                   get name() {
-                      signature[0] = 255 - signature[0];
+                      signature[0] = vector.signature[0];
                       return vector.algorithmName;
                   }
               }, key, signature, vector.data);
@@ -72,7 +72,7 @@ function run_test(algorithmName) {
               data[0] = 255 - data[0];
               isVerified = await subtle.verify({
                   get name() {
-                      data[0] = 255 - data[0];
+                      data[0] = vector.data[0];
                       return vector.algorithmName;
                   }
               }, key, vector.signature, data);

--- a/WebCryptoAPI/sign_verify/eddsa.js
+++ b/WebCryptoAPI/sign_verify/eddsa.js
@@ -23,6 +23,27 @@ function run_test(algorithmName) {
           assert_true(isVerified, "Signature verified");
       }, vector.name + " verification");
 
+      // Test verification with an altered buffer during call
+      promise_test(async() => {
+          let isVerified = false;
+          let key;
+          try {
+              key = await subtle.importKey("spki", vector.publicKeyBuffer, algorithm, false, ["verify"]);
+              var signature = copyBuffer(vector.signature);
+              signature[0] = 255 - signature[0];
+              isVerified = await subtle.verify({
+                  get name() {
+                      signature[0] = 255 - signature[0];
+                      return vector.algorithmName;
+                  }
+              }, key, signature, vector.data);
+          } catch (err) {
+              assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
+              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+          };
+          assert_true(isVerified, "Signature verified");
+      }, vector.name + " verification with altered signature during call");
+
       // Test verification with an altered buffer after call
       promise_test(async() => {
           let isVerified = false;
@@ -40,6 +61,27 @@ function run_test(algorithmName) {
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " verification with altered signature after call");
+
+      // Check for successful verification even if data is altered during call.
+      promise_test(async() => {
+          let isVerified = false;
+          let key;
+          try {
+              key = await subtle.importKey("spki", vector.publicKeyBuffer, algorithm, false, ["verify"]);
+              var data = copyBuffer(vector.data);
+              data[0] = 255 - data[0];
+              isVerified = await subtle.verify({
+                  get name() {
+                      data[0] = 255 - data[0];
+                      return vector.algorithmName;
+                  }
+              }, key, vector.signature, data);
+          } catch (err) {
+              assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
+              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+          };
+          assert_true(isVerified, "Signature verified");
+      }, vector.name + " with altered data during call");
 
       // Check for successful verification even if data is altered after call.
       promise_test(async() => {

--- a/WebCryptoAPI/sign_verify/hmac.js
+++ b/WebCryptoAPI/sign_verify/hmac.js
@@ -47,7 +47,7 @@ function run_test() {
                 var operation = subtle.verify({
                     hash: vector.hash,
                     get name() {
-                        signature[0] = 255 - signature[0];
+                        signature[0] = vector.signature[0];
                         return "HMAC";
                     }
                 }, vector.key, signature, vector.plaintext)
@@ -103,7 +103,7 @@ function run_test() {
                 var operation = subtle.verify({
                     hash: vector.hash,
                     get name() {
-                        plaintext[0] = 255 - plaintext[0];
+                        plaintext[0] = vector.plaintext[0];
                         return "HMAC";
                     }
                 }, vector.key, vector.signature, plaintext)

--- a/WebCryptoAPI/sign_verify/hmac.js
+++ b/WebCryptoAPI/sign_verify/hmac.js
@@ -37,6 +37,37 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with an altered buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                signature[0] = 255 - signature[0];
+                var operation = subtle.verify({
+                    hash: vector.hash,
+                    get name() {
+                        signature[0] = 255 - signature[0];
+                        return "HMAC";
+                    }
+                }, vector.key, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature is not verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with altered signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with altered signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Test verification with an altered buffer after call
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify", "sign"])
@@ -62,6 +93,37 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Check for successful verification even if plaintext is altered during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                plaintext[0] = 255 - plaintext[0];
+                var operation = subtle.verify({
+                    hash: vector.hash,
+                    get name() {
+                        plaintext[0] = 255 - plaintext[0];
+                        return "HMAC";
+                    }
+                }, vector.key, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with altered plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful verification even if plaintext is altered after call.
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify", "sign"])
@@ -81,7 +143,7 @@ function run_test() {
         }, function(err) {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
-            }, "importVectorKeys step: " + vector.name + " with altered plaintext");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/sign_verify/kmac.js
+++ b/WebCryptoAPI/sign_verify/kmac.js
@@ -40,6 +40,41 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with an altered buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                signature[0] = 255 - signature[0];
+                var algorithmParams = {
+                    length: vector.length,
+                    get name() {
+                        signature[0] = 255 - signature[0];
+                        return vector.algorithm;
+                    }
+                };
+                if (vector.customization !== undefined) {
+                    algorithmParams.customization = vector.customization;
+                }
+                var operation = subtle.verify(algorithmParams, vector.key, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature is not verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with altered signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with altered signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Test verification with an altered buffer after call
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify", "sign"])
@@ -69,6 +104,41 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Check for successful verification even if plaintext is altered during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                plaintext[0] = 255 - plaintext[0];
+                var algorithmParams = {
+                    length: vector.length,
+                    get name() {
+                        plaintext[0] = 255 - plaintext[0];
+                        return vector.algorithm;
+                    }
+                };
+                if (vector.customization !== undefined) {
+                    algorithmParams.customization = vector.customization;
+                }
+                var operation = subtle.verify(algorithmParams, vector.key, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with altered plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful verification even if plaintext is altered after call.
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify", "sign"])
@@ -92,7 +162,7 @@ function run_test() {
         }, function(err) {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
-            }, "importVectorKeys step: " + vector.name + " with altered plaintext");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/sign_verify/kmac.js
+++ b/WebCryptoAPI/sign_verify/kmac.js
@@ -50,7 +50,7 @@ function run_test() {
                 var algorithmParams = {
                     length: vector.length,
                     get name() {
-                        signature[0] = 255 - signature[0];
+                        signature[0] = vector.signature[0];
                         return vector.algorithm;
                     }
                 };
@@ -114,7 +114,7 @@ function run_test() {
                 var algorithmParams = {
                     length: vector.length,
                     get name() {
-                        plaintext[0] = 255 - plaintext[0];
+                        plaintext[0] = vector.plaintext[0];
                         return vector.algorithm;
                     }
                 };

--- a/WebCryptoAPI/sign_verify/mldsa.js
+++ b/WebCryptoAPI/sign_verify/mldsa.js
@@ -55,6 +55,61 @@ function run_test() {
     all_promises.push(promise);
   });
 
+  // Test verification with an altered buffer during call
+  testVectors.forEach(function (vector) {
+    var promise = importVectorKeys(vector, ['verify'], ['sign']).then(
+      function (vectors) {
+        promise_test(function (test) {
+          var signature = copyBuffer(vector.signature);
+          signature[0] = 255 - signature[0];
+          var operation = subtle
+            .verify(
+              {
+                get name() {
+                  signature[0] = 255 - signature[0];
+                  return vector.algorithmName;
+                },
+              },
+              vector.publicKey,
+              signature,
+              vector.data
+            )
+            .then(
+              function (is_verified) {
+                assert_true(is_verified, 'Signature verified');
+              },
+              function (err) {
+                assert_unreached(
+                  'Verification should not throw error ' +
+                    vector.name +
+                    ': ' +
+                    err.message +
+                    "'"
+                );
+              }
+            );
+
+          return operation;
+        }, vector.name + ' verification with altered signature during call');
+      },
+      function (err) {
+        promise_test(function (test) {
+          assert_unreached(
+            'importVectorKeys failed for ' +
+              vector.name +
+              ". Message: ''" +
+              err.message +
+              "''"
+          );
+        }, 'importVectorKeys step: ' +
+          vector.name +
+          ' verification with altered signature during call');
+      }
+    );
+
+    all_promises.push(promise);
+  });
+
   // Test verification with an altered buffer after call
   testVectors.forEach(function (vector) {
     var promise = importVectorKeys(vector, ['verify'], ['sign']).then(
@@ -95,6 +150,61 @@ function run_test() {
         }, 'importVectorKeys step: ' +
           vector.name +
           ' verification with altered signature after call');
+      }
+    );
+
+    all_promises.push(promise);
+  });
+
+  // Check for successful verification even if plaintext is altered during call.
+  testVectors.forEach(function (vector) {
+    var promise = importVectorKeys(vector, ['verify'], ['sign']).then(
+      function (vectors) {
+        promise_test(function (test) {
+          var plaintext = copyBuffer(vector.data);
+          plaintext[0] = 255 - plaintext[0];
+          var operation = subtle
+            .verify(
+              {
+                get name() {
+                  plaintext[0] = 255 - plaintext[0];
+                  return vector.algorithmName;
+                },
+              },
+              vector.publicKey,
+              vector.signature,
+              plaintext
+            )
+            .then(
+              function (is_verified) {
+                assert_true(is_verified, 'Signature verified');
+              },
+              function (err) {
+                assert_unreached(
+                  'Verification should not throw error ' +
+                    vector.name +
+                    ': ' +
+                    err.message +
+                    "'"
+                );
+              }
+            );
+
+          return operation;
+        }, vector.name + ' with altered plaintext during call');
+      },
+      function (err) {
+        promise_test(function (test) {
+          assert_unreached(
+            'importVectorKeys failed for ' +
+              vector.name +
+              ". Message: ''" +
+              err.message +
+              "''"
+          );
+        }, 'importVectorKeys step: ' +
+          vector.name +
+          ' with altered plaintext during call');
       }
     );
 

--- a/WebCryptoAPI/sign_verify/mldsa.js
+++ b/WebCryptoAPI/sign_verify/mldsa.js
@@ -66,7 +66,7 @@ function run_test() {
             .verify(
               {
                 get name() {
-                  signature[0] = 255 - signature[0];
+                  signature[0] = vector.signature[0];
                   return vector.algorithmName;
                 },
               },
@@ -167,7 +167,7 @@ function run_test() {
             .verify(
               {
                 get name() {
-                  plaintext[0] = 255 - plaintext[0];
+                  plaintext[0] = vector.data[0];
                   return vector.algorithmName;
                 },
               },

--- a/WebCryptoAPI/sign_verify/rsa.js
+++ b/WebCryptoAPI/sign_verify/rsa.js
@@ -47,7 +47,7 @@ function run_test() {
                 var operation = subtle.verify({
                     ...vector.algorithm,
                     get name() {
-                        signature[0] = 255 - signature[0];
+                        signature[0] = vector.signature[0];
                         return vector.algorithm.name;
                     }
                 }, vector.publicKey, signature, vector.plaintext)
@@ -103,7 +103,7 @@ function run_test() {
                 var operation = subtle.verify({
                     ...vector.algorithm,
                     get name() {
-                        plaintext[0] = 255 - plaintext[0];
+                        plaintext[0] = vector.plaintext[0];
                         return vector.algorithm.name;
                     }
                 }, vector.publicKey, vector.signature, plaintext)

--- a/WebCryptoAPI/sign_verify/rsa.js
+++ b/WebCryptoAPI/sign_verify/rsa.js
@@ -37,6 +37,37 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with an altered buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                signature[0] = 255 - signature[0];
+                var operation = subtle.verify({
+                    ...vector.algorithm,
+                    get name() {
+                        signature[0] = 255 - signature[0];
+                        return vector.algorithm.name;
+                    }
+                }, vector.publicKey, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with altered signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with altered signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Test verification with an altered buffer after call
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify"], ["sign"])
@@ -57,6 +88,37 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " verification with altered signature after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful verification even if plaintext is altered during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                plaintext[0] = 255 - plaintext[0];
+                var operation = subtle.verify({
+                    ...vector.algorithm,
+                    get name() {
+                        plaintext[0] = 255 - plaintext[0];
+                        return vector.algorithm.name;
+                    }
+                }, vector.publicKey, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with altered plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with altered plaintext during call");
         });
 
         all_promises.push(promise);


### PR DESCRIPTION
Add tests for the reading order of arguments in Web Crypto, updated in https://github.com/w3c/webcrypto/pull/426 to match the majority of implementations.

To be merged after https://github.com/w3c/webcrypto/pull/426.