### PR TITLE
Use proper nonexistant host in XHR tests

### DIFF
--- a/xhr/send-redirect-bogus-sync.sub.htm
+++ b/xhr/send-redirect-bogus-sync.sub.htm
@@ -17,9 +17,9 @@
         }, document.title + " (" + code + ": " + location + ")")
       }
       redirect("301", "foobar://abcd")
-      redirect("302", "http://z.")
+      redirect("302", "http://{{hosts[][nonexistent]}}")
       redirect("302", "mailto:someone@example.org")
-      redirect("303", "http://z.")
+      redirect("303", "http://{{hosts[][nonexistent]}}")
       redirect("303", "tel:1234567890")
     </script>
   </body>

--- a/xhr/send-redirect-bogus.sub.htm
+++ b/xhr/send-redirect-bogus.sub.htm
@@ -27,9 +27,9 @@
           client.send(null)
         })
       }
-      redirect("302", "http://example.not")
+      redirect("302", "http://{{hosts[][nonexistent]}}")
       redirect("302", "mailto:someone@example.org")
-      redirect("303", "http://example.not")
+      redirect("303", "http://{{hosts[][nonexistent]}}")
       redirect("303", "foobar:someone@example.org")
     </script>
   </body>


### PR DESCRIPTION
There is no guarantee that `http://z.` and `http://example.not` would not resolve in a given network environment. For at least the jsdom network environment, they took 10 seconds to time out, and the sync variant didn't use timeout=long, so this was causing a harness timeout.