### PR TITLE
[wptrunner] Coerce script timeout to integer for non-wdspec tests

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -81,7 +81,11 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
         return method(script, args=args)
 
     def set_timeout(self, timeout):
-        self.webdriver.timeouts.script = timeout
+        # TODO(webdriver/w3c#1949): The struct definition contradicts the
+        # algorithm on whether fractional timeouts are allowed. There's not a
+        # large difference for non-wdspec testing either way, so coerce to int
+        # until there's a resolution.
+        self.webdriver.timeouts.script = int(timeout)
 
     def create_window(self, type=None, **kwargs):
         # WebKitGTK-based browsers have issues when the test is opened in a new tab instead of a separate window


### PR DESCRIPTION
https://crrev.com/c/7522226 seems to have caused Chrome on iOS results to disappear from wpt.fyi because the final timeout is [fractional]:

```
webdriver.error.InvalidArgumentException: invalid argument (500): Timeouts must be non-negative integers
```

This can be replicated with the right `wpt run --timeout-multiplier`, so avoid fractional timeouts in general. The spec for "Set Timeouts" isn't clear on how they should be handled (w3c/webdriver#1949), but the de facto behavior is to return "invalid argument".

Note that the WebDriver client can still send fractional timeouts to test invalid values.

[fractional]: https://chromium-swarm.appspot.com/task?id=7673a57e106bad10&w=true