### PR TITLE
Add historical permissions-policy tests

### DIFF
--- a/permissions-policy/historical-feature-policy-header.html
+++ b/permissions-policy/historical-feature-policy-header.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Feature-Policy header should not be supported</title>
+<link rel="help" href="https://www.w3.org/TR/permissions-policy/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // Test: Feature-Policy header should be ignored by compliant browsers
+    // The header file sets: Feature-Policy: sync-xhr 'none'
+    // If Feature-Policy is correctly ignored, sync XHR should still work
+    test(() => {
+      const xhr = new XMLHttpRequest();
+      xhr.open("GET", document.location.href, false);
+      xhr.send();
+      assert_equals(
+        xhr.status,
+        200,
+        "Sync XHR should succeed because Feature-Policy header should be ignored"
+      );
+    }, "Feature-Policy header should not block features (use Permissions-Policy instead)");
+  </script>
+</body>

--- a/permissions-policy/historical-feature-policy-header.html.headers
+++ b/permissions-policy/historical-feature-policy-header.html.headers
@@ -1,2 +1,1 @@
-Permissions-Policy: sync-xhr=*
 Feature-Policy: sync-xhr 'none'

--- a/permissions-policy/historical.html
+++ b/permissions-policy/historical.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<title>Historical Feature Policy features should not be present</title>
+<link rel="help" href="https://www.w3.org/TR/permissions-policy/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// Test 1: document.featurePolicy API should not exist (replaced by document.permissionsPolicy)
+test(function() {
+    assert_false('featurePolicy' in document,
+                 'document.featurePolicy should not exist');
+}, 'document.featurePolicy should not be present (use document.permissionsPolicy instead)');
+
+// Test 2: HTMLIFrameElement.featurePolicy API should not exist (replaced by permissionsPolicy)
+test(function() {
+    assert_false('featurePolicy' in HTMLIFrameElement.prototype,
+                 'HTMLIFrameElement.prototype.featurePolicy should not exist');
+}, 'HTMLIFrameElement.prototype.featurePolicy should not be present');
+
+// Test 3: Feature-Policy header should be ignored when Permissions-Policy is present
+// The header file sets: Feature-Policy: sync-xhr 'none'
+// And: Permissions-Policy: sync-xhr=*
+// If Feature-Policy is correctly ignored, sync XHR should work
+test(function() {
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", document.location.href, false);
+    xhr.send();
+    assert_equals(xhr.status, 200, 'Sync XHR should succeed because Permissions-Policy allows it');
+}, 'Feature-Policy header should be ignored when Permissions-Policy is present');
+
+// Test 4: iframe allow attribute should work with Permissions Policy
+async_test(function(t) {
+    var iframe = document.createElement('iframe');
+    iframe.src = 'resources/historical-iframe.html';
+    iframe.allow = "sync-xhr 'none'";
+    
+    window.addEventListener('message', t.step_func_done(function(e) {
+        if (e.source !== iframe.contentWindow) return;
+        assert_equals(e.data.result, 'blocked',
+                      'sync-xhr should be blocked in iframe when allow="sync-xhr \'none\'"');
+    }));
+    
+    document.body.appendChild(iframe);
+}, 'iframe allow attribute blocks features using Permissions Policy syntax');
+</script>
+</body>

--- a/permissions-policy/historical.html
+++ b/permissions-policy/historical.html
@@ -33,13 +33,13 @@ async_test(function(t) {
     var iframe = document.createElement('iframe');
     iframe.src = 'resources/historical-iframe.html';
     iframe.allow = "sync-xhr 'none'";
-    
+
     window.addEventListener('message', t.step_func_done(function(e) {
         if (e.source !== iframe.contentWindow) return;
         assert_equals(e.data.result, 'blocked',
                       'sync-xhr should be blocked in iframe when allow="sync-xhr \'none\'"');
     }));
-    
+
     document.body.appendChild(iframe);
 }, 'iframe allow attribute blocks features using Permissions Policy syntax');
 </script>

--- a/permissions-policy/historical.html
+++ b/permissions-policy/historical.html
@@ -37,24 +37,25 @@
     }, "Feature-Policy header should be ignored when Permissions-Policy is present");
 
     // Test 4: iframe allow attribute should work with Permissions Policy
