### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=297828

### DIFF
--- a/css/css-align/abspos/align-out-of-flow-only-content-ref.html
+++ b/css/css-align/abspos/align-out-of-flow-only-content-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style>
+.container {
+  background: blue;
+  position: relative;
+  width: 100px;
+  height: 100px;
+  display: inline-block;
+  margin-right: 5px;
+}
+
+.child {
+  width: 50px;
+  height: 50px;
+  position: relative;
+  background: green;
+  bottom: -100px;
+}
+</style>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container">
+  <div class="child"></div>
+</div>
+<div class="container">
+  <div class="child"></div>
+</div>

--- a/css/css-align/abspos/align-out-of-flow-only-content.html
+++ b/css/css-align/abspos/align-out-of-flow-only-content.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align/#align-justify-content">
+<link rel="match" href="align-out-of-flow-only-content-ref.html">
+<meta name="assert" content="Ensures that single, absolutely positioned elements take align-content into account.">
+<style>
+.container {
+  background: blue;
+  position: relative;
+  width: 100px;
+  height: 100px;
+  display: inline-block;
+  margin-right: 5px;
+  align-content: end;
+}
+
+.abs {
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  background: green;
+}
+
+.positioned-inline {
+  left: 0;
+}
+
+.positioned-block {
+  bottom: -50px;
+}
+</style>
+<div class="container">
+  <div class="abs"></div>
+</div>
+<div class="container">
+  <div class="abs positioned-block"></div>
+</div>
+<div class="container">
+  <div class="abs positioned-inline"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[align-content\]  out-of-flow box with no sibling ignores align-content](https://bugs.webkit.org/show_bug.cgi?id=297828)