### PR TITLE
layout: Support `svg` in `border-image-source`

### DIFF
--- a/paint-timing/fcp-only/fcp-border-image-with-svg.html
+++ b/paint-timing/fcp-only/fcp-border-image-with-svg.html
@@ -9,7 +9,7 @@
     height: 100px;
     border: 30px solid transparent;
     border-image-source: url(../resources/circle.svg);
-    border-image-width: 0px;
+    border-image-width: 30px;
   }
 </style>
 <div id='bordered'></div>
@@ -23,6 +23,6 @@ promise_test(async t => {
   }).then(() => {
     return assertFirstContentfulPaint(t);
   });
-}, 'Border image triggers First Contentful Paint.');
+}, 'Border image with SVG triggers First Contentful Paint.');
 </script>
 </body>

--- a/paint-timing/fcp-only/fcp-border-image.html
+++ b/paint-timing/fcp-only/fcp-border-image.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<style>
+  #bordered {
+    width: 100px;
+    height: 100px;
+    border: 30px solid transparent;
+    border-image-source: url(../resources/circles.png);
+    border-image-width: 0px;
+  }
+</style>
+<div id='bordered'></div>
+<script>
+setup({"hide_test_state": true});
+promise_test(async t => {
+  const onload = new Promise(r => window.addEventListener('load', r));
+  await onload;
+  return assertNoFirstContentfulPaint(t).then(() => {
+    document.getElementById('bordered').style.borderImageWidth = '30px';
+  }).then(() => {
+    return assertFirstContentfulPaint(t);
+  });
+}, 'Border image triggers First Contentful Paint.');
+</script>
+</body>


### PR DESCRIPTION
Extends the SVG support for `border-image-source`

Testing: `wpt/tests/paint-timing/fcp-only/fcp-border-image-with-fcp.html`
Fixes: #<!-- nolink -->42098

Reviewed in servo/servo#42566