### PR TITLE
script: Use `touchstart` element as event target for `touchmove`/`touchend`/`touchcancel`

### DIFF
--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -74,38 +74,6 @@ def test_touch_pointer_cancel_and_up(session, test_actions_pointer_page, touch_c
 
     assert results['touchstart']
     assert results["touchcancel"]
-    assert results["touchend"]
-    assert not results["click"]
-
-
-def test_touch_pointer_cancel_without_up(session, test_actions_pointer_page, touch_chain):
-    pointerArea = session.find.css("#pointerArea", all=False)
-
-    session.execute_script("""
-        window.events = {
-            touchstart: false,
-            touchcancel: false,
-            touchend: false,
-            click: false
-        };
-        const area = document.getElementById("pointerArea");
-        ['touchstart', 'touchcancel', 'touchend', 'click'].forEach(type => {
-            area.addEventListener(type, () => { window.events[type] = true; });
-        });
-    """)
-
-    touch_chain.pointer_move(0, 0, origin=pointerArea) \
-        .pointer_down() \
-        .pointer_cancel() \
-        .perform()
-
-    # Use delay to allow potential
-    # simulated click to spin (which should not if pointerCancel works)
-    time.sleep(1)
-    results = session.execute_script("return window.events;")
-
-    assert results['touchstart']
-    assert results["touchcancel"]
     assert not results["touchend"]
     assert not results["click"]
 


### PR DESCRIPTION
[Spec](https://w3c.github.io/touch-events/#dfn-touchend:~:text=screen%2E-,The,element,-%2E) for touchmove/touchend/touchcancel:
> The target of this event must be the same Element on which the [touch point](https://w3c.github.io/touch-events/#dfn-touch-point) started when it was first placed on the surface, even if the [touch point](https://w3c.github.io/touch-events/#dfn-touch-point) has since moved outside the interactive area of the target element.

Also, previously `touchend` can be fired after `touchcancel`, which was wrong and fixed in this PR.

Testing: Fully passes `/touch-events/multi-touch-interfaces.html` (511 subtests) and new passes in `pointerevents\compat\pointerevent_touch_target_after_pointerdown_target_removed.tentative.html`.

We also take the chance to update `pointercancel` related tests introduced in https://github.com/servo/servo/pull/41937: `touchcancel` should not be followed by `touchend` according to [spec](https://w3c.github.io/touch-events/#dfn-touchcancel).


Reviewed in servo/servo#42654