### PR TITLE
Picture-in-Picture test not waiting for event handler to run

### DIFF
--- a/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
+++ b/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>Test leavepictureinpicture event</title>
+<meta name="timeout" content="long">
+<script src="/common/media.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/picture-in-picture-helpers.js"></script>
+<body></body>
+<script>
+promise_test(async t => {
+  let pictureInPictureWindow;
+  const video = await loadVideo();
+
+  video.addEventListener('enterpictureinpicture', t.step_func_done(event => {
+    pictureInPictureWindow = event.pictureInPictureWindow;
+  }));
+
+  const leavePipPromise = new Promise(resolve => {
+    video.addEventListener('leavepictureinpicture', t.step_func_done(event => {
+      assert_equals(pictureInPictureWindow, event.pictureInPictureWindow);
+      assert_equals(event.target, video);
+      assert_equals(event.bubbles, true);
+      assert_equals(event.cancelable, false);
+      assert_equals(event.composed, false);
+      assert_equals(document.pictureInPictureElement, null);
+    }));
+  });
+
+  await requestPictureInPictureWithTrustedClick(video);
+  video.disablePictureInPicture = true;
+  await leavePipPromise;
+}, 'leavepictureinpicture event is fired if video.disablePictureInPicture is set to true');
+</script>

--- a/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
+++ b/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
@@ -9,23 +9,24 @@
 <script src="resources/picture-in-picture-helpers.js"></script>
 <body></body>
 <script>
-promise_test(async t => {
+promise_test(async () => {
   let pictureInPictureWindow;
   const video = await loadVideo();
 
-  video.addEventListener('enterpictureinpicture', t.step_func_done(event => {
+  video.addEventListener('enterpictureinpicture', event => {
     pictureInPictureWindow = event.pictureInPictureWindow;
-  }));
+  });
 
   const leavePipPromise = new Promise(resolve => {
-    video.addEventListener('leavepictureinpicture', t.step_func_done(event => {
+    video.addEventListener('leavepictureinpicture', event => {
       assert_equals(pictureInPictureWindow, event.pictureInPictureWindow);
       assert_equals(event.target, video);
       assert_equals(event.bubbles, true);
       assert_equals(event.cancelable, false);
       assert_equals(event.composed, false);
       assert_equals(document.pictureInPictureElement, null);
-    }));
+      resolve();
+    });
   });
 
   await requestPictureInPictureWithTrustedClick(video);

--- a/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
+++ b/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
@@ -10,27 +10,27 @@
 <body></body>
 <script>
 promise_test(async () => {
-  let pictureInPictureWindow;
   const video = await loadVideo();
 
-  video.addEventListener('enterpictureinpicture', event => {
-    pictureInPictureWindow = event.pictureInPictureWindow;
-  });
+  const enterPipEventPromise = new Promise((resolve) =>
+    video.addEventListener('enterpictureinpicture', resolve),
+  );
 
-  const leavePipPromise = new Promise(resolve => {
-    video.addEventListener('leavepictureinpicture', event => {
-      assert_equals(pictureInPictureWindow, event.pictureInPictureWindow);
-      assert_equals(event.target, video);
-      assert_equals(event.bubbles, true);
-      assert_equals(event.cancelable, false);
-      assert_equals(event.composed, false);
-      assert_equals(document.pictureInPictureElement, null);
-      resolve();
-    });
-  });
+  const leavePipEventPromise = new Promise((resolve) =>
+    video.addEventListener('leavepictureinpicture', resolve),
+  );
 
   await requestPictureInPictureWithTrustedClick(video);
+  const { pictureInPictureWindow } = await enterPipEventPromise;
+
   video.disablePictureInPicture = true;
-  await leavePipPromise;
+
+  const event = await leavePipEventPromise;
+  assert_equals(pictureInPictureWindow, event.pictureInPictureWindow);
+  assert_equals(event.target, video);
+  assert_equals(event.bubbles, true);
+  assert_equals(event.cancelable, false);
+  assert_equals(event.composed, false);
+  assert_equals(document.pictureInPictureElement, null);
 }, 'leavepictureinpicture event is fired if video.disablePictureInPicture is set to true');
 </script>

--- a/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
+++ b/picture-in-picture/leave-picture-in-picture-disable-attribute.optional.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Test leavepictureinpicture event</title>
+<title>Test that leavepictureinpicture is seen when setting disablePictureInPicture=true</title>
 <meta name="timeout" content="long">
 <script src="/common/media.js"></script>
 <script src="/resources/testharness.js"></script>

--- a/picture-in-picture/leave-picture-in-picture.html
+++ b/picture-in-picture/leave-picture-in-picture.html
@@ -33,29 +33,4 @@ promise_test(async () => {
   assert_equals(event.composed, false);
   assert_equals(document.pictureInPictureElement, null);
 }, 'leavepictureinpicture event is fired if document.exitPictureInPicture');
-
-promise_test(async () => {
-  const video = await loadVideo();
-
-  const enterPipEventPromise = new Promise((resolve) =>
-    video.addEventListener('enterpictureinpicture', resolve),
-  );
-
-  const leavePipEventPromise = new Promise((resolve) =>
-    video.addEventListener('leavepictureinpicture', resolve),
-  );
-
-  await requestPictureInPictureWithTrustedClick(video);
-  const { pictureInPictureWindow } = await enterPipEventPromise;
-
-  video.disablePictureInPicture = true;
-
-  const event = await leavePipEventPromise;
-  assert_equals(pictureInPictureWindow, event.pictureInPictureWindow);
-  assert_equals(event.target, video);
-  assert_equals(event.bubbles, true);
-  assert_equals(event.cancelable, false);
-  assert_equals(event.composed, false);
-  assert_equals(document.pictureInPictureElement, null);
-}, 'leavepictureinpicture event is fired if video.disablePictureInPicture is set to true');
 </script>


### PR DESCRIPTION
See what the attribute says in the spec: https://w3c.github.io/picture-in-picture/#disable-pip:~:text=so%2E-,When,algorithm%2E and discussion https://github.com/w3c/picture-in-picture/issues/184

This PR also addresses both the newly created one and the only one to actually wait for the event handler to execute so to not pass without running them as before.

This closes #58040 