### PR TITLE
Safari does not allow video elements without renderer to autoplay

### DIFF
--- a/webrtc/RTCRtpSender-replaceTrack.https.html
+++ b/webrtc/RTCRtpSender-replaceTrack.https.html
@@ -333,6 +333,7 @@ if (interop2026) {
     const metadataToBeLoadedAndPlaying = new Promise((resolve) => {
       v.addEventListener('loadedmetadata', async () => {
         await v.play();
+        // note: calling v.play() is required in some browsers, not all.
         resolve();
       });
     });

--- a/webrtc/RTCRtpSender-replaceTrack.https.html
+++ b/webrtc/RTCRtpSender-replaceTrack.https.html
@@ -298,14 +298,15 @@ if (interop2026) {
     pc2.ontrack = (e) => {
       v.srcObject = new MediaStream([e.track]);
     };
-    const metadataToBeLoaded = new Promise((resolve) => {
-      v.addEventListener('loadedmetadata', () => {
+    const metadataToBeLoadedAndPlaying = new Promise((resolve) => {
+      v.addEventListener('loadedmetadata', async () => {
+        await v.play();
         resolve();
       });
     });
     exchangeIceCandidates(pc1, pc2);
     exchangeOfferAnswer(pc1, pc2);
-    await metadataToBeLoaded;
+    await metadataToBeLoadedAndPlaying;
     await detectSignal(t, v, 20);
     await sender.replaceTrack(track2);
     await detectSignal(t, v, 250);
@@ -328,14 +329,15 @@ if (interop2026) {
     pc2.ontrack = (e) => {
       v.srcObject = new MediaStream([e.track]);
     };
-    const metadataToBeLoaded = new Promise((resolve) => {
-      v.addEventListener('loadedmetadata', () => {
+    const metadataToBeLoadedAndPlaying = new Promise((resolve) => {
+      v.addEventListener('loadedmetadata', async () => {
+        await v.play();
         resolve();
       });
     });
     exchangeIceCandidates(pc1, pc2);
     exchangeOfferAnswer(pc1, pc2);
-    await metadataToBeLoaded;
+    await metadataToBeLoadedAndPlaying;
     await detectSignal(t, v, 20);
     await sender.replaceTrack(null);
     await sender.replaceTrack(track2);

--- a/webrtc/RTCRtpSender-replaceTrack.https.html
+++ b/webrtc/RTCRtpSender-replaceTrack.https.html
@@ -301,6 +301,7 @@ if (interop2026) {
     const metadataToBeLoadedAndPlaying = new Promise((resolve) => {
       v.addEventListener('loadedmetadata', async () => {
         await v.play();
+        // note: calling v.play() is required in some browsers, not all.
         resolve();
       });
     });


### PR DESCRIPTION
To workaround this difference, we make the test explictly call play on the video element.
We keep waiting for loadedmetadata to make sure the video element size is as expected.