### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=307788

### DIFF
--- a/scroll-animations/view-timelines/contain-alignment.html
+++ b/scroll-animations/view-timelines/contain-alignment.html
@@ -6,7 +6,7 @@
 
 @keyframes bg {
   from { background-color:  rgb(254, 0, 0); }
-  to { background-color: rgb(0 254, 0); }
+  to { background-color: rgb(0, 254, 0); }
 }
 .item {
   flex-grow: 1;


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] WPT test `view-timelines/contain-alignment.html` fails](https://bugs.webkit.org/show_bug.cgi?id=307788)