### PR TITLE
move popover anchor tests to tentative file

### DIFF
--- a/html/semantics/popovers/popover-types-with-hints-and-anchor.tentative.html
+++ b/html/semantics/popovers/popover-types-with-hints-and-anchor.tentative.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel=help href="https://open-ui.org/components/popover.research.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+  function getPopovers() {
+    return Array.from(document.currentScript.parentElement.querySelectorAll('[popover]'));
+  }
+  function assertState(expectedState,description) {
+    description = description || 'Error';
+    const popovers = getPopovers();
+    const n = popovers.length;
+    assert_equals(expectedState.length,n,'Invalid expected state length');
+    for(let i=0;i<n;++i) {
+      const html = '<' + popovers[i].outerHTML.split('<')[1] + '</div>';
+      assert_equals(popovers[i].matches(':popover-open'),expectedState[i],`${description}, index ${i} (${html})`);
+    }
+  }
+</script>
+
+<div>
+  <div popover>popover 1
+    <div popover>popover 2
+      <p id=anchorid>Anchor</p>
+      <div popover>popover 3</div>
+    </div>
+  </div>
+  <div popover=hint anchor=anchorid>Hint anchored to popover</div>
+  <script>
+  {
+    const popover1 = getPopovers()[0];
+    const popover2 = getPopovers()[1];
+    const popover3 = getPopovers()[2];
+    const hint = getPopovers()[3];
+    test(() => {
+      assertState([false,false,false,false]);
+      popover1.showPopover();
+      popover2.showPopover();
+      popover3.showPopover();
+      assertState([true,true,true,false]);
+      hint.showPopover(); // Because hint is nested in popover2, popover3 should be hidden
+      assertState([true,true,false,true]);
+      popover1.hidePopover(); // Should close the hint, which is anchored to popover2
+      assertState([false,false,false,false]);
+    },'hint is not closed by pre-existing auto');
+  }
+  </script>
+</div>
+

--- a/html/semantics/popovers/popover-types-with-hints.html
+++ b/html/semantics/popovers/popover-types-with-hints.html
@@ -77,35 +77,6 @@
 </div>
 
 <div>
-  <div popover>popover 1
-    <div popover>popover 2
-      <p id=anchorid>Anchor</p>
-      <div popover>popover 3</div>
-    </div>
-  </div>
-  <div popover=hint anchor=anchorid>Hint anchored to popover</div>
-  <script>
-  {
-    const popover1 = getPopovers()[0];
-    const popover2 = getPopovers()[1];
-    const popover3 = getPopovers()[2];
-    const hint = getPopovers()[3];
-    test(() => {
-      assertState([false,false,false,false]);
-      popover1.showPopover();
-      popover2.showPopover();
-      popover3.showPopover();
-      assertState([true,true,true,false]);
-      hint.showPopover(); // Because hint is nested in popover2, popover3 should be hidden
-      assertState([true,true,false,true]);
-      popover1.hidePopover(); // Should close the hint, which is anchored to popover2
-      assertState([false,false,false,false]);
-    },'hint is not closed by pre-existing auto');
-  }
-  </script>
-</div>
-
-<div>
   <div popover=hint>Hint
     <div popover=hint>Nested hint</div>
   </div>


### PR DESCRIPTION
This moves one of the `popover=hint` tests from the `popover-types-with-hints.html` file to a new file: `popover-types-with-hints-and-anchor.tentative.html`.

The reason for this is that this test uses the `anchor=` attribute which hasn't been specified yet (please correct me if that's wrong), therefore I don't think it belongs in a non-tentative test.

/cc @josepharhar @mfreed7 @nt1m @annevk 