### PR TITLE
paint: Bound screenshot to the viewport

### DIFF
--- a/webdriver/tests/classic/take_element_screenshot/screenshot.py
+++ b/webdriver/tests/classic/take_element_screenshot/screenshot.py
@@ -94,7 +94,7 @@ def test_clip_huge_element_to_viewport(session, inline):
     width = "32768px"
     height = "32768px"
 
-    session.url = inline(f"<div style='width: {width}; height: {height}; background-color: black;'></div>")
+    session.url = inline(f"<style>body{{margin:0;}}</style><div style='width: {width}; height: {height}; background-color: black;'></div>")
     element = session.find.css("div", all=False)
 
     response = take_element_screenshot(session, element.id)

--- a/webdriver/tests/classic/take_element_screenshot/screenshot.py
+++ b/webdriver/tests/classic/take_element_screenshot/screenshot.py
@@ -94,7 +94,12 @@ def test_clip_huge_element_to_viewport(session, inline):
     width = "32768px"
     height = "32768px"
 
-    session.url = inline(f"<style>body{{margin:0;}}</style><div style='width: {width}; height: {height}; background-color: black;'></div>")
+    session.url = inline(f"""
+        <style>
+            body {{ margin: 0; }}
+        </style>
+        <div style='width: {width}; height: {height}; background-color: black;'></div>
+    """)
     element = session.find.css("div", all=False)
 
     response = take_element_screenshot(session, element.id)


### PR DESCRIPTION
Ensure that the screenshot rectangle is bounded by the width and height of the viewport.

Testing: The WPT test `test_clip_huge_element_to_viewport` now passes instead of crashing. It is also fixed so that the returned screenshot size is the expected 800x600; it would otherwise be 792x600 due to the body margin.

Fixes: #<!-- nolink -->42530

Reviewed in servo/servo#42739