### PR TITLE
Avoid the test_dirver.sendKeys and use the WebDriver Actions instead

### DIFF
--- a/editing/include/editor-test-utils.js
+++ b/editing/include/editor-test-utils.js
@@ -37,21 +37,10 @@ class EditorTestUtils {
 
   sendKey(key, modifier) {
     if (!modifier) {
-      // send_keys requires element in the light DOM.
-      const elementInLightDOM = (e => {
-        const doc = e.ownerDocument;
-        while (e.getRootNode({composed:false}) !== doc) {
-          e = e.getRootNode({composed:false}).host;
-        }
-        return e;
-      })(this.editingHost);
-      return this.window.test_driver.send_keys(elementInLightDOM, key)
-        .catch(() => {
-          return new this.window.test_driver.Actions()
-          .keyDown(key)
-          .keyUp(key)
-          .send();
-        });
+      return new this.window.test_driver.Actions()
+        .keyDown(key)
+        .keyUp(key)
+        .send();
     }
     return new this.window.test_driver.Actions()
       .keyDown(modifier)


### PR DESCRIPTION
The the test_driver.sendKeys is not working well in Chrome.  The problem was caused by ChromeDriver's send_keys (WebDriver "Element Send Keys") command silently corrupting the caret position in certain cases.

Given that all the major browser have support for the WebDriver actions, perhaps we could get rid of the send_keys mechanisms. 

