### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308912

### DIFF
--- a/css/css-forms/checkbox-checkmark-animation-002.html
+++ b/css/css-forms/checkbox-checkmark-animation-002.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: Web Animations on ::checkmark (checkbox)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#checkmark">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+input {
+  all: unset;
+  appearance: base;
+}
+input::checkmark {
+  all: unset;
+  content: "";
+  display: block;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<input type="checkbox" checked>
+<script>
+document.querySelector("input").animate({
+  backgroundColor: ["green", "green"],
+}, {
+  pseudoElement: "::checkmark",
+  duration: Infinity,
+});
+</script>

--- a/css/css-forms/checkbox-checkmark-animation.html
+++ b/css/css-forms/checkbox-checkmark-animation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: ::checkmark & web animations (checkbox)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#checkmark">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/">
+<meta name="assert" content="This test checks that ::checkmark on checkbox inputs can be animated with Web Animations.">
+<style>
+#checkbox { appearance: base; }
+#checkbox::checkmark { all: unset; content: "x"; }
+</style>
+
+<input type="checkbox" id="checkbox" checked>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  const cs = getComputedStyle(checkbox, "::checkmark");
+  const anim = checkbox.animate([
+    {color: "rgb(0, 100, 200)"},
+    {color: "rgb(200, 0, 100)"},
+  ], {
+    pseudoElement: "::checkmark",
+    duration: 2,
+    delay: -1,
+  });
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+}, "::checkmark pseudo-element animates");
+</script>

--- a/css/css-forms/radio-checkmark-animation-002.html
+++ b/css/css-forms/radio-checkmark-animation-002.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: Web Animations on ::checkmark (radio)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#checkmark">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+input {
+  all: unset;
+  appearance: base;
+}
+input::checkmark {
+  all: unset;
+  content: "";
+  display: block;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<input type="radio" checked>
+<script>
+document.querySelector("input").animate({
+  backgroundColor: ["green", "green"],
+}, {
+  pseudoElement: "::checkmark",
+  duration: Infinity,
+});
+</script>

--- a/css/css-forms/radio-checkmark-animation.html
+++ b/css/css-forms/radio-checkmark-animation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: ::checkmark & web animations (radio)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#checkmark">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/">
+<meta name="assert" content="This test checks that ::checkmark on radio inputs can be animated with Web Animations.">
+<style>
+#radio { appearance: base; }
+#radio::checkmark { all: unset; content: "x"; }
+</style>
+
+<input type="radio" id="radio" checked>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  const cs = getComputedStyle(radio, "::checkmark");
+  const anim = radio.animate([
+    {color: "rgb(0, 100, 200)"},
+    {color: "rgb(200, 0, 100)"},
+  ], {
+    pseudoElement: "::checkmark",
+    duration: 2,
+    delay: -1,
+  });
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+}, "::checkmark pseudo-element animates");
+</script>

--- a/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.customizable-select-option::before {
+  color: green;
+}
+</style>
+
+<p>Click me to start test. PASS if you see a green checkmark.</p>
+
+<button class=customizable-select-button popovertarget=popover id=button>
+  <span class=customizable-select-selectedcontent>option</span>
+</button>
+<div id=popover popover=auto class=customizable-select-popover>
+  <div class="customizable-select-option selected">option</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002.html
+++ b/html/semantics/forms/the-select-element/customizable-select/checkmark-animation-002.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<meta charset="utf-8">
+<title>CSS Test: Web Animations on ::checkmark</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#checkmark">
+<link rel="match" href="checkmark-animation-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-5">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, ::picker(select) { appearance: base-select; }
+:focus-visible { outline: none; }
+</style>
+
+<p id="start">Click me to start test. PASS if you see a green checkmark.</p>
+
+<select id="target">
+  <option id="opt" selected>option</option>
+</select>
+
+<script>
+const target = document.getElementById("target");
+const opt = document.getElementById("opt");
+
+start.onclick = (async () => {
+  await target.showPicker();
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  opt.animate({
+    color: ["green", "green"],
+  }, {
+    pseudoElement: "::checkmark",
+    duration: Infinity,
+  });
+  await new Promise(requestAnimationFrame);
+  document.documentElement.classList.remove("reftest-wait");
+});
+
+window.addEventListener("load", () => {
+  test_driver.click(start);
+});
+</script>

--- a/html/semantics/forms/the-select-element/customizable-select/checkmark-animation.html
+++ b/html/semantics/forms/the-select-element/customizable-select/checkmark-animation.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: ::checkmark & web animations</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#checkmark">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/">
+<meta name="assert" content="This test checks that ::checkmark can be animated with Web Animations.">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, ::picker(select) { appearance: base-select; }
+</style>
+<div id="log"></div>
+<select id="target">
+  <option id="opt" selected>option</option>
+</select>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const opt = document.getElementById("opt");
+
+promise_test(async function() {
+  await test_driver.click(target);
+  const options = {
+    pseudoElement: "::checkmark",
+    duration: 2,
+    delay: -1,
+  };
+  const cs = getComputedStyle(opt, "::checkmark");
+  const anim = opt.animate([
+    {color: "rgb(0, 100, 200)"},
+    {color: "rgb(200, 0, 100)"},
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+}, "::checkmark pseudo-element animates");
+</script>

--- a/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.customizable-select-button::after {
+  color: green;
+}
+</style>
+
+<div class=customizable-select-button>
+  <span class=customizable-select-selectedcontent>option</span>
+</div>

--- a/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002.html
+++ b/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation-002.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: Web Animations on ::picker-icon</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#picker-icon">
+<link rel="match" href="picker-icon-animation-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-5">
+<style>
+select { appearance: base-select; }
+</style>
+<select id="target">
+  <option>option</option>
+</select>
+<script>
+document.getElementById("target").animate({
+  color: ["green", "green"],
+}, {
+  pseudoElement: "::picker-icon",
+  duration: Infinity,
+});
+</script>

--- a/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation.html
+++ b/html/semantics/forms/the-select-element/customizable-select/picker-icon-animation.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: ::picker-icon & web animations</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#picker-icon">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/">
+<meta name="assert" content="This test checks that ::picker-icon can be animated with Web Animations.">
+<style>
+select { appearance: base-select; }
+</style>
+<div id="log"></div>
+<select id="target">
+  <option>option</option>
+</select>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const target = document.getElementById("target");
+
+test(function() {
+  const options = {
+    pseudoElement: "::picker-icon",
+    duration: 2,
+    delay: -1,
+  };
+  const cs = getComputedStyle(target, "::picker-icon");
+  const anim = target.animate([
+    {color: "rgb(0, 100, 200)"},
+    {color: "rgb(200, 0, 100)"},
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+}, "::picker-icon pseudo-element animates");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[appearance: base\] Support animations on ::checkmark pseudo-element](https://bugs.webkit.org/show_bug.cgi?id=308912)