### PR TITLE
Limit wptrunner chrome args to Windows/Linux/Mac DBSC tests

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -148,12 +148,14 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     # This is needed to test extensions, PWA, compilation caches that
     # require local CDP access.
     chrome_options["args"].append("--remote-debugging-pipe")
-    # For Device Bound Session Credentials tests.
-    chrome_options["args"].append("--enable-features=" + ",".join([
-        "EnableBoundSessionCredentialsSoftwareKeysForManualTesting",
-        "DeviceBoundSessions:RefreshQuota/false/RequireOriginTrialTokens/false",
-        "DeviceBoundSessionsFederatedRegistration",
-    ]))
+    # For Device Bound Session Credentials tests, which are only eligible on
+    # Windows, Mac, and Linux.
+    if run_info_data.get("os") in ["win", "mac", "linux"]:
+        chrome_options["args"].append("--enable-features=" + ",".join([
+            "EnableBoundSessionCredentialsSoftwareKeysForManualTesting",
+            "DeviceBoundSessions:RefreshQuota/false/RequireOriginTrialTokens/false",
+            "DeviceBoundSessionsFederatedRegistration",
+        ]))
 
     # Classify `http-local`, `http-public` and https variants in the
     # appropriate IP address spaces.


### PR DESCRIPTION
Not doing this makes unrelated Android WPTs fail in Chrome because they hit a DBSC NOTREACHED since DBSC is not implemented on Android.