### PR TITLE
script: avoid stylesheet blocker underflow after window.stop()

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
+++ b/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42854">
+<link id="link" rel="stylesheet" onerror="window.stop()">
+<script>
+  addEventListener("load", () => {
+    link.href = "about:blank";
+  });
+</script>


### PR DESCRIPTION
Avoid stylesheet blocker underflow after window.stop()

Testing: added crash test
Fixes: #<!-- nolink -->42854

Reviewed in servo/servo#42855