### PR TITLE
DNS server support for wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -96,7 +96,7 @@ class TestEnvironment:
     websockets servers"""
     def __init__(self, test_paths, testharness_timeout_multipler,
                  pause_after_test, debug_test, debug_info, options, ssl_config, env_extras,
-                 enable_webtransport=False, enable_dns=False, mojojs_path=None, inject_script=None,
+                 enable_webtransport=None, enable_dns=None, mojojs_path=None, inject_script=None,
                  suppress_handler_traceback=None, ws_extra=None):
 
         self.test_paths = test_paths
@@ -120,8 +120,16 @@ class TestEnvironment:
         self.env_extras = env_extras
         self.env_extras_cms = None
         self.ssl_config = ssl_config
-        self.enable_webtransport = enable_webtransport
-        self.enable_dns = enable_dns
+        self.enable_webtransport = (
+            enable_webtransport
+            if enable_webtransport is not None
+            else self.options.get("enable_webtransport_h3", False)
+        )
+        self.enable_dns = (
+            enable_dns
+            if enable_dns is not None
+            else self.options.get("enable_dns", False)
+        )
         self.mojojs_path = mojojs_path
         self.inject_script = inject_script
         self.suppress_handler_traceback = suppress_handler_traceback

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -96,7 +96,7 @@ class TestEnvironment:
     websockets servers"""
     def __init__(self, test_paths, testharness_timeout_multipler,
                  pause_after_test, debug_test, debug_info, options, ssl_config, env_extras,
-                 enable_webtransport=False, mojojs_path=None, inject_script=None,
+                 enable_webtransport=False, enable_dns=False, mojojs_path=None, inject_script=None,
                  suppress_handler_traceback=None, ws_extra=None):
 
         self.test_paths = test_paths
@@ -121,6 +121,7 @@ class TestEnvironment:
         self.env_extras_cms = None
         self.ssl_config = ssl_config
         self.enable_webtransport = enable_webtransport
+        self.enable_dns = enable_dns
         self.mojojs_path = mojojs_path
         self.inject_script = inject_script
         self.suppress_handler_traceback = suppress_handler_traceback
@@ -150,7 +151,8 @@ class TestEnvironment:
                                    self.get_routes(),
                                    mp_context=mpcontext.get_context(),
                                    log_handlers=[server_log_handler],
-                                   webtransport_h3=self.enable_webtransport)
+                                   webtransport_h3=self.enable_webtransport,
+                                   dns=self.enable_dns)
 
         if self.options.get("supports_debugger") and self.debug_info and self.debug_info.interactive:
             self._stack.enter_context(self.ignore_interrupts())
@@ -197,6 +199,7 @@ class TestEnvironment:
             "wss": [8889],
             "h2": [9000],
             "webtransport-h3": [11000],
+            "dns": [8053],
         }
         config.ports = ports
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -168,6 +168,12 @@ scheme host and port.""")
                                       help="Enable tests that require WebTransport over HTTP/3 server (default: false)")
     test_selection_group.add_argument("--no-enable-webtransport-h3", action="store_false", dest="enable_webtransport_h3",
                                       help="Do not enable WebTransport tests on experimental channels")
+    test_selection_group.add_argument("--enable-dns",
+                                      action="store_true",
+                                      default=None,
+                                      help="Enable the DNS server for resolving test domains")
+    test_selection_group.add_argument("--no-enable-dns", action="store_false", dest="enable_dns",
+                                      help="Do not enable DNS server")
     test_selection_group.add_argument("--tag", action="append", dest="tags",
                                       help="Labels applied to tests to include in the run. "
                                            "Labels starting dir: are equivalent to top-level directories.")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -477,6 +477,7 @@ def run_tests(config, product, test_paths, **kwargs):
                                  ssl_config,
                                  env_extras,
                                  kwargs["enable_webtransport_h3"],
+                                 kwargs["enable_dns"],
                                  mojojs_path,
                                  inject_script,
                                  kwargs["suppress_handler_traceback"],


### PR DESCRIPTION
I'm not entirely sure if it makes sense to have both of these commits — I'm not sure when `--enable-dns` might be a sensible thing to pass, despite it following the pattern of the rest of the servers, though it is clearly somewhat different.