### PR TITLE
Support backdrop on outer <svg> / <iframe> / <img>.

### DIFF
--- a/html/semantics/popovers/popover-img-backdrop.html
+++ b/html/semantics/popovers/popover-img-backdrop.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>::backdrop is supported on img</title>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2015488">
+<link rel="match" href="popover-img-backdrop-ref.html">
+<style>
+img:popover-open {
+  visibility: hidden;
+  &::backdrop {
+    visibility: visible;
+    background-color: green;
+  }
+}
+</style>
+<img popover="" id="a" style="direction: rtl"/>
+<script>
+a.showPopover({ modal: true });
+</script>
+


### PR DESCRIPTION
Add exceptions for a few elements that do rely on their frame tree size (mostly text controls). These are fixable but separate bug at the very least.

Add reftests for <iframe> and <img>. Also, test all HTML elements in all writing modes to ensure that they don't trigger assertions.

The <svg> case can't be easily reftested, afaict, because fullscreen will change the size of the reftest window and <svg> doesn't support popover.