### PR TITLE
wdspec: add get_element_shadow_root test for select element

### DIFF
--- a/webdriver/tests/classic/get_element_shadow_root/get.py
+++ b/webdriver/tests/classic/get_element_shadow_root/get.py
@@ -95,8 +95,13 @@ def test_get_shadow_root(session, get_test_page):
     assert_same_element(session, host_element, expected_host)
 
 
-def test_no_shadow_root(session, inline):
-    session.url = inline("<div><p>no shadow root</p></div>")
-    element = session.find.css("div", all=False)
+@pytest.mark.parametrize("html, selector", [
+    ("<div><p>no shadow root</p></div>", "div"),
+    ("<select></select>", "select"),
+    ("<video></video>", "video")
+])
+def test_no_shadow_root(session, inline, html, selector):
+    session.url = inline(html)
+    element = session.find.css(selector, all=False)
     response = get_shadow_root(session, element.id)
     assert_error(response, "no such shadow root")


### PR DESCRIPTION
[getShadowRoot](https://www.w3.org/TR/webdriver2/#get-element-shadow-root) should reject with `no such shadow root` when used against a select element. At the moment both Chrome and Firefox return a shadow root in this case. 

See https://github.com/w3c/webdriver/issues/1948