### PR TITLE
Make error message deterministic in random-computed.tentative.html

### DIFF
--- a/css/css-values/random-computed.tentative.html
+++ b/css/css-values/random-computed.tentative.html
@@ -221,7 +221,8 @@ function test_random_computed_value_has_fixed(property, specified, minPercentage
       // split fixed component into its two components
       let [fixedString, fixedValue] = fixedComponent.split(' ');
 
-      test_random_equals(fixedString, 'fixed', `Computed value for ${specified} should include 'fixed'`);
+      // Use assert_true so that error message is deterministic.
+      assert_true(fixedString == 'fixed', `Computed value for ${specified} should include 'fixed'`);
       if (expectedFixedValue) {
         test_random_equals(parseFloat(fixedValue), expectedFixedValue, `Random value for ${specified} should be ${expectedFixedValue}`);
       } else {


### PR DESCRIPTION
This assert is currently failing as: `assert_equals: Computed value for random(10%, 30%) should include 'fixed' expected "fixed" but got "22.250708%"`

where 22.250708% is a random value, because WebKit doesn't support `fixed`.

After this change, it fails as: `assert_true: Computed value for random(10%, 30%) should include 'fixed' expected true got false`