### PR TITLE
Fix description to match assertions in resource-timing-cross-origin

### DIFF
--- a/service-workers/service-worker/resource-timing-cross-origin.https.html
+++ b/service-workers/service-worker/resource-timing-cross-origin.https.html
@@ -25,17 +25,14 @@ function test_sw_resource_timing({ mode }) {
       const entry = entries[0];
       assert_equals(entry.redirectStart, 0, 'redirectStart should be 0 in cross-origin request.');
       assert_equals(entry.redirectEnd, 0, 'redirectEnd should be 0 in cross-origin request.');
-      assert_equals(entry.domainLookupStart, 0, 'domainLookupStart should be 0 in cross-origin request.');
-      assert_equals(entry.domainLookupEnd, 0, 'domainLookupEnd should be 0 in cross-origin request.');
-      assert_equals(entry.connectStart, 0, 'connectStart should be 0 in cross-origin request.');
-      assert_equals(entry.connectEnd, 0, 'connectEnd should be 0 in cross-origin request.');
-      assert_equals(entry.responseStart, 0, 'responseStart should be 0 in cross-origin request.');
-      assert_greater_than(entry.responseStart, entry.fetchStart, 'responseStart is specific to service-workers.');
-      assert_equals(entry.secureConnectionStart, 0, 'secureConnectionStart should be 0 in cross-origin request.');
-      assert_equals(entry.decodedBodySize, 0, 'decodedBodySize should be 0 in cross-origin request.');
-      assert_equals(entry.encodedBodySize, 0, 'encodedBodySize should be 0 in cross-origin request.');
-      assert_equals(entry.transferSize, 0, 'transferSize should be 0 in cross-origin request.');
-      assert_equals(entry.nextHopProtocol, "", 'nextHopProtocol should be 0 in cross-origin request.');
+
+      assert_equals(entry.domainLookupStart, entry.fetchStart, 'domainLookupStart and fetchStart should be the same in cross-origin request.');
+      assert_equals(entry.domainLookupEnd, entry.fetchStart, 'domainLookupEnd and fetchStart should be the same in cross-origin request.');
+      assert_equals(entry.connectStart, entry.fetchStart, 'connectStart and fetchStart should be the same in cross-origin request.');
+      assert_equals(entry.connectEnd, entry.fetchStart, 'connectEnd and fetchStart should be the same in cross-origin request.');
+      assert_equals(entry.responseStart, entry.fetchStart, 'responseStart and fetchStart should be the same in cross-origin request.');
+      assert_equals(entry.secureConnectionStart, entry.fetchStart, 'secureConnectionStart and fetchStart should be the same in cross-origin request.');
+      assert_equals(entry.transferSize, 300, 'transferSize should be 300 in cross-origin request.');
       frame.remove();
       await registration.unregister();
   }, `Test that timing allow check fails when service worker changes origin from same to cross origin (${mode}).`);


### PR DESCRIPTION
From this bug: [Fix prose to match assertions in resource-timing-cross-origin.https.html](https://bugs.webkit.org/show_bug.cgi?id=307379)