### PR TITLE
New `counter-set` tests from suggestions

### DIFF
--- a/css/css-lists/counter-set-003-ref.html
+++ b/css/css-lists/counter-set-003-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Reference: Effect on Elements with No Box (display: none)</title>
+
+<style>
+  .result::before {
+    /* Hard-coded expected result */
+    content: "0";
+  }
+</style>
+
+<div class="result"></div>

--- a/css/css-lists/counter-set-003.html
+++ b/css/css-lists/counter-set-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Effect on Elements with No Box (display: none)</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists/#counter-properties">
+<link rel="match" href="counter-set-003-ref.html">
+<meta name="assert" content="If an element does not generate a box (display: none), the counter-set property must have no effect.">
+
+<style>
+  body {
+    /* Step 1: Initialize counter 'c' to 0 */
+    counter-reset: c 0;
+  }
+  .hidden {
+    /* Step 2: Attempt to set counter to 10 on a hidden element */
+    display: none;
+    counter-set: c 10;
+  }
+  .result::before {
+    /* Step 3: Display the counter. Should remain 0. */
+    content: counter(c);
+  }
+</style>
+
+<div class="hidden"></div>
+
+<div class="result"></div>

--- a/css/css-lists/counter-set-004-ref.html
+++ b/css/css-lists/counter-set-004-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: Effect on Invisible Boxes</title>
+<body>
+  <div id="container">
+    <div style="visibility: hidden;"></div>
+    <div>10</div>
+  </div>
+</body>

--- a/css/css-lists/counter-set-004.html
+++ b/css/css-lists/counter-set-004.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Effect on Invisible Boxes (visibility: hidden)</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists/#counter-set">
+<link rel="match" href="counter-set-004-ref.html">
+<meta name="assert" content="visibility: hidden still generates a box, so counter-set remains active on such elements.">
+<style>
+  .checker::before {
+    content: counter(c);
+  }
+</style>
+<body>
+  <div id="container" style="counter-reset: c 0;">
+    <div style="visibility: hidden; counter-set: c 10;"></div>
+    <div class="checker"></div>
+  </div>
+</body>

--- a/css/css-lists/counter-set-005-ref.html
+++ b/css/css-lists/counter-set-005-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Implicit Instantiation (Self-Nesting) Reference</title>
+
+<style>
+  /* Matches the structure of the test file but using static content */
+</style>
+
+<body>
+  <div>
+    <span>5</span>
+  </div>
+</body>

--- a/css/css-lists/counter-set-005.html
+++ b/css/css-lists/counter-set-005.html
@@ -7,7 +7,7 @@
 
 <style>
   /* Pre-conditions: No existing counter scopes (no `counter-reset` used anywhere). */
