### PR TITLE
Geolocation: set mock position in non-fully-active.http.html

### DIFF
--- a/geolocation/non-fully-active.https.html
+++ b/geolocation/non-fully-active.https.html
@@ -1,20 +1,25 @@
-<!DOCTYPE html>
+<!doctype html>
 <meta charset="utf-8" />
 <title>Geolocation Test: non-fully active document</title>
 <link rel="help" href="https://github.com/w3c/geolocation-api/pull/97" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="support.js"></script>
 <body></body>
 <script>
   promise_setup(async () => {
-    await test_driver.set_permission({ name: "geolocation" }, "granted");
+    await test_driver.bidi.permissions.set_permission({
+      descriptor: { name: "geolocation" },
+      state: "granted",
+    });
+    await test_driver.bidi.emulation.set_geolocation_override({
+      coordinates: { latitude: 51.478, longitude: -0.166, accuracy: 100 },
+    });
   });
 
   promise_test(async (t) => {
-    // Create the iframe, wait for it to load...
     const iframe = document.createElement("iframe");
     await new Promise((resolve) => {
       iframe.src = "resources/iframe.html";
@@ -23,81 +28,134 @@
       document.body.appendChild(iframe);
     });
 
-    // Steal geolocation.
     const geo = iframe.contentWindow.navigator.geolocation;
-
-    // No longer fully active.
     iframe.remove();
 
-    // Try to watch a position while not fully active...
-    const watchError = await new Promise((resolve, reject) => {
-      const watchId = geo.watchPosition(
-        reject, // We don't want a position
-        resolve // We want an error!
-      );
-      // Always return 0.
-      assert_equals(
-        watchId,
-        0,
-        "watchId is 0 when document is not fully-active"
-      );
-      // And again, to make sure it's not changing
-      const watchId2 = geo.watchPosition(
-        () => {},
-        () => {}
-      );
-      assert_equals(
-        watchId2,
-        0,
-        "watchId remains 0 when document is not fully-active"
+    const watchId = geo.watchPosition(
+      () => {},
+      () => {},
+    );
+    assert_equals(watchId, 0, "watchId is 0 when document is not fully-active");
+
+    const watchId2 = geo.watchPosition(
+      () => {},
+      () => {},
+    );
+    assert_equals(
+      watchId2,
+      0,
+      "watchId remains 0 when document is not fully-active",
+    );
+  }, "watchPosition returns 0 for non-fully-active document");
+
+  promise_test(async (t) => {
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
+
+    const geo = iframe.contentWindow.navigator.geolocation;
+    iframe.remove();
+
+    const result = await new Promise((resolve) => {
+      const timeoutId = t.step_timeout(() => {
+        resolve({ timedOut: true });
+      }, 100);
+
+      geo.watchPosition(
+        () => resolve({ success: true }),
+        (error) => {
+          clearTimeout(timeoutId);
+          resolve({ error });
+        },
       );
     });
 
+    assert_false(result.timedOut, "errorCallback should be called");
+    assert_false(result.success, "successCallback should not be called");
     assert_equals(
-      watchError.code,
+      result.error.code,
       GeolocationPositionError.POSITION_UNAVAILABLE,
-      "watchPosition() returns an error on non-fully-active document"
+      "errorCallback receives POSITION_UNAVAILABLE",
     );
+  }, "watchPosition calls errorCallback with POSITION_UNAVAILABLE for non-fully-active document");
 
-    // Now try to get current position while not fully active...
-    const positionError = await new Promise((resolve, reject) => {
+  promise_test(async (t) => {
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
+
+    const geo = iframe.contentWindow.navigator.geolocation;
+    iframe.remove();
+
+    const result = await new Promise((resolve) => {
+      const timeoutId = t.step_timeout(() => {
+        resolve({ timedOut: true });
+      }, 100);
+
       geo.getCurrentPosition(
-        reject, // We don't want a position
-        resolve // We want an error!
+        () => resolve({ success: true }),
+        (error) => {
+          clearTimeout(timeoutId);
+          resolve({ error });
+        },
       );
     });
+
+    assert_false(result.timedOut, "errorCallback should be called");
+    assert_false(result.success, "successCallback should not be called");
     assert_equals(
-      positionError.code,
+      result.error.code,
       GeolocationPositionError.POSITION_UNAVAILABLE,
-      "getCurrentPosition() calls the errorCallback with POSITION_UNAVAILABLE"
+      "errorCallback receives POSITION_UNAVAILABLE",
     );
+  }, "getCurrentPosition calls errorCallback with POSITION_UNAVAILABLE for non-fully-active document");
 
-    // Re-attach, and go back to fully active.
+  promise_test(async (t) => {
+    t.add_cleanup(async () => {
+      await test_driver.bidi.emulation.set_geolocation_override({
+        coordinates: null,
+      });
+    });
+
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
+
+    iframe.remove();
     document.body.appendChild(iframe);
-    iframe.contentWindow.opener = window;
     await new Promise((resolve) =>
-      iframe.addEventListener("load", resolve, { once: true })
+      iframe.addEventListener("load", resolve, { once: true }),
     );
 
-    // And we are back to fully active.
     let watchId;
     let position = await new Promise((resolve, reject) => {
       watchId = iframe.contentWindow.navigator.geolocation.watchPosition(
         resolve,
-        reject
+        reject,
       );
     });
-    assert_true(Number.isInteger(watchId), "Expected some number for watchId");
+    assert_true(Number.isInteger(watchId), "Expected integer watchId");
     assert_true(Boolean(position), "Expected a position");
 
-    // Finally, let's get the position from the reattached document.
     position = await new Promise((resolve, reject) => {
       iframe.contentWindow.navigator.geolocation.getCurrentPosition(
         resolve,
-        reject
+        reject,
       );
     });
     assert_true(Boolean(position), "Expected a position");
     iframe.contentWindow.navigator.geolocation.clearWatch(watchId);
-  }, "non-fully active document behavior");
+  }, "re-attached document restores geolocation functionality");
 </script>


### PR DESCRIPTION
Improved coverage for geolocation API behavior in non-fully-active documents. The main changes include switching to the BiDi testdriver API for permissions and geolocation overrides, and adding new checks for error handling and recovery when documents are detached and reattached.
