### PR TITLE
layout: Fix abspos position when it would be preceded by phantom line

### DIFF
--- a/css/CSS2/abspos/static-inside-inline-001.html
+++ b/css/CSS2/abspos/static-inside-inline-001.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Static position inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  If the #abspos would have had `position: static`, then it would split the #inline (§9.2.1.1).
+
+  The line box containing the preceding fragment of the #inline would have no text, padding,
+  border, margin, preserved newline nor any atomic in-flow content. Thus, it would be treated
+  as a zero-height line box (§9.4.2).
+
+  Therefore, the #abspos' static position for `top` is at the top of the #wrapper (§10.6.4).
+  This is despite the fact that when the #abspos is actually taken out of flow, the #inline
+  isn't split, so the line box has content and it's no longer a treated as a zero-height.
+">
+
+<style>
+#wrapper {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+}
+#inline {
+  line-height: 100px;
+  color: transparent;
+}
+#abspos {
+  position: absolute;
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#red {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+
+<div id="wrapper">
+  <span id="inline">
+    <div id="abspos"></div>
+    X
+  </span>
+</div>

--- a/css/CSS2/abspos/static-inside-inline-002.html
+++ b/css/CSS2/abspos/static-inside-inline-002.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Static position inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  If the #abspos would have had `position: static`, then it would split the #inline (§9.2.1.1).
+
+  The line box containing the preceding fragment of the #inline would have non-zero margin
+  and border. Thus, it wouldn't be treated as a zero-height line box (§9.4.2).
+
+  Therefore, the #abspos' static position for `top` is at 100px from the #wrapper (§10.6.4).
+">
+
+<style>
+#wrapper {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  margin-top: -100px;
+}
+#inline {
+  line-height: 100px;
+  color: transparent;
+  border-left: 100px solid transparent;
+  margin-left: -100px;
+}
+#abspos {
+  position: absolute;
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#red {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+
+<div id="wrapper">
+  <span id="inline">
+    <div id="abspos"></div>
+    X
+  </span>
+</div>

--- a/css/CSS2/abspos/static-inside-inline-003.html
+++ b/css/CSS2/abspos/static-inside-inline-003.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>Static position inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  If the #abspos would have had `position: static`, then it would split the #inline (§9.2.1.1).
+
+  The line box containing the preceding fragment of the #inline would have no text, padding,
+  border, margin, preserved newline nor any atomic in-flow content. Thus, it would be treated
+  as a zero-height line box (§9.4.2).
+
+  Therefore, the #abspos' static position for `top` is at the top of the #wrapper (§10.6.4).
+  This is despite the fact that when the #abspos is actually taken out of flow, the #inline
+  isn't split, so the line box has content and it's no longer a treated as a zero-height.
+">
+
+<style>
+#wrapper {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+}
+#inline {
+  line-height: 100px;
+  color: transparent;
+  border-right: 100px solid transparent;
+}
+#abspos {
+  position: absolute;
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#red {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+
+<div id="wrapper">
+  <span id="inline">
+    <div id="abspos"></div>
+    X
+  </span>
+</div>


### PR DESCRIPTION
The static position of an abspos is the hypothetical position that it would have had in the normal flow. If the abspos is inside inline layout and it had a block-level original display, then the static position is computed as if the abspos was a block-level that breaks the inline.

Usually this places the static position after the current line. However, if the abspos is not preceded by any text, padding, border, margin, preserved newline or atomic inline, then the static position should be as if the abspos was preceded by a 0px tall phantom line. Previously we weren't taking that into account.

Note that browsers aren't completely interoperable in corner cases.

Testing: Adding 3 new tests. Blink fails the 2nd one and Gecko fails the 3rd one. WebKit and Servo pass them all.
Fixes: #<!-- nolink -->41990

Reviewed in servo/servo#42586