### PR TITLE
Remove <hatch> element test coverage since removed from SVG2

### DIFF
--- a/svg/interact/scripted/tabindex-focus-flag.svg
+++ b/svg/interact/scripted/tabindex-focus-flag.svg
@@ -43,7 +43,6 @@
         <clipPath tabindex="0"></clipPath>
         <defs tabindex="0"></defs>
         <desc tabindex="0"></desc>
-        <hatch tabindex="0"></hatch>
         <linearGradient tabindex="0"></linearGradient>
         <marker tabindex="0"></marker>
         <mask tabindex="0"></mask>
@@ -97,7 +96,6 @@
         ['clipPath[tabindex]', false],
         ['defs[tabindex]', false],
         ['desc[tabindex]', false],
-        ['hatch[tabindex]', false],
         ['linearGradient[tabindex]', false],
         ['marker[tabindex]', false],
         ['mask[tabindex]', false],


### PR DESCRIPTION
Hi Team,

This PR is to remove <hatch> element test coverage since it is removed from SVG2 spec [1]:

[1] https://github.com/w3c/svgwg/pull/451

Discussion on SVGWG: https://github.com/w3c/svgwg/issues/1063

Just doing PR to get review + update test support.

Thanks!