### PR TITLE
[WebCryptoAPI] Add tests for transferred `ArrayBuffer`s

### DIFF
--- a/WebCryptoAPI/digest/digest.https.any.js
+++ b/WebCryptoAPI/digest/digest.https.any.js
@@ -113,6 +113,30 @@
                     copiedBuffer[0] = 255 - copiedBuffer[0];
                     return promise;
                 }, upCase + " with " + size + " source data and altered buffer after call");
+
+                promise_test(function(test) {
+                    var copiedBuffer = copyBuffer(sourceData[size]);
+                    copiedBuffer.buffer.transfer();
+                    return subtle.digest({name: upCase}, copiedBuffer)
+                    .then(function(result) {
+                        assert_true(equalBuffers(result, digestedData[alg].empty), "digest() on transferred buffer should yield result for empty buffer for " + alg + ":" + size);
+                    }, function(err) {
+                        assert_unreached("digest() threw an error for transferred buffer for " + alg + ":" + size + ": " + err.message);
+                    });
+                }, upCase + " with " + size + " source data and transferred buffer during call");
+
+                promise_test(function(test) {
+                    var copiedBuffer = copyBuffer(sourceData[size]);
+                    var promise = subtle.digest({name: upCase}, copiedBuffer)
+                    .then(function(result) {
+                        assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
+                    }, function(err) {
+                        assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
+                    });
+
+                    copiedBuffer.buffer.transfer();
+                    return promise;
+                }, upCase + " with " + size + " source data and transferred buffer after call");
             }
         });
     });

--- a/WebCryptoAPI/digest/sha3.tentative.https.any.js
+++ b/WebCryptoAPI/digest/sha3.tentative.https.any.js
@@ -141,6 +141,37 @@ Object.keys(sourceData).forEach(function (size) {
           );
         });
       }, alg + ' with ' + size + ' source data and altered buffer after call');
+
+      promise_test(function (test) {
+        var buffer = new Uint8Array(sourceData[size]);
+        return crypto.subtle
+          .digest({
+            get name() {
+              // Transfer the buffer while calling digest
+              buffer.buffer.transfer();
+              return alg;
+            }
+          }, buffer)
+          .then(function (result) {
+            assert_true(
+              equalBuffers(result, digestedData[alg].empty),
+              'digest on transferred buffer should match result for empty buffer'
+            );
+          });
+      }, alg + ' with ' + size + ' source data and transferred buffer during call');
+
+      promise_test(function (test) {
+        var buffer = new Uint8Array(sourceData[size]);
+        var promise = crypto.subtle.digest(alg, buffer).then(function (result) {
+          assert_true(
+            equalBuffers(result, digestedData[alg][size]),
+            'digest matches expected'
+          );
+        });
+        // Transfer the buffer after calling digest
+        buffer.buffer.transfer();
+        return promise;
+      }, alg + ' with ' + size + ' source data and transferred buffer after call');
     }
   });
 });

--- a/WebCryptoAPI/encrypt_decrypt/rsa.js
+++ b/WebCryptoAPI/encrypt_decrypt/rsa.js
@@ -25,7 +25,7 @@ function run_test() {
                 .then(function(plaintext) {
                     assert_true(equalBuffers(plaintext, vector.plaintext, "Decryption works"));
                 }, function(err) {
-                    assert_unreached("Decryption should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Decryption should not throw error " + vector.name + ": '" + err.message + "'");
                 });
             }, vector.name + " decryption");
 
@@ -62,7 +62,7 @@ function run_test() {
                 .then(function(plaintext) {
                     assert_true(equalBuffers(plaintext, vector.plaintext, "Decryption works"));
                 }, function(err) {
-                    assert_unreached("Decryption should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Decryption should not throw error " + vector.name + ": '" + err.message + "'");
                 });
                 return operation;
             }, vector.name + " decryption with altered ciphertext during call");
