### PR TITLE
[testdriver] `emulation.setTouchOverride`

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -349,4 +349,5 @@ Emulation of browser APIs via [WebDriver BiDi Emulation](https://www.w3.org/TR/w
 .. js:autofunction:: test_driver.bidi.emulation.set_geolocation_override
 .. js:autofunction:: test_driver.bidi.emulation.set_locale_override
 .. js:autofunction:: test_driver.bidi.emulation.set_screen_orientation_override
+.. js:autofunction:: test_driver.bidi.emulation.set_touch_override
 ```

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html.ini
@@ -1,0 +1,3 @@
+[set_touch_override.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html
+++ b/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<title>TestDriver bidi.emulation.set_touch_override method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+    promise_test(async () => {
+        // Get the initial max touch points.
+        const initial_max_touch_points = navigator.maxTouchPoints;
+
+        // Set the max touch points override
+        await test_driver.bidi.emulation.set_touch_override({
+            maxTouchPoints: 2
+        });
+        // Assert the max touch points matches the override.
+        assert_equals(navigator.maxTouchPoints, 2);
+
+        // Set another max touch points override
+        await test_driver.bidi.emulation.set_touch_override({
+            maxTouchPoints: 5
+        });
+
+        // Assert the max touch points matches the override.
+        assert_equals(navigator.maxTouchPoints, 5);
+
+        // Clear the touch override.
+        await test_driver.bidi.emulation.set_touch_override({});
+        // Assert max touch points is set to the original value.
+        assert_equals(navigator.maxTouchPoints, initial_max_touch_points);
+    }, "emulate touch and clear override");
+
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -954,6 +954,36 @@
                     return window.test_driver_internal.bidi.emulation.set_screen_orientation_override(
                         params);
                 },
+                /**
+                 * Overrides the touch configuration for the specified browsing
+                 * contexts.
+                 * Matches the `emulation.setTouchOverride
+                 * <https://w3c.github.io/webdriver-bidi/#command-emulation-setTouchOverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @example
+                 * await test_driver.bidi.emulation.set_touch_override({
+                 *     maxTouchPoints: 5
+                 * });
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|number} params.maxTouchPoints - The
+                 * maximum number of simultaneous touch points to support.
+                 * If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the touch override on. It should be either an array of
+                 * Context objects (window or browsing context id), or null. If
+                 * null or omitted, the override will be set on the current
+                 * browsing context.
+                 * @returns {Promise<void>} Resolves when the touch
+                 * override is successfully set.
+                 */
+                set_touch_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.emulation.set_touch_override(
+                        params);
+                },
             },
             /**
              * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
@@ -2390,6 +2420,10 @@
                 set_screen_orientation_override: function (params) {
                     throw new Error(
                         "bidi.emulation.set_screen_orientation_override is not implemented by testdriver-vendor.js");
+                },
+                set_touch_override: function (params) {
+                    throw new Error(
+                        "bidi.emulation.set_touch_override is not implemented by testdriver-vendor.js");
                 }
             },
             log: {

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -245,6 +245,31 @@ class BidiEmulationSetScreenOrientationOverrideAction:
             screen_orientation, contexts)
 
 
+class BidiEmulationSetTouchOverrideAction:
+    name = "bidi.emulation.set_touch_override"
+
+    def __init__(self, logger, protocol):
+        do_delayed_imports()
+        self.logger = logger
+        self.protocol = protocol
+
+    async def __call__(self, payload):
+        max_touch_points = payload['maxTouchPoints'] \
+            if 'maxTouchPoints' in payload \
+            else None
+
+        if "contexts" not in payload:
+            raise ValueError("Missing required parameter: contexts")
+        contexts = []
+        for context in payload["contexts"]:
+            contexts.append(get_browsing_context_id(context))
+        if len(contexts) == 0:
+            raise ValueError("At least one context must be provided")
+
+        return await self.protocol.bidi_emulation.set_touch_override(
+            max_touch_points, contexts)
+
+
 class BidiSessionSubscribeAction:
     name = "bidi.session.subscribe"
 
@@ -314,6 +339,7 @@ async_actions = [
     BidiEmulationSetGeolocationOverrideAction,
     BidiEmulationSetLocaleOverrideAction,
     BidiEmulationSetScreenOrientationOverrideAction,
+    BidiEmulationSetTouchOverrideAction,
     BidiPermissionsSetPermissionAction,
     BidiSessionSubscribeAction,
     BidiSessionUnsubscribeAction,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -389,6 +389,10 @@ class WebDriverBidiEmulationProtocolPart(BidiEmulationProtocolPart):
         return await self.webdriver.bidi_session.emulation.set_screen_orientation_override(
             screen_orientation=screen_orientation, contexts=contexts)
 
+    async def set_touch_override(self, max_touch_points, contexts):
+        return await self.webdriver.bidi_session.emulation.set_touch_override(
+            max_touch_points=max_touch_points, contexts=contexts)
+
 
 class WebDriverBidiPermissionsProtocolPart(BidiPermissionsProtocolPart):
     def __init__(self, parent):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -649,6 +649,12 @@ class BidiEmulationProtocolPart(ProtocolPart):
             contexts: List[str]) -> None:
         pass
 
+    @abstractmethod
+    async def set_touch_override(self,
+            max_touch_points: Optional[int],
+            contexts: List[str]) -> None:
+        pass
+
 
 class BidiScriptProtocolPart(ProtocolPart):
     """Protocol part for executing BiDi scripts"""

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -443,6 +443,16 @@
                 });
         }
 
+    window.test_driver_internal.bidi.emulation.set_touch_override =
+        function (params) {
+            return create_action(
+                "bidi.emulation.set_touch_override", {
+                    // Default to the current window.
+                    contexts: [window],
+                    ...(params ?? {})
+                });
+        }
+
     window.test_driver_internal.bidi.log.entry_added.subscribe =
         function (params) {
             return subscribe({


### PR DESCRIPTION
Add method `test_driver.bidi.emulation.set_touch_override` matching WebDriver BiDi [`emulation. setTouchOverride`](https://www.w3.org/TR/webdriver-bidi/#commands-emulationsettouchoverride).