### PR TITLE
[css-forms-1] Drop color space argument from color-mix() in UA styles.

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select-listbox/resources/customizable-select-listbox.css
+++ b/html/semantics/forms/the-select-element/customizable-select-listbox/resources/customizable-select-listbox.css
@@ -7,9 +7,9 @@
 }
 
 .customizable-select-listbox.disabled {
-  color: color-mix(in lab, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }
 
 .customizable-select-listbox:not(.disabled) .customizable-select-legend.disabled {
-  color: color-mix(in lab, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }

--- a/html/semantics/forms/the-select-element/customizable-select/resources/customizable-select-styles.css
+++ b/html/semantics/forms/the-select-element/customizable-select/resources/customizable-select-styles.css
@@ -40,7 +40,7 @@
 }
 
 .customizable-select-option.disabled {
-  color: color-mix(in lab, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }
 
 .customizable-select-option::before {
@@ -74,15 +74,15 @@
 }
 
 .customizable-select-button.disabled {
-  color: color-mix(in srgb, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }
 
 .customizable-select-button.hover {
-  background-color: color-mix(in lab, currentColor 10%, transparent);
+  background-color: color-mix(currentColor 10%, transparent);
 }
 
 .customizable-select-button.active {
-  background-color: color-mix(in lab, currentColor 20%, transparent);
+  background-color: color-mix(currentColor 20%, transparent);
 }
 
 .customizable-select-button::after {

--- a/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles.html
@@ -40,14 +40,14 @@ promise_test(async () => {
   await new Promise(requestAnimationFrame);
   assert_equals(getComputedStyle(optionOne).color, 'rgb(0, 0, 0)',
     'Option color while hovering.');
-  assert_equals(getComputedStyle(optionOne).backgroundColor, 'lab(0 0 0 / 0.1)',
+  assert_equals(getComputedStyle(optionOne).backgroundColor, 'oklab(0 0 0 / 0.1)',
     'Option background-color while hovering.');
 
   await (new test_driver.Actions()
     .pointerMove(1, 1, {origin: disabledOption}))
     .send();
   await new Promise(requestAnimationFrame);
-  assert_equals(getComputedStyle(disabledOption).color, 'lab(0 0 0 / 0.5)',
+  assert_equals(getComputedStyle(disabledOption).color, 'oklab(0 0 0 / 0.5)',
     'Disabled option color while hovering.');
   assert_equals(getComputedStyle(disabledOption).backgroundColor, 'rgba(0, 0, 0, 0)',
     'Disabled option background-color while hovering.');


### PR DESCRIPTION
Matches https://github.com/w3c/csswg-drafts/commit/b063dbef8059420dabd93f7643ce64a77102ed68 and https://github.com/w3c/csswg-drafts/issues/13496