### PR TITLE
Avoid code injection in sandbox document-open mutation test

### DIFF
--- a/html/browsers/sandboxing/sandbox-document-open-mutation.window.js
+++ b/html/browsers/sandboxing/sandbox-document-open-mutation.window.js
@@ -1,15 +1,3 @@
-// Return whether the current context is sandboxed or not. The implementation do
-// not matter much, but might have to change over time depending on what side
-// effect sandbox flag have. Feel free to update as needed.
-const is_sandboxed = () => {
-  try {
-    document.domain = document.domain;
-    return "not sandboxed";
-  } catch (error) {
-    return "sandboxed";
-  }
-};
-
 promise_test(async test => {
   const message = new Promise(r => window.addEventListener("message", r));
 
@@ -24,8 +12,15 @@ promise_test(async test => {
     <script>
       parent.frames[0].document.write(\`
         <script>
-          const is_sandboxed = ${is_sandboxed};
-          window.parent.postMessage(is_sandboxed(), '*');
+          // Return whether the current context is sandboxed or not. The implementation does
+          // not matter much, but might have to change over time depending on what side
+          // effect sandbox flags have. Feel free to update as needed.
+          try {
+            document.domain = document.domain;
+            window.parent.postMessage("not sandboxed", "*");
+          } catch (error) {
+            window.parent.postMessage("sandboxed", "*");
+          }
         </scr\`+\`ipt>
       \`);
       parent.frames[0].document.close();


### PR DESCRIPTION
Replace function-serialization injection with an inline sandbox check. Aligns the pattern with sandbox-document-open.html.