### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308186

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative.html
+++ b/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative.html
@@ -10,6 +10,10 @@
 select, ::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html
@@ -12,6 +12,10 @@
 select, ::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html
@@ -12,6 +12,10 @@
 select, ::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html
@@ -12,6 +12,10 @@
 select, ::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html
@@ -14,6 +14,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 body {
   font-style: italic;
   font-weight: bold;

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 div {
   border: 2px solid green;
 }

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html
@@ -11,6 +11,10 @@
 select, ::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 select::picker(select) {
   border: 5px solid red;
 }

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html
@@ -14,6 +14,10 @@
 select.base, select.base::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html
@@ -13,6 +13,10 @@ html {
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html
@@ -13,6 +13,10 @@ html {
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html
@@ -10,6 +10,10 @@
 select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html
@@ -17,6 +17,10 @@ select:open > button {
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-option-images.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-option-images.html
@@ -11,6 +11,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 <select>
   <button>button</button>

--- a/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html
@@ -16,6 +16,10 @@
 select,::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 select.animate::picker(select) {
   transition: display 10000s allow-discrete, overlay 10000s allow-discrete;
 }

--- a/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html
@@ -11,6 +11,10 @@
 select, ::picker(select) {
   appearance: base-select;
 }
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>

--- a/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html
+++ b/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html
@@ -7,7 +7,10 @@
 select, select::picker(select) {
   appearance: base-select;
 }
-
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
 </style>
 
 <select>


### PR DESCRIPTION
WebKit export from bug: [Enhanced <select>: suppress focus outline from WPT reftests](https://bugs.webkit.org/show_bug.cgi?id=308186)