### PR TITLE
[wasm] Check that attribute setter does not throw for missing argument

### DIFF
--- a/wasm/jsapi/global/value-get-set.any.js
+++ b/wasm/jsapi/global/value-get-set.any.js
@@ -131,7 +131,14 @@ test(() => {
   const setter = desc.set;
   assert_equals(typeof setter, "function");
 
-  assert_throws_js(TypeError, () => setter.call(global));
+  assert_equals(global.value, 0);
+
+  assert_equals(setter.call(global, undefined), undefined);
+  assert_equals(global.value, 0);
+
+  // Should behave as if 'undefined' was passed as the argument.
+  assert_equals(setter.call(global), undefined);
+  assert_equals(global.value, 0);
 }, "Calling setter without argument");
 
 test(() => {


### PR DESCRIPTION
The tested behaviour was what was originally specified up until the merge of whatwg/webidl#1498. After that change, this setter should no longer be throwing.

See WebAssembly/spec#2075 for background.