### PR TITLE
[SVG2] Remove `focusable` test coverage since it is not supported by Web Browsers

### DIFF
--- a/svg/interact/scripted/tabindex-focus-flag.svg
+++ b/svg/interact/scripted/tabindex-focus-flag.svg
@@ -8,13 +8,9 @@
         <!-- non-default focusable renderable element -->
         <rect></rect>
         <svg></svg>
-        <!-- for compatibility with SVG Tiny 1.2 focusable attribute, user agents should treat an element with a value of true for that attribute as focusable -->
-        <rect focusable="true"></rect>
         <!-- anchors need a href to be focusable -->
         <a></a>
         <a href=""></a>
-        <!-- Remove default focus behaviour with focusable="false" (SVG Tiny 1.2 compatibility) -->
-        <a href="" focusable="false"></a>
         <!-- iframe, and audio/video with controls are default focusable -->
         <h:iframe src="resources/blank.htm"></h:iframe>
         <h:audio controls="controls"></h:audio>
@@ -67,10 +63,8 @@
     const defaultList = [
         ['rect', false],
         ['svg', false],
-        ['rect[focusable=true]', true],
         ['a', false],
         ['a[href]', true],
-        ['a[focusable=false]', false],
         ['iframe', true],
         ['audio[controls]', true],
         ['video[controls]', true],


### PR DESCRIPTION
Hi Team,

Based on recent SVG2 resolution in below [1]:

[1] https://github.com/w3c/svgwg/issues/736#issuecomment-3925257787

This PR is to remove test coverage for `focusable`, which was not supported by any browser.

Thanks!