### PR TITLE
script: Turn scrollParent into a function and change wpt tests

### DIFF
--- a/css/cssom-view/scrollParent-shadow-tree.html
+++ b/css/cssom-view/scrollParent-shadow-tree.html
@@ -75,19 +75,19 @@ customElements.define('open-component', OpenComponent);
 
 <script>
 test(() => {
-  assert_equals(closedInnerElement.scrollParent, outerScroller);
+  assert_equals(closedInnerElement.scrollParent(), outerScroller);
 }, "scrollParent skips intermediate closed shadow tree nodes");
 
 test(() => {
-  assert_equals(openInnerElement.scrollParent, outerScroller);
+  assert_equals(openInnerElement.scrollParent(), outerScroller);
 }, "scrollParent skips intermediate open shadow tree nodes");
 
 test(() => {
-  assert_equals(closedShadowRoot.querySelector('div').scrollParent, outerScroller);
+  assert_equals(closedShadowRoot.querySelector('div').scrollParent(), outerScroller);
 }, "scrollParent from inside closed shadow tree");
 
 test(() => {
-  assert_equals(openShadowComponent.shadowRoot.querySelector('div').scrollParent, outerScroller);
+  assert_equals(openShadowComponent.shadowRoot.querySelector('div').scrollParent(), outerScroller);
 }, "scrollParent from inside open shadow tree");
 </script>
 </body>

--- a/css/cssom-view/scrollParent.html
+++ b/css/cssom-view/scrollParent.html
@@ -68,27 +68,27 @@
 </div>
 </body>
 <script>
-test(() => { assert_equals(normalChild.scrollParent, scroller1); },
+test(() => { assert_equals(normalChild.scrollParent(), scroller1); },
     "scrollParent returns the nearest scroll container.");
-test(() => { assert_equals(childOfHidden.scrollParent, hidden); },
+test(() => { assert_equals(childOfHidden.scrollParent(), hidden); },
     "hidden element is a scroll container.");
-test(() => { assert_equals(noBox.scrollParent, null); },
+test(() => { assert_equals(noBox.scrollParent(), null); },
     "Element with no box has null scrollParent.");
-test(() => { assert_equals(absPosChild.scrollParent, scroller2); },
+test(() => { assert_equals(absPosChild.scrollParent(), scroller2); },
     "scrollParent follows absolute positioned containing block chain.");
-test(() => { assert_equals(fixedPosChild.scrollParent, scroller3); },
+test(() => { assert_equals(fixedPosChild.scrollParent(), scroller3); },
     "scrollParent follows fixed positioned containing block chain.");
-test(() => { assert_equals(fixedToRoot.scrollParent, null); },
+test(() => { assert_equals(fixedToRoot.scrollParent(), null); },
     "scrollParent of element fixed to root is null.");
-test(() => { assert_equals(childOfRoot.scrollParent, document.scrollingElement); },
+test(() => { assert_equals(childOfRoot.scrollParent(), document.scrollingElement); },
     "scrollParent of child in root viewport returns document scrolling element.");
-test(() => { assert_equals(fixedContainedByRoot.scrollParent, document.scrollingElement); },
+test(() => { assert_equals(fixedContainedByRoot.scrollParent(), document.scrollingElement); },
     "scrollParent of fixed element contained within root is document scrolling element.");
-test(() => { assert_equals(document.body.scrollParent, null); },
+test(() => { assert_equals(document.body.scrollParent(), null); },
     "scrollParent of body is null.");
-test(() => { assert_equals(document.documentElement.scrollParent, null); },
+test(() => { assert_equals(document.documentElement.scrollParent(), null); },
     "scrollParent of root is null.");
-test(() => { assert_equals(childOfDisplayContents.scrollParent, scroller1); },
+test(() => { assert_equals(childOfDisplayContents.scrollParent(), scroller1); },
     "scrollParent skips ancestors with `display: contents`.");
 </script>
 </html>

--- a/interfaces/cssom-view.idl
+++ b/interfaces/cssom-view.idl
@@ -141,7 +141,7 @@ partial interface Element {
 };
 
 partial interface HTMLElement {
-  readonly attribute Element? scrollParent;
+  Element? scrollParent();
   readonly attribute Element? offsetParent;
   readonly attribute long offsetTop;
   readonly attribute long offsetLeft;


### PR DESCRIPTION
Turn `scrollParent` into a function as the CSSWG resolved in https://github.com/w3c/csswg-drafts/issues/12731#issuecomment-3885728833

Testing: updating wpt tests `tests/wpt/tests/css/cssom-view/scrollParent.html` and `tests/wpt/tests/css/cssom-view/scrollParent-shadow-tree.html`
Fixes: #<!-- nolink -->42547
Reviewed in servo/servo#42689