### PR TITLE
Payment Request: remove instructions

### DIFF
--- a/payment-request/payment-request-abort-method.https.html
+++ b/payment-request/payment-request-abort-method.https.html
@@ -80,12 +80,3 @@ promise_test(async t => {
   await promise_rejects_dom(t, "AbortError", acceptPromise);
 }, "Aborting a request before it is shown doesn't prevent it from being shown later.");
 </script>
-<small>
-  If you find a buggy test, please
-  <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a> and
-  tag one of the
-  <a
-    href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml"
-    >suggested reviewers</a
-  >.
-</small>

--- a/payment-request/payment-request-canmakepayment-method.https.html
+++ b/payment-request/payment-request-canmakepayment-method.https.html
@@ -114,7 +114,3 @@ promise_test(async t => {
 }, 'If request.[[state]] is "closed", then return a promise rejected with an "InvalidStateError" DOMException.');
 </script>
 
-<small>
-  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
-  and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">suggested reviewers</a>.
-</small>

--- a/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html
+++ b/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html
@@ -72,7 +72,3 @@ promise_test(async t => {
 }, `If request.[[state]] is "closed", then return a promise rejected with an "InvalidStateError" DOMException.`);
 </script>
 
-<small>
-  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
-  and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">suggested reviewers</a>.
-</small>

--- a/payment-request/payment-request-show-method.https.html
+++ b/payment-request/payment-request-show-method.https.html
@@ -94,12 +94,3 @@ promise_test(async (t) => {
   await promise_rejects_dom(t, "InvalidStateError", p3);
 }, "Calling show() multiple times always returns a new promise.");
 </script>
-<small>
-  If you find a buggy test, please
-  <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a> and
-  tag one of the
-  <a
-    href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml"
-    >suggested reviewers</a
-  >.
-</small>


### PR DESCRIPTION
As these are automated tests, we don't need instructions for users. Plus they were causing some issues with .bless() and the test runner on iOS.