### PR TITLE
Fix syntax error in html/dom/elements-embedded.js

### DIFF
--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -94,9 +94,9 @@ var embeddedElements = {
     loop: "boolean",
     controls: "boolean",
     controlsList: {type: "tokenlist", domAttrName: "controlsList"},
-    defaultMuted: {type: "boolean", domAttrName: "muted"}/*,
+    defaultMuted: {type: "boolean", domAttrName: "muted"},/*
     // Note: once media loading attr is not tentative, uncomment and delete html reflection tests it replaces.
-    loading: {type: "enum", keywords: ["lazy", "eager"], defaultVal: "eager", invalidVal: "eager"}*/
+    loading: {type: "enum", keywords: ["lazy", "eager"], defaultVal: "eager", invalidVal: "eager"},*/
 
     width: "unsigned long",
     height: "unsigned long",
@@ -112,9 +112,9 @@ var embeddedElements = {
     autoplay: "boolean",
     loop: "boolean",
     controls: "boolean",
-    defaultMuted: {type: "boolean", domAttrName: "muted"}/*,
+    defaultMuted: {type: "boolean", domAttrName: "muted"},/*
     // Note: once media loading attr is not tentative, uncomment and delete html reflection tests it replaces.
-    loading: {type: "enum", keywords: ["lazy", "eager"], defaultVal: "eager", invalidVal: "eager"}*/
+    loading: {type: "enum", keywords: ["lazy", "eager"], defaultVal: "eager", invalidVal: "eager"},*/
   },
   source: {
     src: "url",


### PR DESCRIPTION
A followup for #57051

The object literal lacks a comma between properties.