### PR TITLE
[grid-lanes] Make tests not depend on inline-grid-lanes alias

### DIFF
--- a/css/css-display/parsing/tentative/display-computed.html
+++ b/css/css-display/parsing/tentative/display-computed.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Display: getComputedStyle().display</title>
 <link rel="author" title="Ethan Jimenez" href="mailto:ethavar@microsoft.com">
-<link rel="help" href="https://tabatkins.github.io/specs/css-masonry/#masonry-containers">
+<link rel="help" href="https://www.w3.org/TR/css-grid-3/#grid-lanes-containers">
 <meta name="assert" content="position and float can change display computed value.">
 <meta name="assert" content="display computed value is otherwise as specified.">
 <script src="/resources/testharness.js"></script>
@@ -16,17 +16,21 @@
 <script>
 'use strict';
 
-// https://tabatkins.github.io/specs/css-masonry/#masonry-containers
+// https://www.w3.org/TR/css-grid-3/#grid-lanes-containers
 test_computed_value("display", "grid-lanes");
+test_computed_value("display", "block grid-lanes", "grid-lanes");
+test_computed_value("display", "grid-lanes block", "grid-lanes");
 test_computed_value("display", "inline-grid-lanes");
+test_computed_value("display", "inline grid-lanes");
+test_computed_value("display", "grid-lanes inline", "inline grid-lanes");
 
 // https://www.w3.org/TR/CSS2/visuren.html#dis-pos-flo
 function test_display_affected(property, value) {
   const target = document.getElementById('target');
   test(() => {
     target.style[property] = value;
-    target.style.display = 'inline-grid-lanes';
-    assert_equals(getComputedStyle(target).display, 'grid-lanes', 'inline-grid-lanes -> grid-lanes');
+    target.style.display = 'inline grid-lanes';
+    assert_equals(getComputedStyle(target).display, 'grid-lanes', 'inline grid-lanes -> grid-lanes');
 
     target.style[property] = '';
     target.style.display = '';

--- a/css/css-display/parsing/tentative/display-valid.html
+++ b/css/css-display/parsing/tentative/display-valid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Display: Parsing display with valid values</title>
 <link rel="author" title="Ethan Jimenez" href="mailto:ethavar@microsoft.com">
-<link rel="help" href="https://tabatkins.github.io/specs/css-masonry/#masonry-containers">
+<link rel="help" href="https://www.w3.org/TR/css-grid-3/#grid-lanes-containers">
 <meta name="assert" content="display supports the new values 'grid-lanes | inline-grid-lanes'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -12,9 +12,14 @@
 </head>
 <body>
 <script>
-// https://tabatkins.github.io/specs/css-masonry/#masonry-containers
+// https://www.w3.org/TR/css-grid-3/#grid-lanes-containers
 test_valid_value("display", "grid-lanes");
+test_valid_value("display", "block grid-lanes", "grid-lanes");
+test_valid_value("display", "grid-lanes block", "grid-lanes");
 test_valid_value("display", "inline-grid-lanes");
+test_valid_value("display", "inline grid-lanes");
+test_valid_value("display", "grid-lanes inline", "inline grid-lanes");
+
 </script>
 </body>
 </html>

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-001.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-001.html
@@ -20,7 +20,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-002.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-002.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-003.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-003.html
@@ -20,7 +20,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-004.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-004.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,20px);

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-001.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-001.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-002.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-002.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-003.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-003.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,20px);

--- a/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-004.html
+++ b/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-004.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,20px);

--- a/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-001.html
+++ b/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-001.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       background-color: grey;
       position: relative;
       border: solid;

--- a/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-002.html
+++ b/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-002.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       background-color: grey;
       position: relative;
       border: solid;

--- a/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-003.html
+++ b/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-003.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       background-color: grey;
       position: relative;
       border: solid;

--- a/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-001.html
+++ b/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-001.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       background-color: grey;
       position: relative;

--- a/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-002.html
+++ b/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-002.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       background-color: grey;
       position: relative;

--- a/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-003.html
+++ b/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-003.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       background-color: grey;
       position: relative;

