### PR TITLE
wdspec [Perform Actions]: Move missing properties test to `invalid.py`

### DIFF
--- a/webdriver/tests/classic/perform_actions/invalid.py
+++ b/webdriver/tests/classic/perform_actions/invalid.py
@@ -858,9 +858,7 @@ def test_wheel_action_scroll_origin_element_invalid_value(session):
 
 
 @pytest.mark.parametrize("missing", ["x", "y", "deltaX", "deltaY"])
-def test_wheel_action_scroll_missing_property(
-    session, test_actions_scroll_page, wheel_chain, missing
-):
+def test_wheel_action_scroll_missing_property(session, wheel_chain, missing):
     actions = wheel_chain.scroll(0, 0, 5, 10, origin="viewport")
     del actions._actions[-1][missing]
 

--- a/webdriver/tests/classic/perform_actions/invalid.py
+++ b/webdriver/tests/classic/perform_actions/invalid.py
@@ -361,6 +361,14 @@ def test_pointer_action_subtype_invalid_value(session, value):
     assert_error(response, "invalid argument")
 
 
+@pytest.mark.parametrize("missing", ["x", "y"])
+def test_pointer_action_move_missing_coordinates(session, mouse_chain, missing):
+    actions = mouse_chain.pointer_move(x=0, y=0)
+    del actions._actions[-1][missing]
+    with pytest.raises(InvalidArgumentException):
+        actions.perform()
+
+
 @pytest.mark.parametrize("coordinate", ["x", "y"])
 @pytest.mark.parametrize("value", [None, "foo", True, [], {}])
 def test_pointer_action_move_coordinate_invalid_type(session, coordinate, value):
@@ -478,29 +486,6 @@ def test_pointer_action_up_down_button_invalid_value(session, pointer_action, va
     response = perform_actions(
         session, [{"type": "pointer", "id": "foo", "actions": [action]}]
     )
-    assert_error(response, "invalid argument")
-
-
-@pytest.mark.parametrize("missing", ["x", "y"])
-def test_pointer_action_move_missing_property(session, missing):
-    action_dict = {
-        "type": "pointerMove",
-        "duration": 0,
-        "x": 0,
-        "y": 0,
-    }
-
-    del action_dict[missing]
-
-    actions = [
-        {
-            "type": "pointer",
-            "id": "foo",
-            "actions": [action_dict],
-        }
-    ]
-
-    response = perform_actions(session, actions)
     assert_error(response, "invalid argument")
 
 

--- a/webdriver/tests/classic/perform_actions/invalid.py
+++ b/webdriver/tests/classic/perform_actions/invalid.py
@@ -481,6 +481,29 @@ def test_pointer_action_up_down_button_invalid_value(session, pointer_action, va
     assert_error(response, "invalid argument")
 
 
+@pytest.mark.parametrize("missing", ["x", "y"])
+def test_pointer_action_move_missing_property(session, missing):
+    action_dict = {
+        "type": "pointerMove",
+        "duration": 0,
+        "x": 0,
+        "y": 0,
+    }
+
+    del action_dict[missing]
+
+    actions = [
+        {
+            "type": "pointer",
+            "id": "foo",
+            "actions": [action_dict],
+        }
+    ]
+
+    response = perform_actions(session, actions)
+    assert_error(response, "invalid argument")
+
+
 @pytest.mark.parametrize("pointer_action", ["pointerDown", "pointerMove", "pointerUp"])
 @pytest.mark.parametrize("dimension", ["width", "height"])
 @pytest.mark.parametrize("value", [None, "foo", True, 0.1, [], {}])

--- a/webdriver/tests/classic/perform_actions/invalid.py
+++ b/webdriver/tests/classic/perform_actions/invalid.py
@@ -362,9 +362,10 @@ def test_pointer_action_subtype_invalid_value(session, value):
 
 
 @pytest.mark.parametrize("missing", ["x", "y"])
-def test_pointer_action_move_missing_coordinates(session, mouse_chain, missing):
+def test_pointer_action_move_missing_property(session, mouse_chain, missing):
     actions = mouse_chain.pointer_move(x=0, y=0)
     del actions._actions[-1][missing]
+
     with pytest.raises(InvalidArgumentException):
         actions.perform()
 

--- a/webdriver/tests/classic/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/classic/perform_actions/pointer_mouse.py
@@ -339,15 +339,6 @@ def test_move_to_origin_position_within_frame(
     assert events[0][1] == pytest.approx(target_point[1], abs=1.0)
 
 
-@pytest.mark.parametrize("missing", ["x", "y"])
-def test_missing_coordinates(session, test_actions_page, mouse_chain, missing):
-    outer = session.find.css("#outer", all=False)
-    actions = mouse_chain.pointer_move(x=0, y=0, origin=outer)
-    del actions._actions[-1][missing]
-    with pytest.raises(InvalidArgumentException):
-        actions.perform()
-
-
 def test_invalid_element_origin(session, test_actions_page, mouse_chain):
     outer = session.find.css("#outer", all=False)
     actions = mouse_chain.pointer_move(

--- a/webdriver/tests/classic/perform_actions/wheel.py
+++ b/webdriver/tests/classic/perform_actions/wheel.py
@@ -1,18 +1,12 @@
 import pytest
 
-from webdriver.error import InvalidArgumentException, MoveTargetOutOfBoundsException, NoSuchWindowException
+from webdriver.error import MoveTargetOutOfBoundsException, NoSuchWindowException
 
 
 def test_null_response_value(session, wheel_chain):
     value = wheel_chain.scroll(0, 0, 0, 10).perform()
     assert value is None
 
-@pytest.mark.parametrize("missing", ["x", "y", "deltaX", "deltaY"])
-def test_missing_params(session, wheel_chain, missing):
-    actions = wheel_chain.scroll(0, 0, 0, 10)
-    del actions._actions[-1][missing]
-    with pytest.raises(InvalidArgumentException):
-        actions.perform()
 
 def test_no_top_browsing_context(session, closed_window, wheel_chain):
     with pytest.raises(NoSuchWindowException):


### PR DESCRIPTION
As requested in https://github.com/web-platform-tests/wpt/pull/57966#discussion_r2840391734