### PR TITLE
[WebDriver BiDi] add base64 value test for storage.setCookie

### DIFF
--- a/webdriver/tests/bidi/storage/set_cookie/cookie_value.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_value.py
@@ -1,6 +1,6 @@
 import pytest
 from .. import assert_cookie_is_set, create_cookie
-from webdriver.bidi.modules.network import NetworkStringValue
+from webdriver.bidi.modules.network import NetworkBase64Value, NetworkStringValue
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,4 +17,20 @@ async def test_cookie_value_string(bidi_session, set_cookie, test_page, domain_v
     await set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
     await assert_cookie_is_set(bidi_session, value=value, domain=domain_value())
 
-# TODO: test `test_cookie_value_base64`.
+
+@pytest.mark.parametrize(
+    "base64_value, decoded_value",
+    [
+        ("Zm9v", "foo"),
+        ("aGVsbG8gd29ybGQ=", "hello world"),
+    ])
+async def test_cookie_value_base64(bidi_session, set_cookie, test_page, domain_value, base64_value, decoded_value):
+    value = NetworkBase64Value(base64_value)
+
+    await set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
+
+    # Valid UTF-8 base64 values are returned as string type:
+    # https://www.w3.org/TR/webdriver-bidi/#serialize-protocol-bytes
+    await assert_cookie_is_set(
+        bidi_session, value=NetworkStringValue(decoded_value), domain=domain_value()
+    )


### PR DESCRIPTION
Adds the missing test for storage.setCookie when the cookie value is a Base64Value. The cookie_value.py file had a TODO for this since the original parameter coverage work in #44046, this just fills that gap.

Closes #43996