### PR TITLE
wpt.fyi: Remove Servo workaround which runs single process for wdspec

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -87,10 +87,6 @@ def main(product, channel, commit_range, artifact_path, wpt_args):
 
     wpt_args += get_browser_args(product, channel, artifact_path)
 
-    # Hack to run servo with one process only for wdspec
-    if product == "servo" and "--test-type=wdspec" in wpt_args:
-        wpt_args = [item for item in wpt_args if not item.startswith("--processes")]
-
     wpt_args.append(product)
 
     command = ["python3", "./wpt", "run"] + wpt_args


### PR DESCRIPTION
This is the sibling PR of https://github.com/servo/servo/pull/42842. The workaround is introduced 6 years ago, but no longer valid: it introduces discrepancy (more fails/panic) comparing to our own dashboard, e.g. [this](https://wpt.fyi/results/webdriver/tests/classic/take_element_screenshot?run_id=5128593131962368&run_id=5186271220858880&run_id=5149229946503168&run_id=5179428868194304).

[Relevant Zulip thread](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Jump.20in.20WPT.20results/near/575917400).
Reviewed in servo/servo#42867