### PR TITLE
Check `document.fullscreenElement` to decide if the browser is fullscreen

### DIFF
--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -209,7 +209,7 @@ def is_fullscreen(session):
     # Remove the prefixed fallback when
     # https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
     return session.execute_script("""
-        return !!(window.fullScreen || document.webkitIsFullScreen)
+        return !!(document.fullscreenElement || window.fullScreen || document.webkitIsFullScreen)
         """)
 
 


### PR DESCRIPTION
The existing checks of `window.fullScreen` and `document.webkitIsFullScreen` are non-standard. This patch makes use of the Fullscreen API to allow browsers which implement that API to pass the relevant tests.

For reference: This is for the [Ladybird browser](https://github.com/LadybirdBrowser/ladybird), which implements the Fullscreen API, but not the legacy `window.fullScreen` or `document.webkitIsFullScreen`.