### PR TITLE
[testdriver] `test_driver.bidi.user_agent_client_hints.set_client_hints_override`

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html.ini
@@ -1,0 +1,3 @@
+[set_client_hints_override.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html
+++ b/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html
@@ -26,7 +26,7 @@
         await test_driver.bidi.user_agent_client_hints.set_client_hints_override({
             clientHints: MOCK_CLIENT_HINTS
         });
-        
+
         let clientHints = await navigator.userAgentData.getHighEntropyValues([
             "architecture",
             "bitness",
@@ -35,7 +35,7 @@
             "uaFullVersion",
             "wow64"
         ]);
-        
+
         assert_equals(clientHints.architecture, MOCK_CLIENT_HINTS.architecture);
         assert_equals(clientHints.bitness, MOCK_CLIENT_HINTS.bitness);
         assert_equals(clientHints.model, MOCK_CLIENT_HINTS.model);

--- a/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html
+++ b/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver bidi.userAgentClientHints.set_client_hints_override</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+    const MOCK_CLIENT_HINTS = {
+        brands: [
+            {
+                brand: "TestBrand",
+                version: "123"
+            }
+        ],
+        mobile: false,
+        platform: "TestPlatform",
+        architecture: "TestArch",
+        bitness: "64",
+        model: "TestModel",
+        platformVersion: "TestVersion",
+        wow64: false
+    };
+
+    promise_test(async t => {
+        await test_driver.bidi.userAgentClientHints.set_client_hints_override({
+            clientHints: MOCK_CLIENT_HINTS
+        });
+        
+        let clientHints = await navigator.userAgentData.getHighEntropyValues([
+            "architecture",
+            "bitness",
+            "model",
+            "platformVersion",
+            "uaFullVersion",
+            "wow64"
+        ]);
+        
+        assert_equals(clientHints.architecture, MOCK_CLIENT_HINTS.architecture);
+        assert_equals(clientHints.bitness, MOCK_CLIENT_HINTS.bitness);
+        assert_equals(clientHints.model, MOCK_CLIENT_HINTS.model);
+        assert_equals(clientHints.platformVersion, MOCK_CLIENT_HINTS.platformVersion);
+        assert_equals(clientHints.wow64, MOCK_CLIENT_HINTS.wow64);
+        assert_equals(navigator.userAgentData.platform, MOCK_CLIENT_HINTS.platform);
+        assert_equals(navigator.userAgentData.mobile, MOCK_CLIENT_HINTS.mobile);
+
+        await test_driver.bidi.userAgentClientHints.set_client_hints_override({
+            clientHints: null
+        });
+
+    }, "test_driver.bidi.userAgentClientHints.set_client_hints_override");
+</script>

--- a/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html
+++ b/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>TestDriver bidi.userAgentClientHints.set_client_hints_override</title>
+<title>TestDriver bidi.user_agent_client_hints.set_client_hints_override</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js?feature=bidi"></script>
@@ -23,7 +23,7 @@
     };
 
     promise_test(async t => {
-        await test_driver.bidi.userAgentClientHints.set_client_hints_override({
+        await test_driver.bidi.user_agent_client_hints.set_client_hints_override({
             clientHints: MOCK_CLIENT_HINTS
         });
         
@@ -44,9 +44,9 @@
         assert_equals(navigator.userAgentData.platform, MOCK_CLIENT_HINTS.platform);
         assert_equals(navigator.userAgentData.mobile, MOCK_CLIENT_HINTS.mobile);
 
-        await test_driver.bidi.userAgentClientHints.set_client_hints_override({
+        await test_driver.bidi.user_agent_client_hints.set_client_hints_override({
             clientHints: null
         });
 
-    }, "test_driver.bidi.userAgentClientHints.set_client_hints_override");
+    }, "test_driver.bidi.user_agent_client_hints.set_client_hints_override");
 </script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -986,6 +986,35 @@
                 },
             },
             /**
+            /**
+             * `userAgentClientHints <https://w3c.github.io/webdriver-bidi/#module-userAgentClientHints>`_ module.
+             */
+            userAgentClientHints: {
+                /**
+                 * Overrides the user agent client hints configuration for the specified browsing
+                 * contexts. Matches the `userAgentClientHints.setClientHintsOverride
+                 * <https://wicg.github.io/ua-client-hints/#emulation-setclienthintsoverride>`_
+                 * WebDriver BiDi command.
+                 *
+                 * @param {object} params - Parameters for the command.
+                 * @param {null|object} params.clientHints - The client hints to override.
+                 * Matches the `userAgentClientHints.ClientHints` type.
+                 * If null or omitted, the override will be removed.
+                 * @param {null|Array.<(Context)>} [params.contexts] The
+                 * optional contexts parameter specifies which browsing contexts
+                 * to set the override on.
+                 * @param {null|Array.<(string)>} [params.userContexts] The
+                 * optional userContexts parameter specifies which user contexts
+                 * to set the override on.
+                 * @returns {Promise<void>} Resolves when the override is successfully set.
+                 */
+                set_client_hints_override: function (params) {
+                    assertBidiIsEnabled();
+                    return window.test_driver_internal.bidi.userAgentClientHints.set_client_hints_override(
+                        params);
+                }
+            },
+
              * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
              */
             log: {
@@ -2425,6 +2454,13 @@
                     throw new Error(
                         "bidi.emulation.set_touch_override is not implemented by testdriver-vendor.js");
                 }
