### PR TITLE
Add support for product plugins to wptrunner/wpt run

### DIFF
--- a/docs/running-tests/custom-products.md
+++ b/docs/running-tests/custom-products.md
@@ -1,0 +1,54 @@
+# Custom Products
+
+External browser products can be registered with wptrunner using entry points. Once installed, these products are available to the `./wpt run` command.
+
+## Installation
+
+Custom products do not support automatic browser installation. Install the browser
+manually before running tests.
+
+Which command-line arguments are required (such as `--binary` or
+`--webdriver-binary`) depends on the product plugin. Consult the plugin's
+documentation.
+
+## Usage
+
+First, install the custom product plugin into the same Python that `./wpt` uses:
+
+```bash
+python3 -m pip install wptrunner-mybrowser
+```
+
+Then run tests using the product name:
+
+```bash
+./wpt run mybrowser test.html
+```
+
+Some products require a browser binary path:
+
+```bash
+./wpt run mybrowser --binary=/path/to/mybrowser test.html
+```
+
+Some products require a WebDriver binary path:
+
+```bash
+./wpt run mybrowser --webdriver-binary=/path/to/mydriver test.html
+```
+
+Additional arguments can be passed to the browser using `--binary-arg`:
+
+```bash
+./wpt run mybrowser --binary=/path/to/mybrowser --binary-arg=--headless test.html
+```
+
+## Troubleshooting
+
+If you see "Product mybrowser not found":
+
+* The plugin may not be installed: `python3 -m pip install wptrunner-mybrowser`
+* Check that the plugin is registered correctly (run `python3 -m pip show wptrunner-mybrowser`)
+
+For information on creating custom product plugins, see the
+[wptrunner plugin documentation](../../tools/wptrunner/docs/plugins.rst).

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -89,7 +89,7 @@ def get_file_github(repo: str, ref: str, path: str) -> bytes:
     return data
 
 
-class Browser(metaclass=ABCMeta):
+class Browser:
     def __init__(self, logger):
         self.logger = logger
 
@@ -141,7 +141,6 @@ class Browser(metaclass=ABCMeta):
 
         return output_path
 
-    @abstractmethod
     def download(self, dest=None, channel=None, rename=None):
         """Download a package or installer for the browser
         :param dest: Directory in which to put the dowloaded package
@@ -150,9 +149,8 @@ class Browser(metaclass=ABCMeta):
                        extension is preserved.
         :return: The path to the downloaded package/installer
         """
-        return NotImplemented
+        raise NotImplementedError
 
-    @abstractmethod
     def install(self, dest=None, channel=None):
         """Download and install the browser.
 
@@ -162,9 +160,8 @@ class Browser(metaclass=ABCMeta):
         :param channel: Browser channel to install
         :return: The path to the installed browser
         """
-        return NotImplemented
+        raise NotImplementedError
 
-    @abstractmethod
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
         """Download and install the WebDriver implementation for this browser.
 
@@ -173,9 +170,8 @@ class Browser(metaclass=ABCMeta):
         :param browser_binary: The path to the browser binary
         :return: The path to the installed WebDriver
         """
-        return NotImplemented
+        raise NotImplementedError
 
-    @abstractmethod
     def find_binary(self, venv_path=None, channel=None):
         """Find the binary of the browser.
 
@@ -183,22 +179,20 @@ class Browser(metaclass=ABCMeta):
         method doesn't need to be implemented, in which case NotImplementedError
         is suggested to be raised to prevent accidental use.
         """
-        return NotImplemented
+        return None
 
-    @abstractmethod
     def find_webdriver(self, venv_path=None, channel=None):
         """Find the binary of the WebDriver."""
-        return NotImplemented
+        return None
 
-    @abstractmethod
     def version(self, binary=None, webdriver_binary=None):
         """Retrieve the release version of the installed browser."""
-        return NotImplemented
+        return None
 
-    @abstractmethod
+    @property
     def requirements(self):
         """Name of the browser-specific wptrunner requirements file"""
-        return NotImplemented
+        return None
 
 
 class FirefoxPrefs:
@@ -729,9 +723,6 @@ class FirefoxAndroid(Browser):
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
         return self._fx_browser.install_webdriver(dest, channel, None)
-
-    def version(self, binary=None, webdriver_binary=None):
-        return None
 
 
 class ChromeChromiumBase(Browser):
@@ -1565,12 +1556,6 @@ class HeadlessShell(ChromeChromiumBase):
         # TODO(crbug.com/344669542): Download binaries via CfT.
         raise NotImplementedError
 
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
-
     def find_binary(self, venv_path=None, channel=None):
         # `which()` adds `.exe` extension automatically for Windows.
         # Chromium builds an executable named `headless_shell`, whereas CfT
@@ -1596,15 +1581,9 @@ class ChromeAndroidBase(Browser, metaclass=ABCMeta):
         self.device_serial = None
         self.adb_binary = "adb"
 
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
     @abstractmethod
     def find_binary(self, venv_path=None, channel=None):
-        raise NotImplementedError
+        pass
 
     def find_webdriver(self, venv_path=None, channel=None):
         return which("chromedriver")
