### PR TITLE
layout: Fix bottom margin of block-in-inline getting ignored

### DIFF
--- a/css/CSS2/normal-flow/block-in-inline-margins-005.html
+++ b/css/CSS2/normal-flow/block-in-inline-margins-005.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline with bottom margin</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://github.com/servo/servo/issues/42469">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+
+<style>
+div {
+  width: 200px;
+  height: 200px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: red">
+  <span>
+    <div style="margin-bottom: -200px"></div>
+  </span>
+  <div style="background: green"></div>
+</div>


### PR DESCRIPTION
In order to know whether a block box can collapse its bottom margin with the bottom margin of its last child, we need to check its tentative block size. Most usually, this will be the block size of the containing block that is used when laying out the children.

However, anonymous blocks do not establish a containing block. So using the containing block for children meant that we were using the tentative block size of its parent. If that parent had a definite size, this would prevent the anonymous block from collapsing bottom margins with its children. This situation could happen when placing a block-level inside of an inline box.

This patch fixes the problem by using an indefinite tentative block size for anonymous blocks, instead of the containing block for children.

Testing: Adding new test
Fixes: #<!-- nolink -->42469

Reviewed in servo/servo#42889