### PR TITLE
Payment Request: use InvalidState for non-fully active docs

### DIFF
--- a/payment-request/META.yml
+++ b/payment-request/META.yml
@@ -1,7 +1,4 @@
 spec: https://w3c.github.io/payment-request/
 suggested_reviewers:
   - marcoscaceres
-  - rsolomakhin
-  - zouhir
-  - romandev
-  - aestes
+  - stephenmcgruer

--- a/payment-request/META.yml
+++ b/payment-request/META.yml
@@ -1,4 +1,5 @@
 spec: https://w3c.github.io/payment-request/
 suggested_reviewers:
   - marcoscaceres
+  - romandev
   - stephenmcgruer

--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -91,6 +91,7 @@
       // Finally, request2 should have been "closed", so trying to show
       // it will again result in promise rejected with an InvalidStateError.
       // See: https://github.com/w3c/payment-request/pull/821
+      await test_driver.bless("payment request show()");
       const rejectedPromise = request2.show();
       await promise_rejects_dom(
         t,

--- a/payment-request/payment-response/rejects_if_not_active-manual.https.html
+++ b/payment-request/payment-response/rejects_if_not_active-manual.https.html
@@ -52,7 +52,7 @@ function getLoadedPaymentResponse(iframe, url) {
   });
 }
 