@@ -93,7 +93,7 @@ function run_test() {
                 .then(function(plaintext) {
                     assert_true(equalBuffers(plaintext, vector.plaintext, "Decryption works"));
                 }, function(err) {
-                    assert_unreached("Decryption should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Decryption should not throw error " + vector.name + ": '" + err.message + "'");
                 });
                 ciphertext[0] = 255 - ciphertext[0];
                 return operation;
@@ -162,7 +162,7 @@ function run_test() {
                 .then(function(plaintext) {
                     assert_true(equalBuffers(plaintext, vector.plaintext, "Decryption works"));
                 }, function(err) {
-                    assert_unreached("Decryption should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Decryption should not throw error " + vector.name + ": '" + err.message + "'");
                 });
                 ciphertext.buffer.transfer();
                 return operation;
@@ -186,7 +186,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.decrypt(vector.algorithm, vector.publicKey, vector.ciphertext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for using publicKey to decrypt in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for using publicKey to decrypt in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of " + err.message);
                 });
@@ -214,7 +214,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.decrypt(vector.algorithm, vector.publicKey, vector.ciphertext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for no decrypt usage in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for no decrypt usage in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of " + err.message);
                 });
@@ -254,7 +254,7 @@ function run_test() {
                         assert_true(equalBuffers(result, vector.plaintext), "Round trip returns original plaintext");
                         return ciphertext;
                     }, function(err) {
-                        assert_unreached("decrypt error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("decrypt error for test " + vector.name + ": '" + err.message + "'");
                     });
                 })
                 .then(function(priorCiphertext) {
@@ -298,7 +298,7 @@ function run_test() {
                         assert_true(equalBuffers(result, vector.plaintext), "Round trip returns original plaintext");
                         return ciphertext;
                     }, function(err) {
-                        assert_unreached("decrypt error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("decrypt error for test " + vector.name + ": '" + err.message + "'");
                     });
                 })
                 .then(function(priorCiphertext) {
@@ -384,7 +384,7 @@ function run_test() {
                         assert_true(equalBuffers(result, vector.plaintext), "Round trip returns original plaintext");
                         return ciphertext;
                     }, function(err) {
-                        assert_unreached("decrypt error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("decrypt error for test " + vector.name + ": '" + err.message + "'");
                     });
                 })
                 .then(function(priorCiphertext) {
@@ -429,7 +429,7 @@ function run_test() {
                         assert_true(equalBuffers(result, vector.plaintext), "Round trip returns original plaintext");
                         return ciphertext;
                     }, function(err) {
-                        assert_unreached("decrypt error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("decrypt error for test " + vector.name + ": '" + err.message + "'");
                     });
                 })
                 .then(function(priorCiphertext) {
@@ -467,7 +467,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.encrypt(vector.algorithm, vector.publicKey, plaintext)
                 .then(function(ciphertext) {
-                    assert_unreached("Should have thrown error for too long plaintext in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for too long plaintext in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "OperationError", "Should throw OperationError instead of " + err.message);
                 });
@@ -492,7 +492,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.encrypt(vector.algorithm, vector.privateKey, vector.plaintext)
                 .then(function(ciphertext) {
-                    assert_unreached("Should have thrown error for using privateKey to encrypt in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for using privateKey to encrypt in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of " + err.message);
                 });
@@ -520,7 +520,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.encrypt(vector.algorithm, vector.publicKey, vector.plaintext)
                 .then(function(ciphertext) {
-                    assert_unreached("Should have thrown error for no encrypt usage in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for no encrypt usage in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of " + err.message);
                 });

--- a/WebCryptoAPI/sign_verify/ecdsa.js
+++ b/WebCryptoAPI/sign_verify/ecdsa.js
@@ -97,6 +97,63 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with a transferred buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var algorithm = {
+                    get name() {
+                        signature.buffer.transfer();
+                        return vector.algorithmName;
+                    },
+                    hash: vector.hashName
+                };
+                var operation = subtle.verify(algorithm, vector.publicKey, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with transferred signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Test verification with a transferred buffer after call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            var algorithm = {name: vector.algorithmName, hash: vector.hashName};
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var operation = subtle.verify(algorithm, vector.publicKey, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                signature.buffer.transfer();
+                return operation;
+            }, vector.name + " verification with transferred signature after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature after call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful verification even if plaintext is altered during call.
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify"], ["sign"])
@@ -150,6 +207,63 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for failed verification if plaintext is transferred during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var algorithm = {
+                    get name() {
+                        plaintext.buffer.transfer();
+                        return vector.algorithmName;
+                    },
+                    hash: vector.hashName
+                };
+                var operation = subtle.verify(algorithm, vector.publicKey, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with transferred plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful verification even if plaintext is transferred after call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            var algorithm = {name: vector.algorithmName, hash: vector.hashName};
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var operation = subtle.verify(algorithm, vector.publicKey, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                plaintext.buffer.transfer();
+                return operation;
+            }, vector.name + " with transferred plaintext after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/sign_verify/ecdsa.js
+++ b/WebCryptoAPI/sign_verify/ecdsa.js
@@ -22,7 +22,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -57,7 +57,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -82,7 +82,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature[0] = 255 - signature[0];
@@ -114,7 +114,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -139,7 +139,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature.buffer.transfer();
@@ -172,7 +172,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -197,7 +197,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext[0] = 255 - plaintext[0];
@@ -229,7 +229,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -254,7 +254,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext.buffer.transfer();
@@ -277,7 +277,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.verify(algorithm, vector.privateKey, vector.signature, vector.plaintext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for using privateKey to verify in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for using privateKey to verify in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -300,7 +300,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.sign(algorithm, vector.publicKey, vector.plaintext)
                 .then(function(signature) {
-                    assert_unreached("Should have thrown error for using publicKey to sign in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for using publicKey to sign in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -324,7 +324,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.verify(algorithm, vector.publicKey, vector.signature, vector.plaintext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -352,7 +352,7 @@ function run_test() {
                         assert_true(is_verified, "Round trip verification works");
                         return signature;
                     }, function(err) {
-                        assert_unreached("verify error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("verify error for test " + vector.name + ": '" + err.message + "'");
                     });
                 }, function(err) {
                     assert_unreached("sign error for test " + vector.name + ": '" + err.message + "'");
@@ -452,7 +452,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -483,7 +483,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -540,7 +540,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -569,7 +569,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -596,7 +596,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature unexpectedly verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;

--- a/WebCryptoAPI/sign_verify/eddsa.js
+++ b/WebCryptoAPI/sign_verify/eddsa.js
@@ -18,7 +18,7 @@ function run_test(algorithmName) {
               isVerified = await subtle.verify(algorithm, key, vector.signature, vector.data)
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " verification");
@@ -39,7 +39,7 @@ function run_test(algorithmName) {
               }, key, signature, vector.data);
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " verification with altered signature during call");
@@ -57,7 +57,7 @@ function run_test(algorithmName) {
               ]);
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " verification with altered signature after call");
@@ -77,7 +77,7 @@ function run_test(algorithmName) {
               }, key, signature, vector.data);
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_false(isVerified, "Signature is NOT verified");
       }, vector.name + " verification with transferred signature during call");
@@ -94,7 +94,7 @@ function run_test(algorithmName) {
               isVerified = await operation;
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " verification with transferred signature after call");
@@ -115,7 +115,7 @@ function run_test(algorithmName) {
               }, key, vector.signature, data);
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " with altered data during call");
@@ -133,7 +133,7 @@ function run_test(algorithmName) {
               ]);
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " with altered data after call");
@@ -153,7 +153,7 @@ function run_test(algorithmName) {
               }, key, vector.signature, data);
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_false(isVerified, "Signature is NOT verified");
       }, vector.name + " with transferred data during call");
