### PR TITLE
Add test for overflow-clip-margin with multiple values

### DIFF
--- a/css/css-overflow/parsing/overflow-clip-margin.html
+++ b/css/css-overflow/parsing/overflow-clip-margin.html
@@ -29,6 +29,7 @@ test_valid_value("overflow-clip-margin", '10px border-box', 'border-box 10px');
 
 test_invalid_value("overflow-clip-margin", 'margin-box');
 test_invalid_value("overflow-clip-margin", 'inset(10px)');
+test_invalid_value("overflow-clip-margin", '50px 50px');
 </script>
 </body>
 </html>


### PR DESCRIPTION
`overflow-clip-margin`, as opposed to regular `margin` does not support multiple values.
I'm currently restricting this in [Ladybird](https://github.com/LadybirdBrowser/ladybird) and wrote this test as part of that.