### PR TITLE
Don't divide by zero on perfect matches

### DIFF
--- a/webaudio/resources/convolution-testing.js
+++ b/webaudio/resources/convolution-testing.js
@@ -69,7 +69,9 @@ function checkTriangularPulse(rendered, reference, should) {
   // difference between the true triangular pulse and the
   // rendered pulse.
   let allowedDeviationDecibels = -124.41;
-  let maxDeviationDecibels = linearToDecibel(maxDelta / valueAtMaxDelta);
+  let maxDeviationDecibels = 0;
+  if (valueAtMaxDelta !== 0)
+    maxDeviationDecibels = linearToDecibel(maxDelta / valueAtMaxDelta);
 
   should(
       maxDeviationDecibels,
@@ -103,7 +105,9 @@ function checkTail1(data, reference, breakpoint, should) {
   // value of tail1MaxDecibels.
   let threshold1 = -129.7;
 
-  let tail1MaxDecibels = linearToDecibel(tail1Max / refMax);
+  let tail1MaxDecibels = 0;
+  if (refMax !== 0)
+    tail1MaxDecibels = linearToDecibel(tail1Max / refMax);
   should(tail1MaxDecibels, 'Deviation in first part of tail of convolutions')
       .beLessThanOrEqualTo(threshold1);
 

--- a/webaudio/resources/convolution-testing.js
+++ b/webaudio/resources/convolution-testing.js
@@ -70,8 +70,11 @@ function checkTriangularPulse(rendered, reference, should) {
   // rendered pulse.
   let allowedDeviationDecibels = -124.41;
   let maxDeviationDecibels = 0;
-  if (valueAtMaxDelta !== 0)
+  if (valueAtMaxDelta !== 0) {
     maxDeviationDecibels = linearToDecibel(maxDelta / valueAtMaxDelta);
+  } else {
+    maxDeviationDecibels = (maxDelta === 0) ? -Infinity : Infinity;
+  }
 
   should(
       maxDeviationDecibels,
@@ -106,8 +109,11 @@ function checkTail1(data, reference, breakpoint, should) {
   let threshold1 = -129.7;
 
   let tail1MaxDecibels = 0;
-  if (refMax !== 0)
+  if (refMax !== 0) {
     tail1MaxDecibels = linearToDecibel(tail1Max / refMax);
+  } else {
+    tail1MaxDecibels = (tail1Max === 0) ? -Infinity : Infinity;
+  }
   should(tail1MaxDecibels, 'Deviation in first part of tail of convolutions')
       .beLessThanOrEqualTo(threshold1);
 


### PR DESCRIPTION
`valueAtMaxDelta` can be zero at triangle wave boundaries.