### PR TITLE
Correct scale() accumulation with iterationComposite:accumulate

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html
@@ -52,7 +52,7 @@ animation_test({
 }, {
   iterationComposite: "accumulate",
   keyframes: ["translateX(0px) scale(3)", "translateX(100px) scale(4)"],
-  expected: "translateX(250px) scale(11.5)"
+  expected: "translateX(250px) scale(9.5)"
 }, 'Animating a custom property of type <transform-list> containing multiple values with iterationComposite');
 
 animation_test({


### PR DESCRIPTION
The test in custom-property-animation-transform-list-multiple-values.html sets up a subtest with

- `iterationComposite: "accumulate"`
- start keyframe: `translateX(0px) scale(3)`
- end keyframe: `translateX(100px) scale(4)`

And then evaluates the value at iteration 2, fraction 0.5. At this point, `scale` should have been accumulated twice and then interpolated.

However, the initial value for interpolation of `scale()`  is 1, so accumulation must take that into account:

`Vresult = Va + Vb - 1`

https://drafts.csswg.org/filter-effects-1/#accumulation

In our scenario, the accumulated start keyframe becomes:
- initial: `scale = 3`
- iteration 1: `scale = 3 + 4 - 1 = 6`
- iteration 2: `scale = 6 + 4 - 1 = 9`

Accumulated end keyframe:
- initial: `scale = 4`
- iteration 1: `scale = 4 + 4 - 1 = 7`
- iteration 2: `scale = 7 + 4 - 1 = 10`

We then interpolate at iteration 2, fraction 0.5:
- `scale(9) + (scale(10) - scale(9)) × 0.5 = scale(9.5)`

https://drafts.csswg.org/css-transforms-2/#combining-transform-lists