@@ -1690,21 +1669,6 @@ class ChromeiOS(Browser):
     product = "chrome_ios"
     requirements = None
 
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
-    def find_binary(self, venv_path=None, channel=None):
-        raise NotImplementedError
-
-    def find_webdriver(self, venv_path=None, channel=None):
-        raise NotImplementedError
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
-
     def version(self, binary=None, webdriver_binary=None):
         if webdriver_binary is None:
             self.logger.warning(
@@ -1742,12 +1706,6 @@ class Opera(Browser):
         self.logger.warning("Unable to find the browser binary.")
         return None
 
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
     def platform_string(self):
         platform = {
             "Linux": "linux",
@@ -1766,9 +1724,6 @@ class Opera(Browser):
             bits = "32"
 
         return "%s%s" % (platform, bits)
-
-    def find_binary(self, venv_path=None, channel=None):
-        raise NotImplementedError
 
     def find_webdriver(self, venv_path=None, channel=None):
         return which("operadriver")
@@ -1914,9 +1869,6 @@ class Edge(Browser):
 
     def find_webdriver(self, venv_path=None, channel=None):
         return which("msedgedriver")
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
         if dest is None:
@@ -2229,17 +2181,11 @@ class Safari(Browser):
         # requires admin permissions to install.
         raise NotImplementedError
 
-    def find_binary(self, venv_path=None, channel=None):
-        raise NotImplementedError
-
     def find_webdriver(self, venv_path=None, channel=None):
         path = None
         if channel == "preview":
             path = "/Applications/Safari Technology Preview.app/Contents/MacOS"
         return which("safaridriver", path=path)
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
 
     def version(self, binary=None, webdriver_binary=None):
         if webdriver_binary is None:
@@ -2326,12 +2272,6 @@ class Servo(Browser):
             path = which("servo")
         return path
 
-    def find_webdriver(self, venv_path=None, channel=None):
-        return None
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
-
     def version(self, binary=None, webdriver_binary=None):
         """Retrieve the release version of the installed browser."""
         output = call(binary, "--version")
@@ -2350,24 +2290,6 @@ class Sauce(Browser):
     product = "sauce"
     requirements = "requirements_sauce.txt"
 
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
-    def find_binary(self, venev_path=None, channel=None):
-        raise NotImplementedError
-
-    def find_webdriver(self, venv_path=None, channel=None):
-        raise NotImplementedError
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
-
-    def version(self, binary=None, webdriver_binary=None):
-        return None
-
 
 class WebKit(Browser):
     """WebKit-specific interface."""
@@ -2375,42 +2297,15 @@ class WebKit(Browser):
     product = "webkit"
     requirements = None
 
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
-    def find_binary(self, venv_path=None, channel=None):
-        return None
-
-    def find_webdriver(self, venv_path=None, channel=None):
-        return None
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
-
-    def version(self, binary=None, webdriver_binary=None):
-        return None
-
 class Ladybird(Browser):
     product = "ladybird"
     requirements = None
-
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
 
     def find_binary(self, venv_path=None, channel=None):
         return which("ladybird")
 
     def find_webdriver(self, venv_path=None, channel=None):
         return which("WebDriver")
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
 
     def version(self, binary=None, webdriver_binary=None):
         if not binary:
@@ -2515,15 +2410,9 @@ class WebKitTestRunner(Browser):
         with open(installer_path, "rb") as f:
             unzip(f, dest)
 
-    def install_webdriver(self, dest=None, channel="main", browser_binary=None):
-        raise NotImplementedError
-
     def find_binary(self, venv_path=None, channel="main"):
         path = self._get_browser_binary_dir(venv_path, channel)
         return which("WebKitTestRunner", path=os.path.join(path, "Release"))
-
-    def find_webdriver(self, venv_path=None, channel="main"):
-        return None
 
     def version(self, binary=None, webdriver_binary=None):
         dirname = os.path.dirname(binary)
@@ -2704,20 +2593,11 @@ class Epiphany(Browser):
     product = "epiphany"
     requirements = None
 
-    def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
-
-    def install(self, dest=None, channel=None):
-        raise NotImplementedError
-
     def find_binary(self, venv_path=None, channel=None):
         return which("epiphany")
 
     def find_webdriver(self, venv_path=None, channel=None):
         return which("WebKitWebDriver")
-
-    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        raise NotImplementedError
 
     def version(self, binary=None, webdriver_binary=None):
         if binary is None:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -9,8 +9,7 @@ from shutil import copyfile, which
 from typing import ClassVar, Tuple, Type
 
 import mozlog
-
-from wptrunner import wptcommandline, wptrunner
+from wptrunner import products, wptcommandline, wptrunner
 
 from ..serve import serve
 from . import browser, install, testfiles
@@ -109,9 +108,13 @@ otherwise install OpenSSL and ensure that it's on your $PATH.""")
 
 
 def check_environ(product):
-    if product not in ("android_webview", "chrome", "chrome_android", "chrome_ios",
-                       "edge", "firefox", "firefox_android", "headless_shell",
-                       "ladybird", "servo", "wktr"):
+    builtin_skip = {
+        "android_webview", "chrome", "chrome_android", "chrome_ios",
+        "edge", "firefox", "firefox_android", "headless_shell",
+        "ladybird", "servo", "wktr"
+    }
+
+    if product not in builtin_skip:
         config_builder = serve.build_config(os.path.join(wpt_root, "config.json"))
         # Override the ports to avoid looking for free ports
         config_builder.ssl = {"type": "none"}
@@ -215,8 +218,8 @@ class AndroidLogcat:
 
 
 class BrowserSetup:
-    name: ClassVar[str]
-    browser_cls: ClassVar[Type[browser.Browser]]
+    name: str
+    browser_cls: Type[browser.Browser]
 
     def __init__(self, venv, prompt=True):
         self.browser = self.browser_cls(logger)
@@ -250,6 +253,14 @@ class BrowserSetup:
 
     def teardown(self):
         pass
+
+
+class GenericBrowserSetup(BrowserSetup):
+    browser_cls = browser.Browser
+
+    def __init__(self, venv, prompt, product_name):
+        self.name = product_name
+        super().__init__(venv, prompt)
 
 
 def safe_unsetenv(env_var):
@@ -527,7 +538,7 @@ class ChromeAndEdgeSetup(BrowserSetup):
 
 class Chrome(ChromeAndEdgeSetup):
     name = "chrome"
-    browser_cls: ClassVar[Type[browser.ChromeChromiumBase]] = browser.Chrome
+    browser_cls: Type[browser.ChromeChromiumBase] = browser.Chrome
     webdriver_name = "chromedriver"
 
     def setup_kwargs(self, kwargs):
@@ -572,7 +583,7 @@ class HeadlessShell(BrowserSetup):
 
 class Chromium(Chrome):
     name = "chromium"
-    browser_cls: ClassVar[Type[browser.ChromeChromiumBase]] = browser.Chromium
+    browser_cls: Type[browser.ChromeChromiumBase] = browser.Chromium
     experimental_channels = ("nightly",)
 
 
@@ -824,7 +835,7 @@ class Epiphany(BrowserSetup):
             kwargs["webdriver_binary"] = webdriver_binary
 
 
-product_setup = {
+BUILTIN_PRODUCT_SETUP = {
     "android_webview": AndroidWebview,
     "firefox": Firefox,
     "firefox_android": FirefoxAndroid,
@@ -847,6 +858,33 @@ product_setup = {
     "ladybird": Ladybird,
 }
 
+
+def get_product_setup(product_name, venv, prompt):
+    """Get BrowserSetup instance for product (built-in or external).
+
+    Args:
+        product_name: Name of the product (e.g., "chrome", "firefox")
+        venv: Virtual environment object
+        prompt: Whether to prompt user for confirmations
+
+    Returns:
+        BrowserSetup instance for the product
+
+    Raises:
+        WptrunError: If product is unknown
+    """
+    if product_name in BUILTIN_PRODUCT_SETUP:
+        return BUILTIN_PRODUCT_SETUP[product_name](venv, prompt)
+
+    try:
+        products.Product.from_product_name(product_name)
+    except Exception as e:
+        raise WptrunError(f"Unsupported product {product_name}") from e
+    else:
+        return GenericBrowserSetup(venv, prompt, product_name)
+
+
+product_setup = BUILTIN_PRODUCT_SETUP
 
 
 def setup_logging(kwargs, default_config=None, formatter_defaults=None):
@@ -872,13 +910,10 @@ def setup_wptrunner(venv, **kwargs):
     check_environ(kwargs["product"])
     args_general(kwargs)
 
-    if kwargs["product"] not in product_setup:
-        if kwargs["product"] == "edgechromium":
-            raise WptrunError("edgechromium has been renamed to edge.")
+    if kwargs["product"] == "edgechromium":
+        raise WptrunError("edgechromium has been renamed to edge.")
 
-        raise WptrunError("Unsupported product %s" % kwargs["product"])
-
-    setup_cls = product_setup[kwargs["product"]](venv, kwargs["prompt"])
+    setup_cls = get_product_setup(kwargs["product"], venv, kwargs["prompt"])
     if not venv.skip_virtualenv_setup:
         requirements = [os.path.join(wpt_root, "tools", "wptrunner", "requirements.txt")]
         requirements.extend(setup_cls.requirements())

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -245,6 +245,9 @@ class BrowserSetup:
     def setup(self, kwargs):
         self.setup_kwargs(kwargs)
 
+    def setup_kwargs(self, kwargs):
+        pass
+
     def teardown(self):
         pass
 
@@ -729,38 +732,16 @@ class ServoLegacy(Servo):
     name = "servo_legacy"
     browser_cls = browser.ServoLegacy
 
-    def install(self, channel=None):
-        if self.prompt_install(self.name):
-            return self.browser.install(self.venv.path)
-
-    def setup_kwargs(self, kwargs):
-        if kwargs["binary"] is None:
-            binary = self.browser.find_binary(self.venv.path, None)
-
-            if binary is None:
-                raise WptrunError("Unable to find servoshell binary in PATH")
-            kwargs["binary"] = binary
-
 
 class WebKit(BrowserSetup):
     name = "webkit"
     browser_cls = browser.WebKit
 
-    def install(self, channel=None):
-        raise NotImplementedError
-
-    def setup_kwargs(self, kwargs):
-        pass
 
 class Ladybird(BrowserSetup):
     name = "ladybird"
     browser_cls = browser.Ladybird
 
-    def install(self, channel=None):
-        raise NotImplementedError
-
-    def setup_kwargs(self, kwargs):
-        pass
 
 class WebKitTestRunner(BrowserSetup):
     name = "wktr"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -8,11 +8,14 @@ import sys
 from shutil import copyfile, which
 from typing import ClassVar, Tuple, Type
 
-wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
-sys.path.insert(0, os.path.abspath(os.path.join(wpt_root, "tools")))
+import mozlog
 
-from . import browser, install, testfiles
+from wptrunner import wptcommandline, wptrunner
+
 from ..serve import serve
+from . import browser, install, testfiles
+
+wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 
 logger = None
 
@@ -35,7 +38,6 @@ class WptrunnerHelpAction(argparse.Action):
             help=help)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        from wptrunner import wptcommandline
         wptparser = wptcommandline.create_parser()
         wptparser.usage = parser.usage
         wptparser.print_help()
@@ -43,8 +45,6 @@ class WptrunnerHelpAction(argparse.Action):
 
 
 def create_parser():
-    from wptrunner import wptcommandline
-
     parser = argparse.ArgumentParser(add_help=False, parents=[install.channel_args])
     parser.add_argument("product", help="Browser to run tests in")
     parser.add_argument("--affected", help="Run affected tests since revish")
@@ -344,8 +344,9 @@ class FirefoxAndroid(BrowserSetup):
     browser_cls = browser.FirefoxAndroid
 
     def setup_kwargs(self, kwargs):
-        from . import android
         import mozdevice
+
+        from . import android
 
         # We don't support multiple channels for android yet
         if kwargs["browser_channel"] is None:
@@ -847,10 +848,8 @@ product_setup = {
 }
 
 
-def setup_logging(kwargs, default_config=None, formatter_defaults=None):
-    import mozlog
-    from wptrunner import wptrunner
 
+def setup_logging(kwargs, default_config=None, formatter_defaults=None):
     global logger
 
     # Use the grouped formatter by default where mozlog 3.9+ is installed
@@ -866,8 +865,6 @@ def setup_logging(kwargs, default_config=None, formatter_defaults=None):
 
 
 def setup_wptrunner(venv, **kwargs):
-    from wptrunner import wptcommandline
-
     kwargs = kwargs.copy()
 
     kwargs["product"] = kwargs["product"].replace("-", "_")
@@ -961,5 +958,4 @@ def run(venv, **kwargs):
 
 
 def run_single(venv, **kwargs):
-    from wptrunner import wptrunner
     return wptrunner.start(**kwargs)

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -9,7 +9,7 @@ import pytest
 
 from tools.wpt import run
 from tools import localpaths  # noqa: F401
-from wptrunner.browsers import product_list
+from wptrunner.products import get_all_products
 
 
 @pytest.fixture(scope="module")
@@ -60,7 +60,7 @@ def test_check_environ_fail(platform):
     assert "wpt make-hosts-file" in str(excinfo.value)
 
 
-@pytest.mark.parametrize("product", product_list)
+@pytest.mark.parametrize("product", list(get_all_products()))
 def test_setup_wptrunner(venv, logger, product):
     if product == "firefox_android":
         pytest.skip("Android emulator doesn't work on docker")

--- a/tools/wpt/update.py
+++ b/tools/wpt/update.py
@@ -5,12 +5,13 @@ import sys
 
 from mozlog import commandline
 
+from tools.manifest import manifest
+from wptrunner import metadata, wptcommandline
+
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
-sys.path.insert(0, os.path.abspath(os.path.join(wpt_root, "tools")))
 
 
 def manifest_update(test_paths):
-    from manifest import manifest  # type: ignore
     for url_base, paths in test_paths.items():
         manifest.load_and_update(
             paths.tests_path,
@@ -19,14 +20,10 @@ def manifest_update(test_paths):
 
 
 def create_parser_update():
-    from wptrunner import wptcommandline
-
     return wptcommandline.create_parser_metadata_update()
 
 
 def update_expectations(_, **kwargs):
-    from wptrunner import metadata, wptcommandline
-
     commandline.setup_logging("web-platform-tests",
                               kwargs,
                               {"mach": sys.stdout},

--- a/tools/wptrunner/docs/plugins.rst
+++ b/tools/wptrunner/docs/plugins.rst
@@ -108,6 +108,32 @@ Add custom metadata to test run information::
 
     # Include in Product(..., run_info_extras=run_info_extras)
 
+Custom Command-Line Arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Products can register their own command-line arguments that appear when users
+run ``./wpt run --help``. Use the ``add_arguments`` attribute to add a function
+that receives an ``argparse.ArgumentParser`` and adds product-specific options::
+
+    def add_arguments(parser):
+        group = parser.add_argument_group("MyBrowser-specific")
+        group.add_argument(
+            "--mybrowser-profile",
+            help="Path to browser profile directory"
+        )
+        group.add_argument(
+            "--mybrowser-debug",
+            action="store_true",
+            help="Enable debug mode"
+        )
+
+    # Include in Product(..., add_arguments=add_arguments)
+
+These arguments will be available in your ``check_args``, ``browser_kwargs``,
+and other functions via ``**kwargs``. The ``add_arguments`` function is called
+for all available products during argument parser setup, so arguments are
+always visible regardless of which product is selected.
+
 API Reference
 -------------
 

--- a/tools/wptrunner/docs/plugins.rst
+++ b/tools/wptrunner/docs/plugins.rst
@@ -1,0 +1,146 @@
+Product Plugins
+===============
+
+External packages can register custom browser products with wptrunner using
+entry points. Products registered this way are automatically
+available to both the wptrunner test harness and the ``./wpt run`` CLI command.
+
+Creating a Product Plugin
+-------------------------
+
+A product plugin consists of three components:
+
+* A Python package containing your product implementation
+* A ``get_product()`` function that returns a :py:class:`~products.Product` instance
+* An entry point registration in ``setup.py`` or ``pyproject.toml``
+
+Entry Point Registration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register via the ``wptrunner.products`` entry point group. Example ``setup.py``::
+
+    setup(
+        name='wptrunner-mybrowser',
+        install_requires=['wptrunner'],
+        entry_points={
+            'wptrunner.products': ['mybrowser = wptrunner_mybrowser:get_product']
+        }
+    )
+
+Or ``pyproject.toml``::
+
+    [project.entry-points."wptrunner.products"]
+    mybrowser = "wptrunner_mybrowser:get_product"
+
+Product Module Implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Implement a Browser class and helper functions::
+
+    from wptrunner.products import Product
+    from wptrunner.browsers.base import Browser
+    from wptrunner.executors.executorwebdriver import (
+        WebDriverTestharnessExecutor,
+        WebDriverRefTestExecutor,
+    )
+
+    class MyBrowser(Browser):
+        def start(self, **kwargs):
+            # Launch browser process
+            # ...
+
+        def stop(self, force=False):
+            # ...
+
+        def is_alive(self):
+            # ...
+
+        def executor_browser(self):
+            from wptrunner.executors.executorwebdriver import WebDriverBrowser
+            return WebDriverBrowser, {"webdriver_url": self.webdriver_url}
+
+    def check_args(**kwargs):
+        pass  # Validate required arguments
+
+    def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
+        return {"binary": kwargs.get("binary")}
+
+    def executor_kwargs(logger, test_type, test_environment, run_info_data,
+                        subsuite, **kwargs):
+        return {"capabilities": {"browserName": "mybrowser"}}
+
+    def get_product():
+        return Product(
+            name="mybrowser",
+            browser_classes={None: MyBrowser},
+            check_args=check_args,
+            get_browser_kwargs=browser_kwargs,
+            get_executor_kwargs=executor_kwargs,
+            env_options={"host": "web-platform.test", "bind_address": True},
+            get_env_extras=lambda **kw: [],
+            get_timeout_multiplier=lambda *a, **kw: 1.0,
+            executor_classes={
+                "testharness": WebDriverTestharnessExecutor,
+                "reftest": WebDriverRefTestExecutor,
+            },
+        )
+
+Advanced Features
+-----------------
+
+Multi-Browser Support
+~~~~~~~~~~~~~~~~~~~~~
+
+Specify different browser classes per test type::
+
+    browser_classes={
+        None: MyBrowser,              # Default
+        "wdspec": MyWdSpecBrowser,    # WebDriver spec tests
+    }
+
+Run Info Extras
+~~~~~~~~~~~~~~~
+
+Add custom metadata to test run information::
+
+    def run_info_extras(logger, **kwargs):
+        return {"mybrowser_version": "1.0.0"}
+
+    # Include in Product(..., run_info_extras=run_info_extras)
+
+API Reference
+-------------
+
+See the :py:class:`~products.Product` dataclass documentation for complete
+field descriptions. All fields are documented in the Product class docstring,
+including required and optional attributes, function signatures, and usage
+examples.
+
+Troubleshooting
+---------------
+
+Product Not Found
+~~~~~~~~~~~~~~~~~
+
+If your product doesn't appear in ``./wpt run --help``:
+
+* Verify entry point is registered correctly
+* Reinstall: ``pip uninstall wptrunner-mybrowser && pip install -e .``
+
+Import Errors
+~~~~~~~~~~~~~
+
+Ensure all imports are available::
+
+    from wptrunner.products import Product
+    from wptrunner.browsers.base import Browser
+
+Product Name Mismatch
+~~~~~~~~~~~~~~~~~~~~~
+
+Entry point name must match Product name::
+
+    'mybrowser = ...'  # Entry point
+    Product(name="mybrowser", ...)  # Product
+
+For usage with ``./wpt run``, see the running-tests documentation.

--- a/tools/wptrunner/wptrunner/browsers/__init__.py
+++ b/tools/wptrunner/wptrunner/browsers/__init__.py
@@ -21,24 +21,3 @@ a dictionary with the fields
 All classes and functions named in the above dict must be imported into the
 module global scope.
 """
-
-product_list = ["android_webview",
-                "chrome",
-                "chrome_android",
-                "chrome_ios",
-                "chromium",
-                "edge",
-                "firefox",
-                "firefox_android",
-                "headless_shell",
-                "safari",
-                "sauce",
-                "servo",
-                "servo_legacy",
-                "opera",
-                "webkit",
-                "webkitgtk_minibrowser",
-                "wpewebkit_minibrowser",
-                "wktr",
-                "epiphany",
-                "ladybird"]

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import functools
 import importlib
+import itertools
+import sys
 from dataclasses import dataclass
+from importlib.metadata import EntryPoint, entry_points
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -10,10 +14,8 @@ from typing import (
 )
 
 from ._default_if_sentinel import DefaultIfSentinel
-from .browsers import product_list
 
 if TYPE_CHECKING:
-    import sys
     from collections.abc import Mapping, Sequence
     from types import ModuleType
 
@@ -32,6 +34,88 @@ if TYPE_CHECKING:
 
 
 JSON: TypeAlias = "Mapping[str, 'JSON'] | Sequence['JSON'] | str | int | float | bool | None"
+
+
+# Hardcoded tuple of built-in products
+BUILTIN_PRODUCTS = frozenset(
+    (
+        "android_webview",
+        "chrome",
+        "chrome_android",
+        "chrome_ios",
+        "chromium",
+        "edge",
+        "epiphany",
+        "firefox",
+        "firefox_android",
+        "headless_shell",
+        "ladybird",
+        "opera",
+        "safari",
+        "sauce",
+        "servo",
+        "servo_legacy",
+        "webkit",
+        "webkitgtk_minibrowser",
+        "wktr",
+        "wpewebkit_minibrowser",
+    )
+)
+
+
+class _BuiltinLoaders:
+    """Namespace for builtin product loader functions.
+
+    Used by EntryPoint objects to provide a module:attribute reference
+    for builtin products.
+    """
+
+
+def _builtin_loader(name: str) -> Product:
+    if name not in BUILTIN_PRODUCTS:
+        raise ValueError(f"Unknown product: {name!r}")
+
+    module = importlib.import_module(f"wptrunner.browsers.{name}")
+    if not hasattr(module, "__wptrunner__"):
+        raise ValueError("Product module does not define __wptrunner__ variable")
+
+    return Product._from_dunder_wptrunner(module)
+
+
+for __product_name in BUILTIN_PRODUCTS:
+    setattr(
+        _BuiltinLoaders,
+        __product_name,
+        functools.partial(_builtin_loader, __product_name),
+    )
+
+
+_BUILTIN_ENTRY_POINTS: Sequence[EntryPoint] = [
+    EntryPoint(
+        name=product_name,
+        value=f"wptrunner.products:_BuiltinLoaders.{product_name}",
+        group="wptrunner.products",
+    )
+    for product_name in BUILTIN_PRODUCTS
+]
+
+
+def get_all_products() -> Mapping[str, EntryPoint]:
+    """Get a mapping of available products to their entry points.
+    """
+    if sys.version_info >= (3, 10):
+        eps = entry_points(group="wptrunner.products")
+    else:
+        eps = entry_points().get("wptrunner.products", [])
+
+    # We iterate over entry points in reverse order so the earlier ones
+    # (typically from earlier in sys.path) win over later ones. External
+    # entry points come after builtins, so they override builtins with the
+    # same name.
+    return {
+        ep.name: ep
+        for ep in itertools.chain(_BUILTIN_ENTRY_POINTS, reversed(eps))
+    }
 
 
 class CheckArgs(Protocol):
@@ -103,17 +187,6 @@ class WptrunnerModuleDict(_WptrunnerModuleDictOptional):
     executor: Mapping[str, str]
 
 
-def _product_module(product: str) -> ModuleType:
-    if product not in product_list:
-        raise ValueError(f"Unknown product {product!r}")
-
-    module = importlib.import_module("wptrunner.browsers." + product)
-    if not hasattr(module, "__wptrunner__"):
-        raise ValueError("Product module does not define __wptrunner__ variable")
-
-    return module
-
-
 def default_run_info_extras(logger: StructuredLogger, **kwargs: Any) -> Mapping[str, JSON]:
     return {}
 
@@ -179,7 +252,6 @@ class Product:
     name: str
     # Once we can rely on Python 3.10, we should add:
     # _: KW_ONLY
-    # This matches __init__ below.
     browser_classes: Mapping[str | None, type[browsers_base.Browser]]
     check_args: CheckArgs
     get_browser_kwargs: BrowserKwargs
@@ -268,6 +340,11 @@ class Product:
     def from_product_name(name: str) -> Product:
         """Load a Product by name.
 
+        Works for both builtin and external products via entry points.
+        Builtin products use synthetic EntryPoint objects that load from
+        wptrunner.browsers modules. External products use real entry points
+        from installed packages.
+
         Args:
             name: Product name (e.g., "chrome", "firefox", "mybrowser")
 
@@ -278,9 +355,22 @@ class Product:
             ValueError: If product name is unknown or entry point invalid
 
         """
-        module = _product_module(name)
-        product = Product._from_dunder_wptrunner(module)
-        if name != product.name:
-            msg = f"Product {name!r} calls itself {product.name!r}, which differs"
-            raise ValueError(msg)
+        all_products = get_all_products()
+
+        if name not in all_products:
+            raise ValueError(f"Unknown product {name!r}")
+
+        product = all_products[name].load()()
+
+        if not isinstance(product, Product):
+            raise TypeError(
+                f"Entry point {name!r} returned {type(product).__name__} "
+                f"instead of Product"
+            )
+
+        if product.name != name:
+            raise ValueError(
+                f"Entry point {name!r} returned Product with name={product.name!r}"
+            )
+
         return product

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -120,6 +120,62 @@ def default_run_info_extras(logger: StructuredLogger, **kwargs: Any) -> Mapping[
 
 @dataclass(frozen=True)
 class Product:
+    """Defines a browser product for wptrunner testing.
+
+    Product instances specify how to launch a browser, execute tests, and
+    collect results. They are used by both the wptrunner test harness and the
+    ./wpt run CLI command.
+
+    External packages can register custom products via entry points
+    in the 'wptrunner.products' group. See the wptrunner plugin documentation
+    for details on creating custom products.
+
+    Attributes:
+        name: Product identifier (e.g., "chrome", "firefox", "safari"). Must
+            match the entry point name when registered as a plugin.
+        browser_classes: Mapping from test type to Browser class. Use None
+            as the key for the default browser class used by most test types.
+            Can specify per-test-type browsers (e.g., {None: DefaultBrowser,
+            "wdspec": WdSpecBrowser}) for products that need different browser
+            behavior for different test types.
+        check_args: Function to validate command-line arguments specific to
+            this product. Called before test execution to ensure required
+            arguments are present and valid.
+        get_browser_kwargs: Function that returns kwargs for Browser
+            instantiation. Takes logger, test_type, run_info_data, config,
+            subsuite, and additional kwargs. Returns a dictionary of arguments
+            passed to the Browser class constructor.
+        get_executor_kwargs: Function that returns kwargs for Executor
+            instantiation. Takes logger, test_type, test_environment,
+            run_info_data, subsuite, and additional kwargs. Returns a
+            dictionary of arguments passed to the TestExecutor class
+            constructor.
+        env_options: Environment configuration dictionary. Must include 'host'
+            (hostname for test server) and 'bind_address' (whether to bind
+            to specific address). May include 'supports_debugger' and other
+            environment-specific options.
+        get_env_extras: Function that returns additional environment setup.
+            Takes kwargs and returns a sequence of objects used during test
+            environment initialization.
+        get_timeout_multiplier: Function that returns a timeout multiplier for
+            tests. Takes test_type, run_info_data, and kwargs. Returns a float
+            multiplier applied to test timeouts (e.g., 2.0 for slower browsers,
+            0.5 for faster ones).
+        executor_classes: Mapping from test type to Executor class. Must
+            include entries for each test type the product supports (e.g.,
+            {"testharness": WebDriverTestharnessExecutor, "reftest":
+            WebDriverRefTestExecutor}).
+        run_info_extras: Optional function that returns extra information to
+            include in run_info.json. Takes logger and kwargs, returns a
+            dictionary of additional metadata (e.g., browser version, build
+            number). Defaults to returning an empty dictionary if not provided.
+        update_properties: Optional tuple of (unconditional_properties,
+            conditional_properties) specifying which properties should trigger
+            manifest updates. Unconditional properties are always updated,
+            conditional properties depend on test conditions. Defaults to
+            (["product"], {}) if not provided.
+
+    """
     name: str
     # Once we can rely on Python 3.10, we should add:
     # _: KW_ONLY
@@ -150,6 +206,18 @@ class Product:
 
     @staticmethod
     def _from_dunder_wptrunner(module: ModuleType) -> Product:
+        """Create a Product instance from a module's __wptrunner__ dict.
+
+        Args:
+            module: Module containing __wptrunner__ dict with product configuration
+
+        Returns:
+            Product instance with all fields populated from the __wptrunner__ dict
+
+        Raises:
+            ValueError: If __wptrunner__ is missing or invalid
+
+        """
         data: WptrunnerModuleDict = module.__wptrunner__
 
         name = data["product"]
@@ -198,6 +266,18 @@ class Product:
 
     @staticmethod
     def from_product_name(name: str) -> Product:
+        """Load a Product by name.
+
+        Args:
+            name: Product name (e.g., "chrome", "firefox", "mybrowser")
+
+        Returns:
+            Product instance
+
+        Raises:
+            ValueError: If product name is unknown or entry point invalid
+
+        """
         module = _product_module(name)
         product = Product._from_dunder_wptrunner(module)
         if name != product.name:

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import functools
 import importlib
 import itertools
@@ -170,9 +171,15 @@ class TimeoutMultiplier(Protocol):
         ...
 
 
+class AddArguments(Protocol):
+    def __call__(self, parser: argparse.ArgumentParser) -> None:
+        ...
+
+
 class _WptrunnerModuleDictOptional(TypedDict, total=False):
     run_info_extras: str
     update_properties: str
+    add_arguments: str
 
 
 class WptrunnerModuleDict(_WptrunnerModuleDictOptional):
@@ -189,6 +196,10 @@ class WptrunnerModuleDict(_WptrunnerModuleDictOptional):
 
 def default_run_info_extras(logger: StructuredLogger, **kwargs: Any) -> Mapping[str, JSON]:
     return {}
+
+
+def default_add_arguments(parser: argparse.ArgumentParser) -> None:
+    pass
 
 
 @dataclass(frozen=True)
@@ -247,6 +258,10 @@ class Product:
             manifest updates. Unconditional properties are always updated,
             conditional properties depend on test conditions. Defaults to
             (["product"], {}) if not provided.
+        add_arguments: Optional function to add product-specific command-line
+            arguments to the argument parser. Takes an ArgumentParser and adds
+            any product-specific arguments. Called during argument parser setup
+            for all available products. Defaults to a no-op if not provided.
 
     """
     name: str
@@ -269,6 +284,9 @@ class Product:
             Mapping[str, Sequence[str]],
         ],
     ] = DefaultIfSentinel(default_factory=lambda: (["product"], {}))
+    add_arguments: DefaultIfSentinel[
+        AddArguments,
+    ] = DefaultIfSentinel(default=default_add_arguments)
 
     def get_browser_cls(self, test_type: str) -> type[browsers_base.Browser]:
         cls = self.browser_classes.get(test_type)
@@ -321,6 +339,11 @@ class Product:
             if "update_properties" in data
             else None
         )
+        add_arguments = (
+            getattr(module, data["add_arguments"])
+            if "add_arguments" in data
+            else None
+        )
 
         return Product(
             name=name,
@@ -334,6 +357,7 @@ class Product:
             executor_classes=executor_classes,
             run_info_extras=run_info_extras,
             update_properties=update_properties,
+            add_arguments=add_arguments,
         )
 
     @staticmethod

--- a/tools/wptrunner/wptrunner/tests/base.py
+++ b/tools/wptrunner/wptrunner/tests/base.py
@@ -1,33 +1,29 @@
 # mypy: allow-untyped-defs
 
 import os
-import sys
 
-from os.path import dirname, join
 
 import pytest
 
-sys.path.insert(0, join(dirname(__file__), "..", ".."))
-
-from .. import browsers
+from ..products import get_all_products
 
 
-_products = browsers.product_list
+_products = set(get_all_products())
 _active_products = set()
 
 if "CURRENT_TOX_ENV" in os.environ:
-    current_tox_env_split = os.environ["CURRENT_TOX_ENV"].split("-")
+    current_tox_env_split = set(os.environ["CURRENT_TOX_ENV"].split("-"))
 
     tox_env_extra_browsers = {
         "chrome": {"chrome_android"},
         "servo": {"servo_legacy"},
     }
 
-    _active_products = set(_products) & set(current_tox_env_split)
+    _active_products = _products & set(current_tox_env_split)
     for product in frozenset(_active_products):
         _active_products |= tox_env_extra_browsers.get(product, set())
 else:
-    _active_products = set(_products)
+    _active_products = _products
 
 
 class all_products:

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -91,12 +91,18 @@ def test_default_if_none_descriptor_with_none() -> None:
 
     assert product.run_info_extras is products.default_run_info_extras
     assert product.update_properties == (["product"], {})
+    assert product.add_arguments is products.default_add_arguments
 
 
 def test_default_if_none_descriptor_with_provided_values() -> None:
     """Test that _DefaultIfNone descriptor preserves provided values"""
     def custom_run_info_extras(logger, **kwargs):
         return {"custom": "value"}
+
+    def custom_add_arguments(parser):
+        group = parser.add_argument_group("Test-specific")
+        group.add_argument("--test-option", help="A test option")
+        group.add_argument("--another-option", type=int, default=42)
 
     custom_update_properties = (["custom"], {"prop": ["value"]})
 
@@ -112,10 +118,29 @@ def test_default_if_none_descriptor_with_provided_values() -> None:
         executor_classes={},
         run_info_extras=custom_run_info_extras,
         update_properties=custom_update_properties,
+        add_arguments=custom_add_arguments,
     )
 
     assert product.run_info_extras is custom_run_info_extras
     assert product.update_properties is custom_update_properties
+    assert product.add_arguments is custom_add_arguments
+
+
+def test_create_parser_calls_add_arguments() -> None:
+    """Test that create_parser calls add_arguments for available products."""
+    def custom_add_arguments(parser):
+        parser.add_argument("--custom-product-option")
+
+    mock_product = mock.MagicMock(spec=products.Product)
+    mock_product.add_arguments = custom_add_arguments
+
+    with mock.patch("wptrunner.products.get_all_products", return_value={"mockbrowser": mock.MagicMock()}):
+        with mock.patch("wptrunner.products.Product.from_product_name", return_value=mock_product):
+            parser = wptcommandline.create_parser(product_choices=["mockbrowser"])
+
+    args = parser.parse_args(["--product", "mockbrowser", "--custom-product-option", "value"])
+    assert args.custom_product_option == "value"
+
 
 @pytest.mark.parametrize("product", products.BUILTIN_PRODUCTS)
 def test_get_product_names_includes_builtins(product):

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -1,15 +1,15 @@
 # mypy: allow-untyped-defs, allow-untyped-calls
 
+import sys
 import warnings
-from os.path import join, dirname
+from os.path import dirname, join
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 
-from .base import all_products, active_products
-from .. import environment
-from .. import products
-from .. import wptcommandline
+from .. import environment, products, wptcommandline
+from .base import active_products, all_products
 
 wpt_root = join(dirname(__file__), "..", "..", "..", "..")
 
@@ -38,6 +38,12 @@ def test_load_all_products(product):
             products.Product.from_product_name(product)
         except ImportError:
             pass
+
+
+def test_product_from_name_unknown():
+    """Test that Product.from_product_name raises ValueError for unknown products."""
+    with pytest.raises(ValueError, match="Unknown product"):
+        products.Product.from_product_name("nonexistent_product")
 
 
 @active_products("product", marks={
@@ -110,3 +116,85 @@ def test_default_if_none_descriptor_with_provided_values() -> None:
 
     assert product.run_info_extras is custom_run_info_extras
     assert product.update_properties is custom_update_properties
+
+@pytest.mark.parametrize("product", products.BUILTIN_PRODUCTS)
+def test_get_product_names_includes_builtins(product):
+    """Test that built-in products are included."""
+    names = products.get_all_products()
+    assert product in names
+
+
+def test_entry_point_is_callable():
+    """Test that loading a non-callable entry point raises TypeError."""
+    mock_ep = Mock()
+    mock_ep.name = "badproduct"
+    mock_ep.load.return_value = "not callable"
+
+    if sys.version_info >= (3, 10):
+        return_value = [mock_ep]
+    else:
+        return_value = {"wptrunner.products": [mock_ep]}
+
+    with mock.patch("wptrunner.products.entry_points", autospec=True, return_value=return_value):
+        with pytest.raises(TypeError):
+            products.Product.from_product_name("badproduct")
+
+
+def test_entry_point_returns_product():
+    """Test that entry point callable must return Product instance."""
+    mock_ep = Mock()
+    mock_ep.name = "badproduct"
+    mock_ep.load.return_value = lambda: "not a Product instance"
+
+    if sys.version_info >= (3, 10):
+        return_value = [mock_ep]
+    else:
+        return_value = {"wptrunner.products": [mock_ep]}
+
+    with mock.patch("wptrunner.products.entry_points", autospec=True, return_value=return_value):
+        with pytest.raises(TypeError, match="instead of Product"):
+            products.Product.from_product_name("badproduct")
+
+
+def test_entry_point_product_name_validation():
+    """Test that entry point name must match Product.name."""
+    def get_product_wrong_name():
+        mock_product = Mock(spec=products.Product)
+        mock_product.name = "actual_name"
+        return mock_product
+
+    mock_ep = Mock()
+    mock_ep.name = "wrong_name"
+    mock_ep.load.return_value = get_product_wrong_name
+
+    if sys.version_info >= (3, 10):
+        return_value = [mock_ep]
+    else:
+        return_value = {"wptrunner.products": [mock_ep]}
+
+    with mock.patch("wptrunner.products.entry_points", autospec=True, return_value=return_value):
+        with pytest.raises(ValueError, match="name="):
+            products.Product.from_product_name("wrong_name")
+
+
+@active_products("product")
+def test_entry_point_shadows_builtin(product):
+    """Test that external entry points can shadow built-in products."""
+    if product not in products.BUILTIN_PRODUCTS:
+        pytest.skip("Only applies to built-ins")
+
+    ep = next(ep for ep in products._BUILTIN_ENTRY_POINTS if ep.name == product)
+
+    mock_ep = Mock(wraps=ep)
+    mock_ep.name = ep.name
+    mock_ep.load.return_value = lambda: None
+
+    if sys.version_info >= (3, 10):
+        return_value = [mock_ep]
+    else:
+        return_value = {"wptrunner.products": [mock_ep]}
+
+    with mock.patch("wptrunner.products.entry_points", autospec=True, return_value=return_value):
+        with pytest.raises(TypeError, match="instead of Product"):
+            product = products.Product.from_product_name(product)
+        mock_ep.load.assert_called_once()

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -445,6 +445,16 @@ scheme host and port.""")
     commandline.log_formatters["wptscreenshot"] = (wptscreenshot.WptscreenshotFormatter, "wpt.fyi screenshots")
 
     commandline.add_logging_group(parser)
+
+    for product_name in products.get_all_products():
+        try:
+            product = products.Product.from_product_name(product_name)
+        except Exception as e:
+            print(f"Warning: could not load product {product_name!r} for argument registration: {e}",
+                  file=sys.stderr)
+        else:
+            product.add_arguments(parser)
+
     return parser
 
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -41,7 +41,7 @@ def create_parser(product_choices=None):
     from mozlog import commandline
 
     if product_choices is None:
-        product_choices = products.product_list
+        product_choices = list(products.get_all_products())
 
     parser = argparse.ArgumentParser(description="""Runner for web-platform-tests tests.""",
                                      usage="""%(prog)s [OPTION]... [TEST]...
@@ -741,7 +741,7 @@ def create_parser_metadata_update(product_choices=None):
     from . import products
 
     if product_choices is None:
-        product_choices = products.product_list
+        product_choices = list(products.get_all_products())
 
     parser = argparse.ArgumentParser("web-platform-tests-update",
                                      description="Update script for web-platform-tests tests.")


### PR DESCRIPTION
This builds on top of #57503, adding the ability to define products external to wptrunner. It probably makes sense to review that (the first commit on this branch) separately.