@@ -170,7 +170,7 @@ function run_test(algorithmName) {
               isVerified = await operation;
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Signature verified");
       }, vector.name + " with transferred data after call");
@@ -239,7 +239,7 @@ function run_test(algorithmName) {
           } catch (err) {
               assert_false(publicKey === undefined || privateKey === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
               assert_false(signature === undefined, "sign error for test " + vector.name + ": '" + err.message + "'");
-              assert_unreached("verify error for test " + vector.name + ": " + err.message + "'");
+              assert_unreached("verify error for test " + vector.name + ": '" + err.message + "'");
           };
           assert_true(isVerified, "Round trip verification works");
       }, vector.name + " round trip");
@@ -288,7 +288,7 @@ function run_test(algorithmName) {
               isVerified = await subtle.verify(algorithm, key, signature, vector.data)
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_false(isVerified, "Signature verified");
       }, vector.name + " verification failure due to altered signature");
@@ -303,7 +303,7 @@ function run_test(algorithmName) {
               isVerified = await subtle.verify(algorithm, key, signature, vector.data)
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_false(isVerified, "Signature verified");
       }, vector.name + " verification failure due to shortened signature");
@@ -319,7 +319,7 @@ function run_test(algorithmName) {
               isVerified = await subtle.verify(algorithm, key, vector.signature, data)
           } catch (err) {
               assert_false(key === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
-              assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
           };
           assert_false(isVerified, "Signature verified");
       }, vector.name + " verification failure due to altered data");

