### PR TITLE
Correct the fcp-opacity-descendant test to make it more robust and simple.

### DIFF
--- a/paint-timing/fcp-only/fcp-opacity-descendant.html
+++ b/paint-timing/fcp-only/fcp-opacity-descendant.html
@@ -8,23 +8,11 @@
         left: 0px;
         position: relative;
         top: 0;
+        opacity: 0;
     }
 
     #child {
-        opacity: 0;
-    }
-
-    /* contentful and intermediate classes are defined in test_fcp script. */
-    #main.contentful #child {
         opacity: 1;
-    }
-
-    #main.intermediate #child {
-        opacity: 1;
-    }
-
-    #main.intermediate {
-        opacity: 0;
     }
 
     #main.contentful {


### PR DESCRIPTION
- Simplify the test.
- Remove `intermediate` class.