### PR TITLE
[Manual] WebKit Export - https://bugs.webkit.org/show_bug.cgi?id=244025

### DIFF
--- a/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill.html‎
+++ b/svg/pservers/reftests/css-color-visited-currentcolor-svg-fill.html‎
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS test: propagate `:visited` link color to an SVG element thorough `fill="currentColor"`</title>
+<link rel="help" href="https://www.w3.org/TR/selectors-4/#link">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#currentcolor-color">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#resolving-other-colors">
+<link rel="help" href="https://www.w3.org/TR/SVG2/painting.html#SpecifyingFillPaint">
+<link rel="author" title="Masataka Yakura" href="mailto:masataka.yakura@gmail.com">
+<link rel="match" href="../../../css/reference/ref-filled-green-100px-square.xht">
+<style>
+:any-link {
+  color: red;
+}
+:visited {
+  color: green;
+}
+</style>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<a href="">
+  <svg width="100" height="100">
+    <rect width="100%" height="100%" fill="currentColor"/>
+  </svg>
+</a>
+</body>

--- a/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle.html
+++ b/svg/pservers/scripted/svg-fill-currentcolor-visited-getcomputedstyle.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG paint servers with :visited don't leak information via getComputedStyle</title>
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#currentcolor-color">
+<link rel="help" href="https://www.w3.org/TR/SVG2/painting.html#SpecifyingFillPaint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+a:link { color: red; }
+a:visited { color: green; }
+</style>
+
+<a href="">
+  <svg width="100" height="100">
+    <rect id="target" width="100%" height="100%" fill="currentColor"/>
+  </svg>
+</a>
+<script>
+test_computed_value("fill", "currentColor", "rgb(255, 0, 0)", "should not leak :visited for SVG fill with currentColor");
+</script>


### PR DESCRIPTION
Hi All,

Please test cases for coverage of :visited link color propagation to SVG through currentColor.

It is working fine on Chrome + now in WebKit, it is good to get coverage.

Thanks!