### PR TITLE
layout: Add initial support for first-letter pseudo element

### DIFF
--- a/css/css-backgrounds/reference/first-letter-space-not-selected-ref.html
+++ b/css/css-backgrounds/reference/first-letter-space-not-selected-ref.html
@@ -3,6 +3,11 @@
 <head>
     <title>CSS Reftest Reference</title>
     <link rel="author" title="Ethan Malasky" href="mailto:emalasky@adobe.com">
+    <style type="text/css">
+        .test::first-letter {
+            font-size: 3em;
+        }
+    </style>
 </head>
 <body>
     <p>Test passes if there is no red.</p>
@@ -13,5 +18,6 @@
     <div class="test">&emsp;</div>
     <div class="test">&emsp;C</div></body>
     <div class="test">&thinsp;</div>
-    <div class="test">&thinsp;D</div></body>
+    <div class="test">&thinsp;D</div>
+</body>
 </html>

--- a/paint-timing/fcp-only/fcp-typographic-pseudo.html
+++ b/paint-timing/fcp-only/fcp-typographic-pseudo.html
@@ -23,7 +23,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/utils.js"></script>
 <div id="main">
-    <div>Abc</div>
+    <div>A</div>
 </div>
 <script>
     test_fcp("First contentful paint fires only when some of the text is visible, considering ::first-letter.")

--- a/paint-timing/fcp-only/fcp-typographic-pseudo.html
+++ b/paint-timing/fcp-only/fcp-typographic-pseudo.html
@@ -23,7 +23,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/utils.js"></script>
 <div id="main">
-    <div>A</div>
+    <div>Abc</div>
 </div>
 <script>
     test_fcp("First contentful paint fires only when some of the text is visible, considering ::first-letter.")


### PR DESCRIPTION
This and the accompanying stylo PR (https://github.com/servo/stylo/pull/320) is a partial implementation of the `first-letter` pseudo element. The current implementation doesn't support `float` and nesting/inheritance (see spec https://drafts.csswg.org/css-pseudo/#first-letter-tree). These will be supported in future PRs.

Because the first letter would be split into a separate `InlineItem` from the rest of the text, this PR introduces a hack (zero-width joiner codepoint) to address the problem where letters would be written differently when joined together in some languages like Arabic. This hack currently only checks if the language tag is `"ar"` or `"fa"` as I have limited knowledge on such writing systems. A proper solution for this is needed.

Testing: Existing WPT tests. There is one WPT test (fcp-typographic-pseudo.html) that servo currently fails would timeout with this PR because nesting/inheritance is not well supported in this PR.
Fixes: #<!-- nolink -->43008 
Part of: #<!-- nolink -->15413 

Reviewed in servo/servo#43027