### PR TITLE
Migrate clipboard-apis tests from Feature-Policy to Permissions-Policy

### DIFF
--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-disabled-by-feature-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-disabled-by-feature-policy.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-read 'none'

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-cross-origin.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-cross-origin.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-read *

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-read *

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-read 'self'

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-disabled-by-feature-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-disabled-by-feature-policy.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-write 'none'

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-cross-origin.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-cross-origin.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-write *

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-write *

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html.headers
@@ -1,1 +1,0 @@
-Feature-Policy: clipboard-write 'self'

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-disabled-by-permissions-policy.tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-disabled-by-permissions-policy.tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-read.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-read.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -18,7 +18,7 @@ promise_test(async t => {
   await tryGrantReadPermission();
   return promise_rejects_dom(t, 'NotAllowedError',
       navigator.clipboard.readText('test text'));
-}, 'Feature-Policy header clipboard-read "none" disallows the top-level document.');
+}, 'Permissions-Policy header clipboard-read=() disallows the top-level document.');
 
 async_test(t => {
   test_feature_availability(
@@ -27,7 +27,7 @@ async_test(t => {
     same_origin_src,
     expect_feature_unavailable_default
   );
-}, 'Feature-Policy header clipboard-read "none" disallows same-origin iframes.');
+}, 'Permissions-Policy header clipboard-read=() disallows same-origin iframes.');
 
 async_test(t => {
   test_feature_availability(
@@ -36,6 +36,6 @@ async_test(t => {
     cross_origin_src,
     expect_feature_unavailable_default
   );
-}, 'Feature-Policy header clipboard-read "none" disallows cross-origin iframes.');
+}, 'Permissions-Policy header clipboard-read=() disallows cross-origin iframes.');
 </script>
 </body>

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-disabled-by-permissions-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-disabled-by-permissions-policy.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-read=()

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-attribute-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-attribute-cross-origin-tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-write.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-read.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -21,11 +21,11 @@ const cross_origin_src =
 promise_test(async t => {
   await waitForUserActivation();
   test_feature_availability(
-    'navigator.clipboard.writeText("test text")',
+    'navigator.clipboard.readText()',
     t,
     cross_origin_src,
     expect_feature_available_default,
-    'clipboard-write'
+    'clipboard-read'
   );
-}, 'Feature policy "clipboard-write" can be enabled in cross-origin iframe using allow="clipboard-write" attribute');
+}, 'Permissions policy "clipboard-read" can be enabled in cross-origin iframe using allow="clipboard-read" attribute');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-attribute-tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-attribute-tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-read.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-read.html';
 
 promise_test(async t => {
   await waitForUserActivation();
@@ -21,5 +21,5 @@ promise_test(async t => {
     expect_feature_available_default,
     'clipboard-read'
   );
-}, 'Feature policy "clipboard-read" can be enabled in same-origin iframe using allow="clipboard-read" attribute');
+}, 'Permissions policy "clipboard-read" can be enabled in same-origin iframe using allow="clipboard-read" attribute');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-cross-origin-tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-write.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-read.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -21,10 +21,10 @@ const cross_origin_src =
 promise_test(async t => {
   await waitForUserActivation();
   test_feature_availability(
-    'navigator.clipboard.writeText("test text")',
+    'navigator.clipboard.readText()',
     t,
     cross_origin_src,
     expect_feature_available_default
   );
-}, 'Feature-Policy header clipboard-write "*" allows cross-origin iframes.');
+}, 'Permissions-Policy header clipboard-read=* allows cross-origin iframes.');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-cross-origin.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy-cross-origin.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-read=*

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy.tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy.tentative.https.sub.html
@@ -4,28 +4,29 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-read.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-read.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
-// TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
-// In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome
-// only, cross-origin focus is asynchronous. Implement WPT support for
-// cross-origin focus.
+promise_test(async t => {
+  await tryGrantReadPermission();
+  await waitForUserActivation();
+  await navigator.clipboard.readText('test text');
+}, 'Permissions-Policy header clipboard-read=* allows the top-level document.');
+
 promise_test(async t => {
   await waitForUserActivation();
   test_feature_availability(
     'navigator.clipboard.readText()',
     t,
-    cross_origin_src,
-    expect_feature_available_default,
-    'clipboard-read'
+    same_origin_src,
+    expect_feature_available_default
   );
-}, 'Feature policy "clipboard-read" can be enabled in cross-origin iframe using allow="clipboard-read" attribute');
+}, 'Permissions-Policy header clipboard-read=* allows same-origin iframes.');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-by-permissions-policy.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-read=*

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-read.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-read.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -18,7 +18,7 @@ promise_test(async t => {
   await tryGrantReadPermission();
   await waitForUserActivation();
   await navigator.clipboard.readText('test text');
-}, 'Feature-Policy header clipboard-read "*" allows the top-level document.');
+}, 'Permissions-Policy header clipboard-read=self allows the top-level document.');
 
 promise_test(async t => {
   await waitForUserActivation();
@@ -28,5 +28,18 @@ promise_test(async t => {
     same_origin_src,
     expect_feature_available_default
   );
-}, 'Feature-Policy header clipboard-read "*" allows same-origin iframes.');
+}, 'Permissions-Policy header clipboard-read=self allows same-origin iframes.');
+
+// TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
+// In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome
+// only, cross-origin focus is asynchronous. Implement WPT support for
+// cross-origin focus.
+promise_test(async t => {
+  test_feature_availability(
+    'navigator.clipboard.readText()',
+    t,
+    cross_origin_src,
+    expect_feature_unavailable_default
+  );
+}, 'Permissions-Policy header clipboard-read=self disallows cross-origin iframes.');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-read=self

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-disabled-by-permissions-policy.tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-disabled-by-permissions-policy.tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-write.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-write.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -18,7 +18,7 @@ promise_test(async t => {
   await tryGrantWritePermission();
   return promise_rejects_dom(t, 'NotAllowedError',
       navigator.clipboard.writeText('test text'));
-}, 'Feature-Policy header clipboard-write "none" disallows the top-level document.');
+}, 'Permissions-Policy header clipboard-write=() disallows the top-level document.');
 
 async_test(t => {
   test_feature_availability(
@@ -27,7 +27,7 @@ async_test(t => {
     same_origin_src,
     expect_feature_unavailable_default
   );
-}, 'Feature-Policy header clipboard-write "none" disallows same-origin iframes.');
+}, 'Permissions-Policy header clipboard-write=() disallows same-origin iframes.');
 
 async_test(t => {
   test_feature_availability(
@@ -36,6 +36,6 @@ async_test(t => {
     cross_origin_src,
     expect_feature_unavailable_default
   );
-}, 'Feature-Policy header clipboard-write "none" disallows cross-origin iframes.');
+}, 'Permissions-Policy header clipboard-write=() disallows cross-origin iframes.');
 </script>
 </body>

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-disabled-by-permissions-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-disabled-by-permissions-policy.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-write=()

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-attribute-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-attribute-cross-origin-tentative.https.sub.html
@@ -4,42 +4,28 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-read.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-write.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
-
-promise_test(async t => {
-  await tryGrantReadPermission();
-  await waitForUserActivation();
-  await navigator.clipboard.readText('test text');
-}, 'Feature-Policy header clipboard-read "self" allows the top-level document.');
-
-promise_test(async t => {
-  await waitForUserActivation();
-  test_feature_availability(
-    'navigator.clipboard.readText()',
-    t,
-    same_origin_src,
-    expect_feature_available_default
-  );
-}, 'Feature-Policy header clipboard-read "self" allows same-origin iframes.');
 
 // TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
 // In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome
 // only, cross-origin focus is asynchronous. Implement WPT support for
 // cross-origin focus.
 promise_test(async t => {
+  await waitForUserActivation();
   test_feature_availability(
-    'navigator.clipboard.readText()',
+    'navigator.clipboard.writeText("test text")',
     t,
     cross_origin_src,
-    expect_feature_unavailable_default
+    expect_feature_available_default,
+    'clipboard-write'
   );
-}, 'Feature-Policy header clipboard-read "self" disallows cross-origin iframes.');
+}, 'Permissions policy "clipboard-write" can be enabled in cross-origin iframe using allow="clipboard-write" attribute');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-attribute-tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-attribute-tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-write.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-write.html';
 
 promise_test(async t => {
   await waitForUserActivation();
@@ -21,5 +21,5 @@ promise_test(async t => {
     expect_feature_available_default,
     'clipboard-write'
   );
-}, 'Feature policy "clipboard-write" can be enabled in same-origin iframe using allow="clipboard-write" attribute');
+}, 'Permissions policy "clipboard-write" can be enabled in same-origin iframe using allow="clipboard-write" attribute');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-cross-origin-tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-read.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-write.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -21,10 +21,10 @@ const cross_origin_src =
 promise_test(async t => {
   await waitForUserActivation();
   test_feature_availability(
-    'navigator.clipboard.readText()',
+    'navigator.clipboard.writeText("test text")',
     t,
     cross_origin_src,
     expect_feature_available_default
   );
-}, 'Feature-Policy header clipboard-read "*" allows cross-origin iframes.');
+}, 'Permissions-Policy header clipboard-write=* allows cross-origin iframes.');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-cross-origin.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy-cross-origin.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-write=*

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy.tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy.tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-write.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-write.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -18,7 +18,7 @@ promise_test(async t => {
   await tryGrantWritePermission();
   await waitForUserActivation();
   await navigator.clipboard.writeText('test text');
-}, 'Feature-Policy header clipboard-write "*" allows the top-level document.');
+}, 'Permissions-Policy header clipboard-write=* allows the top-level document.');
 
 promise_test(async t => {
   await waitForUserActivation();
@@ -28,5 +28,5 @@ promise_test(async t => {
     same_origin_src,
     expect_feature_available_default
   );
-}, 'Feature-Policy header clipboard-write "*" allows same-origin iframes.');
+}, 'Permissions-Policy header clipboard-write=* allows same-origin iframes.');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-by-permissions-policy.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-write=*

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="../../resources/user-activation.js"></script>
 <script>
 'use strict';
 
 const same_origin_src =
