### PR TITLE
layout: Let `OutsideMarker` store an `IndependentFormattingContext`

### DIFF
--- a/css/CSS2/lists/list-item-dynamic-color-ref.html
+++ b/css/CSS2/lists/list-item-dynamic-color-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Reference: list item with dynamically changing `color`</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+ol {
+  padding-left: 160px;
+}
+li {
+  font: 64px/1 Ahem;
+  list-style-type: square;
+  color: green;
+}
+</style>
+
+<p>Test passes if there are 2 filled green squares and <strong>no red</strong>.</p>
+<ol>
+  <li>X</li>
+</ol>

--- a/css/CSS2/lists/list-item-dynamic-color.html
+++ b/css/CSS2/lists/list-item-dynamic-color.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: list item with dynamically changing `color`</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#lists">
+<link rel="match" href="list-item-dynamic-color-ref.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+ol {
+  padding-left: 160px;
+}
+li {
+  font: 64px/1 Ahem;
+  list-style-type: square;
+  color: red;
+}
+</style>
+
+<p>Test passes if there are 2 filled green squares and <strong>no red</strong>.</p>
+<ol>
+  <li id="target">X</li>
+</ol>
+
+<script src="/common/reftest-wait.js"></script>
+<script>
+requestAnimationFrame(() => requestAnimationFrame(() => {
+  document.getElementById("target").style.color = "green";
+  takeScreenshot();
+}));
+</script>
+</html>


### PR DESCRIPTION
`OutsideMarker` was storing the `BlockFormattingContext` and the `LayoutBoxBase` in separate fields. Now it will store an entire `IndependentFormattingContext` in a single field.

In particular, this fixes the issue that `OutsideMarker::repair_style()` wasn't calling `BlockFormattingContext::repair_style()`. Now we can just rely on `IndependentFormattingContext::repair_style()`, which correctly repairs the style of both the `BlockFormattingContext` and the `LayoutBoxBase`.

Also, the `BlockLevelBox::repair_style()` was repairing the style of the `LayoutBoxBase` twice, for all kinds of block-level boxes. This removes the duplication.

Testing: Adding a new test
Fixes: #<!-- nolink -->42779

Reviewed in servo/servo#42864