### PR TITLE
Add mismatch reference catching Safari's issues

### DIFF
--- a/html-ruby-extensions/html-ruby-001.html
+++ b/html-ruby-extensions/html-ruby-001.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-002.html
+++ b/html-ruby-extensions/html-ruby-002.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-003.html
+++ b/html-ruby-extensions/html-ruby-003.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-004.html
+++ b/html-ruby-extensions/html-ruby-004.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-005.html
+++ b/html-ruby-extensions/html-ruby-005.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-006.html
+++ b/html-ruby-extensions/html-ruby-006.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-007.html
+++ b/html-ruby-extensions/html-ruby-007.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-009.html
+++ b/html-ruby-extensions/html-ruby-009.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-013.html
+++ b/html-ruby-extensions/html-ruby-013.html
@@ -13,6 +13,8 @@
 <link rel="mismatch" href="reference/html-ruby-013-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-013-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-013-f-ref.html">
+<link rel="mismatch" href="reference/html-ruby-013-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-013-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-013-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-101.html
+++ b/html-ruby-extensions/html-ruby-101.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-102.html
+++ b/html-ruby-extensions/html-ruby-102.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-103.html
+++ b/html-ruby-extensions/html-ruby-103.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-104.html
+++ b/html-ruby-extensions/html-ruby-104.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-105.html
+++ b/html-ruby-extensions/html-ruby-105.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-106.html
+++ b/html-ruby-extensions/html-ruby-106.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-107.html
+++ b/html-ruby-extensions/html-ruby-107.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-108.html
+++ b/html-ruby-extensions/html-ruby-108.html
@@ -18,6 +18,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-109.html
+++ b/html-ruby-extensions/html-ruby-109.html
@@ -18,6 +18,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-201.html
+++ b/html-ruby-extensions/html-ruby-201.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-202.html
+++ b/html-ruby-extensions/html-ruby-202.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-203.html
+++ b/html-ruby-extensions/html-ruby-203.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-204.html
+++ b/html-ruby-extensions/html-ruby-204.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-205.html
+++ b/html-ruby-extensions/html-ruby-205.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-206.html
+++ b/html-ruby-extensions/html-ruby-206.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-207.html
+++ b/html-ruby-extensions/html-ruby-207.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-208.html
+++ b/html-ruby-extensions/html-ruby-208.html
@@ -19,6 +19,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-209.html
+++ b/html-ruby-extensions/html-ruby-209.html
@@ -19,6 +19,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-301.html
+++ b/html-ruby-extensions/html-ruby-301.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-302.html
+++ b/html-ruby-extensions/html-ruby-302.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-303.html
+++ b/html-ruby-extensions/html-ruby-303.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-304.html
+++ b/html-ruby-extensions/html-ruby-304.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-305.html
+++ b/html-ruby-extensions/html-ruby-305.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-306.html
+++ b/html-ruby-extensions/html-ruby-306.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-307.html
+++ b/html-ruby-extensions/html-ruby-307.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-308.html
+++ b/html-ruby-extensions/html-ruby-308.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-309.html
+++ b/html-ruby-extensions/html-ruby-309.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-313.html
+++ b/html-ruby-extensions/html-ruby-313.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-314.html
+++ b/html-ruby-extensions/html-ruby-314.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-315.html
+++ b/html-ruby-extensions/html-ruby-315.html
@@ -14,6 +14,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-316.html
+++ b/html-ruby-extensions/html-ruby-316.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-401.html
+++ b/html-ruby-extensions/html-ruby-401.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-402.html
+++ b/html-ruby-extensions/html-ruby-402.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-403.html
+++ b/html-ruby-extensions/html-ruby-403.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-404.html
+++ b/html-ruby-extensions/html-ruby-404.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-405.html
+++ b/html-ruby-extensions/html-ruby-405.html
@@ -18,6 +18,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-406.html
+++ b/html-ruby-extensions/html-ruby-406.html
@@ -18,6 +18,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-407.html
+++ b/html-ruby-extensions/html-ruby-407.html
@@ -18,6 +18,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-408.html
+++ b/html-ruby-extensions/html-ruby-408.html
@@ -20,6 +20,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-409.html
+++ b/html-ruby-extensions/html-ruby-409.html
@@ -20,6 +20,7 @@
 <link rel="mismatch" href="reference/html-ruby-008-g-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-i-ref.html">
+<link rel="mismatch" href="reference/html-ruby-008-j-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-008-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-413.html
+++ b/html-ruby-extensions/html-ruby-413.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-414.html
+++ b/html-ruby-extensions/html-ruby-414.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-415.html
+++ b/html-ruby-extensions/html-ruby-415.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-416.html
+++ b/html-ruby-extensions/html-ruby-416.html
@@ -17,6 +17,7 @@
 <link rel="mismatch" href="reference/html-ruby-001-e-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-g-ref.html">
