### PR TITLE
script: Fix crash when failed requests finish from a previous generation

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
+++ b/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42477">
+<link id="link" href="does-not-exist-A.css">
+<script>
+  link.rel = "stylesheet";
+  link.href = "does-not-exist-B.css";
+</script>


### PR DESCRIPTION
Most likely a regression introduced in #<!-- nolink -->42208 where the pending loads counter has been reset. For successful request this wasn't an issue, but for failed requests it was. Therefore, guard against these generation request problems by bailing out as soon as we post-process the request (which we do for all failed requests).

Fixes #<!-- nolink -->42477
Reviewed in servo/servo#42481