-  '/feature-policy/resources/feature-policy-clipboard-write.html';
+  '/permissions-policy/resources/permissions-policy-clipboard-write.html';
 const cross_origin_src =
   'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
@@ -18,7 +18,7 @@ promise_test(async t => {
   await tryGrantWritePermission();
   await waitForUserActivation();
   await navigator.clipboard.writeText('test text');
-}, 'Feature-Policy header clipboard-write "self" allows the top-level document.');
+}, 'Permissions-Policy header clipboard-write=self allows the top-level document.');
 
 promise_test(async t => {
   await waitForUserActivation();
@@ -28,7 +28,7 @@ promise_test(async t => {
     same_origin_src,
     expect_feature_available_default
   );
-}, 'Feature-Policy header clipboard-write "self" allows same-origin iframes.');
+}, 'Permissions-Policy header clipboard-write=self allows same-origin iframes.');
 
 promise_test(async t => {
   test_feature_availability(
@@ -37,5 +37,5 @@ promise_test(async t => {
     cross_origin_src,
     expect_feature_unavailable_default
   );
-}, 'Feature-Policy header clipboard-write "self" disallows cross-origin iframes.');
+}, 'Permissions-Policy header clipboard-write=self disallows cross-origin iframes.');
 </script>

--- a/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html.headers
+++ b/clipboard-apis/permissions-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-permissions-policy.tentative.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: clipboard-write=self


### PR DESCRIPTION
Rename feature-policy/ directory to permissions-policy/ and update header files to use Permissions-Policy header instead of the deprecated Feature-Policy header.