--- a/WebCryptoAPI/sign_verify/hmac.js
+++ b/WebCryptoAPI/sign_verify/hmac.js
@@ -20,7 +20,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -54,7 +54,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -78,7 +78,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature[0] = 255 - signature[0];
@@ -109,7 +109,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -133,7 +133,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature.buffer.transfer();
@@ -165,7 +165,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -189,7 +189,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext[0] = 255 - plaintext[0];
@@ -220,7 +220,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -244,7 +244,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext.buffer.transfer();
@@ -268,7 +268,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.verify({name: "HMAC", hash: vector.hash}, vector.key, vector.signature, vector.plaintext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -296,7 +296,7 @@ function run_test() {
                         assert_true(is_verified, "Round trip verifies");
                         return signature;
                     }, function(err) {
-                        assert_unreached("verify error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("verify error for test " + vector.name + ": '" + err.message + "'");
                     });
                 });
             }, vector.name + " round trip");
@@ -391,7 +391,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -419,7 +419,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -446,7 +446,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;

--- a/WebCryptoAPI/sign_verify/hmac.js
+++ b/WebCryptoAPI/sign_verify/hmac.js
@@ -45,11 +45,11 @@ function run_test() {
                 var signature = copyBuffer(vector.signature);
                 signature[0] = 255 - signature[0];
                 var operation = subtle.verify({
-                    hash: vector.hash,
                     get name() {
                         signature[0] = vector.signature[0];
                         return "HMAC";
-                    }
+                    },
+                    hash: vector.hash
                 }, vector.key, signature, vector.plaintext)
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
@@ -88,6 +88,61 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " verification with altered signature after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Test verification with a transferred buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var operation = subtle.verify({
+                    get name() {
+                        signature.buffer.transfer();
+                        return "HMAC";
+                    },
+                    hash: vector.hash
+                }, vector.key, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with transferred signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Test verification with a transferred buffer after call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var operation = subtle.verify({name: "HMAC", hash: vector.hash}, vector.key, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature is not verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                signature.buffer.transfer();
+                return operation;
+            }, vector.name + " verification with transferred signature after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature after call");
         });
 
         all_promises.push(promise);