+<link rel="mismatch" href="reference/html-ruby-001-h-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-001-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-502.html
+++ b/html-ruby-extensions/html-ruby-502.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-502-c-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-e-ref.html">
+<link rel="mismatch" href="reference/html-ruby-502-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-503.html
+++ b/html-ruby-extensions/html-ruby-503.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-503-c-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-e-ref.html">
+<link rel="mismatch" href="reference/html-ruby-503-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-504.html
+++ b/html-ruby-extensions/html-ruby-504.html
@@ -13,6 +13,7 @@
 <link rel="mismatch" href="reference/html-ruby-504-c-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-e-ref.html">
+<link rel="mismatch" href="reference/html-ruby-504-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-602.html
+++ b/html-ruby-extensions/html-ruby-602.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-502-c-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-e-ref.html">
+<link rel="mismatch" href="reference/html-ruby-502-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-502-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-603.html
+++ b/html-ruby-extensions/html-ruby-603.html
@@ -16,6 +16,7 @@
 <link rel="mismatch" href="reference/html-ruby-503-c-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-e-ref.html">
+<link rel="mismatch" href="reference/html-ruby-503-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-503-z-ref.html">
 <style>

--- a/html-ruby-extensions/html-ruby-604.html
+++ b/html-ruby-extensions/html-ruby-604.html
@@ -15,6 +15,7 @@
 <link rel="mismatch" href="reference/html-ruby-504-c-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-d-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-e-ref.html">
+<link rel="mismatch" href="reference/html-ruby-504-f-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-y-ref.html">
 <link rel="mismatch" href="reference/html-ruby-504-z-ref.html">
 <style>

--- a/html-ruby-extensions/reference/html-ruby-001-h-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-001-h-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+.r3 { color: purple; }
+</style>
+<body>
+<p>The example below consists of 3 base characters, each annotated with its pronunciation.
+“<span class=r1>浄</span>” is annotated by “<span class=r1>じょう</span>”.
+“<span class=r2>瑠</span>” is annotated by “<span class=r2>る</span>”.
+“<span class=r3>璃</span>” is annotated by “<span class=r3>り</span>”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: first annotation spanning by all 3 bases, remaining annotations floating over nothing -->
+例文は<ruby><span class=r1>浄</span><span class=r2>瑠</span><span class=r3>璃</span><rt class=r1>じょう</ruby><ruby><rt class=r2>る</ruby><ruby><rt class=r3>り</ruby>

--- a/html-ruby-extensions/reference/html-ruby-008-j-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-008-j-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+.r3 { color: purple; }
+</style>
+<body>
+<p>The example below consists of 3 base characters, each annotated with its pronunciation.
+“<span class=r1>浄</span>” is annotated by “<span class=r1>じょう</span>”.
+“<span class=r2>瑠</span>” is annotated by “<span class=r2>る</span>”.
+“<span class=r3>璃</span>” is annotated by “<span class=r3>り</span>”.
+There is also one excess annotation with no base: “け”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base, and
+    <li>the excess annotation appears to be annotating an empty base.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: first annotation spanning by all 3 bases, remaining annotations floating over nothing -->
+例文は<ruby><span class=r1>浄</span><span class=r2>瑠</span><span class=r3>璃</span><rt class=r1>じょう</ruby><ruby><rt class=r2>る</ruby><ruby><rt class=r3>り</ruby><ruby><rt>け</ruby>

--- a/html-ruby-extensions/reference/html-ruby-013-g-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-013-g-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+.r3 { color: purple; }
+</style>
+<body>
+<p>The example below consists of 3 base characters, each annotated with its pronunciation.
+“<span class=r1>浄</span>” is annotated by “<span class=r1>じょう</span>”.
+“<span class=r2>瑠</span>” is annotated by “<span class=r2>る</span>”.
+“<span class=r3>璃</span>” is annotated by “<span class=r3>り</span>”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: first annotation spanning by all 3 bases, remaining annotations floating over nothing -->
+例文は<ruby> <span class=r1>浄</span> <span class=r2>瑠</span> <span class=r3>璃</span><rt class=r1>じょう</ruby><ruby><rt class=r2>る<rt style="margin-left:-1ch" class=r3>り</ruby>

