### PR TITLE
webdriver: Check missing params before dispatch scroll action

### DIFF
--- a/webdriver/tests/classic/perform_actions/wheel.py
+++ b/webdriver/tests/classic/perform_actions/wheel.py
@@ -1,12 +1,18 @@
 import pytest
 
-from webdriver.error import MoveTargetOutOfBoundsException, NoSuchWindowException
+from webdriver.error import InvalidArgumentException, MoveTargetOutOfBoundsException, NoSuchWindowException
 
 
 def test_null_response_value(session, wheel_chain):
     value = wheel_chain.scroll(0, 0, 0, 10).perform()
     assert value is None
 
+@pytest.mark.parametrize("missing", ["x", "y", "deltaX", "deltaY"])
+def test_missing_params(session, wheel_chain, missing):
+    actions = wheel_chain.scroll(0, 0, 0, 10)
+    del actions._actions[-1][missing]
+    with pytest.raises(InvalidArgumentException):
+        actions.perform()
 
 def test_no_top_browsing_context(session, closed_window, wheel_chain):
     with pytest.raises(NoSuchWindowException):


### PR DESCRIPTION
This actually happens at a very early stage: https://w3c.github.io/webdriver/#dfn-process-a-wheel-action
However, for some reason webdriver crate does not check it for this particular case.
This PR moves the check to the beginning of dispatch scroll action.

Testing: Added a wdspec test.
Reviewed in servo/servo#42745