### PR TITLE
`pointerevent_support.js`: touchScrollInTarget smoothly

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -252,6 +252,18 @@ function checkPointerEventType(event) {
   assert_equals(event.pointerType, expectedPointerType, "pointerType should be the same as the requested device.");
 }
 
+function getInViewCenterPoint(rect) {
+  var left = Math.max(0, rect.left);
+  var right = Math.min(window.innerWidth, rect.right);
+  var top = Math.max(0, rect.top);
+  var bottom = Math.min(window.innerHeight, rect.bottom);
+
+  var x = 0.5 * (left + right);
+  var y = 0.5 * (top + bottom);
+
+  return [x, y];
+}
+
 function touchScrollInTarget(target, direction) {
   var x_delta = 0;
   var y_delta = 0;
@@ -270,16 +282,20 @@ function touchScrollInTarget(target, direction) {
   } else {
     throw("scroll direction '" + direction + "' is not expected, direction should be 'down', 'up', 'left' or 'right'");
   }
+  // Target's initial position relative to the viewport.
+  const rect = target.getBoundingClientRect();
+  const [startX, startY] = getInViewCenterPoint(rect);
+
   return new test_driver.Actions()
     .addPointer("touchPointer1", "touch")
-    .pointerMove(0, 0, {origin: target})
+    .pointerMove(startX, startY, {origin: 'viewport'})
     .pointerDown()
-    .pointerMove(x_delta, y_delta, {origin: target})
-    .pointerMove(2 * x_delta, 2 * y_delta, {origin: target})
-    .pointerMove(3 * x_delta, 3 * y_delta, {origin: target})
-    .pointerMove(4 * x_delta, 4 * y_delta, {origin: target})
-    .pointerMove(5 * x_delta, 5 * y_delta, {origin: target})
-    .pointerMove(6 * x_delta, 6 * y_delta, {origin: target})
+    .pointerMove(startX + x_delta, startY + y_delta, {origin: "viewport"})
+    .pointerMove(startX + 2 * x_delta, startY + 2 * y_delta, {origin: "viewport"})
+    .pointerMove(startX + 3 * x_delta, startY + 3 * y_delta, {origin: "viewport"})
+    .pointerMove(startX + 4 * x_delta, startY + 4 * y_delta, {origin: "viewport"})
+    .pointerMove(startX + 5 * x_delta, startY + 5 * y_delta, {origin: "viewport"})
+    .pointerMove(startX + 6 * x_delta, startY + 6 * y_delta, {origin: "viewport"})
     .pause(100)
     .pointerUp()
     .send();


### PR DESCRIPTION
The util `function touchScrollInTarget` aims to touch scroll the target smoothly. However, currently it creates **accelerating** scrolling: as the coordinates of `target` keep changing during the touch move which we use as origin. This is not intended.

What's worse, this can trigger [out of bound](https://w3c.github.io/webdriver/#ref-for-dfn-move-target-out-of-bounds-2:~:text=If%20y%20is%20less%20than%200%20or%20greater%20than%20the%20height%20of%20the%20viewport%20in%20CSS%20pixels%2C%20then%20return%20error%20with%20error%20code%20move%20target%20out%20of%20bounds%2E) WebDriver error, and the tests never work.

This has caused problem for Firefox/Safari as well, e.g. [pointerevent_touch-action-table-none-test_touch.html](https://wpt.fyi/results/pointerevents/pointerevent_touch-action-table-none-test_touch.html?run_id=5177777654595584&run_id=5095681367998464&run_id=5083756189974528).

Testing: Updated expectations of existing tests.




Before for `pointerevent_touch-action-table-none-test_touch.html`:

https://github.com/user-attachments/assets/7f14eee7-bdec-4ea4-a83e-684b2b65d951

After:


https://github.com/user-attachments/assets/9b05a9e6-164d-419c-a519-383dab856a4c



Reviewed in servo/servo#42652