+            userAgentClientHints: {
+                set_client_hints_override: function (params) {
+                    throw new Error(
+                        "bidi.userAgentClientHints.set_client_hints_override is not implemented by testdriver-vendor.js");
+                }
+            },
+
             },
             log: {
                 entry_added: {

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -986,7 +986,7 @@
                 },
             },
             /**
-             * `user_agent_client_hints <https://w3c.github.io/webdriver-bidi/#module-userAgentClientHints>`_ module.
+             * `user_agent_client_hints <https://wicg.github.io/ua-client-hints/#automation>`_ module.
              */
             user_agent_client_hints: {
                 /**

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -986,10 +986,9 @@
                 },
             },
             /**
-            /**
-             * `userAgentClientHints <https://w3c.github.io/webdriver-bidi/#module-userAgentClientHints>`_ module.
+             * `user_agent_client_hints <https://w3c.github.io/webdriver-bidi/#module-userAgentClientHints>`_ module.
              */
-            userAgentClientHints: {
+            user_agent_client_hints: {
                 /**
                  * Overrides the user agent client hints configuration for the specified browsing
                  * contexts. Matches the `userAgentClientHints.setClientHintsOverride
@@ -1003,18 +1002,15 @@
                  * @param {null|Array.<(Context)>} [params.contexts] The
                  * optional contexts parameter specifies which browsing contexts
                  * to set the override on.
-                 * @param {null|Array.<(string)>} [params.userContexts] The
-                 * optional userContexts parameter specifies which user contexts
-                 * to set the override on.
                  * @returns {Promise<void>} Resolves when the override is successfully set.
                  */
                 set_client_hints_override: function (params) {
                     assertBidiIsEnabled();
-                    return window.test_driver_internal.bidi.userAgentClientHints.set_client_hints_override(
+                    return window.test_driver_internal.bidi.user_agent_client_hints.set_client_hints_override(
                         params);
                 }
             },
-
+            /**
              * `log <https://www.w3.org/TR/webdriver-bidi/#module-log>`_ module.
              */
             log: {
@@ -2454,13 +2450,12 @@
                     throw new Error(
                         "bidi.emulation.set_touch_override is not implemented by testdriver-vendor.js");
                 }
-            userAgentClientHints: {
+            },
+            user_agent_client_hints: {
                 set_client_hints_override: function (params) {
                     throw new Error(
-                        "bidi.userAgentClientHints.set_client_hints_override is not implemented by testdriver-vendor.js");
+                        "bidi.user_agent_client_hints.set_client_hints_override is not implemented by testdriver-vendor.js");
                 }
-            },
-
             },
             log: {
                 entry_added: {

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -289,7 +289,7 @@ class BidiSessionSubscribeAction:
 
 
 class BidiUserAgentClientHintsSetClientHintsOverrideAction:
-    name = "bidi.userAgentClientHints.set_client_hints_override"
+    name = "bidi.user_agent_client_hints.set_client_hints_override"
 
     def __init__(self, logger, protocol):
         do_delayed_imports()
@@ -302,12 +302,8 @@ class BidiUserAgentClientHintsSetClientHintsOverrideAction:
         contexts = payload.get("contexts", None)
         if contexts is not None:
              contexts = [get_browsing_context_id(context) for context in contexts]
-
-        user_contexts = payload.get("userContexts", None)
-
         return await self.protocol.bidi_user_agent_client_hints.set_client_hints_override(
-            client_hints, contexts, user_contexts)
-
+            client_hints, contexts)
 
 
 class BidiSessionUnsubscribeAction:
@@ -362,8 +358,8 @@ async_actions = [
     BidiEmulationSetLocaleOverrideAction,
     BidiEmulationSetScreenOrientationOverrideAction,
     BidiEmulationSetTouchOverrideAction,
+    BidiUserAgentClientHintsSetClientHintsOverrideAction,
     BidiPermissionsSetPermissionAction,
     BidiSessionSubscribeAction,
     BidiSessionUnsubscribeAction,
-    BidiPermissionsSetPermissionAction,
-    BidiSessionSubscribeAction]
+    BidiPermissionsSetPermissionAction]

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -301,7 +301,7 @@ class BidiUserAgentClientHintsSetClientHintsOverrideAction:
 
         contexts = payload.get("contexts", None)
         if contexts is not None:
-             contexts = [get_browsing_context_id(context) for context in contexts]
+            contexts = [get_browsing_context_id(context) for context in contexts]
         return await self.protocol.bidi_user_agent_client_hints.set_client_hints_override(
             client_hints, contexts)
 

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -288,6 +288,28 @@ class BidiSessionSubscribeAction:
         return await self.protocol.bidi_events.subscribe(events, contexts)
 
 
+class BidiUserAgentClientHintsSetClientHintsOverrideAction:
+    name = "bidi.userAgentClientHints.set_client_hints_override"
+
+    def __init__(self, logger, protocol):
+        do_delayed_imports()
+        self.logger = logger
+        self.protocol = protocol
+
+    async def __call__(self, payload):
+        client_hints = payload.get("clientHints", None)
+
+        contexts = payload.get("contexts", None)
+        if contexts is not None:
+             contexts = [get_browsing_context_id(context) for context in contexts]
+
+        user_contexts = payload.get("userContexts", None)
+
+        return await self.protocol.bidi_user_agent_client_hints.set_client_hints_override(
+            client_hints, contexts, user_contexts)
+
+
+
 class BidiSessionUnsubscribeAction:
     name = "bidi.session.unsubscribe"
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -352,6 +352,20 @@ class WebDriverBidiEventsProtocolPart(BidiEventsProtocolPart):
         return self.webdriver.bidi_session.add_event_listener(name=name, fn=fn)
 
 
+class WebDriverBidiUserAgentClientHintsProtocolPart(BidiUserAgentClientHintsProtocolPart):
+    def __init__(self, parent):
+        super().__init__(parent)
+
+    @property
+    def webdriver(self):
+        return self.parent.webdriver
+
+    async def set_client_hints_override(self, client_hints, contexts, user_contexts):
+        return await self.webdriver.bidi_session.user_agent_client_hints.set_client_hints_override(
+            client_hints=client_hints, contexts=contexts, user_contexts=user_contexts)
+
+
+
 class WebDriverBidiScriptProtocolPart(BidiScriptProtocolPart):
     def __init__(self, parent):
         super().__init__(parent)
@@ -1131,6 +1145,8 @@ class WebDriverBidiProtocol(WebDriverProtocol):
                   WebDriverBidiPermissionsProtocolPart,
                   WebDriverBidiScriptProtocolPart,
                   WebDriverBidiWebExtensionsProtocolPart,
+                  WebDriverBidiUserAgentClientHintsProtocolPart,
+
                   *(part for part in WebDriverProtocol.implements)
                   ]
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1146,7 +1146,6 @@ class WebDriverBidiProtocol(WebDriverProtocol):
                   WebDriverBidiScriptProtocolPart,
                   WebDriverBidiWebExtensionsProtocolPart,
                   WebDriverBidiUserAgentClientHintsProtocolPart,
