### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308183

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style.html
@@ -171,7 +171,7 @@ test(() => {
 
 test(() => {
   const expectedProperties = {
-    'content': `"${String.fromCodePoint(10003)}"`
+    'content': `"${String.fromCodePoint(10003)}" / ""`
   }
   testProperties(getComputedStyle(option, '::checkmark'), expectedProperties);
 }, 'UA styles of base appearance option::checkmark.');


### PR DESCRIPTION
WebKit export from bug: [Enhanced <select>: fix checkmark style in select-base-appearance-computed-style.html WPT](https://bugs.webkit.org/show_bug.cgi?id=308183)