### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=299259

### DIFF
--- a/css/css-scroll-snap/parsing/scroll-snap-type-invalid.html
+++ b/css/css-scroll-snap/parsing/scroll-snap-type-invalid.html
@@ -16,6 +16,8 @@ test_invalid_value("scroll-snap-type", "auto");
 test_invalid_value("scroll-snap-type", "x y");
 test_invalid_value("scroll-snap-type", "block mandatory inline");
 
+test_invalid_value("scroll-snap-type", "none both");
+test_invalid_value("scroll-snap-type", "none mandatory");
 test_invalid_value("scroll-snap-type", "both none");
 test_invalid_value("scroll-snap-type", "mandatory");
 test_invalid_value("scroll-snap-type", "proximity");


### PR DESCRIPTION
WebKit export from bug: [\[Style\] Convert the 'scroll-snap-align' and 'scroll-snap-type` properties to strong style types](https://bugs.webkit.org/show_bug.cgi?id=299259)