### PR TITLE
fix webm support in common/media.js

### DIFF
--- a/common/media.js
+++ b/common/media.js
@@ -9,12 +9,12 @@ function getVideoURI(base)
 
     var videotag = document.createElement("video");
 
-    if ( videotag.canPlayType )
-    {
-      if (videotag.canPlayType('video/webm; codecs="vp9, opus"') )
-      {
-          extension = '.webm';
-      }
+    if (videotag.canPlayType) {
+        // check for both VP8/Vorbis and VP9/Opus since either means webm is fine
+        if (videotag.canPlayType('video/webm; codecs="vp8, vorbis"') ||
+            videotag.canPlayType('video/webm; codecs="vp9, opus"')) {
+            extension = '.webm';
+        }
     }
 
     return base + extension;
@@ -31,9 +31,8 @@ function getAudioURI(base)
 
     var audiotag = document.createElement("audio");
 
-    if ( audiotag.canPlayType &&
-         audiotag.canPlayType('audio/ogg') )
-    {
+    if (audiotag.canPlayType &&
+        audiotag.canPlayType('audio/ogg; codecs="vorbis"')) {
         extension = '.oga';
     }
 


### PR DESCRIPTION
getVideoURI was only checking for VP9/Opus which meant browsers that
support VP8/Vorbis webm (older Firefox, some mobile) would always fall
back to mp4 even though they could play webm just fine. Added VP8/Vorbis
as a fallback check.

Also tightened the audio/ogg check in getAudioURI to include the vorbis
codec explicitly, since the .oga files in /media/ are vorbis encoded.

Fixes issue https://github.com/web-platform-tests/wpt/issues/2829

