### PR TITLE
wdspec: Add real `test_no_browsing_context` test for get_current_url

### DIFF
--- a/webdriver/tests/classic/get_current_url/get.py
+++ b/webdriver/tests/classic/get_current_url/get.py
@@ -18,11 +18,9 @@ def test_no_top_browsing_context(session, closed_window):
     assert_error(response, "no such window")
 
 
-def test_no_browsing_context(session, closed_frame, doc):
-    session.url = doc
-
+def test_no_browsing_context(session, closed_frame):
     response = get_current_url(session)
-    assert_success(response, doc)
+    assert_error(response, "no such window")
 
 
 def test_get_current_url_matches_location(session, doc):


### PR DESCRIPTION
Previous test is duplicate of https://github.com/web-platform-tests/wpt/blob/90dfcf76b7fb07bede0b2d2cfe095b348dea5dfb/webdriver/tests/classic/navigate_to/navigate.py#L33-L39

Migrated from #58027