### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=296134

### DIFF
--- a/css/css-properties-values-api/registered-property-computation-color-006.html
+++ b/css/css-properties-values-api/registered-property-computation-color-006.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-properties-values-api/#calculation-of-computed-values" />
+<link rel="author" title="Sam Weinig" href="sam@webkit.org">
+<link rel="match" href="registered-property-computation-color-001-ref.html">
+<style>
+@property --x {
+  inherits: true;
+  initial-value: currentcolor;
+  syntax: "<color>";
+}
+:root {
+  color: green;
+}
+div {
+  background-color: var(--x);
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div></div>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(296337@main): currentcolor used in custom property no longer resolves correctly](https://bugs.webkit.org/show_bug.cgi?id=296134)