### PR TITLE
Fix test title indentation.

### DIFF
--- a/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html
+++ b/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>
-View transitions: mismatched snapshot containing block size skips transition.
+  View transitions: mismatched snapshot containing block size skips transition.
 </title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
 <link rel="author" href="mailto:bokan@chromium.org">


### PR DESCRIPTION
Add title indentation to be consistent with other tests, and to avoid confusing the metadata processing code.