### PR TITLE
Switch to test window after creating it in Marionette external reftest implementation

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -670,16 +670,16 @@ class MarionettePrintProtocolPart(PrintProtocolPart):
         self.runner_handle = None
 
     def load_runner(self):
-        url = urljoin(self.parent.executor.server_url("http"), "/print_pdf_runner.html")
-        self.logger.debug("Loading %s" % url)
+        self.url = urljoin(self.parent.executor.server_url("http"), "/print_pdf_runner.html")
+        self.logger.debug("Loading %s" % self.url)
         try:
-            self.marionette.navigate(url)
+            self.marionette.navigate(self.url)
         except Exception as e:
             self.logger.critical(
                 "Loading initial page %s failed. Ensure that the "
                 "there are no other programs bound to this port and "
                 "that your firewall rules or network setup does not "
-                "prevent access.\n%s" % (url, traceback.format_exc(e)))
+                "prevent access.\n%s" % (self.url, traceback.format_exc(e)))
             raise
         self.runner_handle = self.marionette.current_window_handle
 
@@ -705,6 +705,10 @@ class MarionettePrintProtocolPart(PrintProtocolPart):
         handle = self.marionette.current_window_handle
         _switch_to_window(self.marionette, self.runner_handle)
         try:
+            current_url = self.marionette.get_url()
+            assert (
+                current_url == self.url
+            ), f"Runner window has unexpected URL: {current_url}"
             rv = self.marionette.execute_async_script("""
 let callback = arguments[arguments.length - 1];
 render('%s').then(result => callback(result))""" % pdf_base64, new_sandbox=False, sandbox=None)
@@ -1192,7 +1196,8 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                 self.has_window = False
 
             if not self.has_window:
-                self.protocol.base.create_window(type="window")
+                test_window = self.protocol.base.create_window(type="window")
+                self.protocol.base.set_window(test_window)
                 # Resize the browser window so that its inner dimensions have
                 # exactly a size of 800x600 pixels, which means ignoring all
                 # visible toolbars and sidebars.

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -510,16 +510,16 @@ class WebDriverPrintProtocolPart(PrintProtocolPart):
         self.runner_handle = None
 
     def load_runner(self):
-        url = urljoin(self.parent.executor.server_url("http"), "/print_pdf_runner.html")
-        self.logger.debug("Loading %s" % url)
+        self.url = urljoin(self.parent.executor.server_url("http"), "/print_pdf_runner.html")
+        self.logger.debug("Loading %s" % self.url)
         try:
-            self.webdriver.url = url
+            self.webdriver.url = self.url
         except Exception as e:
             self.logger.critical(
                 "Loading initial page %s failed. Ensure that the "
                 "there are no other programs bound to this port and "
                 "that your firewall rules or network setup does not "
-                "prevent access.\n%s" % (url, traceback.format_exc(e)))
+                "prevent access.\n%s" % (self.url, traceback.format_exc(e)))
             raise
         self.runner_handle = self.webdriver.window_handle
 
@@ -539,6 +539,10 @@ class WebDriverPrintProtocolPart(PrintProtocolPart):
         handle = self.webdriver.window_handle
         self.webdriver.window_handle = self.runner_handle
         try:
+            current_url = self.webdriver.url
+            assert (
+                current_url == self.url
+            ), f"Runner window has unexpected URL: {current_url}"
             rv = self.webdriver.execute_async_script("""
 let callback = arguments[arguments.length - 1];
 render('%s').then(result => callback(result))""" % pdf_base64)


### PR DESCRIPTION
The reftest executor's do_test() was calling create_window() without switching to the returned handle. Since Marionette's NewWindow command does not switch context, subsequent operations (resize, load, render) ran in the original window. For print-reftests this overwrote print_pdf_runner.html in the runner window, breaking pdf_to_png.