### PR TITLE
Add plumbing for safe printable inset to wptrunner and webdriver.

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -293,10 +293,16 @@ class PrintRefTest(RefTest):
     def page_ranges(self) -> PageRanges:
         return cast(PageRanges, self._extras.get("page_ranges", {}))
 
+    @property
+    def safe_printable_inset(self) -> float:
+        return self._extras.get("safe_printable_inset")
+
     def to_json(self):  # type: ignore
         rv = super().to_json()
         if self.page_ranges:
             rv[-1]["page_ranges"] = self.page_ranges
+        if self.safe_printable_inset:
+            rv[-1]["safe_printable_inset"] = self.safe_printable_inset
         return rv
 
 

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -295,7 +295,7 @@ class PrintRefTest(RefTest):
 
     @property
     def safe_printable_inset(self) -> float:
-        return self._extras.get("safe_printable_inset")
+        return cast(float, self._extras.get("safe_printable_inset"))
 
     def to_json(self):  # type: ignore
         rv = super().to_json()

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -294,8 +294,8 @@ class PrintRefTest(RefTest):
         return cast(PageRanges, self._extras.get("page_ranges", {}))
 
     @property
-    def safe_printable_inset(self) -> float:
-        return cast(float, self._extras.get("safe_printable_inset"))
+    def safe_printable_inset(self) -> Optional[float]:
+        return self._extras.get("safe_printable_inset")
 
     def to_json(self):  # type: ignore
         rv = super().to_json()

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -676,6 +676,14 @@ class SourceFile:
         return rv
 
     @cached_property
+    def safe_printable_inset(self) -> Optional[float]:
+        """The safe printable inset to simulate (in centimeters)"""
+        for entry in self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='safe-printable-inset']"):
+            key_data, value = self.parse_ref_keyed_meta(entry)
+            return float(value)
+        return None
+
+    @cached_property
     def testharness_nodes(self) -> List[ElementTree.Element]:
         """List of ElementTree Elements corresponding to nodes representing a
         testharness.js script"""
@@ -1023,6 +1031,7 @@ class SourceFile:
                     viewport_size=self.viewport_size,
                     fuzzy=self.fuzzy,
                     page_ranges=self.page_ranges,
+                    safe_printable_inset=self.safe_printable_inset,
                     testdriver=self.has_testdriver,
                 )]
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -678,6 +678,7 @@ class SourceFile:
     @cached_property
     def safe_printable_inset(self) -> Optional[float]:
         """The safe printable inset to simulate (in centimeters)"""
+        assert self.root is not None
         for entry in self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='safe-printable-inset']"):
             key_data, value = self.parse_ref_keyed_meta(entry)
             return float(value)

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -681,7 +681,10 @@ class SourceFile:
         assert self.root is not None
         for entry in self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='safe-printable-inset']"):
             key_data, value = self.parse_ref_keyed_meta(entry)
-            return float(value)
+            result = float(value)
+            if result < 0:
+                raise ValueError("Negative value")
+            return result
         return None
 
     @cached_property

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -988,7 +988,7 @@ def test_safe_printable_inset(safe_printable_inset, expected):
     assert s.safe_printable_inset == {"/foo/test-print.html": expected}
 
 
