### PR TITLE
servoshell: Rename executable to servoshell.

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -2315,7 +2315,7 @@ class Servo(Browser):
 
         resp = self._get(channel)
         decompress(resp.raw, dest=dest)
-        path = which("servo", path=os.path.join(dest, "servo"))
+        path = which("servoshell", path=os.path.join(dest, "servo"))
         st = os.stat(path)
         os.chmod(path, st.st_mode | stat.S_IEXEC)
         return path

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -721,7 +721,7 @@ class Servo(BrowserSetup):
             binary = self.browser.find_binary(self.venv.path, None)
 
             if binary is None:
-                raise WptrunError("Unable to find servo binary in PATH")
+                raise WptrunError("Unable to find servoshell binary in PATH")
             kwargs["binary"] = binary
 
 
@@ -738,7 +738,7 @@ class ServoLegacy(Servo):
             binary = self.browser.find_binary(self.venv.path, None)
 
             if binary is None:
-                raise WptrunError("Unable to find servo binary in PATH")
+                raise WptrunError("Unable to find servoshell binary in PATH")
             kwargs["binary"] = binary
 
 

--- a/tools/wptrunner/wptrunner/browsers/servo_legacy.py
+++ b/tools/wptrunner/wptrunner/browsers/servo_legacy.py
@@ -95,7 +95,7 @@ class ServoLegacyBrowser(NullBrowser):
 
 class ServoLegacyWdspecBrowser(WebDriverBrowser):
     # TODO: could share an implemenation with servodriver.py, perhaps
-    def __init__(self, logger, binary="servo", webdriver_binary="servo",
+    def __init__(self, logger, binary="servoshell", webdriver_binary="servoshell",
                  binary_args=None, webdriver_args=None, env=None, port=None,
                  headless=None,
                  **kwargs):


### PR DESCRIPTION
This should help clarify the difference between servo the library / engine and servoshell the browser (demo).

Other changes: 

- Removed etc/servo.sb ( [apple sandbox profile format](https://angelica.gitbook.io/hacktricks/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-sandbox#sandbox-profiles)) since it is not needed anymore. See [this comment](https://github.com/servo/servo/pull/42958#discussion_r2876253489) for more details.

Testing: This is a very invasive change, and there are bound to be scripts / places I have overlooked. Searching for usages of `servo` is very hard, since it's also the name of the library.
Try run: https://github.com/servo/servo/actions/runs/22637676818

Reviewed in servo/servo#42958