### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308167

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
-<meta name=fuzzy content="maxDifference=0-55;totalPixels=0-8">
+<meta name=fuzzy content="maxDifference=0-55;totalPixels=0-75">
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://github.com/whatwg/html/issues/9799">
 <link rel=match href="select-appearance-font-inheriting-ref.html">


### PR DESCRIPTION
WebKit export from bug: [Enhanced <select>: update fuzzy metadata for select-appearance-font-inheriting.html WPT](https://bugs.webkit.org/show_bug.cgi?id=308167)