### PR TITLE
Invisible `<img loading="lazy" srcset="...">` should not set complete

### DIFF
--- a/html/semantics/embedded-content/the-img-element/img-loading-lazy-srcset-complete.html
+++ b/html/semantics/embedded-content/the-img-element/img-loading-lazy-srcset-complete.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>complete should be false for invisible lazy-loading image with srcset</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#update-the-image-data">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2016233">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<img id="nonLazy" src="/images/green-256x256.png">
+<img id="lazy" loading="lazy" style="display:none">
+<script>
+promise_test(async t => {
+  await new Promise(resolve => {
+    addEventListener("load", resolve);
+  });
+  let loadEventFired = false;
+  lazy.addEventListener('load', () => {
+    loadEventFired = true;
+  });
+  lazy.srcset = nonLazy.src;
+  assert_false(lazy.complete, "complete should not be set to true until lazy-loading image comes into view.");
+  // wait for load event (not) to fire
+  await new Promise(resolve => setTimeout(resolve));
+  assert_false(loadEventFired, "load event should not be fired until lazy-loading image comes into view.");
+});
+</script>


### PR DESCRIPTION
Relevant Gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2016233

There is inconsistency between browsers about whether setting the `srcset` attribute of a lazy-loading `<img>` element to an [available image](https://html.spec.whatwg.org/multipage/images.html#list-of-available-images) causes `complete` to be set to true. Currently WebKit and Blink set it to true, while Gecko sets it to false.

I think Gecko's behavior is correct here - in this case, complete should be true if the current image request's state is completely available. As far as I can tell this only happens at step 7.4.4 of [update the image data](https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data) (which doesn't apply here since `src` is not set), and step 27, which only happens after the image is lazy-loaded.

It's also worth mentioning that [reacting to environment changes](https://html.spec.whatwg.org/multipage/images.html#reacting-to-environment-changes) can skip lazy loading (there's a [spec issue about that](https://github.com/whatwg/html/issues/4646)). The standard is vague about what counts as a change to the environment, but I think it's reasonable to assume that just changing `srcset` doesn't count (doing so runs "update the image data" anyways, and it would be weird to do both).