-
                   *(part for part in WebDriverProtocol.implements)
                   ]
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -40,6 +40,7 @@ from .protocol import (BaseProtocolPart,
                        BidiBluetoothProtocolPart,
                        BidiBrowsingContextProtocolPart,
                        BidiEmulationProtocolPart,
+                       BidiUserAgentClientHintsProtocolPart,
                        BidiEventsProtocolPart,
                        BidiPermissionsProtocolPart,
                        BidiScriptProtocolPart,
@@ -355,15 +356,14 @@ class WebDriverBidiEventsProtocolPart(BidiEventsProtocolPart):
 class WebDriverBidiUserAgentClientHintsProtocolPart(BidiUserAgentClientHintsProtocolPart):
     def __init__(self, parent):
         super().__init__(parent)
+        self.webdriver = None
 
-    @property
-    def webdriver(self):
-        return self.parent.webdriver
+    def setup(self):
+        self.webdriver = self.parent.webdriver
 
-    async def set_client_hints_override(self, client_hints, contexts, user_contexts):
+    async def set_client_hints_override(self, client_hints, contexts):
         return await self.webdriver.bidi_session.user_agent_client_hints.set_client_hints_override(
-            client_hints=client_hints, contexts=contexts, user_contexts=user_contexts)
-
+            client_hints=client_hints, contexts=contexts)
 
 
 class WebDriverBidiScriptProtocolPart(BidiScriptProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -656,6 +656,20 @@ class BidiEmulationProtocolPart(ProtocolPart):
         pass
 
 
+class BidiUserAgentClientHintsProtocolPart(ProtocolPart):
+    """Protocol part for User Agent Client Hints"""
+    name = "bidi_user_agent_client_hints"
+
+    @abstractmethod
+    async def set_client_hints_override(
+            self,
+            client_hints: Optional[Mapping[str, Any]],
+            contexts: Optional[List[str]],
+            user_contexts: Optional[List[str]]) -> None:
+        pass
+
+
+
 class BidiScriptProtocolPart(ProtocolPart):
     """Protocol part for executing BiDi scripts"""
     __metaclass__ = ABCMeta

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -658,6 +658,7 @@ class BidiEmulationProtocolPart(ProtocolPart):
 
 class BidiUserAgentClientHintsProtocolPart(ProtocolPart):
     """Protocol part for User Agent Client Hints"""
+    __metaclass__ = ABCMeta
     name = "bidi_user_agent_client_hints"
 
     @abstractmethod

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -670,7 +670,6 @@ class BidiUserAgentClientHintsProtocolPart(ProtocolPart):
         pass
 
 
-
 class BidiScriptProtocolPart(ProtocolPart):
     """Protocol part for executing BiDi scripts"""
     __metaclass__ = ABCMeta

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -425,6 +425,16 @@
             });
         }
 
