### PR TITLE
Migrate magnetometer tests from Feature-Policy to Permissions-Policy

### DIFF
--- a/generic-sensor/generic-sensor-feature-policy-test.sub.js
+++ b/generic-sensor/generic-sensor-feature-policy-test.sub.js
@@ -1,4 +1,4 @@
-const feature_policies = {
+const permissions_policies = {
   "AmbientLightSensor" : ["ambient-light-sensor"],
   "Accelerometer" : ["accelerometer"],
   "LinearAccelerationSensor" : ["accelerometer"],
@@ -17,14 +17,14 @@ const cross_origin_src =
   "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
 const base_src = "/feature-policy/resources/redirect-on-load.html#";
 
-function get_feature_policies_for_sensor(sensorType) {
-  return feature_policies[sensorType];
+function get_permissions_policies_for_sensor(sensorType) {
+  return permissions_policies[sensorType];
 }
 
-function run_fp_tests_disabled(sensorName) {
+function run_permissions_policy_tests_disabled(sensorName) {
   const sensorType = self[sensorName];
-  const featureNameList = feature_policies[sensorName];
-  const header = "Feature-Policy header " + featureNameList.join(" 'none';") + " 'none'";
+  const featureNameList = permissions_policies[sensorName];
+  const header = "Permissions-Policy header " + featureNameList.join("=();") + "=()";
   const desc = "'new " + sensorName + "()'";
 
   test(() => {
@@ -53,9 +53,9 @@ function run_fp_tests_disabled(sensorName) {
   }, `${sensorName}: ${header} disallows cross-origin iframes.`);
 }
 
-function run_fp_tests_enabled(sensorName) {
-  const featureNameList = feature_policies[sensorName];
-  const header = "Feature-Policy header " + featureNameList.join(" *;") + " *";
+function run_permissions_policy_tests_enabled(sensorName) {
+  const featureNameList = permissions_policies[sensorName];
+  const header = "Permissions-Policy header " + featureNameList.join("=*;") + "=*";
   const desc = "'new " + sensorName + "()'";
 
   test(() => {
@@ -81,14 +81,14 @@ function run_fp_tests_enabled(sensorName) {
       t,
       cross_origin_src + sensorName,
       expect_feature_available_default,
-      feature_policies[sensorName].join(";")
+      permissions_policies[sensorName].join(";")
     );
   }, `${sensorName}: ${header} allows cross-origin iframes.`);
 }
 
-function run_fp_tests_enabled_by_attribute(sensorName) {
-  const featureNameList = feature_policies[sensorName];
-  const header = "Feature-Policy allow='" + featureNameList.join(" ") + "' attribute";
+function run_permissions_policy_tests_enabled_by_attribute(sensorName) {
+  const featureNameList = permissions_policies[sensorName];
+  const header = "Permissions-Policy allow='" + featureNameList.join(" ") + "' attribute";
   const desc = "'new " + sensorName + "()'";
 
   async_test(t => {
@@ -114,9 +114,9 @@ function run_fp_tests_enabled_by_attribute(sensorName) {
   }, `${sensorName}: ${header} allows cross-origin iframe`);
 }
 
-function run_fp_tests_enabled_by_attribute_redirect_on_load(sensorName) {
-  const featureNameList = feature_policies[sensorName];
-  const header = "Feature-Policy allow='" + featureNameList.join(" ") + "' attribute";
+function run_permissions_policy_tests_enabled_by_attribute_redirect_on_load(sensorName) {
+  const featureNameList = permissions_policies[sensorName];
+  const header = "Permissions-Policy allow='" + featureNameList.join(" ") + "' attribute";
   const desc = "'new " + sensorName + "()'";
 
   async_test(t => {
@@ -142,9 +142,9 @@ function run_fp_tests_enabled_by_attribute_redirect_on_load(sensorName) {
   }, `${sensorName}: ${header} disallows cross-origin relocation`);
 }
 
-function run_fp_tests_enabled_on_self_origin(sensorName) {
-  const featureNameList = feature_policies[sensorName];
-  const header = "Feature-Policy header " + featureNameList.join(" 'self';") + " 'self'";
+function run_permissions_policy_tests_enabled_on_self_origin(sensorName) {
+  const featureNameList = permissions_policies[sensorName];
+  const header = "Permissions-Policy header " + featureNameList.join("=(self);") + "=(self)";
   const desc = "'new " + sensorName + "()'";
 
   test(() => {
@@ -171,3 +171,13 @@ function run_fp_tests_enabled_on_self_origin(sensorName) {
     );
   }, `${sensorName}: ${header} disallows cross-origin iframes.`);
 }
+
+// Backward compatibility aliases for legacy function names
+// TODO: Remove these once all test files are updated to use the new names
+const feature_policies = permissions_policies;
+const get_feature_policies_for_sensor = get_permissions_policies_for_sensor;
+const run_fp_tests_disabled = run_permissions_policy_tests_disabled;
+const run_fp_tests_enabled = run_permissions_policy_tests_enabled;
+const run_fp_tests_enabled_by_attribute = run_permissions_policy_tests_enabled_by_attribute;
+const run_fp_tests_enabled_by_attribute_redirect_on_load = run_permissions_policy_tests_enabled_by_attribute_redirect_on_load;
+const run_fp_tests_enabled_on_self_origin = run_permissions_policy_tests_enabled_on_self_origin;

--- a/generic-sensor/generic-sensor-iframe-tests.sub.js
+++ b/generic-sensor/generic-sensor-iframe-tests.sub.js
@@ -29,7 +29,7 @@ function run_generic_sensor_iframe_tests(sensorData, readingData) {
 
   const {sensorName, permissionName, testDriverName} = sensorData;
   const sensorType = self[sensorName];
-  const featurePolicies = get_feature_policies_for_sensor(sensorName);
+  const featurePolicies = get_permissions_policies_for_sensor(sensorName);
 
   // When comparing timestamps in the tests below, we need to account for small
   // deviations coming from the way time is coarsened according to the High

--- a/magnetometer/Magnetometer-disabled-by-feature-policy.https.html
+++ b/magnetometer/Magnetometer-disabled-by-feature-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Disabled</title>
+<title>Magnetometer Permissions Policy Test: Disabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/magnetometer/Magnetometer-disabled-by-feature-policy.https.html
+++ b/magnetometer/Magnetometer-disabled-by-feature-policy.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_disabled('Magnetometer');
-run_fp_tests_disabled('UncalibratedMagnetometer');
+run_permissions_policy_tests_disabled('Magnetometer');
+run_permissions_policy_tests_disabled('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Disabled</title>
+<title>Magnetometer Permissions Policy Test: Disabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_disabled('Magnetometer');
-run_fp_tests_disabled('UncalibratedMagnetometer');
+run_permissions_policy_tests_disabled('Magnetometer');
+run_permissions_policy_tests_disabled('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<body>
+<title>Magnetometer Feature Policy Test: Disabled</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_disabled('Magnetometer');
+run_fp_tests_disabled('UncalibratedMagnetometer');
+</script>
+</body>

--- a/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html.headers
+++ b/magnetometer/Magnetometer-disabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: magnetometer=()

--- a/magnetometer/Magnetometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
+++ b/magnetometer/Magnetometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled by attribute redirect on load</title>
+<title>Magnetometer Permissions Policy Test: Enabled by attribute redirect on load</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/magnetometer/Magnetometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
+++ b/magnetometer/Magnetometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute_redirect_on_load('Magnetometer');
-run_fp_tests_enabled_by_attribute_redirect_on_load('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('Magnetometer');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-by-feature-policy-attribute.https.html
+++ b/magnetometer/Magnetometer-enabled-by-feature-policy-attribute.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute('Magnetometer');
-run_fp_tests_enabled_by_attribute('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled_by_attribute('Magnetometer');
+run_permissions_policy_tests_enabled_by_attribute('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-by-feature-policy-attribute.https.html
+++ b/magnetometer/Magnetometer-enabled-by-feature-policy-attribute.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled by attribute</title>
+<title>Magnetometer Permissions Policy Test: Enabled by attribute</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/magnetometer/Magnetometer-enabled-by-feature-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-by-feature-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled</title>
+<title>Magnetometer Permissions Policy Test: Enabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/magnetometer/Magnetometer-enabled-by-feature-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-by-feature-policy.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled('Magnetometer');
-run_fp_tests_enabled('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled('Magnetometer');
+run_permissions_policy_tests_enabled('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute_redirect_on_load('Magnetometer');
-run_fp_tests_enabled_by_attribute_redirect_on_load('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('Magnetometer');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<body>
+<title>Magnetometer Feature Policy Test: Enabled by attribute redirect on load</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled_by_attribute_redirect_on_load('Magnetometer');
+run_fp_tests_enabled_by_attribute_redirect_on_load('UncalibratedMagnetometer');
+</script>
+</body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled by attribute redirect on load</title>
+<title>Magnetometer Permissions Policy Test: Enabled by attribute redirect on load</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute.https.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<body>
+<title>Magnetometer Feature Policy Test: Enabled by attribute</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled_by_attribute('Magnetometer');
+run_fp_tests_enabled_by_attribute('UncalibratedMagnetometer');
+</script>
+</body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute('Magnetometer');
-run_fp_tests_enabled_by_attribute('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled_by_attribute('Magnetometer');
+run_permissions_policy_tests_enabled_by_attribute('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy-attribute.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled by attribute</title>
+<title>Magnetometer Permissions Policy Test: Enabled by attribute</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<body>
+<title>Magnetometer Feature Policy Test: Enabled</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled('Magnetometer');
+run_fp_tests_enabled('UncalibratedMagnetometer');
+</script>
+</body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled('Magnetometer');
-run_fp_tests_enabled('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled('Magnetometer');
+run_permissions_policy_tests_enabled('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled</title>
+<title>Magnetometer Permissions Policy Test: Enabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html.headers
+++ b/magnetometer/Magnetometer-enabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: magnetometer=*

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-feature-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-feature-policy.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_on_self_origin('Magnetometer');
-run_fp_tests_enabled_on_self_origin('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled_on_self_origin('Magnetometer');
+run_permissions_policy_tests_enabled_on_self_origin('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-feature-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-feature-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled on self origin</title>
+<title>Magnetometer Permissions Policy Test: Enabled on self origin</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html
@@ -8,7 +8,7 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_on_self_origin('Magnetometer');
-run_fp_tests_enabled_on_self_origin('UncalibratedMagnetometer');
+run_permissions_policy_tests_enabled_on_self_origin('Magnetometer');
+run_permissions_policy_tests_enabled_on_self_origin('UncalibratedMagnetometer');
 </script>
 </body>

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<body>
+<title>Magnetometer Feature Policy Test: Enabled on self origin</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled_on_self_origin('Magnetometer');
+run_fp_tests_enabled_on_self_origin('UncalibratedMagnetometer');
+</script>
+</body>

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Magnetometer Feature Policy Test: Enabled on self origin</title>
+<title>Magnetometer Permissions Policy Test: Enabled on self origin</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,1 +1,1 @@
-Permissions-Policy: magnetometer=self
+Permissions-Policy: magnetometer=(self)

--- a/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/magnetometer/Magnetometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: magnetometer=self

--- a/magnetometer/Magnetometer-supported-by-permissions-policy.html
+++ b/magnetometer/Magnetometer-supported-by-permissions-policy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Test that magnetometer is advertised in the feature list</title>
+<link rel="help" href="https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicy-features">
+<link rel="help" href="https://w3c.github.io/sensors/#permissions-policy-api">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+    assert_in_array('magnetometer', document.permissionsPolicy.features());
+}, 'document.permissionsPolicy.features should advertise magnetometer.');
+</script>


### PR DESCRIPTION
Rename test files and update header files to use Permissions-Policy header instead of the deprecated Feature-Policy header.