### PR TITLE
servo harness: Reduce recursive execution for shutdown

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -138,7 +138,7 @@ class ServoBrowser(WebDriverBrowser):
         try:
             requests.get(f"http://{self.host}:{self.port}/status", timeout=3)
         except requests.exceptions.Timeout:
-            # FIXME: This indicates a hanged browser. 
+            # FIXME: This indicates a hanged browser.
             # Server is waiting for response of the previous command.
             # It happens with ~0.1% probability in our CI runs.
             self.logger.debug("Servo webdriver status request timed out.")
@@ -173,7 +173,7 @@ class ServoBrowser(WebDriverBrowser):
                 )
                 self.logger.warning("Hanged server. Killing instead.")
                 break
- 
+
             time.sleep(1)
         else:
             self.logger.warning("Max retry exceeded to normally shut down. Killing instead.")


### PR DESCRIPTION
I like `servo` runner, or better known as its previous name `servodriver` to some people.
However, it is getting quite often that I use `legacy`, or better known as its previous name `servo`.
This is because `servo (previously servodriver)` harness shutdown very slowly due to its shutdown command https://github.com/servo/servo/pull/40455

- This PR improves the shutdown command in the way as titled.
- Avoids accidental Prockill that may happen after regular shutdown. This may be related to @jschwe's report that coverage for WPT still reports empty more often than it should.

Previously, shutdown is like:
```
 0:15.06 INFO Trying to shut down gracefully by extension command
 0:18.13 DEBUG Servo has shut down normally. HTTPConnectionPool(host='127.0.0.1', port=8378): Max retries exceeded with url: /status (Caused by NewConnectionError("HTTPConnection(host='127.0.0.1', port=8378): Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it"))
 0:18.13 DEBUG Stopping WebDriver
 0:20.19 DEBUG Servo has shut down normally. HTTPConnectionPool(host='127.0.0.1', port=8378): Max retries exceeded with url: /status (Caused by NewConnectionError("HTTPConnection(host='127.0.0.1', port=8378): Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it"))
 0:22.24 DEBUG Servo has shut down normally. HTTPConnectionPool(host='127.0.0.1', port=8378): Max retries exceeded with url: /status (Caused by NewConnectionError("HTTPConnection(host='127.0.0.1', port=8378): Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it"))
 0:14.99 DEBUG Hanging up on WebDriver session
```

Now:
```
 INFO Trying to shut down gracefully by extension command
 0:18.41 DEBUG Servo has shut down normally. HTTPConnectionPool(host='127.0.0.1', port=9098): Max retries exceeded with url: /status (Caused by NewConnectionError("HTTPConnection(host='127.0.0.1', port=9098): Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it"))
 0:18.41 DEBUG TestRunnerManager cleanup
 0:15.30 DEBUG Hanging up on WebDriver session
```

Testing: Locally, this reduce shutdown time from about 5 sec to 1 sec, counting from "Trying to shut down gracefully by extension command". 
[Try](https://github.com/servo/servo/actions/runs/22295662553/job/64492009162).

Reviewed in servo/servo#42770