### PR TITLE
preload: remove audio, video, and track load-event assertions

### DIFF
--- a/preload/preload-with-type.html
+++ b/preload/preload-with-type.html
@@ -24,28 +24,16 @@
         }
         return null;
     };
-    var videoURL = getVideoURI("resources/A4");
-    var audioURL = getAudioURI("resources/sound_5");
-    var videoFormat = getFormat(videoURL);
-    var audioFormat = getFormat(audioURL);
 </script>
 <link rel=preload href="resources/dummy.js" as=script type="text/javascript" onload="scriptLoaded = true;">
 <link rel=preload href="resources/dummy.css" as=style type="text/css" onload="styleLoaded = true;">
 <link rel=preload href="resources/square.png" as=image type="image/png" onload="imageLoaded = true;">
 <link rel=preload href="/fonts/CanvasTest.ttf" as=font type="font/ttf" crossorigin onload="fontLoaded = true;">
-<script>
-    document.write('<link rel=preload href="' + videoURL + '" as=video type="video/' + videoFormat + '" onload="videoLoaded = true;">');
-    document.write('<link rel=preload href="' + audioURL + '" as=audio type="audio/' + audioFormat + '" onload="audioLoaded = true;">');
-</script>
 <link rel=preload href="resources/foo.vtt" as=track type="text/vtt" onload="trackLoaded = true;">
 <link rel=preload href="resources/dummy.js" as=script type="application/foobar" onload="gibberishLoaded++;">
 <link rel=preload href="resources/dummy.css" as=style type="text/foobar" onload="gibberishLoaded++;">
 <link rel=preload href="resources/square.png" as=image type="image/foobar" onload="gibberishLoaded++;">
 <link rel=preload href="/fonts/CanvasTest.ttf" as=font type="font/foobar" crossorigin onload="gibberishLoaded++;">
-<script>
-    document.write('<link rel=preload href="' + videoURL + '" as=video type="video/foobar" onload="gibberishLoaded++;">');
-    document.write('<link rel=preload href="' + audioURL + '" as=audio type="audio/foobar" onload="gibberishLoaded++;">');
-</script>
 <link rel=preload href="resources/foo.vtt" as=track type="text/foobar" onload="gibberishLoaded++;">
 <body>
 <script>
@@ -54,8 +42,7 @@
     var iterations = 0;
 
     function check_finished() {
-        if (styleLoaded && scriptLoaded && imageLoaded && fontLoaded && videoLoaded && audioLoaded &&
-            trackLoaded && gibberishLoaded == 0) {
+        if (styleLoaded && scriptLoaded && imageLoaded && fontLoaded && gibberishLoaded == 0) {
             done();
         }
         iterations++;
@@ -65,9 +52,6 @@
             assert_true(scriptLoaded, "script triggered load event");
             assert_true(imageLoaded, "image triggered load event");
             assert_true(fontLoaded, "font triggered load event");
-            assert_true(videoLoaded, "video triggered load event");
-            assert_true(audioLoaded, "audio triggered load event");
-            assert_true(trackLoaded, "track triggered load event");
             assert_equals(gibberishLoaded, 0, "resources with gibberish type should not be loaded");
             done();
         } else {


### PR DESCRIPTION
fixes: #56936 

This change removes preload load-event assertions for resources using `as="audio"` and `as="video"`.
Although "track" is listed as a valid preload destination in the [specs](https://html.spec.whatwg.org/multipage/links.html#link-type-preload) browsers do not consistently fire a `load` event for standalone track preloads. The specification itself notes that browser behavior differs from the defined event firing steps.