### PR TITLE
WebDriverBrowser.stop() should only check the WebDriver server

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -389,7 +389,7 @@ class WebDriverBrowser(Browser):
     def stop(self, force: bool = False) -> bool:
         self.logger.debug("Stopping WebDriver")
         clean = True
-        if self.is_alive():
+        if WebDriverBrowser.is_alive(self):
             proc = cast(mozprocess.ProcessHandler, self._proc)
             # Pass a timeout value to mozprocess Processhandler.kill()
             # to ensure it always returns within it.
@@ -398,7 +398,7 @@ class WebDriverBrowser(Browser):
             if force and kill_result != 0:
                 clean = False
                 proc.kill(9, timeout=5)
-        success = not self.is_alive()
+        success = not WebDriverBrowser.is_alive(self)
         if success and self._output_handler is not None:
             # Only try to do output post-processing if we managed to shut down
             self._output_handler.after_process_stop(clean)


### PR DESCRIPTION
Previously, we'd check any overridden `is_alive` method; thus we might
not stop the WebDriver server process if any part of the browser was
not still alive.

For example, if the SafariBrowser class had:

```
def is_alive(self):
    return (
        process_is_alive("Safari")
        and process_is_alive("webinspectord")
        and super().is_alive()
    )

def stop(self, force=False):
    terminate_process("Safari")
    super().stop(force=force)
```

Then we would never terminate `safaridriver` in the superclass,
because we would've already have terminated Safari and thus the
browser would report itself as no longer alive, which seems like the
desired behaviour given it's no longer in a state to run tests.