-function methodNotFullyActive(button, method, ...args) {
+function methodNotFullyActive(button, methodName, ...args) {
   const text = button.textContent.trim();
   promise_test(async t => {
     const iframe = document.createElement("iframe");

--- a/payment-request/payment-response/rejects_if_not_active-manual.https.html
+++ b/payment-request/payment-response/rejects_if_not_active-manual.https.html
@@ -74,9 +74,9 @@ function methodNotFullyActive(button, method, ...args) {
     const promise = response[methodName](...args);
     await promise_rejects_dom(
       t,
-      "AbortError",
+      "InvalidStateError",
       promise,
-      "Inactive document, so must throw AbortError"
+      "Inactive document, so must throw InvalidStateError"
     );
     // We are done, so clean up.
     iframe.remove();
@@ -109,9 +109,9 @@ function methodBecomesNotFullyActive(button, methodName, ...args) {
     // So, promise needs to reject appropriately.
     await promise_rejects_dom(
       t,
-      "AbortError",
+      "InvalidStateError",
       promise,
-      "Inactive document, so must throw AbortError"
+      "Inactive document, so must throw InvalidStateError"
     );
     // We are done, so clean up.
     iframe.remove();

--- a/payment-request/payment-response/rejects_if_not_active-manual.https.html
+++ b/payment-request/payment-response/rejects_if_not_active-manual.https.html
@@ -109,9 +109,9 @@ function methodBecomesNotFullyActive(button, methodName, ...args) {
     // So, promise needs to reject appropriately.
     await promise_rejects_dom(
       t,
-      "InvalidStateError",
+      "AbortError",
       promise,
-      "Inactive document, so must throw InvalidStateError"
+      "Document became inactive, so must throw AbortError"
     );
     // We are done, so clean up.
     iframe.remove();

--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -72,10 +72,10 @@
       // So, call .show(), and make sure it rejects appropriately.
       await promise_rejects_dom(
         t,
-        "AbortError",
+        "InvalidStateError",
         frameDOMException1,
         request1.show(),
-        "Inactive document, so must throw AbortError"
+        "Inactive document, so must throw InvalidStateError"
       );
       // request2 has an active document tho, so confirm it's working as expected:
       // Get transient activation
@@ -132,10 +132,10 @@
       // So, call request.show() and make sure it rejects appropriately.
       await promise_rejects_dom(
         t,
-        "AbortError",
+        "InvalidStateError",
         innerIframeDOMException,
         showPromise,
-        "Active, but not fully active, so must throw AbortError"
+        "Active, but not fully active, so must throw InvalidStateError"
       );
     }, "PaymentRequest.show() aborts if the document is active, but not fully active.");
   </script>

--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -83,6 +83,8 @@
       await test_driver.bless("payment 2", () => {}, iframe.contentWindow);
       request2.show();
       await request2.abort();
+      // Need another bless() because the previous one was consumed by show()
+      await test_driver.bless("payment 3", () => {}, iframe.contentWindow);
       await promise_rejects_dom(
         t,
         "InvalidStateError",

--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
-<title>PaymentRequest show() rejects if doc is not fully active</title>
+<title>PaymentRequest methods reject if doc is not fully active</title>
 <link rel="help" href="https://w3c.github.io/payment-request/#show-method" />
+<link rel="help" href="https://w3c.github.io/payment-request/#canmakepayment-method" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -138,5 +139,87 @@
         "Active, but not fully active, so must throw InvalidStateError"
       );
     }, "PaymentRequest.show() aborts if the document is active, but not fully active.");
+
+    promise_test(async (t) => {
+      const iframe = document.createElement("iframe");
+      iframe.allow = "payment";
+      document.body.appendChild(iframe);
+      t.add_cleanup(() => {
+        iframe.remove();
+      });
+      // We first go to page1.html, grab a PaymentRequest instance.
+      const request1 = await getLoadedPaymentRequest(
+        iframe,
+        "./resources/page1.html"
+      );
+      // Save the DOMException of page1.html before navigating away.
+      const frameDOMException1 = iframe.contentWindow.DOMException;
+
+      // We navigate the iframe again, putting request1's document into an non-fully active state.
+      const request2 = await getLoadedPaymentRequest(
+        iframe,
+        "./resources/page2.html"
+      );
+
+      // Now, request1's relevant global object's document is no longer active.
+      // So, call .canMakePayment(), and make sure it rejects appropriately.
+      await promise_rejects_dom(
+        t,
+        "InvalidStateError",
+        frameDOMException1,
+        request1.canMakePayment(),
+        "Inactive document, so must throw InvalidStateError"
+      );
+      // request2 has an active document, so confirm it's working as expected:
+      const result = await request2.canMakePayment();
+      assert_true(typeof result === "boolean", "canMakePayment() should return a boolean");
+    }, "PaymentRequest.canMakePayment() rejects if the document is not active.");
+
+    promise_test(async (t) => {
+      // We nest two iframes and wait for them to load.
+      const outerIframe = document.createElement("iframe");
+      outerIframe.allow = "payment";
+      document.body.appendChild(outerIframe);
+      t.add_cleanup(() => {
+        outerIframe.remove();
+      });
+      // Load the outer iframe (we don't care about the awaited request)
+      await getLoadedPaymentRequest(outerIframe, "./resources/page1.html");
+
+      // Now we create the inner iframe
+      const innerIframe = outerIframe.contentDocument.createElement("iframe");
+      innerIframe.allow = "payment";
+
+      // nest them
+      outerIframe.contentDocument.body.appendChild(innerIframe);
+
+      // load innerIframe, and get the PaymentRequest instance
+      const request = await getLoadedPaymentRequest(
+        innerIframe,
+        "./resources/page2.html"
+      );
+      // Save DOMException from innerIframe before navigating away.
+      const innerIframeDOMException = innerIframe.contentWindow.DOMException;
+
+      // Navigate the outer iframe to a new location.
+      // Wait for the load event to fire.
+      await new Promise((resolve) => {
+        outerIframe.addEventListener("load", resolve);
+        outerIframe.src = "./resources/page2.html";
+      });
+
+      const canMakePaymentPromise = request.canMakePayment();
+      // Now, request's relevant global object's document is still active
+      // (it is the active document of the inner iframe), but is not fully active
+      // (since the parent of the inner iframe is itself no longer active).
+      // So, call request.canMakePayment() and make sure it rejects appropriately.
+      await promise_rejects_dom(
+        t,
+        "InvalidStateError",
+        innerIframeDOMException,
+        canMakePaymentPromise,
+        "Active, but not fully active, so must throw InvalidStateError"
+      );
+    }, "PaymentRequest.canMakePayment() rejects if the document is active, but not fully active.");
   </script>
 </body>


### PR DESCRIPTION
Tests for https://github.com/w3c/payment-request/pull/1056 

* also, AbortError, when frame is navigated or removed (making it non-fully active)