### PR TITLE
layout: Let `TableSlotCell` store an `IndependentFormattingContext`

### DIFF
--- a/css/CSS2/tables/table-cell-dynamic-color.html
+++ b/css/CSS2/tables/table-cell-dynamic-color.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: table cell with dynamically changing `color`</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-display">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+#target {
+  display: table-cell;
+  font: 200px/1 Ahem;
+  color: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="target">X</div>
+
+<script src="/common/reftest-wait.js"></script>
+<script>
+requestAnimationFrame(() => requestAnimationFrame(() => {
+  document.getElementById("target").style.color = "green";
+  takeScreenshot();
+}));
+</script>
+</html>


### PR DESCRIPTION
`TableSlotCell` was storing the `BlockFormattingContext` and the `LayoutBoxBase` in separate fields. Now it will store an entire `IndependentFormattingContext` in a single field.

In particular, this fixes the issue that `TableSlotCell::repair_style()` wasn't calling `BlockFormattingContext::repair_style()`. Now we can just rely on the correct `IndependentFormattingContext::repair_style()`.

Testing: Adding a new test
Fixes: #<!-- nolink -->42777

Reviewed in servo/servo#42778