### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309123

### DIFF
--- a/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote.html
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text: hanging-punctuation first with ASCII quote characters</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#hanging-punctuation-property">
+<link rel="match" href="reference/hanging-punctuation-first-ascii-quote-ref.html">
+<meta name="assert" content="hanging-punctuation: first causes U+0022 QUOTATION MARK and U+0027 APOSTROPHE to hang at the start of the first line.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { hanging-punctuation: first; margin:1em }
+</style>
+<div class="hang">"This should hang.</div>
+<div class="hang">'This should hang.</div>

--- a/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote.html
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text: hanging-punctuation last with ASCII quote characters</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#hanging-punctuation-property">
+<link rel="match" href="reference/hanging-punctuation-last-ascii-quote-ref.html">
+<meta name="assert" content="hanging-punctuation: last causes U+0022 QUOTATION MARK and U+0027 APOSTROPHE to hang at the end of the last line.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { hanging-punctuation: last; margin:1em }
+</style>
+<div class="hang" style="width:4em;">Yes <span>"</span></div>
+<div class="hang" style="width:4em;">Yes <span>'</span></div>

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-ascii-quote-ref.html
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-ascii-quote-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { margin:1em }
+</style>
+<div class="hang" id="ref1">"This should hang.</div>
+<div class="hang" id="ref2">'This should hang.</div>
+<script>
+function setIndent(id, char) {
+    const probe = document.createElement('span');
+    probe.textContent = char;
+    probe.style.visibility = 'hidden';
+    document.body.appendChild(probe);
+    const width = probe.getBoundingClientRect().width;
+    document.body.removeChild(probe);
+    document.getElementById(id).style.textIndent = `-${width}px`;
+}
+setIndent('ref1', '"');
+setIndent('ref2', "'");
+</script>

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-ascii-quote-ref.html
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-ascii-quote-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { margin:1em }
+</style>
+<div class="hang" style="width:5em;">Yes <span>"</span></div>
+<div class="hang" style="width:5em;">Yes <span>'</span></div>


### PR DESCRIPTION
WebKit export from bug: [\[hanging-punctuation\] U+0027 and U+0022 should work as hangable quotes](https://bugs.webkit.org/show_bug.cgi?id=309123)