### PR TITLE
[manifest] Guard against duplicate fuzzy keys

### DIFF
--- a/css/css-masking/clip-path/clip-path-circle-001.html
+++ b/css/css-masking/clip-path/clip-path-circle-001.html
@@ -8,7 +8,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. Test absolute values for arguments. On pass you
     should see a green circle and no red.">

--- a/css/css-masking/clip-path/clip-path-circle-002.html
+++ b/css/css-masking/clip-path/clip-path-circle-002.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. Test percentage values for arguments. If no
     reference box was specified, percentage is relative to border-box. On pass

--- a/css/css-masking/clip-path/clip-path-circle-003.html
+++ b/css/css-masking/clip-path/clip-path-circle-003.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. Test percentage value as argument for radius and no
     position arguments. The circle should be in the center of the element. On

--- a/css/css-masking/clip-path/clip-path-circle-004.html
+++ b/css/css-masking/clip-path/clip-path-circle-004.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. Test percentage value as argument for position and
     no radius argument. The circle must behave like it has a radius of

--- a/css/css-masking/clip-path/clip-path-circle-005.html
+++ b/css/css-masking/clip-path/clip-path-circle-005.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. The circle has a radius of 'closest-side'. This test
     has a squred div-box. Therefore, 'closest-side', 50% and 'farthest-side'

--- a/css/css-masking/clip-path/clip-path-circle-006.html
+++ b/css/css-masking/clip-path/clip-path-circle-006.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. The circle has a radius of 'farthest-side'. This
     test has a squred div-box. Therefore, 'closest-side', 50% and

--- a/css/css-masking/clip-path/clip-path-circle-007.html
+++ b/css/css-masking/clip-path/clip-path-circle-007.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-2-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. The clipped div box is twice as wide as it is
     height. With 'closest-side', there should be a full green circle.">

--- a/css/css-masking/clip-path/clip-path-circle-008.html
+++ b/css/css-masking/clip-path/clip-path-circle-008.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-3-ref.html">
-    <meta name="fuzzy" content="0-38; 0-800">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping. The clipped div box is twice as high as it is
     wide. With 'closest-side', there should be a full green circle.">

--- a/css/css-masking/clip-path/clip-path-ellipse-001.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-001.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test absolute values for radii and position
 	arguments. On pass you should see a green ellipse.">

--- a/css/css-masking/clip-path/clip-path-ellipse-002.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-002.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test percentage values for radii and position
 	arguments. Percentage values are relative to a reference box. If no

--- a/css/css-masking/clip-path/clip-path-ellipse-003.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-003.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-circle-ref.html">
-	<meta name="fuzzy" content="0-38; 0-800">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test percentage values for radii and position
 	arguments. Percentage values are relative to a reference box. If no

--- a/css/css-masking/clip-path/clip-path-ellipse-004.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-004.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test absolute values for arguments. On pass you
 	should see a green ellipse.">

--- a/css/css-masking/clip-path/clip-path-ellipse-005.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-005.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test percentage values for radii and position
 	arguments. Percentage values are relative to a reference box. If no

--- a/css/css-masking/clip-path/clip-path-ellipse-006.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-006.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test absolute values for radii and position
 	arguments. On pass you should see a green circle.">

--- a/css/css-masking/clip-path/clip-path-ellipse-007.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-007.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. If no further arguments were specified, the radii
 	are 'closest-side' each. The position is initialised to the center of the

--- a/css/css-masking/clip-path/clip-path-ellipse-008.html
+++ b/css/css-masking/clip-path/clip-path-ellipse-008.html
@@ -6,7 +6,6 @@
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
 	<link rel="help" href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">
 	<link rel="match" href="reference/clip-path-ellipse-ref.html">
-	<meta name="fuzzy" content="0-38; 0-400">
 	<meta name="assert" content="The clip-path property takes the basic shape
 	'ellipse' for clipping. Test percentage values for radii and position
 	arguments. Percentage values are relative to a reference box. If no

--- a/css/filter-effects/backdrop-filter-backdrop-root-opacity.html
+++ b/css/filter-effects/backdrop-filter-backdrop-root-opacity.html
@@ -5,8 +5,7 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropRoot">
 <link rel=stylesheet  href="resources/backdrop-filter-backdrop-root.css">
 <link rel="match"  href="backdrop-filter-backdrop-root-opacity-ref.html">
-<meta name="fuzzy" content="0-2;0-2696">
-<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-500">
+<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-2696">
 
 <!-- A Backdrop Root is formed, anywhere in the document, by:
      - An element with an opacity value less than 1.

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -623,6 +623,8 @@ class SourceFile:
                     positional_args.append(range_value)
                 else:
                     arg_values[name] = range_value
+            if key in rv:
+                raise ValueError("Got multiple fuzzy values for key %s" % (key,))
             rv[key] = []
             for arg_name in args:
                 if arg_values.get(arg_name):

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -918,6 +918,22 @@ def test_reftest_fuzzy_multi(fuzzy, expected):
     assert s.content_is_ref_node
     assert s.fuzzy == expected
 
+@pytest.mark.parametrize("fuzzy", [
+    [b"0-1;100-200", b"0-55;0-8"],
+    [b"ref-1.html:0-1;100-200", b"ref-1.html:0-55;0-8"],
+])
+def test_reftest_fuzzy_duplicate_key(fuzzy):
+    content = b"""<link rel=match href=ref-1.html>
+"""
+    for item in fuzzy:
+        content += b'\n<meta name=fuzzy content="%s">' % item
+
+    s = create("foo/test.html", content)
+
+    with pytest.raises(ValueError):
+        s.fuzzy
+
+
 @pytest.mark.parametrize("pac, expected", [
     (b"proxy.pac", "proxy.pac")])
 def test_pac(pac, expected):


### PR DESCRIPTION
This requires updating a number of tests, but in the case of
css/css-masking/clip-path/* this doesn't change anything (it just
removes the previously overridden first fuzzy annotation), as the
second was broader anyway. The only notable test change is
css/filter-effects/backdrop-filter-backdrop-root-opacity.html where
the fuzzy annotation *does* need to be broadened to encompass both of
what was intended.