--- a/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-001.html
+++ b/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-001.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 10px 20px;
   grid-template-columns: repeat(4,auto);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-002.html
+++ b/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-002.html
@@ -22,7 +22,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: repeat(4,auto);
   color: #444;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/grid-lanes-not-inhibited-001.html
+++ b/css/css-grid/grid-lanes/tentative/grid-lanes-not-inhibited-001.html
@@ -7,7 +7,7 @@
 <style>
 grid {
   vertical-align: top;
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: 60px 60px;
   border: 2px solid black;
 }

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix1.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-005.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-005.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-006.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-006.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   border: 1px solid;
   padding: 0 1px 0 2px;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-007.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-007.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   border: 1px solid;
   padding: 0 1px 0 2px;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-auto.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-fr.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix1.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-auto.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-auto.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-fr.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix1.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix1.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix2.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-005.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-005.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-006.html
+++ b/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-006.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-001.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-001.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(2, 100px);
       flow-tolerance: normal; /* Should resolve to 1em (16px) */

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-002.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-002.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(3, 100px);
       flow-tolerance: normal; /* Should resolve to 1em (16px) */

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-003.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-003.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(3, 100px);
       flow-tolerance: 51px; /* Tracks within 51px are considered equal */

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-004.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-004.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(2, 100px);
       flow-tolerance: infinite; /* Always place in order */

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html
@@ -12,7 +12,7 @@
     }
 
     .grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-rows: repeat(2, 100px);
       gap: 10px;
       border: 1px solid;

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html
@@ -15,7 +15,7 @@
     }
 
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-rows: repeat(2, 100px);
       gap: 10px;
       flow-tolerance: normal;

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-001.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-001.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-002.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-002.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-003.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-003.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-004.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-004.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-001.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-001.html
@@ -15,7 +15,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px 20px;
       grid-template-columns: repeat(4,80px);
       color: #444;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-002.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-002.html
@@ -15,7 +15,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px 20px;
       grid-auto-columns: 80px;
       color: #444;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-003.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-003.html
@@ -15,7 +15,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px 20px;
       grid-auto-flow: dense;
       grid-auto-columns: 80px;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-004.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-004.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-005.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-005.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-006.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-006.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-007.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-007.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-008.html
+++ b/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-008.html
@@ -10,7 +10,7 @@
 <body>
 <style>
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: repeat( auto-fill, minmax(200px, 400px) );
   gap: 30px;
   max-width: 50vw;

