### PR TITLE
script: Fix loading of about:srcdoc documents

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-to-eager-srcdoc.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-to-eager-srcdoc.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<head>
+  <title>Below-viewport srcdoc iframes with loading='lazy' load when set to
+         loading='eager' or the `loading` attribute is removed</title>
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t = async_test("Below-viewport srcdoc iframes with loading='lazy' load when " +
+                       "set to loading='eager' or the `loading` attribute is " +
+                       "removed");
+
+  const iframe_1_onload = t.unreached_func("#iframe_1 should not load before " +
+                                           "the window load event");
+  const iframe_2_onload = t.unreached_func("#iframe_2 should not load before " +
+                                           "the window load event");
+  window.iframe_1_img_loaded = t.unreached_func("Img in iframe_1 should not load before " +
+                                           "the window load event");
+  window.iframe_2_img_loaded = t.unreached_func("Img in iframe_2 should not load before " +
+                                           "the window load event");
+
+  window.addEventListener("load", t.step_func(() => {
+    const iframe_1 = document.querySelector('#iframe_1');
+    const iframe_2 = document.querySelector('#iframe_2');
+
+    const iframe_1_promise = new Promise((resolve, reject) => {
+      iframe_1.onerror = reject;
+      iframe_1.onload = resolve;
+    });
+
+    const iframe_2_promise = new Promise((resolve, reject) => {
+      iframe_2.onerror = reject;
+      iframe_2.onload = resolve;
+    });
+
+    const img_frame_1_promise = new Promise((resolve) => {
+      window.iframe_1_img_loaded = resolve;
+    });
+
+    const img_frame_2_promise = new Promise((resolve) => {
+      window.iframe_2_img_loaded = resolve;
+    });
+
+    Promise.all([iframe_1_promise, iframe_2_promise, img_frame_1_promise, img_frame_2_promise])
+      .then(t.step_func_done())
+      .catch(t.unreached_func("The iframes should load successfully"));
+
+    // Kick off the requests.
+    iframe_1.loading = 'eager';
+    iframe_2.removeAttribute('loading'); // unset the attribute, putting it in
+                                         // the default (eager) state.
+  }));
+
+</script>
+
+<body>
+  <div style="height:1000vh;"></div>
+  <iframe id="iframe_1"
+          srcdoc="<body><img src='/common/square.png?below-viewport'
+                  onload='parent.iframe_1_img_loaded();'></body>"
+          loading="lazy" onload="iframe_1_onload();"></iframe>
+  <iframe id="iframe_2"
+          srcdoc="<body><img src='/common/square.png?below-viewport'
+                  onload='parent.iframe_2_img_loaded();'></body>"
+          loading="lazy" onload="iframe_2_onload();"></iframe>
+</body>


### PR DESCRIPTION
Align with the spec and implement part of its lazy loading
steps. Most tests use non-srcdoc lazy loading URLs, so most
tests will not pass until the other parts are implemented
as well.
Reviewed in servo/servo#41959