-    async_test((t) => {
+    promise_test(async () => {
       const iframe = document.createElement("iframe");
       iframe.src = "resources/historical-iframe.html";
       iframe.allow = "sync-xhr 'none'";
 
-      window.addEventListener(
-        "message",
-        t.step_func_done((e) => {
-          if (e.source !== iframe.contentWindow) return;
-          assert_equals(
-            e.data.result,
-            "blocked",
-            "sync-xhr should be blocked in iframe when allow=\"sync-xhr 'none'\""
-          );
-        })
-      );
+      const result = await new Promise((resolve) => {
+        window.addEventListener("message", (e) => {
+          if (e.source === iframe.contentWindow) {
+            resolve(e.data);
+          }
+        });
+        document.body.appendChild(iframe);
+      });
 
-      document.body.appendChild(iframe);
+      assert_equals(
+        result.result,
+        "blocked",
+        "sync-xhr should be blocked in iframe when allow=\"sync-xhr 'none'\""
+      );
     }, "iframe allow attribute blocks features using Permissions Policy syntax");
   </script>
 </body>

--- a/permissions-policy/historical.html
+++ b/permissions-policy/historical.html
@@ -1,46 +1,60 @@
 <!DOCTYPE html>
 <title>Historical Feature Policy features should not be present</title>
-<link rel="help" href="https://www.w3.org/TR/permissions-policy/">
+<link rel="help" href="https://www.w3.org/TR/permissions-policy/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<script>
-// Test 1: document.featurePolicy API should not exist (replaced by document.permissionsPolicy)
-test(function() {
-    assert_false('featurePolicy' in document,
-                 'document.featurePolicy should not exist');
-}, 'document.featurePolicy should not be present (use document.permissionsPolicy instead)');
+  <script>
+    // Test 1: document.featurePolicy API should not exist (replaced by document.permissionsPolicy)
+    test(() => {
+      assert_false(
+        "featurePolicy" in document,
+        "document.featurePolicy should not exist"
+      );
+    }, "document.featurePolicy should not be present (use document.permissionsPolicy instead)");
 
-// Test 2: HTMLIFrameElement.featurePolicy API should not exist (replaced by permissionsPolicy)
-test(function() {
-    assert_false('featurePolicy' in HTMLIFrameElement.prototype,
-                 'HTMLIFrameElement.prototype.featurePolicy should not exist');
-}, 'HTMLIFrameElement.prototype.featurePolicy should not be present');
+    // Test 2: HTMLIFrameElement.featurePolicy API should not exist (replaced by permissionsPolicy)
+    test(() => {
+      assert_false(
+        "featurePolicy" in HTMLIFrameElement.prototype,
+        "HTMLIFrameElement.prototype.featurePolicy should not exist"
+      );
+    }, "HTMLIFrameElement.prototype.featurePolicy should not be present");
 
-// Test 3: Feature-Policy header should be ignored when Permissions-Policy is present
-// The header file sets: Feature-Policy: sync-xhr 'none'
-// And: Permissions-Policy: sync-xhr=*
-// If Feature-Policy is correctly ignored, sync XHR should work
-test(function() {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", document.location.href, false);
-    xhr.send();
-    assert_equals(xhr.status, 200, 'Sync XHR should succeed because Permissions-Policy allows it');
-}, 'Feature-Policy header should be ignored when Permissions-Policy is present');
+    // Test 3: Feature-Policy header should be ignored when Permissions-Policy is present
+    // The header file sets: Feature-Policy: sync-xhr 'none'
+    // And: Permissions-Policy: sync-xhr=*
+    // If Feature-Policy is correctly ignored, sync XHR should work
+    test(() => {
+      const xhr = new XMLHttpRequest();
+      xhr.open("GET", document.location.href, false);
+      xhr.send();
+      assert_equals(
+        xhr.status,
+        200,
+        "Sync XHR should succeed because Permissions-Policy allows it"
+      );
+    }, "Feature-Policy header should be ignored when Permissions-Policy is present");
 
-// Test 4: iframe allow attribute should work with Permissions Policy
-async_test(function(t) {
-    var iframe = document.createElement('iframe');
-    iframe.src = 'resources/historical-iframe.html';
-    iframe.allow = "sync-xhr 'none'";
+    // Test 4: iframe allow attribute should work with Permissions Policy
+    async_test((t) => {
+      const iframe = document.createElement("iframe");
+      iframe.src = "resources/historical-iframe.html";
+      iframe.allow = "sync-xhr 'none'";
 
-    window.addEventListener('message', t.step_func_done(function(e) {
-        if (e.source !== iframe.contentWindow) return;
-        assert_equals(e.data.result, 'blocked',
-                      'sync-xhr should be blocked in iframe when allow="sync-xhr \'none\'"');
-    }));
+      window.addEventListener(
+        "message",
+        t.step_func_done((e) => {
+          if (e.source !== iframe.contentWindow) return;
+          assert_equals(
+            e.data.result,
+            "blocked",
+            "sync-xhr should be blocked in iframe when allow=\"sync-xhr 'none'\""
+          );
+        })
+      );
 
-    document.body.appendChild(iframe);
-}, 'iframe allow attribute blocks features using Permissions Policy syntax');
-</script>
+      document.body.appendChild(iframe);
+    }, "iframe allow attribute blocks features using Permissions Policy syntax");
+  </script>
 </body>

--- a/permissions-policy/historical.html
+++ b/permissions-policy/historical.html
@@ -21,10 +21,11 @@
       );
     }, "HTMLIFrameElement.prototype.featurePolicy should not be present");
 
