### PR TITLE
fs: add tests for null WriteParams members throwing TypeError

### DIFF
--- a/fs/script-tests/FileSystemWritableFileStream-write.js
+++ b/fs/script-tests/FileSystemWritableFileStream-write.js
@@ -329,6 +329,25 @@ directory_test(async (t, root) => {
 }, 'WriteParams: seek missing position param');
 
 directory_test(async (t, root) => {
+  const handle = await createFileWithContents('content.txt', 'seekable', root);
+  const stream = await handle.createWritable();
+
+  await promise_rejects_js(
+      t, TypeError, stream.write({type: 'seek', position: null}),
+      'seek with null position');
+}, 'WriteParams: seek null position param');
+
+directory_test(async (t, root) => {
+  const handle =
+      await createFileWithContents('content.txt', 'very long string', root);
+  const stream = await handle.createWritable();
+
+  await promise_rejects_js(
+      t, TypeError, stream.write({type: 'truncate', size: null}),
+      'truncate with null size');
+}, 'WriteParams: truncate null size param');
+
+directory_test(async (t, root) => {
   const source_file =
       await createFileWithContents('source_file', 'source data', root);
   const source_blob = await source_file.getFile();


### PR DESCRIPTION
`size`, `position`, and `data` in `WriteParams` are being made non-nullable (whatwg/fs#181). Add tests to verify that passing null for each of these members throws a TypeError at the WebIDL boundary.

A test for `data: null` already existed; this adds the missing cases
for `position: null` and `size: null`.