-  
+
   /* Step 1: Create a div with `counter-set: new-counter 5`. */
   .test-wrapper {
     counter-set: new-counter 5;

--- a/css/css-lists/counter-set-005.html
+++ b/css/css-lists/counter-set-005.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Implicit Instantiation (Self-Nesting)</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists/#counter-set">
+<link rel="match" href="counter-set-005-ref.html">
+<meta name="assert" content="If the counter does not exist, counter-set instantiates a new counter of that name... and then sets the value.">
+
+<style>
+  /* Pre-conditions: No existing counter scopes (no `counter-reset` used anywhere). */
+  
+  /* Step 1: Create a div with `counter-set: new-counter 5`. */
+  .test-wrapper {
+    counter-set: new-counter 5;
+  }
+
+  /* Step 2: Inside this div, create a span displaying `counter(new-counter)`. */
+  .test-wrapper span::before {
+    content: counter(new-counter);
+  }
+</style>
+
+<body>
+  <div class="test-wrapper">
+    <span></span>
+  </div>
+</body>

--- a/css/css-lists/counter-set-006-ref.html
+++ b/css/css-lists/counter-set-006-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Reference: Interaction: Reset and Set on Same Element</title>
+</head>
+<body>
+    <div>10</div>
+</body>
+</html>

--- a/css/css-lists/counter-set-006.html
+++ b/css/css-lists/counter-set-006.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Interaction: Reset and Set on Same Element</title>
+    <link rel="help" href="https://drafts.csswg.org/css-lists/#counter-properties">
+    <link rel="match" href="counter-set-006-ref.html">
+    <meta name="assert" content="The span displays '10' (Resolution order: Reset -> Set).">
+    <style>
+        .test-container {
+            counter-reset: c 0;
+            counter-set: c 10;
+        }
+        .test-container span::before {
+            content: counter(c);
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <span></span>
+    </div>
+</body>
+</html>

--- a/css/css-lists/counter-set-007-ref.html
+++ b/css/css-lists/counter-set-007-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Override HTML 'value' Attribute Reference</title>
+</head>
+<body>
+    <ol>
+        <li value="10"></li>
+    </ol>
+</body>
+</html>

--- a/css/css-lists/counter-set-007.html
+++ b/css/css-lists/counter-set-007.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Override HTML 'value' Attribute</title>
+    <link rel="help" href="https://drafts.csswg.org/css-lists/#counter-set-properties">
+    <link rel="match" href="counter-set-007-ref.html">
+    <meta name="assert" content="The list item marker displays '10', ignoring the HTML attribute value of '5'.">
+    <style>
+        li {
+            counter-set: list-item 10;
+        }
+    </style>
+</head>
+<body>
+    <ol>
+        <li value="5"></li>
+    </ol>
+</body>
+</html>

--- a/css/css-lists/counter-set-008-ref.html
+++ b/css/css-lists/counter-set-008-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Pseudo-element with No Content Reference</title>
+</head>
+<body>
+<div>0</div>
+</body>
+</html>

--- a/css/css-lists/counter-set-008.html
+++ b/css/css-lists/counter-set-008.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Pseudo-element with No Content</title>
+<link rel="help" href="https://drafts.csswg.org/css-content/">
+<link rel="help" href="https://drafts.csswg.org/css-lists/">
+<link rel="match" href="counter-set-008-ref.html">
+<meta name="assert" content="The displayed value remains '0' (the pseudo-element does not trigger the set operation).">
+<style>
+  div {
+    /* Pre-conditions: Container with an initialized counter 'c' at 0. */
+    counter-reset: c 0;
+  }
+
+  div::before {
+    /* Step 1: Target `div::before` with `content: none` and `counter-set: c 10`. */
+    content: none;
+    counter-set: c 10;
+  }
+
+  div::after {
+    /* Step 2: Display `counter(c)` in the main `div`. */
+    content: counter(c);
+  }
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>


### PR DESCRIPTION
6 new test suggestions were generated for this Web feature:

```
<test_suggestions>
<test_suggestion>
    <title>Effect on Elements with No Box (display: none)</title>
    <category>Existence</category>
    <spec_logic>If an element does not generate a box (e.g., display: none), the counter-set property must have no effect.</spec_logic>
    <pre_conditions>HTML body with a container div</pre_conditions>
    <steps>
        <step>1. Initialize a counter 'c' with value 0 on the body.</step>
        <step>2. Create a child div with `display: none` and `counter-set: c 10`.</step>
        <step>3. Create a subsequent sibling div that displays `counter(c)`.</step>
    </steps>
    <expected_result>The subsequent sibling displays "0" (the set operation is ignored), not "10".</expected_result>
</test_suggestion>

<test_suggestion>
    <title>Effect on Invisible Boxes (visibility: hidden)</title>
    <category>Existence</category>
    <spec_logic>visibility: hidden still generates a box, so counter-set remains active on such elements.</spec_logic>
    <pre_conditions>HTML body with a container div</pre_conditions>
    <steps>
        <step>1. Initialize a counter 'c' with value 0 on the body.</step>
        <step>2. Create a child div with `visibility: hidden` and `counter-set: c 10`.</step>
        <step>3. Create a subsequent sibling div that displays `counter(c)`.</step>
    </steps>
    <expected_result>The subsequent sibling displays "10" (the set operation is applied).</expected_result>
</test_suggestion>

<test_suggestion>
    <title>Implicit Instantiation (Self-Nesting)</title>
    <category>Common Use Case</category>
    <spec_logic>If the counter does not exist, counter-set instantiates a new counter of that name... and then sets the value.</spec_logic>
    <pre_conditions>No existing counter scopes (no `counter-reset` used anywhere).</pre_conditions>
    <steps>
        <step>1. Create a div with `counter-set: new-counter 5`.</step>
        <step>2. Inside this div, create a span displaying `counter(new-counter)`.</step>
        <step>3. Verify the counter exists and has the correct value.</step>
    </steps>
    <expected_result>The span displays "5", proving the counter was instantiated solely by `counter-set`.</expected_result>
</test_suggestion>

<test_suggestion>
    <title>Interaction: Reset and Set on Same Element</title>
    <category>Integration</category>
    <spec_logic>If counter-reset creates a new scope on an element, counter-set on that same element will modify the value of that newly created counter.</spec_logic>
    <pre_conditions>None</pre_conditions>
    <steps>
        <step>1. Create a div with both `counter-reset: c 0` and `counter-set: c 10`.</step>
        <step>2. Inside this div, create a span displaying `counter(c)`.</step>
    </steps>
    <expected_result>The span displays "10" (Resolution order: Reset -> Set).</expected_result>
</test_suggestion>

<test_suggestion>
    <title>Override HTML 'value' Attribute</title>
    <category>Integration</category>
    <spec_logic>The counter-set property is the mechanism used to implement the behavior of the value attribute. Author styles should override UA styles.</spec_logic>
    <pre_conditions>An Ordered List (`ol`)</pre_conditions>
    <steps>
        <step>1. Create an `li` element with HTML attribute `value="5"`.</step>
        <step>2. Apply CSS `counter-set: list-item 10` to this `li`.</step>
        <step>3. Observe the marker value.</step>
    </steps>
    <expected_result>The list item marker displays "10", ignoring the HTML attribute value of "5".</expected_result>
</test_suggestion>

<test_suggestion>
    <title>Pseudo-element with No Content</title>
    <category>Error Scenario</category>
    <spec_logic>If a pseudo-element has `content: none`, it does not generate a box, and `counter-set` should have no effect.</spec_logic>
    <pre_conditions>Container with an initialized counter 'c' at 0.</pre_conditions>
    <steps>
        <step>1. Target `div::before` with `content: none` and `counter-set: c 10`.</step>
        <step>2. Display `counter(c)` in the main `div`.</step>
    </steps>
    <expected_result>The displayed value remains "0" (the pseudo-element does not trigger the set operation).</expected_result>
</test_suggestion>
</test_suggestions>
```