### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308137

### DIFF
--- a/css/css-viewport/zoom/contain-intrinsic-height.html
+++ b/css/css-viewport/zoom/contain-intrinsic-height.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+html {
+  font-size: 1px;
+}
+p {
+  font-size: initial;
+}
+.containment {
+  zoom: 10;
+  width: 10px;
+  contain-intrinsic-height: 10rem;
+  contain: size;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="containment">
+    <div style="width: 10px; height: 10px;"></div>
+  </div>
+</body>
+</html>

--- a/css/css-viewport/zoom/contain-intrinsic-width.html
+++ b/css/css-viewport/zoom/contain-intrinsic-width.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+html {
+  font-size: 1px;
+}
+p {
+  font-size: initial;
+}
+.containment {
+  zoom: 10;
+  width: min-content;
+  contain-intrinsic-width: 10rem;
+  contain: inline-size;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="containment">
+    <div style="width: 10px; height: 10px;"></div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [GitHub.com: File names in files changed tab of pull request can get cut off when zoomed in](https://bugs.webkit.org/show_bug.cgi?id=308137)