### PR TITLE
webdriver: Enable `pointerMove` to perform smooth transition over specified duration

### DIFF
--- a/uievents/mouse/mousemove-action-interpolation.html
+++ b/uievents/mouse/mousemove-action-interpolation.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Mousemove should transition smoothly over specified duration</title>
+<link rel=help href="https://github.com/servo/servo/issues/42950">
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<div id="dot" style="position:fixed; width:10px; height:10px; background:red; border-radius:50%; pointer-events:none;">
+</div>
+
+<script>
+    promise_test(async t => {
+        const dot = document.getElementById('dot');
+        const mouse_move_coordinates = [];
+        const handler = (event) => {
+            mouse_move_coordinates.push({ x: event.clientX, y: event.clientY });
+            dot.style.transform = `translate(${event.clientX}px, ${event.clientY}px)`;
+        };
+        document.addEventListener('mousemove', handler);
+        t.add_cleanup(() => document.removeEventListener('mousemove', handler));
+
+        await new test_driver.Actions()
+            .pointerMove(10, 10)
+            .pointerMove(250, 250, { duration: 500 })
+            .send();
+
+        assert_greater_than(mouse_move_coordinates.length, 10,
+            "Should have more than 10 mousemove events over 500ms");
+
+        const uniqueX = new Set(mouse_move_coordinates.map(coordinates => coordinates.x));
+        const uniqueY = new Set(mouse_move_coordinates.map(coordinates => coordinates.y));
+
+        assert_equals(uniqueX.size, mouse_move_coordinates.length, "Every X-coordinate must be unique");
+        assert_equals(uniqueY.size, mouse_move_coordinates.length, "Every Y-coordinate must be unique");
+    }, "Mousemove should transition smoothly over specified duration");
+</script>

--- a/uievents/mouse/mousemove-action-interpolation.html
+++ b/uievents/mouse/mousemove-action-interpolation.html
@@ -21,7 +21,10 @@
             dot.style.transform = `translate(${event.clientX}px, ${event.clientY}px)`;
         };
         document.addEventListener('mousemove', handler);
-        t.add_cleanup(() => document.removeEventListener('mousemove', handler));
+        t.add_cleanup(() => {
+            document.removeEventListener('mousemove', handler);
+            dot.remove();
+        });
 
         await new test_driver.Actions()
             .pointerMove(10, 10)


### PR DESCRIPTION
Enable `pointerMove` to perform a smooth transition over specified duration.

- Sync move/scroll interval with default tick duraiton in testdriver: https://github.com/servo/servo/blob/a60a8b1b4d2ba39bde4ae777262b05d14ed48855/tests/wpt/tests/resources/testdriver-actions.js#L34-L38
- Fully process all pending pointer moves within this tick. This is one of the conditions that is [required](https://w3c.github.io/webdriver/#dfn-perform-a-pointer-move:~:text=There%20are%20no%20pending%20asynchronous%20waits%20arising%20from%20the%20last%20invocation%20of%20the%20dispatch%20tick%20actions%20steps%2E) to finish this tick. Previously, the pending move events might be processed in next Tick, if they have long duration.

https://github.com/user-attachments/assets/8692086f-32bb-45f3-ae0c-a072f68e1e84

https://github.com/user-attachments/assets/35af99a9-889b-41c1-91e2-55f22ad453a1

Testing: Added a WPT test. I'm surprised it is not covered by existing tests, given the huge behaviour difference.
Fixes: https://github.com/servo/servo/issues/42950
Part of https://github.com/servo/servo/issues/41620
Reviewed in servo/servo#42946