### PR TITLE
Fix `broken-image-icon.html` test for LCP

### DIFF
--- a/largest-contentful-paint/broken-image-icon.html
+++ b/largest-contentful-paint/broken-image-icon.html
@@ -27,16 +27,15 @@
       // There should be only 1 LCP entry and it should be the colors-16x8.png though
       // being smaller than the broken image icon. The broken image icon should not
       // emit an LCP entry.
-      let LcpEntryListLength = await new Promise(resolve => {
+      await new Promise(resolve => {
         new PerformanceObserver((entryList, observer) => {
+          assert_equals(entryList.getEntries().length, 1, 'There should be one and only one LCP entry.');
           const filteredEntries = entryList.getEntries().filter(e => e.url.includes('colors-16x8.png'));
+          assert_equals(filteredEntries.length, 1, 'Got LCP entry from colors-16x8.png.');
           observer.disconnect();
-          resolve(filteredEntries.length);
+          resolve();
         }).observe({ type: 'largest-contentful-paint', buffered: true });
       });
-
-      assert_equals(LcpEntryListLength, 1, 'There should be one and only one LCP entry.');
-
     }, "The broken image icon should not emit an LCP entry.");
   </script>
 </body>


### PR DESCRIPTION
This was overlooked in ##58146.

We need to check the `entryList` and then check the `filteredEntries`.
