### PR TITLE
Migrate accelerometer tests from Feature-Policy to Permissions-Policy

### DIFF
--- a/accelerometer/Accelerometer-disabled-by-feature-policy.https.html
+++ b/accelerometer/Accelerometer-disabled-by-feature-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Disabled</title>
+<title>Accelerometer Permissions Policy Test: Disabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/accelerometer/Accelerometer-disabled-by-feature-policy.https.html
+++ b/accelerometer/Accelerometer-disabled-by-feature-policy.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_disabled('Accelerometer');
-run_fp_tests_disabled('LinearAccelerationSensor');
-run_fp_tests_disabled('GravitySensor');
+run_permissions_policy_tests_disabled('Accelerometer');
+run_permissions_policy_tests_disabled('LinearAccelerationSensor');
+run_permissions_policy_tests_disabled('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Disabled</title>
+<title>Accelerometer Permissions Policy Test: Disabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<title>Accelerometer Feature Policy Test: Disabled</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_disabled('Accelerometer');
+run_fp_tests_disabled('LinearAccelerationSensor');
+run_fp_tests_disabled('GravitySensor');
+</script>
+</body>

--- a/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_disabled('Accelerometer');
-run_fp_tests_disabled('LinearAccelerationSensor');
-run_fp_tests_disabled('GravitySensor');
+run_permissions_policy_tests_disabled('Accelerometer');
+run_permissions_policy_tests_disabled('LinearAccelerationSensor');
+run_permissions_policy_tests_disabled('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html.headers
+++ b/accelerometer/Accelerometer-disabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=()

--- a/accelerometer/Accelerometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
+++ b/accelerometer/Accelerometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled by attribute redirect on load</title>
+<title>Accelerometer Permissions Policy Test: Enabled by attribute redirect on load</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/accelerometer/Accelerometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
+++ b/accelerometer/Accelerometer-enabled-by-feature-policy-attribute-redirect-on-load.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute_redirect_on_load('Accelerometer');
-run_fp_tests_enabled_by_attribute_redirect_on_load('LinearAccelerationSensor');
-run_fp_tests_enabled_by_attribute_redirect_on_load('GravitySensor');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('Accelerometer');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-by-feature-policy-attribute.https.html
+++ b/accelerometer/Accelerometer-enabled-by-feature-policy-attribute.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute('Accelerometer');
-run_fp_tests_enabled_by_attribute('LinearAccelerationSensor');
-run_fp_tests_enabled_by_attribute('GravitySensor');
+run_permissions_policy_tests_enabled_by_attribute('Accelerometer');
+run_permissions_policy_tests_enabled_by_attribute('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled_by_attribute('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-by-feature-policy-attribute.https.html
+++ b/accelerometer/Accelerometer-enabled-by-feature-policy-attribute.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled by attribute</title>
+<title>Accelerometer Permissions Policy Test: Enabled by attribute</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/accelerometer/Accelerometer-enabled-by-feature-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-by-feature-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled</title>
+<title>Accelerometer Permissions Policy Test: Enabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/accelerometer/Accelerometer-enabled-by-feature-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-by-feature-policy.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled('Accelerometer');
-run_fp_tests_enabled('LinearAccelerationSensor');
-run_fp_tests_enabled('GravitySensor');
+run_permissions_policy_tests_enabled('Accelerometer');
+run_permissions_policy_tests_enabled('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<title>Accelerometer Feature Policy Test: Enabled by attribute redirect on load</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled_by_attribute_redirect_on_load('Accelerometer');
+run_fp_tests_enabled_by_attribute_redirect_on_load('LinearAccelerationSensor');
+run_fp_tests_enabled_by_attribute_redirect_on_load('GravitySensor');
+</script>
+</body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled by attribute redirect on load</title>
+<title>Accelerometer Permissions Policy Test: Enabled by attribute redirect on load</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute_redirect_on_load('Accelerometer');
-run_fp_tests_enabled_by_attribute_redirect_on_load('LinearAccelerationSensor');
-run_fp_tests_enabled_by_attribute_redirect_on_load('GravitySensor');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('Accelerometer');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled_by_attribute_redirect_on_load('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute.https.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<title>Accelerometer Feature Policy Test: Enabled by attribute</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled_by_attribute('Accelerometer');
+run_fp_tests_enabled_by_attribute('LinearAccelerationSensor');
+run_fp_tests_enabled_by_attribute('GravitySensor');
+</script>
+</body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled by attribute</title>
+<title>Accelerometer Permissions Policy Test: Enabled by attribute</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy-attribute.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_by_attribute('Accelerometer');
-run_fp_tests_enabled_by_attribute('LinearAccelerationSensor');
-run_fp_tests_enabled_by_attribute('GravitySensor');
+run_permissions_policy_tests_enabled_by_attribute('Accelerometer');
+run_permissions_policy_tests_enabled_by_attribute('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled_by_attribute('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<title>Accelerometer Feature Policy Test: Enabled</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled('Accelerometer');
+run_fp_tests_enabled('LinearAccelerationSensor');
+run_fp_tests_enabled('GravitySensor');
+</script>
+</body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled</title>
+<title>Accelerometer Permissions Policy Test: Enabled</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled('Accelerometer');
-run_fp_tests_enabled('LinearAccelerationSensor');
-run_fp_tests_enabled('GravitySensor');
+run_permissions_policy_tests_enabled('Accelerometer');
+run_permissions_policy_tests_enabled('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html.headers
+++ b/accelerometer/Accelerometer-enabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=*

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-feature-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-feature-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled on self origin</title>
+<title>Accelerometer Permissions Policy Test: Enabled on self origin</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-feature-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-feature-policy.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_on_self_origin('Accelerometer');
-run_fp_tests_enabled_on_self_origin('LinearAccelerationSensor');
-run_fp_tests_enabled_on_self_origin('GravitySensor');
+run_permissions_policy_tests_enabled_on_self_origin('Accelerometer');
+run_permissions_policy_tests_enabled_on_self_origin('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled_on_self_origin('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<title>Accelerometer Feature Policy Test: Enabled on self origin</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/generic-sensor/generic-sensor-feature-policy-test.sub.js"></script>
+<script>
+"use strict";
+
+run_fp_tests_enabled_on_self_origin('Accelerometer');
+run_fp_tests_enabled_on_self_origin('LinearAccelerationSensor');
+run_fp_tests_enabled_on_self_origin('GravitySensor');
+</script>
+</body>

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
-<title>Accelerometer Feature Policy Test: Enabled on self origin</title>
+<title>Accelerometer Permissions Policy Test: Enabled on self origin</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/permissions-policy/resources/permissions-policy.js"></script>

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html
@@ -8,8 +8,8 @@
 <script>
 "use strict";
 
-run_fp_tests_enabled_on_self_origin('Accelerometer');
-run_fp_tests_enabled_on_self_origin('LinearAccelerationSensor');
-run_fp_tests_enabled_on_self_origin('GravitySensor');
+run_permissions_policy_tests_enabled_on_self_origin('Accelerometer');
+run_permissions_policy_tests_enabled_on_self_origin('LinearAccelerationSensor');
+run_permissions_policy_tests_enabled_on_self_origin('GravitySensor');
 </script>
 </body>

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,1 +1,1 @@
-Permissions-Policy: accelerometer=self
+Permissions-Policy: accelerometer=(self)

--- a/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/accelerometer/Accelerometer-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=self

--- a/accelerometer/Accelerometer-supported-by-permissions-policy.html
+++ b/accelerometer/Accelerometer-supported-by-permissions-policy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Test that accelerometer is advertised in the feature list</title>
+<link rel="help" href="https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicy-features">
+<link rel="help" href="https://w3c.github.io/sensors/#permissions-policy-api">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+    assert_in_array('accelerometer', document.permissionsPolicy.features());
+}, 'document.permissionsPolicy.features should advertise accelerometer.');
+</script>


### PR DESCRIPTION
Rename test files and update header files to use Permissions-Policy header instead of the deprecated Feature-Policy header.