-    // Test 3: Feature-Policy header should be ignored when Permissions-Policy is present
-    // The header file sets: Feature-Policy: sync-xhr 'none'
-    // And: Permissions-Policy: sync-xhr=*
-    // If Feature-Policy is correctly ignored, sync XHR should work
+    // Test 3: Permissions-Policy header takes precedence over Feature-Policy header
+    // The header file sets:
+    //   Permissions-Policy: sync-xhr=*  (allows sync-xhr)
+    //   Feature-Policy: sync-xhr 'none' (would block sync-xhr)
+    // If Permissions-Policy correctly takes precedence, sync XHR should work
     test(() => {
       const xhr = new XMLHttpRequest();
       xhr.open("GET", document.location.href, false);
@@ -34,7 +35,7 @@
         200,
         "Sync XHR should succeed because Permissions-Policy allows it"
       );
-    }, "Feature-Policy header should be ignored when Permissions-Policy is present");
+    }, "Permissions-Policy header takes precedence over Feature-Policy header");
 
     // Test 4: iframe allow attribute should work with Permissions Policy
     promise_test(async () => {

--- a/permissions-policy/historical.html.headers
+++ b/permissions-policy/historical.html.headers
@@ -1,0 +1,2 @@
+Feature-Policy: sync-xhr 'none'
+Permissions-Policy: sync-xhr=*

--- a/permissions-policy/resources/historical-iframe.html
+++ b/permissions-policy/resources/historical-iframe.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <title>Historical iframe helper</title>
 <script>
-try {
-    var xhr = new XMLHttpRequest();
+  try {
+    const xhr = new XMLHttpRequest();
     xhr.open("GET", document.location.href, false);
     xhr.send();
-    window.parent.postMessage({ result: 'allowed' }, '*');
-} catch (e) {
-    window.parent.postMessage({ result: 'blocked', error: e.name }, '*');
-}
+    window.parent.postMessage({ result: "allowed" }, "*");
+  } catch (e) {
+    window.parent.postMessage({ result: "blocked", error: e.name }, "*");
+  }
 </script>

--- a/permissions-policy/resources/historical-iframe.html
+++ b/permissions-policy/resources/historical-iframe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Historical iframe helper</title>
+<script>
+try {
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", document.location.href, false);
+    xhr.send();
+    window.parent.postMessage({ result: 'allowed' }, '*');
+} catch (e) {
+    window.parent.postMessage({ result: 'blocked', error: e.name }, '*');
+}
+</script>


### PR DESCRIPTION
Add tests for historically-defined policy-controlled features that are now obsolete. These tests verify backward compatibility for deprecated features.