### PR TITLE
move select parsing test to tentative

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-parsing-extended.tentative.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-parsing-extended.tentative.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/12050">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<select class=test
+    data-description='Input tags should parse inside select if nested in another tag'
+    data-expect='<div><input></div>'>
+  <div>
+    <input>
+  </div>
+</select>
+
+<div id=afterlast>
+  keep this div after the last test case
+</div>
+
+<script>
+function removeWhitespace(t) {
+  return t.replace(/\s/g,'');
+}
+document.querySelectorAll('select.test').forEach(s => {
+  assert_true(!!s.dataset.description.length);
+  test(() => {
+    // The document.body check here and in the other tests is to make sure that a
+    // previous test case didn't leave the HTML parser open on another element.
+    assert_equals(s.parentNode, document.body);
+    assert_equals(removeWhitespace(s.innerHTML),removeWhitespace(s.dataset.expect));
+  },s.dataset.description)
+});
+
+test(() => {
+  assert_equals(document.getElementById('afterlast').parentNode, document.body);
+}, 'The last test should not leave any tags open after parsing');
+</script>

--- a/html/semantics/forms/the-select-element/customizable-select/select-parsing.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-parsing.html
@@ -97,14 +97,6 @@
 </select>
 
 <select class=test
-    data-description='Input tags should parse inside select if nested in another tag'
-    data-expect='<div><input></div>'>
-  <div>
-    <input>
-  </div>
-</select>
-
-<select class=test
         data-description='Input tags should close select when directly inside an <option>'
         data-expect='<option></option>'>
   <option>


### PR DESCRIPTION
This change moves a test from the `select-parsing.html` suite to a new `select-parsing.tentative.html` suite.

The test in question asserts that `<input>` elements should not close `<select>` if they're nested. As best as I can tell this is a feature in Chrome only when the `InputInSelectEnabled()` feature is enabled (https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/parser/html_tree_builder.cc;l=777-813?q=html_tree_builder). This isn't to spec.

From what I can gather this is a feature for filtering in custom selects, and so pertains to https://github.com/whatwg/html/issues/12050. Therefore I think we should move it to the tentative file so we know what is actually required from the spec and what is proposed behaviour that has yet to be specced.

/cc @josepharhar

/cc @annevk who AFAICT worked on the WebKit changes around these tests. Note - Webkit fails this split-out test in 238 Preview.