@@ -144,6 +199,61 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for failed verification if plaintext is transferred during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var operation = subtle.verify({
+                    get name() {
+                        plaintext.buffer.transfer();
+                        return "HMAC";
+                    },
+                    hash: vector.hash
+                }, vector.key, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with transferred plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful verification even if plaintext is transferred after call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var operation = subtle.verify({name: "HMAC", hash: vector.hash}, vector.key, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                plaintext.buffer.transfer();
+                return operation;
+            }, vector.name + " with transferred plaintext after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/sign_verify/kmac.js
+++ b/WebCryptoAPI/sign_verify/kmac.js
@@ -23,7 +23,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -61,7 +61,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -89,7 +89,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature[0] = 255 - signature[0];
@@ -124,7 +124,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -152,7 +152,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature is not verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature.buffer.transfer();
@@ -188,7 +188,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -216,7 +216,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext[0] = 255 - plaintext[0];
@@ -251,7 +251,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -279,7 +279,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext.buffer.transfer();
@@ -307,7 +307,7 @@ function run_test() {
                 }
                 return subtle.verify(algorithmParams, vector.key, vector.signature, vector.plaintext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -339,7 +339,7 @@ function run_test() {
                         assert_true(is_verified, "Round trip verifies");
                         return signature;
                     }, function(err) {
-                        assert_unreached("verify error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("verify error for test " + vector.name + ": '" + err.message + "'");
                     });
                 });
             }, vector.name + " round trip");
@@ -446,7 +446,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -478,7 +478,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -509,7 +509,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -540,7 +540,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified with wrong length");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;

--- a/WebCryptoAPI/sign_verify/kmac.js
+++ b/WebCryptoAPI/sign_verify/kmac.js
@@ -104,6 +104,69 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with a transferred buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var algorithmParams = {
+                    get name() {
+                        signature.buffer.transfer();
+                        return vector.algorithm;
+                    },
+                    length: vector.length
+                };
+                if (vector.customization !== undefined) {
+                    algorithmParams.customization = vector.customization;
+                }
+                var operation = subtle.verify(algorithmParams, vector.key, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with transferred signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Test verification with a transferred buffer after call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var algorithmParams = {name: vector.algorithm, length: vector.length};
+                if (vector.customization !== undefined) {
+                    algorithmParams.customization = vector.customization;
+                }
+                var operation = subtle.verify(algorithmParams, vector.key, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature is not verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                signature.buffer.transfer();
+                return operation;
+            }, vector.name + " verification with transferred signature after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature after call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful verification even if plaintext is altered during call.
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify", "sign"])
@@ -163,6 +226,69 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for failed verification if plaintext is transferred during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var algorithmParams = {
+                    get name() {
+                        plaintext.buffer.transfer();
+                        return vector.algorithm;
+                    },
+                    length: vector.length
+                };
+                if (vector.customization !== undefined) {
+                    algorithmParams.customization = vector.customization;
+                }
+                var operation = subtle.verify(algorithmParams, vector.key, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with transferred plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful verification even if plaintext is transferred after call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify", "sign"])
+        .then(function(vector) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var algorithmParams = {name: vector.algorithm, length: vector.length};
+                if (vector.customization !== undefined) {
+                    algorithmParams.customization = vector.customization;
+                }
+                var operation = subtle.verify(algorithmParams, vector.key, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                plaintext.buffer.transfer();
+                return operation;
+            }, vector.name + " with transferred plaintext after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext after call");
         });
 
         all_promises.push(promise);