--- a/html-ruby-extensions/reference/html-ruby-013-h-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-013-h-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+.r3 { color: purple; }
+</style>
+<body>
+<p>The example below consists of 3 base characters, each annotated with its pronunciation.
+“<span class=r1>浄</span>” is annotated by “<span class=r1>じょう</span>”.
+“<span class=r2>瑠</span>” is annotated by “<span class=r2>る</span>”.
+“<span class=r3>璃</span>” is annotated by “<span class=r3>り</span>”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: first annotation spanning by all 3 bases, remaining annotations floating over nothing, with manual "kerning" adjusted to match safari's incorrect rendering -->
+例文は<ruby> <span class=r1>浄</span> <span class=r2>瑠</span> <span class=r3>璃</span><rt class=r1>じょう</ruby><ruby><rt class=r2>る<rt style="margin-left:-1ch" class=r3>り</ruby>

--- a/html-ruby-extensions/reference/html-ruby-502-f-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-502-f-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+</style>
+<body>
+<p>The example below consists of 2 base characters, each annotated twice with its pronunciation (once in the latin alphabet, once in kana)
+“<span class=r1>京</span>” is annotated by “<span class=r1>きょう</span>” and “<span class=r1>kyo</span>”.
+“<span class=r2>都</span>” is annotated by “<span class=r2>と</span>” and “<span class=r2>to</span>”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: second annotation displayed over empty bases -->
+例文は<ruby><rb class=r1>京<rb class=r2>都<rtc><rt class=r1>きょう<rt class=r2>と</ruby><ruby><rt><span class=r1>kyo</span><span class=r2>to</span></ruby>

--- a/html-ruby-extensions/reference/html-ruby-503-f-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-503-f-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+.r3 { color: purple; }
+</style>
+<body>
+<p>The example below consists of 3 base characters, each annotated twice, and then all jointly annotated once more.
+“<span class=r1>あ</span>” is annotated by “<span class=r1>1</span>” and “<span class=r1>a</span>”.
+“<span class=r2>い</span>” is annotated by “<span class=r2>2</span>” and “<span class=r2>b</span>”.
+“<span class=r3>う</span>” is annotated by “<span class=r3>3</span>” and “<span class=r3>c</span>”.
+The whole is annotated with “altogether”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base, and
+    <li>the joint annotation is associated with the whole base, not just a part.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: last annotation level's first annotation wrongly spanning, with extra annotations floating over empty bases; other annotation levels annotation displayed as bases -->
+例文は<ruby><span class=r1>あ</span><span class=r2>い</span><span class=r3>う</span><span class=r1>a</span><span class=r2>b</span><span class=r3>c</span>altogether<rt class=r1>1</ruby><ruby><rt class=r2>2</ruby><ruby><rt class=r3>3</ruby>

--- a/html-ruby-extensions/reference/html-ruby-504-f-ref.html
+++ b/html-ruby-extensions/reference/html-ruby-504-f-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" >
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel='author' title='Florian Rivoal' href='https://florian.rivoal.net'>
+<style>
+.r1 { color: orange; }
+.r2 { color: blue; }
+.r3 { color: purple; }
+</style>
+<body>
+<p>The example below consists of 3 base characters, each annotated individually, and also all jointly annotated.
+“<span class=r1>あ</span>” is annotated by “<span class=r1>1</span>”.
+“<span class=r2>い</span>” is annotated by “<span class=r2>2</span>”.
+“<span class=r3>う</span>” is annotated by “<span class=r3>3</span>”.
+The whole is annotated with “altogether”.
+For ease of comparison, it is preceded by some context text: “例文は”.
+This test passes if:
+<ul>
+    <li>each base character is presented inline with and similarly to the context text, as if they are all part of the same sentence, and
+    <li>each annotation is presented as an annotation, and
+    <li>the correct annotation is presented clearly as being associated with the correct base, and
+    <li>the joint annotation is associated with the whole base, not just a part.
+</ul>
+
+<p>Note: The colors are not part of the test,
+they are merely provided as help to the person running the test,
+to make it easier to recognize the various parts of the text.
+
+<p>Note: This is not a layout or rendering test.
+The precise appearance is not specified,
+and implementations may therefore validly vary.
+
+<hr> <!-- incorrect rendering: last annotation level's first annotation wrongly spanning, with extra annotations floating over empty bases; other annotation level annotation displayed as bases -->
+例文は<ruby><span class=r1>あ</span><span class=r2>い</span><span class=r3>う</span>altogether<rt class=r1>1</ruby><ruby><rt class=r2>2</ruby><ruby><rt class=r3>3</ruby>


### PR DESCRIPTION
Follow up to #58150, adding mismatch references to account for rendering differences between Chrome and Safari. Some mismatch references which worked in Chrome failed to catch tests that should fail in Safari due to the fact that ruby with a zero-width-space as the base get rendered more widely than "zero-with" in Safari. Adding corresponding mismatch references with empty bases rather than zero-wdith-space bases, (and one case of manual kerning between two adjacent empty bases) as that does catch the expected failures.