### PR TITLE
Add WPTs for SVG textPath path attribute error handling (w3c/svgwg#393)

### DIFF
--- a/svg/text/reftests/textpath-path-attr-empty-no-fallback.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-empty-no-fallback.tentative.svg
@@ -1,0 +1,15 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Empty `path` attribute takes precedence over `href` and does not render</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/393"/>
+    <html:link rel="match" href="textpath-path-attr-empty-ref.tentative.svg"/>
+  </metadata>
+  <defs>
+    <path id="curve" d="M 10 50 Q 100 10 200 50 T 390 50"/>
+  </defs>
+  <text font-size="20" fill="black">
+    <textPath href="#curve" path="">Empty path</textPath>
+  </text>
+</svg>

--- a/svg/text/reftests/textpath-path-attr-empty-ref.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-empty-ref.tentative.svg
@@ -1,0 +1,1 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg"/>

--- a/svg/text/reftests/textpath-path-attr-invalid-no-fallback.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-invalid-no-fallback.tentative.svg
@@ -1,0 +1,16 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Invalid `path` attribute does not fallback to `href`</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/393"/>
+    <html:link rel="match" href="textpath-path-attr-empty-ref.tentative.svg"/>
+  </metadata>
+  <defs>
+    <path id="curve" d="M 10 50 Q 100 10 200 50 T 390 50"/>
+  </defs>
+  <text font-size="20" fill="black">
+    <textPath href="#curve" path="Invalid path">Empty path</textPath>
+  </text>
+</svg>

--- a/svg/text/reftests/textpath-path-attr-use-up-to-first-error.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-use-up-to-first-error.tentative.svg
@@ -1,0 +1,13 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>textPath path data is used up to the first parse error</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/393"/>
+    <html:link rel="match" href="textpath-path-attr-ref.svg"/>
+  </metadata>
+  <text font-size="20" fill="black">
+    <textPath path="M 10 50 Q 100 10 200 50 T 390 50 INVALID">Text along a quadratic curve</textPath>
+  </text>
+</svg>


### PR DESCRIPTION
Add tentative reftests for the SVG <textPath> element's path attribute
 to cover error handling behavior discussed in w3c/svgwg#393.

New tests:

1. textpath-path-attr-use-up-to-first-error: Verifies that valid path
 data before the first parse error is still used for rendering.
2. textpath-path-attr-invalid-no-fallback: Verifies that a completely
 invalid path attribute does not fall back to href.
3. textpath-path-attr-empty-no-fallback: Verifies that an empty path
 attribute takes precedence over href and renders nothing.

Spec references:

https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute
https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling
https://github.com/w3c/svgwg/issues/393