### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308846

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-explicit-size.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-explicit-size.html
@@ -2,7 +2,7 @@
 <!-- Tests that select respects explicit size -->
 <link rel=author href="mailto:pkotwicz@chromium.org">
 <link rel="match" href="select-explicit-size-ref.html">
-
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1">
 <style>
 select {
   width:400px;


### PR DESCRIPTION
WebKit export from bug: [Enhanced <select>: add fuzzy metadata to select-explicit-size.html WPT](https://bugs.webkit.org/show_bug.cgi?id=308846)