### PR TITLE
media: Propagate errors from `GStreamerMediaStream::encoded`

### DIFF
--- a/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource-mediaStreamAudioDestination-stream-crash.html
+++ b/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource-mediaStreamAudioDestination-stream-crash.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<link rel="help" href="https://github.com/servo/servo/issues/36844">
+<script>
+var context = new AudioContext();
+var stream = (new MediaStreamAudioDestinationNode(context)).stream;
+new MediaStreamAudioSourceNode(context,{mediaStream:stream}) ;
+new MediaStreamAudioSourceNode(context,{mediaStream:stream});
+</script>


### PR DESCRIPTION
Instead of unwrapping in `GStreamerMediaStream::encoded`, properly
propagate errors to callers. This prevents panics when we fail to
build GStreamer pipelines in this code path. This is probably the first
of many changes to avoid `unwrap()`ing in this code.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->36844.

Reviewed in servo/servo#42914