### PR TITLE
Simplify reference filter-invalid-ref.html

### DIFF
--- a/css/filter-effects/filter-invalid-ref.html
+++ b/css/filter-effects/filter-invalid-ref.html
@@ -2,18 +2,10 @@
 <meta charset="utf-8">
 <title>CSS Test Reference</title>
 <style>
-div, rect {
+div {
   width: 100px;
   height: 100px;
 }
-div {
-  background-color: blue;
-}
-rect {
-  fill: purple;
-}
 </style>
-<div></div>
-<svg>
-  <rect></rect>
-</svg>
+<div style="background-color: blue"></div>
+<div style="background-color: purple"></div>


### PR DESCRIPTION
Servo doesn't support `rect`, shows following and yet passes some WPT test. 

<img width="774" height="449" alt="image" src="https://github.com/user-attachments/assets/e7b87a18-32b1-43c6-b4df-b7f01d5a6e31" />
