### PR TITLE
<select>: suppress focus outline in ref as well

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in-ref.html
@@ -3,6 +3,13 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
+<style>
+/* :focus-visible behavior is UA-defined, do not exercise in the test */
+select:focus-visible {
+  outline: none;
+}
+</style>
+
 <select>
   <option>option</option>
 </select>


### PR DESCRIPTION
Because this does test_driver.click the outline will be visible here, but since it was removed on the test side, this started failing.