--- a/WebCryptoAPI/sign_verify/rsa.js
+++ b/WebCryptoAPI/sign_verify/rsa.js
@@ -20,7 +20,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -54,7 +54,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -78,7 +78,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature[0] = 255 - signature[0];
@@ -109,7 +109,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -133,7 +133,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 signature.buffer.transfer();
@@ -165,7 +165,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -189,7 +189,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext[0] = 255 - plaintext[0];
@@ -220,7 +220,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature is NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -244,7 +244,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_true(is_verified, "Signature verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 plaintext.buffer.transfer();
@@ -266,7 +266,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.verify(vector.algorithm, vector.privateKey, vector.signature, vector.plaintext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for using privateKey to verify in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for using privateKey to verify in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -288,7 +288,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.sign(vector.algorithm, vector.publicKey, vector.plaintext)
                 .then(function(signature) {
-                    assert_unreached("Should have thrown error for using publicKey to sign in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for using publicKey to sign in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -311,7 +311,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.verify(vector.algorithm, vector.publicKey, vector.signature, vector.plaintext)
                 .then(function(plaintext) {
-                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": '" + err.message + "'");
                 }, function(err) {
                     assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
                 });
@@ -344,7 +344,7 @@ function run_test() {
                         assert_true(is_verified, "Round trip verifies");
                         return signature;
                     }, function(err) {
-                        assert_unreached("verify error for test " + vector.name + ": " + err.message + "'");
+                        assert_unreached("verify error for test " + vector.name + ": '" + err.message + "'");
                     });
                 })
                 .then(function(priorSignature) {
@@ -461,7 +461,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;
@@ -489,7 +489,7 @@ function run_test() {
                     .then(function(is_verified) {
                         assert_false(is_verified, "Signature NOT verified");
                     }, function(err) {
-                        assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                        assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                     });
 
                     return operation;
@@ -518,7 +518,7 @@ function run_test() {
                 .then(function(is_verified) {
                     assert_false(is_verified, "Signature NOT verified");
                 }, function(err) {
-                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                    assert_unreached("Verification should not throw error " + vector.name + ": '" + err.message + "'");
                 });
 
                 return operation;

--- a/WebCryptoAPI/sign_verify/rsa.js
+++ b/WebCryptoAPI/sign_verify/rsa.js
@@ -93,6 +93,61 @@ function run_test() {
         all_promises.push(promise);
     });
 
+    // Test verification with a transferred buffer during call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var operation = subtle.verify({
+                    ...vector.algorithm,
+                    get name() {
+                        signature.buffer.transfer();
+                        return vector.algorithm.name;
+                    }
+                }, vector.publicKey, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " verification with transferred signature during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Test verification with a transferred buffer after call
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var signature = copyBuffer(vector.signature);
+                var operation = subtle.verify(vector.algorithm, vector.publicKey, signature, vector.plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                signature.buffer.transfer();
+                return operation;
+            }, vector.name + " verification with transferred signature after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " verification with transferred signature after call");
+        });
+
+        all_promises.push(promise);
+    });
+
     // Check for successful verification even if plaintext is altered during call.
     testVectors.forEach(function(vector) {
         var promise = importVectorKeys(vector, ["verify"], ["sign"])
@@ -144,6 +199,61 @@ function run_test() {
             promise_test(function(test) {
                 assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
             }, "importVectorKeys step: " + vector.name + " with altered plaintext after call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for failed verification if plaintext is transferred during call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var operation = subtle.verify({
+                    ...vector.algorithm,
+                    get name() {
+                        plaintext.buffer.transfer();
+                        return vector.algorithm.name;
+                    }
+                }, vector.publicKey, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_false(is_verified, "Signature is NOT verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                return operation;
+            }, vector.name + " with transferred plaintext during call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext during call");
+        });
+
+        all_promises.push(promise);
+    });
+
+    // Check for successful verification even if plaintext is transferred after call.
+    testVectors.forEach(function(vector) {
+        var promise = importVectorKeys(vector, ["verify"], ["sign"])
+        .then(function(vectors) {
+            promise_test(function(test) {
+                var plaintext = copyBuffer(vector.plaintext);
+                var operation = subtle.verify(vector.algorithm, vector.publicKey, vector.signature, plaintext)
+                .then(function(is_verified) {
+                    assert_true(is_verified, "Signature verified");
+                }, function(err) {
+                    assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+                });
+
+                plaintext.buffer.transfer();
+                return operation;
+            }, vector.name + " with transferred plaintext after call");
+        }, function(err) {
+            promise_test(function(test) {
+                assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+            }, "importVectorKeys step: " + vector.name + " with transferred plaintext after call");
         });
 
         all_promises.push(promise);


### PR DESCRIPTION
- When transferring an input buffer during a call to Web Crypto, the input should be treated as an empty buffer.
- Transferring an input buffer after a call to Web Crypto should have no effect.

See diff in https://github.com/web-platform-tests/wpt/commit/3b53b43ca9d0e72f2b519bcfb55b8bd1d1f7992a.

To be merged after https://github.com/w3c/webcrypto/pull/426 and https://github.com/web-platform-tests/wpt/pull/57614.