-@pytest.mark.parametrize("safe_printable_inset", [b"banana", b"auto", b"-1", b"0,0"])
+@pytest.mark.parametrize("safe_printable_inset", [b"ananas", b"auto", b"-1", b"0,0"])
 def test_safe_printable_inset_invalid(safe_printable_inset):
     content = b"""<link rel=match href=ref.html>
 <meta name=safe-printable-inset content="%s">

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -973,6 +973,32 @@ def test_page_ranges_invalid(page_ranges):
         s.page_ranges
 
 
+@pytest.mark.parametrize("safe_printable_area, expected", [
+    (b"0", 0),
+    (b"0.5", 0.5),
+    (b"2.54", 2.54),
+    (b"100", 100)])
+def test_safe_printable_area(safe_printable_area, expected):
+    content = b"""<link rel=match href=ref.html>
+<meta name=reftest-pages content="%s">
+""" % safe_printable_area
+
+    s = create("foo/test-print.html", content)
+
+    assert s.safe_printable_area == {"/foo/test-print.html": expected}
+
+
+@pytest.mark.parametrize("safe_printable_area", [b"banana", b"auto", b"-1", b"0,0"])
+def test_safe_printable_area_invalid(safe_printable_area):
+    content = b"""<link rel=match href=ref.html>
+<meta name=reftest-pages content="%s">
+""" % safe_printable_area
+
+    s = create("foo/test-print.html", content)
+    with pytest.raises(ValueError):
+        s.safe_printable_area
+
+
 def test_hash():
     s = SourceFile("/", "foo", "/", contents=b"Hello, World!")
     assert "b45ef6fec89518d314f546fd6c3025367b721684" == s.hash

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -980,7 +980,7 @@ def test_page_ranges_invalid(page_ranges):
     (b"100", 100)])
 def test_safe_printable_inset(safe_printable_inset, expected):
     content = b"""<link rel=match href=ref.html>
-<meta name=reftest-pages content="%s">
+<meta name=safe-printable-inset content="%s">
 """ % safe_printable_inset
 
     s = create("foo/test-print.html", content)
@@ -991,7 +991,7 @@ def test_safe_printable_inset(safe_printable_inset, expected):
 @pytest.mark.parametrize("safe_printable_inset", [b"banana", b"auto", b"-1", b"0,0"])
 def test_safe_printable_inset_invalid(safe_printable_inset):
     content = b"""<link rel=match href=ref.html>
-<meta name=reftest-pages content="%s">
+<meta name=safe-printable-inset content="%s">
 """ % safe_printable_inset
 
     s = create("foo/test-print.html", content)

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -973,30 +973,30 @@ def test_page_ranges_invalid(page_ranges):
         s.page_ranges
 
 
-@pytest.mark.parametrize("safe_printable_area, expected", [
+@pytest.mark.parametrize("safe_printable_inset, expected", [
     (b"0", 0),
     (b"0.5", 0.5),
     (b"2.54", 2.54),
     (b"100", 100)])
-def test_safe_printable_area(safe_printable_area, expected):
+def test_safe_printable_inset(safe_printable_inset, expected):
     content = b"""<link rel=match href=ref.html>
 <meta name=reftest-pages content="%s">
-""" % safe_printable_area
+""" % safe_printable_inset
 
     s = create("foo/test-print.html", content)
 
