### PR TITLE
Fix wrong TextDecoder testcase

### DIFF
--- a/encoding/textdecoder-arguments.any.js
+++ b/encoding/textdecoder-arguments.any.js
@@ -60,6 +60,6 @@ test(t => {
     }
   };
   assert_equals(
-    decoder.decode(arr, options), Array(10000 + 1).join('*'),
-    'Decoding should work with underlying array buffer detached during options conversion');
+    decoder.decode(arr, options), '',
+    'Decoding should return an empty string with underlying array buffer detached during options conversion');
 }, 'TextDecoder decode() with array buffer detached during arg conversion');


### PR DESCRIPTION
#57992 that was auto-merged 4 days ago appears to be wrong

Options conversion to `dictionary` should happen first, and that runs getters, see https://github.com/web-platform-tests/wpt/pull/57992#issuecomment-3971629481:
> It should run getters. https://webidl.spec.whatwg.org/#js-dictionary step 4.1.3.1.

And only inside `decode()`, these steps are run:

https://encoding.spec.whatwg.org/#dom-textdecoder-decode:

> 3. If `input` is given, then [push](https://encoding.spec.whatwg.org/#concept-stream-push) a [copy of](https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy) `input` to [this](https://webidl.spec.whatwg.org/#this)’s [I/O queue](https://encoding.spec.whatwg.org/#textdecodercommon-i-o-queue).

https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy:

> 7. If [IsDetachedBuffer](https://tc39.es/ecma262/multipage/structured-data.html#sec-isdetachedbuffer)(jsArrayBuffer) is true, then return the empty [byte sequence](https://infra.spec.whatwg.org/#byte-sequence).

At that point the ArrayBuffer is detached, so decode() should behave as if it received an empty byte sequence
And should return an empty string.