+    window.test_driver_internal.bidi.userAgentClientHints = { 
+        set_client_hints_override: function(params) { 
+            return create_action("bidi.userAgentClientHints.set_client_hints_override", { 
+                contexts: [window], 
+                ...(params ?? {}) 
+            }); 
+        } 
+    };
+
+
     window.test_driver_internal.bidi.emulation.set_locale_override = function (params) {
         return create_action("bidi.emulation.set_locale_override", {
             // Default to the current window.

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -425,9 +425,9 @@
             });
         }
 
-    window.test_driver_internal.bidi.userAgentClientHints = { 
+    window.test_driver_internal.bidi.user_agent_client_hints = { 
         set_client_hints_override: function(params) { 
-            return create_action("bidi.userAgentClientHints.set_client_hints_override", { 
+            return create_action("bidi.user_agent_client_hints.set_client_hints_override", { 
                 contexts: [window], 
                 ...(params ?? {}) 
             }); 

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -434,7 +434,6 @@
         } 
     };
 
-
     window.test_driver_internal.bidi.emulation.set_locale_override = function (params) {
         return create_action("bidi.emulation.set_locale_override", {
             // Default to the current window.


### PR DESCRIPTION
Expose `bidi.user_agent_client_hints.set_client_hints_override` to testdriver.js matching [`userAgentClientHints.setClientHintsOverride`](https://wicg.github.io/ua-client-hints/#cddl-type-useragentclienthintssetclienthintsoverridecommand).