--- a/css/css-grid/grid-lanes/tentative/items/column-fit-content-percentage.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-fit-content-percentage.html
@@ -10,7 +10,7 @@
   margin-top: 10px;
 }
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   background: blue;
 }
 .item {

--- a/css/css-grid/grid-lanes/tentative/items/column-intrinsic-track-sizes-min-size.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-intrinsic-track-sizes-min-size.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes{
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: minmax(auto,0) minmax(auto,0);
   background: red;
   height: 100px;

--- a/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-001.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-001.html
@@ -7,7 +7,7 @@
 <link rel="match" href="../../../../reference/ref-filled-green-100px-square.xht">
 <style>
 #grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: minmax(auto, 0);
     width: 200px;
 }

--- a/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-002.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-002.html
@@ -7,7 +7,7 @@
 <link rel="match" href="column-item-minmax-img-002-ref.html">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: minmax(auto, 0);
     border: 5px solid goldenrod;
     vertical-align: top;

--- a/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-001.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-001.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   height: 10px;
   width: 10px;
   grid-template-columns: 3px auto 4px;

--- a/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-002.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-002.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   height: 10px;
   width: 10px;
   grid-template-columns: 3px auto 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-003.html
+++ b/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-003.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   height: 10px;
   width: 10px;
   grid-template-columns: 3px auto 4px;

--- a/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-001.html
+++ b/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-001.html
@@ -7,7 +7,7 @@
 <link rel="match" href="../../../../reference/ref-filled-green-100px-square.xht">
 <style>
 #grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     grid-template-rows: minmax(auto, 0);
     height: 200px;

--- a/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-002.html
+++ b/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-002.html
@@ -7,7 +7,7 @@
 <link rel="match" href="row-item-minmax-img-002-ref.html">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     grid-template-rows: minmax(auto, 0);
     border: 5px solid goldenrod;

--- a/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-001.html
+++ b/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-001.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   height: 10px;
   width: 10px;

--- a/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-002.html
+++ b/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-002.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   height: 10px;
   width: 10px;

--- a/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-003.html
+++ b/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-003.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   height: 10px;
   width: 10px;

--- a/css/css-grid/grid-lanes/tentative/order/grid-lanes-order-001.html
+++ b/css/css-grid/grid-lanes/tentative/order/grid-lanes-order-001.html
@@ -16,7 +16,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 10px 20px;
   grid-template-columns:  repeat(4,auto);
   color: #444;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001a.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001b.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001c.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001d.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001e.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001e.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002a.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002b.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002c.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002d.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002e.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002e.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002f.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002f.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002g.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002g.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002h.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002h.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002i.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002i.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001a.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001b.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001c.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001d.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002b.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002c.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002d.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002e.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002e.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002f.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002f.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002g.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002g.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002h.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002h.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002i.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002i.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex.html
@@ -12,7 +12,7 @@
   <link rel="match" href="grid-lanes-subgrid-flex-ref.html">
   <style>
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-columns: 1fr 2fr 3fr;
       border: 1px solid;
       background: lightgrey;

--- a/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
@@ -12,7 +12,7 @@
   <link rel="match" href="grid-lanes-subgrid-intrinsic-sizing-ref.html">
   <style>
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-columns: auto min-content max-content;
       border: 1px solid;
       background: lightgrey;

--- a/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid.html
+++ b/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid.html
@@ -12,7 +12,7 @@
   <link rel="match" href="grid-lanes-subgrid-ref.html">
   <style>
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-columns: 50px 100px 200px;
       border: 1px solid;
       background: lightgrey;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-003.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-003.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, 50px);

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-004.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-004.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, 50px);

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-006.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     height: 100px;
     min-width: 60%;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-007.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-007.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     width: 100px;
     min-height: 60%;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-010.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-010.html
@@ -8,7 +8,7 @@
 <style>
 .grid-lanes {
     position: relative;
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: repeat(auto-fill, 25%);
     min-width: 50%;
     height: 200px;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-015.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-015.html
@@ -5,7 +5,7 @@
 <link rel="match" href="column-auto-repeat-015-ref.html">
 <style>
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   border: 1px solid black;
   grid-template-columns: [u] repeat(auto-fill, [v] 10px [w] 10px [x] 10px [y]) [z];
   grid-column-gap: 3px;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-006.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, auto);

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-007.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-007.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, auto);

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-008.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-008.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     height: 100px;
     min-width: 60%;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-006.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-007.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-007.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-008.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-008.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     background: green;
     width: 100px;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-003.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-003.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-004.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-004.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-006.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     background: green;
     width: 100px;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-009.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-009.html
@@ -8,7 +8,7 @@
 <style>
 .grid-lanes {
     position: relative;
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     grid-template-rows: repeat(auto-fill, 20%);
     min-height: 50%;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-014.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-014.html
@@ -5,7 +5,7 @@
 <link rel="match" href="row-auto-repeat-014-ref.html">
 <style>
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   border: 1px solid black;
   grid-template-rows: [u] repeat(auto-fill, [v] 10px [w] 10px [x] 10px [y]) [z];
   grid-lanes-direction: row;

--- a/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html
+++ b/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html
@@ -12,7 +12,7 @@
 
 <style>
   grid {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: auto;
     grid-gap: 10px;
     border: 10px;


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/issues/10961

This commit does three things:
* Makes layout tests use 'inline grid-lanes' which will be valid in any case.
* Ensures parsing tests for both 'inline grid-lanes' and 'inline-grid-lanes', that check for correct behaior in implementations that support the alias as well as those that don't. At least one of these tests will fail in each implementation, to remind us to revisit once the CSSWG settles this issue.
* Adds parsing tests for 'block grid-lanes' while we're at it.