### PR TITLE
layout: Correctly repair `OutsideMarker::list_item_style`

### DIFF
--- a/css/css-lists/list-item-dynamic-padding-ref.html
+++ b/css/css-lists/list-item-dynamic-padding-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: List item with dynamic padding</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<ul>
+  <li style="padding-left: 100px">text</li>
+</ul>

--- a/css/css-lists/list-item-dynamic-padding.html
+++ b/css/css-lists/list-item-dynamic-padding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Test: List item with dynamic padding</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-4/#valdef-display-list-item">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#paddings">
+<link rel="match" href="list-item-dynamic-padding-ref.html">
+<ul>
+  <li id="target">text</li>
+</ul>
+<script src="/common/reftest-wait.js"></script>
+<script>
+requestAnimationFrame(() => requestAnimationFrame(() => {
+  document.getElementById("target").style.paddingLeft = "100px";
+  takeScreenshot();
+}));
+</script>
+</html>


### PR DESCRIPTION
`OutsideMarker::repair_style()` was setting `list_item_style` to the style of the marker, not the style of the list item.

This patch sets it to `node.parent_style(context)` instead, and it fixes `ServoThreadSafeLayoutNode::parent_style()` to take the pseudo-element chain into account. This requires modifying a bunch of logic to pass the `SharedStyleContext` around.

Testing: Adding a new test

Reviewed in servo/servo#42825