### PR TITLE
Increase height to prevent scrolling offset rounding errors

### DIFF
--- a/mathml/relations/html5-tree/href-click-001.tentative.html
+++ b/mathml/relations/html5-tree/href-click-001.tentative.html
@@ -28,7 +28,7 @@
     </math>
     <div style="height: 500px;"></div>
     <math id="target">
-      <mspace width="150px" height="150px" style="background: green"/>
+      <mspace width="150px" height="154px" style="background: green"/>
     </math>
   </div>
 

--- a/mathml/relations/html5-tree/href-click-002.tentative.html
+++ b/mathml/relations/html5-tree/href-click-002.tentative.html
@@ -32,7 +32,7 @@
     </math>
     <div style="height: 500px;"></div>
     <math id="target">
-      <mspace width="150px" height="150px" style="background: green"/>
+      <mspace width="150px" height="154px" style="background: green"/>
     </math>
   </div>
 


### PR DESCRIPTION
These tests have an issue where if the scroll to `#target` is a bit off, then the rounding can cause a 1px line difference in the bottom of the square. By making the scrolling target taller it doesn't matter if the scroll is imprecise (as the goal of the test is not to check if the scroll is precise). The final shape is clamped by the `overflow: hidden` div, so it is always a 150x150 px square.

cc @fred-wang