### PR TITLE
Fix broken image icon test for LCP.

### DIFF
--- a/largest-contentful-paint/broken-image-icon.html
+++ b/largest-contentful-paint/broken-image-icon.html
@@ -29,10 +29,9 @@
       // emit an LCP entry.
       let LcpEntryListLength = await new Promise(resolve => {
         new PerformanceObserver((entryList, observer) => {
-          if (entryList.getEntries().filter(e => e.url.includes('colors-16x8.png'))) {
-            observer.disconnect();
-            resolve(entryList.getEntries().length);
-          }
+          const filteredEntries = entryList.getEntries().filter(e => e.url.includes('colors-16x8.png'));
+          observer.disconnect();
+          resolve(filteredEntries.length);
         }).observe({ type: 'largest-contentful-paint', buffered: true });
       });
 


### PR DESCRIPTION
The if blocks returns true even if filtered entries doesn't contain the URL.

Because in JS empty `[]` is truthy.

Found while working on https://github.com/servo/servo/pull/42833