### PR TITLE
fix manifest generation failure on Windows

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import unicodedata
 from collections import defaultdict
 from typing import (Any, Callable, Dict, IO, Iterable, List, Optional, Sequence, Set, Text, Tuple,
                     Type, TypeVar)
@@ -836,6 +837,24 @@ def check_all_paths(repo_root: Text, paths: List[Text]) -> List[rules.Error]:
     return errors
 
 
+def check_filename_portability(repo_root: Text, path: Text) -> List[rules.Error]:
+    """
+    Checks that the filename contains only characters that are portable
+    across operating systems and common encodings (e.g. Windows CP1252).
+
+    Invisible Unicode format/control characters like U+200E (LEFT-TO-RIGHT MARK)
+    are valid UTF-8 but cannot be encoded by Windows codepage encodings, causing
+    UnicodeEncodeError when tools write cache files containing the path.
+    """
+    filename = os.path.basename(path)
+    for char in filename:
+        category = unicodedata.category(char)
+        if category in ("Cf", "Cc"):
+            char_info = f"U+{ord(char):04X} ({unicodedata.name(char, 'UNKNOWN')})"
+            return [rules.NonPortableFilename.error(path, (char_info,))]
+    return []
+
+
 def check_file_contents(repo_root: Text, path: Text, f: Optional[IO[bytes]] = None) -> List[rules.Error]:
     """
     Runs lints that check the file contents.
@@ -1126,7 +1145,7 @@ def lint(repo_root: Text,
 
 path_lints = [check_file_type, check_path_length, check_worker_collision, check_ahem_copy,
               check_mojom_js, check_tentative_directories, check_gitignore_file,
-              check_web_features_file_path]
+              check_web_features_file_path, check_filename_portability]
 file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata,
               check_ahem_system_font, check_meta_file, check_web_features_file]
 

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -361,6 +361,10 @@ class TentativeDirectoryName(Rule):
     description = "Directories for tentative tests must be named exactly 'tentative'"
     to_fix = "rename directory to be called 'tentative'"
 
+class NonPortableFilename(Rule):
+    name = "NON-PORTABLE-FILENAME"
+    description = "Filename contains a non-portable character: %s"
+    to_fix = "Rename the file to remove any invisible or non-ASCII control characters (e.g. U+200E LEFT-TO-RIGHT MARK)"
 
 class InvalidMetaFile(Rule):
     name = "INVALID-META-FILE"

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -167,7 +167,7 @@ class CacheFile(metaclass=abc.ABCMeta):
         data: Dict[Text, Any] = {}
         try:
             if not rebuild:
-                with open(self.path) as f:
+                with open(self.path, encoding="utf-8") as f:
                     try:
                         data = jsonlib.load(f)
                     except ValueError:

--- a/tools/web_features/manifest.py
+++ b/tools/web_features/manifest.py
@@ -181,13 +181,17 @@ def write_manifest_file(path: str, web_features_map: WebFeaturesMap) -> None:
         web_features_map (WebFeaturesMap): The object containing the mapping between
                                            web-features and their corresponding test paths.
     """
-    with open(path, "w") as outfile:
-        outfile.write(
-            json.dumps(
-                {
-                    "version": 1,
-                    "data": web_features_map
-                }, cls=WebFeatureManifestEncoder, sort_keys=True))
+    with open(path, "w", encoding="utf-8", newline="\n") as outfile:
+        json.dump(
+            {
+                "version": 1,
+                "data": web_features_map
+            },
+            outfile,
+            cls=WebFeatureManifestEncoder,
+            sort_keys=True,
+            ensure_ascii=False
+        )
 
 
 def main(venv: Any = None, **kwargs: Any) -> int:


### PR DESCRIPTION
fixes: #57721 

Fix manifest generation failure on Windows caused by non-ASCII Unicode characters in test paths. Force UTF-8 encoding when writing manifest files to ensure cross-platform compatibility.