-    assert s.safe_printable_area == {"/foo/test-print.html": expected}
+    assert s.safe_printable_inset == {"/foo/test-print.html": expected}
 
 
-@pytest.mark.parametrize("safe_printable_area", [b"banana", b"auto", b"-1", b"0,0"])
-def test_safe_printable_area_invalid(safe_printable_area):
+@pytest.mark.parametrize("safe_printable_inset", [b"banana", b"auto", b"-1", b"0,0"])
+def test_safe_printable_inset_invalid(safe_printable_inset):
     content = b"""<link rel=match href=ref.html>
 <meta name=reftest-pages content="%s">
-""" % safe_printable_area
+""" % safe_printable_inset
 
     s = create("foo/test-print.html", content)
     with pytest.raises(ValueError):
-        s.safe_printable_area
+        s.safe_printable_inset
 
 
 def test_hash():

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -985,7 +985,7 @@ def test_safe_printable_inset(safe_printable_inset, expected):
 
     s = create("foo/test-print.html", content)
 
-    assert s.safe_printable_inset == {"/foo/test-print.html": expected}
+    assert s.safe_printable_inset == expected
 
 
 @pytest.mark.parametrize("safe_printable_inset", [b"ananas", b"auto", b"-1", b"0,0"])

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -791,6 +791,7 @@ class Session:
         orientation=None,
         page=None,
         page_ranges=None,
+        safe_printable_inset=None,
         scale=None,
         shrink_to_fit=None,
     ):
@@ -801,6 +802,7 @@ class Session:
             "orientation": orientation,
             "page": page,
             "pageRanges": page_ranges,
+            "safePrintableInset": safe_printable_inset,
             "scale": scale,
             "shrinkToFit": shrink_to_fit,
         }.items():

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -418,11 +418,11 @@ class RefTestImplementation:
     def logger(self):
         return self.executor.logger
 
-    def get_hash(self, test, viewport_size, dpi, page_ranges):
+    def get_hash(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         key = (test.url, viewport_size, dpi)
 
         if key not in self.screenshot_cache:
-            success, data = self.get_screenshot_list(test, viewport_size, dpi, page_ranges)
+            success, data = self.get_screenshot_list(test, viewport_size, dpi, page_ranges, safe_printable_inset)
 
             if not success:
                 return False, data
@@ -524,8 +524,8 @@ class RefTestImplementation:
         viewport_size = test.viewport_size
         dpi = test.dpi
         page_ranges = test.page_ranges
+        safe_printable_inset = test.safe_printable_inset
         self.message = []
-
 
         # Depth-first search of reference tree, with the goal
         # of reachings a leaf node with only pass results
@@ -541,7 +541,7 @@ class RefTestImplementation:
             fuzzy = self.get_fuzzy(test, nodes, relation)
 
             for i, node in enumerate(nodes):
-                success, data = self.get_hash(node, viewport_size, dpi, page_ranges)
+                success, data = self.get_hash(node, viewport_size, dpi, page_ranges, safe_printable_inset)
                 if success is False:
                     return {"status": data[0], "message": data[1]}
 
@@ -575,7 +575,7 @@ class RefTestImplementation:
 
         for i, (node, screenshot) in enumerate(zip(nodes, screenshots)):
             if screenshot is None:
-                success, screenshot = self.retake_screenshot(node, viewport_size, dpi, page_ranges)
+                success, screenshot = self.retake_screenshot(node, viewport_size, dpi, page_ranges, safe_printable_inset)
                 if success:
                     screenshots[i] = screenshot
 
@@ -606,11 +606,12 @@ class RefTestImplementation:
                 break
         return value
 
-    def retake_screenshot(self, node, viewport_size, dpi, page_ranges):
+    def retake_screenshot(self, node, viewport_size, dpi, page_ranges, safe_printable_inset):
         success, data = self.get_screenshot_list(node,
                                                  viewport_size,
                                                  dpi,
-                                                 page_ranges)
+                                                 page_ranges,
+                                                 safe_printable_inset)
         if not success:
             return False, data
 
@@ -641,8 +642,8 @@ class RefTestImplementation:
 
         return struct.unpack(">LL", image_data[16:24])
 
-    def get_screenshot_list(self, node, viewport_size, dpi, page_ranges):
-        success, data = self.executor.screenshot(node, viewport_size, dpi, page_ranges)
+    def get_screenshot_list(self, node, viewport_size, dpi, page_ranges, safe_printable_inset):
+        success, data = self.executor.screenshot(node, viewport_size, dpi, page_ranges, safe_printable_inset)
         viewport_size = (800, 600) if viewport_size is None else viewport_size
         dpi = 96 if dpi is None else dpi
         dpcm = dpi / 2.54

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -419,7 +419,7 @@ class RefTestImplementation:
         return self.executor.logger
 
     def get_hash(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
-        key = (test.url, viewport_size, dpi)
+        key = (test.url, viewport_size, dpi, safe_printable_inset)
 
         if key not in self.screenshot_cache:
             success, data = self.get_screenshot_list(test, viewport_size, dpi, page_ranges, safe_printable_inset)

--- a/tools/wptrunner/wptrunner/executors/executoredge.py
+++ b/tools/wptrunner/wptrunner/executors/executoredge.py
@@ -35,7 +35,7 @@ class EdgeDriverPrintRefTestExecutor(EdgeDriverRefTestExecutor):
         with open(os.path.join(here, "reftest.js")) as f:
             self.script = f.read()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         # https://github.com/web-platform-tests/wpt/issues/7140
         assert dpi is None
 
@@ -62,7 +62,7 @@ class EdgeDriverPrintRefTestExecutor(EdgeDriverRefTestExecutor):
 
         protocol.base.execute_script(self.wait_script, asynchronous=True)
 
-        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size)
+        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size, self.safe_printable_inset)
         screenshots = protocol.pdf_print.pdf_to_png(pdf, self.page_ranges)
         for i, screenshot in enumerate(screenshots):
             # strip off the data:img/png, part of the url

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -683,7 +683,7 @@ class MarionettePrintProtocolPart(PrintProtocolPart):
             raise
         self.runner_handle = self.marionette.current_window_handle
 
-    def render_as_pdf(self, width, height):
+    def render_as_pdf(self, width, height, safe_printable_inset):
         margin = 0.5 * 2.54
         body = {
             "page": {
@@ -701,7 +701,7 @@ class MarionettePrintProtocolPart(PrintProtocolPart):
         }
         return self.marionette._send_message("WebDriver:Print", body, key="value")
 
-    def pdf_to_png(self, pdf_base64, page_ranges):
+    def pdf_to_png(self, pdf_base64, page_ranges, safe_printable_inset):
         handle = self.marionette.current_window_handle
         _switch_to_window(self.marionette, self.runner_handle)
         try:
@@ -1227,7 +1227,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
 
         return self.convert_result(test, result)
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         # https://github.com/web-platform-tests/wpt/issues/7135
         assert viewport_size is None
         assert dpi is None
@@ -1431,7 +1431,7 @@ class MarionettePrintRefTestExecutor(MarionetteRefTestExecutor):
         if not isinstance(self.implementation, InternalRefTestImplementation):
             self.protocol.pdf_print.load_runner()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         # https://github.com/web-platform-tests/wpt/issues/7140
         assert dpi is None
 
@@ -1453,7 +1453,7 @@ class MarionettePrintRefTestExecutor(MarionetteRefTestExecutor):
 
         protocol.base.execute_script(self.wait_script, asynchronous=True)
 
-        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size)
+        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size, self.safe_printable_inset)
         screenshots = protocol.pdf_print.pdf_to_png(pdf, self.page_ranges)
         for i, screenshot in enumerate(screenshots):
             # strip off the data:img/png, part of the url

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -442,7 +442,7 @@ class SeleniumRefTestExecutor(RefTestExecutor):
 
         return self.convert_result(test, result)
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         # https://github.com/web-platform-tests/wpt/issues/7135
         assert viewport_size is None
         assert dpi is None

--- a/tools/wptrunner/wptrunner/executors/executorservolegacy.py
+++ b/tools/wptrunner/wptrunner/executors/executorservolegacy.py
@@ -244,7 +244,7 @@ class ServoLegacyRefTestExecutor(ServoExecutorMixin, RefTestExecutor):
         os.rmdir(self.tempdir)
         super().teardown()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         with TempFilename(self.tempdir) as output_path:
             extra_args = ["--exit",
                           "--output=%s" % output_path,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -519,7 +519,7 @@ class WebDriverPrintProtocolPart(PrintProtocolPart):
             raise
         self.runner_handle = self.webdriver.window_handle
 
-    def render_as_pdf(self, width, height):
+    def render_as_pdf(self, width, height, safe_printable_inset_param):
         # All units passed to `print()` are in cm. See [0] for testing specifications.
         #
         # [0]: https://web-platform-tests.org/writing-tests/print-reftests.html
@@ -527,6 +527,7 @@ class WebDriverPrintProtocolPart(PrintProtocolPart):
         pdf_base64 = self.webdriver.print(page={"width": width, "height": height},
                                           margin={"top": margin, "right": margin, "bottom": margin,
                                                   "left": margin},
+                                          safe_printable_inset=safe_printable_inset_param,
                                           background=True,
                                           shrink_to_fit=False)
         return pdf_base64
@@ -1383,7 +1384,7 @@ class WebDriverRefTestExecutor(RefTestExecutor):
 
         return self.convert_result(test, result)
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         # https://github.com/web-platform-tests/wpt/issues/7135
         assert viewport_size is None
         assert dpi is None
@@ -1423,7 +1424,7 @@ class WebDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
         with open(os.path.join(here, "reftest.js")) as f:
             self.script = f.read()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, safe_printable_inset):
         # https://github.com/web-platform-tests/wpt/issues/7140
         assert dpi is None
 
@@ -1434,6 +1435,7 @@ class WebDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
 
         self.viewport_size = viewport_size
         self.page_ranges = page_ranges.get(test.url)
+        self.safe_printable_inset = safe_printable_inset
         timeout = self.timeout_multiplier * test.timeout if self.debug_info is None else None
         test_url = self.test_url(test)
 
@@ -1449,7 +1451,7 @@ class WebDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
         # return value.
         protocol.testdriver.run(url, self.wait_script)
 
-        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size)
+        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size, self.safe_printable_inset)
         screenshots = protocol.pdf_print.pdf_to_png(pdf, self.page_ranges)
         for i, screenshot in enumerate(screenshots):
             # strip off the data:img/png, part of the url

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1134,7 +1134,7 @@ class PrintProtocolPart(ProtocolPart):
     name = "pdf_print"
 
     @abstractmethod
-    def render_as_pdf(self, width, height):
+    def render_as_pdf(self, width, height, safe_printable_inset):
         """Output document as PDF"""
         pass
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -699,22 +699,28 @@ class ReftestTest(Test):
     def page_ranges(self):
         return {}
 
+    @property
+    def safe_printable_inset(self):
+        return 0
 
 class PrintReftestTest(ReftestTest):
     test_type = "print-reftest"
 
     def __init__(self, url_base, tests_root, url, inherit_metadata, test_metadata, references,
                  timeout=None, path=None, viewport_size=None, dpi=None, fuzzy=None,
-                 page_ranges=None, protocol="http", subdomain=False, testdriver=False):
+                 page_ranges=None, safe_printable_inset=None, protocol="http", subdomain=False,
+                 testdriver=False):
         super().__init__(url_base, tests_root, url, inherit_metadata, test_metadata,
                          references, timeout, path, viewport_size, dpi,
                          fuzzy, protocol, subdomain=subdomain, testdriver=testdriver)
         self._page_ranges = page_ranges
+        self._safe_printable_inset = safe_printable_inset
 
     @classmethod
     def cls_kwargs(cls, manifest_test):
         rv = super().cls_kwargs(manifest_test)
         rv["page_ranges"] = manifest_test.page_ranges
+        rv["safe_printable_inset"] = manifest_test.safe_printable_inset
         return rv
 
     def get_viewport_size(self, override):
@@ -725,6 +731,9 @@ class PrintReftestTest(ReftestTest):
     def page_ranges(self):
         return self._page_ranges
 
+    @property
+    def safe_printable_inset(self):
+        return self._safe_printable_inset
 
 class WdspecTest(Test):
     result_cls = WdspecResult


### PR DESCRIPTION
For print reftests, check `<meta name="safe-printable-inset">` to simulate
an unprintable region along the paper edges. The `content` attribute
takes a non-negative number, which is the safe printable inset specified
in centimeters.

This is for testing the `page-margin-safety` descriptor in `@page` and
page margin box contexts.

Only implemented for executorwebdriver.

Spec: https://drafts.csswg.org/css-page-3/#page-margin-safety
Spec discussion: https://github.com/w3c/csswg-drafts/issues/11395
RFC: https://github.com/web-platform-tests/rfcs/pull/233
webdriver spec change: https://github.com/w3c/webdriver/pull/1950

For background, see https://drafts.csswg.org/css-page-3/#printable-area
