### PR TITLE
Convert GroupMetadata and RunnerManagerState into dataclasses

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -580,22 +580,19 @@ class FirefoxOutputHandler(OutputHandler):
         self.lsan_handler = None
         self.mozleak_allowed = None
         self.mozleak_thresholds = None
-        self.group_metadata = {}
+        self.group_metadata = None
 
-    def start(self, group_metadata=None, lsan_disabled=False, lsan_allowed=None,
+    def start(self, group_metadata, lsan_disabled=False, lsan_allowed=None,
               lsan_max_stack_depth=None, mozleak_allowed=None, mozleak_thresholds=None,
               **kwargs):
         """Configure the output handler"""
-        if group_metadata is None:
-            group_metadata = {}
         self.group_metadata = group_metadata
-
         self.mozleak_allowed = mozleak_allowed
         self.mozleak_thresholds = mozleak_thresholds
 
         if self.asan:
             self.lsan_handler = mozleak.LSANLeaks(self.logger,
-                                                  scope=group_metadata.get("scope", "/"),
+                                                  scope=group_metadata.scope,
                                                   allowed=lsan_allowed,
                                                   maxNumRecordedFrames=lsan_max_stack_depth,
                                                   allowAll=lsan_disabled)
@@ -623,7 +620,7 @@ class FirefoxOutputHandler(OutputHandler):
                     ignore_missing_leaks=["tab", "gmplugin"],
                     log=self.logger,
                     stack_fixer=self.stack_fixer,
-                    scope=self.group_metadata.get("scope"),
+                    scope=self.group_metadata.scope,
                     allowed=self.mozleak_allowed)
             if processed_files:
                 for path in processed_files:
@@ -915,7 +912,7 @@ class FirefoxBrowser(Browser):
                           "testdriver": True if test.test_type == "testharness" else getattr(test, "testdriver", False)}
         return self._settings
 
-    def start(self, group_metadata=None, **kwargs):
+    def start(self, group_metadata, **kwargs):
         self.instance = self.instance_manager.get()
         self.instance.output_handler.start(group_metadata,
                                            **kwargs)

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -1277,7 +1277,7 @@ class InternalRefTestImplementation(RefTestImplementation):
                 "cacheScreenshots": self.executor.cache_screenshots}
         if self.executor.group_metadata is not None:
             data["urlCount"] = {urljoin(self.executor.server_url(key[0]), key[1]):value
-                                for key, value in self.executor.group_metadata.get("url_count", {}).items()
+                                for key, value in self.executor.group_metadata.extra.get("url_count", {}).items()
                                 if value > 1}
         self.chrome_scope = chrome_scope
         if chrome_scope:

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-calls, allow-untyped-defs
 from __future__ import annotations
+from dataclasses import dataclass
 
 import abc
 import hashlib
@@ -9,7 +10,7 @@ import os
 import queue
 from urllib.parse import urlsplit
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict, deque, namedtuple
+from collections import defaultdict, deque
 from typing import (cast, Any, Callable, Dict, Deque, List, Mapping, MutableMapping, Optional, Set,
                     Tuple, Type)
 
@@ -517,8 +518,26 @@ def get_test_queue_builder(**kwargs: Any) -> Tuple[TestQueueBuilder, Mapping[str
     return builder_cls(**builder_kwargs), chunker_kwargs
 
 
-TestGroup = namedtuple("TestGroup", ["group", "subsuite", "test_type", "metadata"])
-GroupMetadata = Mapping[str, Any]
+@dataclass
+class GroupMetadata:
+    scope: str
+    extra: MutableMapping[str, Any]
+
+    def __init__(self, scope: str):
+        self.scope = scope
+        self.extra = {}
+
+
+@dataclass
+class TestGroup:
+    test_queue: Deque[wpttest.Test]
+    subsuite: Optional[str]
+    test_type: str
+    metadata: GroupMetadata
+
+    @property
+    def name(self) -> str:
+        return f"{self.subsuite}:{self.metadata.scope}" if self.subsuite is not None else "/"
 
 
 class TestQueueBuilder:
@@ -547,7 +566,7 @@ class TestQueueBuilder:
                 group.test_type,
                 # Next, run larger groups first to avoid straggler runners. Use
                 # timeout to give slow tests greater relative weight.
-                sum(test.timeout for test in group.group),
+                sum(test.timeout for test in group.test_queue),
             ), reverse=True)
         for item in groups:
             test_queue.put(item)
@@ -564,7 +583,7 @@ class TestQueueBuilder:
         pass
 
     def group_metadata(self, state: Mapping[str, Any]) -> GroupMetadata:
-        return {"scope": "/"}
+        return GroupMetadata(scope="/")
 
     def process_count(self, requested_processes: int, num_test_groups: int) -> int:
         """Get the number of processes to use.
@@ -585,20 +604,20 @@ class SingleTestSource(TestQueueBuilder):
                 group = queues[idx]
                 metadata = metadatas[idx]
                 group.append(test)
-                test.update_metadata(metadata)
+                test.update_metadata(metadata.extra)
 
-            for item in zip(queues,
-                            itertools.repeat(subsuite),
-                            itertools.repeat(test_type),
-                            metadatas):
-                if len(item[0]) > 0:
-                    groups.append(TestGroup(*item))
+            for group, subsuite, test_type, metadata in zip(queues,
+                                                            itertools.repeat(subsuite),
+                                                            itertools.repeat(test_type),
+                                                            metadatas):
+                if len(group) > 0:
+                    groups.append(TestGroup(group, subsuite, test_type, metadata))
         return groups
 
     def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
         groups: MutableMapping[str, List[str]] = defaultdict(list)
         for (subsuite, test_type), tests in tests_by_type.items():
-            group_name = f"{subsuite}:{self.group_metadata({})['scope']}"
+            group_name = f"{subsuite}:{self.group_metadata({}).scope}"
             groups[group_name].extend(test.id for test in tests)
         return groups
 
@@ -641,9 +660,9 @@ class PathGroupedSource(TestQueueBuilder):
                 if not in_one_group and self.new_group(state, subsuite, test_type, test):
                     group_metadata = self.group_metadata(state)
                     groups.append(TestGroup(deque(), subsuite, test_type, group_metadata))
-                group, _, _, metadata = groups[-1]
-                group.append(test)
-                test.update_metadata(metadata)
+                last_group = groups[-1]
+                last_group.test_queue.append(test)
+                test.update_metadata(last_group.metadata.extra)
         return groups
 
     def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
@@ -653,7 +672,7 @@ class PathGroupedSource(TestQueueBuilder):
             in_one_group = self.in_one_group(subsuite, tests)
             for test in tests:
                 if not in_one_group and self.new_group(state, subsuite, test_type, test):
-                    group = self.group_metadata(state)['scope']
+                    group = self.group_metadata(state).scope
                 if in_one_group:
                     group_name = f"{subsuite}:/"
                 elif subsuite:
@@ -664,7 +683,8 @@ class PathGroupedSource(TestQueueBuilder):
         return groups
 
     def group_metadata(self, state: Mapping[str, Any]) -> GroupMetadata:
-        return {"scope": "/%s" % "/".join(state["prev_group_key"][2])}
+        scope = f"/{'/'.join(state['prev_group_key'][2])}"
+        return GroupMetadata(scope)
 
 
 class FullyParallelGroupedSource(PathGroupedSource):
@@ -693,12 +713,12 @@ class GroupFileTestSource(TestQueueBuilder):
             tests_by_group = self.tests_by_group({(subsuite, test_type): tests})
             ids_to_tests = {test.id: test for test in tests}
             for group_name, test_ids in tests_by_group.items():
-                group_metadata = {"scope": group_name}
+                group_metadata = GroupMetadata(group_name)
                 group: Deque[wpttest.Test] = deque()
                 for test_id in test_ids:
                     test = ids_to_tests[test_id]
                     group.append(test)
-                    test.update_metadata(group_metadata)
+                    test.update_metadata(group_metadata.extra)
                 groups.append(TestGroup(group, subsuite, test_type, group_metadata))
         return groups
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+from dataclasses import dataclass
 
 import random
 import threading
@@ -6,11 +7,11 @@ import time
 import traceback
 from queue import Empty
 from collections import namedtuple, defaultdict
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Tuple, Union
 
 from mozlog import structuredlog, capture
 
-from . import mpcontext, testloader
+from . import mpcontext, testloader, wpttest
 
 # Special value used as a sentinal in various commands
 Stop = object()
@@ -307,34 +308,68 @@ class TestSource:
     def __init__(self, logger: structuredlog.StructuredLogger, test_queue: testloader.ReadQueue):
         self.logger = logger
         self.test_queue = test_queue
-        self.current_group = testloader.TestGroup(None, None, None, None)
+        self.current_group: Optional[testloader.TestGroup] = None
 
-    def group(self) -> testloader.TestGroup:
-        if not self.current_group.group or len(self.current_group.group) == 0:
+    def next_group(self) -> Optional[testloader.TestGroup]:
+        if self.current_group is None or len(self.current_group.test_queue) == 0:
             try:
                 self.current_group = self.test_queue.get()
-                self.logger.debug(f"Got new test group subsuite:{self.current_group[1]!r} "
-                                  f"test_type:{self.current_group[2]}")
+                assert self.current_group is not None
+                self.logger.debug(f"Got new test group subsuite:{self.current_group.subsuite!r} "
+                                  f"test_type:{self.current_group.test_type}")
             except Empty:
-                return testloader.TestGroup(None, None, None, None)
+                return None
         return self.current_group
 
 
-class _RunnerManagerState:
-    before_init = namedtuple("before_init", [])
-    initializing = namedtuple("initializing",
-                              ["subsuite", "test_type", "test", "test_group",
-                               "group_metadata", "failure_count"])
-    running = namedtuple("running", ["subsuite", "test_type", "test", "test_group", "group_metadata"])
-    restarting = namedtuple("restarting", ["subsuite", "test_type", "test", "test_group",
-                                           "group_metadata", "force_stop"])
-    switching_executor = namedtuple("switching_executor",
-                                    ["subsuite", "test_type", "test", "test_group", "group_metadata"])
-    error = namedtuple("error", [])
-    stop = namedtuple("stop", ["force_stop"])
+@dataclass
+class BeforeInitState:
+    pass
 
 
-RunnerManagerState = _RunnerManagerState()
+@dataclass
+class InitializingState:
+    test_group: testloader.TestGroup
+    test: wpttest.Test
+    failure_count: int
+
+
+@dataclass
+class RunningState:
+    test_group: testloader.TestGroup
+    test: wpttest.Test
+
+
+@dataclass
+class RestartingState:
+    test_group: testloader.TestGroup
+    test: wpttest.Test
+    force_stop: bool
+
+
+@dataclass
+class SwitchingExecutorState:
+    test_group: testloader.TestGroup
+    test: wpttest.Test
+
+
+@dataclass
+class ErrorState:
+    pass
+
+
+@dataclass
+class StopState:
+    force_stop: bool
+
+
+RunnerManagerState = Union[BeforeInitState,
+                           InitializingState,
+                           RunningState,
+                           RestartingState,
+                           SwitchingExecutorState,
+                           ErrorState,
+                           StopState]
 
 
 class TestRunnerManager(threading.Thread):
@@ -400,6 +435,7 @@ class TestRunnerManager(threading.Thread):
         self.timer = None
         self.test_runner_proc = None
         self.browser = None
+        self.state = BeforeInitState()
 
         super().__init__(name=f"TestRunnerManager-{index}", target=self.run_loop, args=[test_queue], daemon=True)
 
@@ -421,16 +457,14 @@ class TestRunnerManager(threading.Thread):
         self.remote_queue = mp.Queue()
 
         dispatch = {
-            RunnerManagerState.before_init: self.start_init,
-            RunnerManagerState.initializing: self.init,
-            RunnerManagerState.running: self.run_test,
-            RunnerManagerState.restarting: self.restart_runner,
+            BeforeInitState: self.start_init,
+            InitializingState: self.init,
+            RunningState: self.run_test,
+            RestartingState: self.restart_runner,
         }
 
-        self.state = RunnerManagerState.before_init()
-        end_states = (RunnerManagerState.stop,
-                      RunnerManagerState.error)
-
+        end_states = (StopState, ErrorState)
+        assert isinstance(self.state, BeforeInitState)
         try:
             while not isinstance(self.state, end_states):
                 f = dispatch.get(self.state.__class__)
@@ -467,20 +501,20 @@ class TestRunnerManager(threading.Thread):
             self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")
 
             skipped_tests = []
-            test_group, subsuite, _, _ = self.test_source.current_group
-            while test_group is not None and len(test_group) > 0:
-                test = test_group.popleft()
+            current_group = self.test_source.current_group
+            while current_group.test_queue is not None and len(current_group.test_queue) > 0:
+                test = current_group.test_queue.popleft()
                 skipped_tests.append(test)
 
             if skipped_tests:
                 self.logger.critical(
-                    f"Tests left in the queue: {subsuite!r}:{skipped_tests[0].id!r} "
+                    f"Tests left in the queue: {current_group.subsuite!r}:{skipped_tests[0].id!r} "
                     f"and {len(skipped_tests) - 1} others"
                 )
                 for test in skipped_tests[1:]:
-                    self.logger.debug(f"Test left in the queue: {subsuite!r}:{test.id!r}")
+                    self.logger.debug(f"Test left in the queue: {current_group.subsuite!r}:{test.id!r}")
 
-            force_stop = (not isinstance(self.state, RunnerManagerState.stop) or
+            force_stop = (not isinstance(self.state, StopState) or
                           self.state.force_stop)
             self.stop_runner(force=force_stop)
             self.teardown()
@@ -496,25 +530,25 @@ class TestRunnerManager(threading.Thread):
 
     def wait_event(self):
         dispatch = {
-            RunnerManagerState.before_init: {},
-            RunnerManagerState.initializing:
+            BeforeInitState: {},
+            InitializingState:
             {
                 "init_succeeded": self.init_succeeded,
                 "init_failed": self.init_failed,
             },
-            RunnerManagerState.running:
+            RunningState:
             {
                 "test_ended": self.test_ended,
                 "wait_finished": self.wait_finished,
             },
-            RunnerManagerState.switching_executor:
+            SwitchingExecutorState:
             {
                 "switch_executor_succeeded": self.switch_executor_succeeded,
                 "switch_executor_failed": self.switch_executor_failed,
             },
-            RunnerManagerState.restarting: {},
-            RunnerManagerState.error: {},
-            RunnerManagerState.stop: {},
+            RestartingState: {},
+            ErrorState: {},
+            StopState: {},
             None: {
                 "log": self.log,
                 "error": self.error,
@@ -525,20 +559,17 @@ class TestRunnerManager(threading.Thread):
             self.logger.debug("Got command: %r" % command)
         except OSError:
             self.logger.error("Got IOError from poll")
-            return RunnerManagerState.restarting(self.state.subsuite,
-                                                 self.state.test_type,
-                                                 self.state.test,
-                                                 self.state.test_group,
-                                                 self.state.group_metadata,
-                                                 False)
+            return RestartingState(self.state.test_group,
+                                   self.state.test,
+                                   False)
         except Empty:
             if (self.debug_info and self.debug_info.interactive and
                 self.browser.started and not self.browser.is_alive()):
                 self.logger.debug("Debugger exited")
-                return RunnerManagerState.stop(False)
+                return StopState(False)
 
             # `test_runner_proc` must be nonnull in the manager's `running` state.
-            if (isinstance(self.state, RunnerManagerState.running) and
+            if (isinstance(self.state, RunningState) and
                 not self.test_runner_proc.is_alive()):
                 if not self.command_queue.empty():
                     # We got a new message so process that
@@ -554,13 +585,11 @@ class TestRunnerManager(threading.Thread):
                     # Need to consider the unlikely case where one test causes the
                     # runner process to repeatedly die
                     self.logger.critical("Last test did not complete")
-                    return RunnerManagerState.error()
+                    return ErrorState()
                 self.logger.warning("More tests found, but runner process died, restarting")
-                return RunnerManagerState.restarting(self.state.test_type,
-                                                     self.state.test,
-                                                     self.state.test_group,
-                                                     self.state.group_metadata,
-                                                     False)
+                return RestartingState(self.state.test_group,
+                                       self.state.test,
+                                       False)
         else:
             f = (dispatch.get(self.state.__class__, {}).get(command) or
                  dispatch.get(None, {}).get(command))
@@ -574,18 +603,18 @@ class TestRunnerManager(threading.Thread):
         return self.child_stop_flag.is_set() or self.parent_stop_flag.should_stop()
 
     def start_init(self):
-        subsuite, test_type, test, test_group, group_metadata = self.get_next_test()
+        next_test = self.get_next_test()
+        if next_test is None:
+            return StopState(True)
+        test_group, test = next_test
         self.recording.set(["testrunner", "init"])
-        if test is None:
-            return RunnerManagerState.stop(True)
-        else:
-            return RunnerManagerState.initializing(subsuite, test_type, test, test_group, group_metadata, 0)
+        return InitializingState(test_group, test, 0)
 
     def init(self):
-        assert isinstance(self.state, RunnerManagerState.initializing)
+        assert isinstance(self.state, InitializingState)
         if self.state.failure_count > self.max_restarts:
             self.logger.critical("Max restarts exceeded")
-            return RunnerManagerState.error()
+            return ErrorState()
         elif self.state.failure_count > 0 and self.max_restart_backoff:
             # Subtract one so we start with 2**0 (i.e., 1)
             base_backoff = min(self.max_restart_backoff, 2**(self.state.failure_count-1))
@@ -593,11 +622,11 @@ class TestRunnerManager(threading.Thread):
             self.logger.info(f"Waiting {used_backoff:.2f}s before restarting browser")
             time.sleep(used_backoff)
 
-        if (self.state.subsuite, self.state.test_type) != self.test_implementation_key:
+        if (self.state.test_group.subsuite, self.state.test_group.test_type) != self.test_implementation_key:
             if self.browser is not None:
                 assert self.browser.browser is not None
                 self.browser.browser.cleanup()
-            impl = self.test_implementations[(self.state.subsuite, self.state.test_type)]
+            impl = self.test_implementations[(self.state.test_group.subsuite, self.state.test_group.test_type)]
             browser = impl.browser_cls(self.logger,
                                        manager_number=self.manager_number,
                                        **impl.browser_kwargs)
@@ -606,12 +635,12 @@ class TestRunnerManager(threading.Thread):
                                           browser,
                                           self.command_queue,
                                           no_timeout=self.debug_info is not None)
-            self.test_implementation_key = (self.state.subsuite, self.state.test_type)
+            self.test_implementation_key = (self.state.test_group.subsuite, self.state.test_group.test_type)
 
         assert self.browser is not None
         self.browser.update_settings(self.state.test)
 
-        result = self.browser.init(self.state.group_metadata)
+        result = self.browser.init(self.state.test_group.metadata)
         if not result:
             return self.init_failed()
 
@@ -621,11 +650,11 @@ class TestRunnerManager(threading.Thread):
         # Note that we need to be careful to start the browser before the
         # test runner to ensure that any state set when the browser is started
         # can be passed in to the test runner.
-        assert isinstance(self.state, RunnerManagerState.initializing)
+        assert isinstance(self.state, InitializingState)
         assert self.command_queue is not None
         assert self.remote_queue is not None
         self.logger.info("Starting runner")
-        impl = self.test_implementations[(self.state.subsuite, self.state.test_type)]
+        impl = self.test_implementations[(self.state.test_group.subsuite, self.state.test_group.test_type)]
         self.executor_implementation = self.get_executor_implementation(impl)
 
         args = (self.remote_queue,
@@ -645,7 +674,7 @@ class TestRunnerManager(threading.Thread):
 
     def get_executor_implementation(self, impl):
         executor_kwargs = impl.executor_kwargs
-        executor_kwargs["group_metadata"] = self.state.group_metadata
+        executor_kwargs["group_metadata"] = self.state.test_group.metadata
         executor_kwargs["browser_settings"] = self.browser.browser_settings
         executor_browser_cls, executor_browser_kwargs = self.browser.browser.executor_browser()
         return ExecutorImplementation(impl.executor_cls,
@@ -654,55 +683,46 @@ class TestRunnerManager(threading.Thread):
                                       executor_browser_kwargs)
 
     def init_succeeded(self):
-        assert isinstance(self.state, RunnerManagerState.initializing)
+        assert isinstance(self.state, InitializingState)
         self.browser.after_init()
-        return RunnerManagerState.running(self.state.subsuite,
-                                          self.state.test_type,
-                                          self.state.test,
-                                          self.state.test_group,
-                                          self.state.group_metadata)
+        return RunningState(self.state.test_group,
+                            self.state.test)
 
     def init_failed(self):
-        assert isinstance(self.state, RunnerManagerState.initializing)
+        assert isinstance(self.state, InitializingState)
         self.browser.check_crash(None)
         self.browser.after_init()
         self.stop_runner(force=True)
-        return RunnerManagerState.initializing(self.state.subsuite,
-                                               self.state.test_type,
-                                               self.state.test,
-                                               self.state.test_group,
-                                               self.state.group_metadata,
-                                               self.state.failure_count + 1)
+        return InitializingState(self.state.test_group,
+                                 self.state.test,
+                                 self.state.failure_count + 1)
 
-    def get_next_test(self):
-        # returns test_type, test, test_group, group_metadata
-        test = None
-        test_group = None
+    def get_next_test(self) -> Optional[Tuple[testloader.TestGroup, wpttest.Test]]:
+        test: Optional[wpttest.Test] = None
+        test_group: Optional[testloader.TestGroup] = None
         while test is None:
-            while test_group is None or len(test_group) == 0:
-                test_group, subsuite, test_type, group_metadata = self.test_source.group()
+            while test_group is None or len(test_group.test_queue) == 0:
+                test_group = self.test_source.next_group()
                 if test_group is None:
                     self.logger.info("No more tests")
-                    return None, None, None, None, None
-            test = test_group.popleft()
+                    return None
+            test = test_group.test_queue.popleft()
         self.run_count = 0
-        return subsuite, test_type, test, test_group, group_metadata
+        assert test_group is not None
+        return test_group, test
 
     def run_test(self):
-        assert isinstance(self.state, RunnerManagerState.running)
+        assert isinstance(self.state, RunningState)
         assert self.state.test is not None
 
         if self.browser.update_settings(self.state.test):
             self.logger.info("Restarting browser for new test environment")
-            return RunnerManagerState.restarting(self.state.subsuite,
-                                                 self.state.test_type,
-                                                 self.state.test,
-                                                 self.state.test_group,
-                                                 self.state.group_metadata,
-                                                 False)
+            return RestartingState(self.state.test_group,
+                                   self.state.test,
+                                   False)
 
         self.recording.set(["testrunner", "test"] + self.state.test.id.split("/")[1:])
-        self.logger.test_start(self.state.test.id, subsuite=self.state.subsuite)
+        self.logger.test_start(self.state.test.id, subsuite=self.state.test_group.subsuite)
         if self.rerun > 1:
             self.logger.info(f"Run {self.run_count + 1}/{self.rerun}")
             self.send_message("reset")
@@ -739,7 +759,7 @@ class TestRunnerManager(threading.Thread):
         Output the result of each subtest, and the result of the overall
         harness to the logs.
         """
-        if ((not isinstance(self.state, RunnerManagerState.running)) or
+        if ((not isinstance(self.state, RunningState)) or
             (test != self.state.test)):
             # Due to inherent race conditions in EXTERNAL-TIMEOUT, we might
             # receive multiple test_ended for a test (e.g. from both Executor
@@ -791,7 +811,7 @@ class TestRunnerManager(threading.Thread):
                                     expected=expected,
                                     known_intermittent=known_intermittent,
                                     stack=result.stack,
-                                    subsuite=self.state.subsuite)
+                                    subsuite=self.state.test_group.subsuite)
 
         expected = file_result.expected
         known_intermittent = file_result.known_intermittent
@@ -825,9 +845,9 @@ class TestRunnerManager(threading.Thread):
         is_unexpected_pass = ((is_unexpected or subtest_unexpected) and
                               is_pass_or_expected and subtest_all_pass_or_expected)
         if is_unexpected_pass:
-            self.unexpected_pass_tests[self.state.subsuite, test.test_type].append(test)
+            self.unexpected_pass_tests[self.state.test_group.subsuite, test.test_type].append(test)
         elif is_unexpected or subtest_unexpected:
-            self.unexpected_fail_tests[self.state.subsuite, test.test_type].append(test)
+            self.unexpected_fail_tests[self.state.test_group.subsuite, test.test_type].append(test)
 
         if "assertion_count" in file_result.extra:
             assertion_count = file_result.extra["assertion_count"]
@@ -849,7 +869,7 @@ class TestRunnerManager(threading.Thread):
                              known_intermittent=known_intermittent,
                              extra=file_result.extra,
                              stack=file_result.stack,
-                             subsuite=self.state.subsuite)
+                             subsuite=self.state.test_group.subsuite)
 
         restart_before_next = (self.retry_index > 0 or test.restart_after or
                                file_result.status in ("CRASH", "EXTERNAL-TIMEOUT", "INTERNAL-ERROR") or
@@ -867,7 +887,7 @@ class TestRunnerManager(threading.Thread):
             return self.after_test_end(test, restart_before_next, force_stop=force_stop)
 
     def wait_finished(self, rerun=False):
-        assert isinstance(self.state, RunnerManagerState.running)
+        assert isinstance(self.state, RunningState)
         self.logger.debug("Wait finished")
 
         # The browser should be stopped already, but this ensures we do any
@@ -875,68 +895,57 @@ class TestRunnerManager(threading.Thread):
         return self.after_test_end(self.state.test, not rerun, force_rerun=rerun)
 
     def switch_executor_succeeded(self):
-        assert isinstance(self.state, RunnerManagerState.switching_executor)
-        return RunnerManagerState.running(self.state.subsuite,
-                                          self.state.test_type,
-                                          self.state.test,
-                                          self.state.test_group,
-                                          self.state.group_metadata)
+        assert isinstance(self.state, SwitchingExecutorState)
+        return RunningState(self.state.test_group,
+                            self.state.test)
 
     def switch_executor_failed(self):
-        assert isinstance(self.state, RunnerManagerState.switching_executor)
-        return RunnerManagerState.restarting(self.state.subsuite,
-                                             self.state.test_type,
-                                             self.state.test,
-                                             self.state.test_group,
-                                             self.state.group_metadata,
-                                             False)
+        assert isinstance(self.state, SwitchingExecutorState)
+        return RestartingState(self.state.test_group,
+                               self.state.test,
+                               False)
 
     def after_test_end(self, test, restart, force_rerun=False, force_stop=False):
-        assert isinstance(self.state, RunnerManagerState.running)
+        assert isinstance(self.state, RunningState)
         # Mixing manual reruns and automatic reruns is confusing; we currently assume
         # that as long as we've done at least the automatic run count in total we can
         # continue with the next test.
         if not force_rerun and self.run_count >= self.rerun:
-            subsuite, test_type, test, test_group, group_metadata = self.get_next_test()
-            if test is None:
-                return RunnerManagerState.stop(force_stop)
-            if subsuite != self.state.subsuite:
-                self.logger.info(f"Restarting browser for new subsuite:{subsuite!r}")
+            next_test = self.get_next_test()
+            if next_test is None:
+                return StopState(force_stop)
+            test_group, test = next_test
+            if test_group.subsuite != self.state.test_group.subsuite:
+                self.logger.info(f"Restarting browser for new subsuite:{test_group.subsuite!r}")
                 restart = True
             elif self.restart_on_new_group and test_group is not self.state.test_group:
                 self.logger.info("Restarting browser for new test group")
                 restart = True
-            elif test_type != self.state.test_type:
-                if self.browser.browser.restart_on_test_type_change(test_type, self.state.test_type):
-                    self.logger.info(f"Restarting browser for new test type:{test_type}")
+            elif test_group.test_type != self.state.test_group.test_type:
+                if self.browser.browser.restart_on_test_type_change(test_group.test_type, self.state.test_group.test_type):
+                    self.logger.info(f"Restarting browser for new test type:{test_group.test_type}")
                     restart = True
                 else:
-                    self.logger.info(f"Switching executor for new test type: {self.state.test_type} => {test_type}")
-                    impl = self.test_implementations[subsuite, test_type]
+                    self.logger.info(f"Switching executor for new test type: {self.state.test_group.test_type} => {test_group.test_type}")
+                    impl = self.test_implementations[test_group.subsuite, test_group.test_type]
                     self.executor_implementation = self.get_executor_implementation(impl)
                     self.send_message("switch_executor", self.executor_implementation)
-                    return RunnerManagerState.switching_executor(
-                        subsuite, test_type, test, test_group, group_metadata)
+                    return SwitchingExecutorState(test_group, test)
         else:
-            subsuite = self.state.subsuite
-            test_type = self.state.test_type
             test_group = self.state.test_group
-            group_metadata = self.state.group_metadata
+            test = self.state.test
 
         if restart:
-            return RunnerManagerState.restarting(
-                subsuite, test_type, test, test_group, group_metadata, force_stop)
+            return RestartingState(test_group, test, force_stop)
         else:
-            return RunnerManagerState.running(
-                subsuite, test_type, test, test_group, group_metadata)
+            return RunningState(test_group, test)
+
 
     def restart_runner(self):
         """Stop and restart the TestRunner"""
-        assert isinstance(self.state, RunnerManagerState.restarting)
+        assert isinstance(self.state, RestartingState)
         self.stop_runner(force=self.state.force_stop)
-        return RunnerManagerState.initializing(
-            self.state.subsuite, self.state.test_type, self.state.test,
-            self.state.test_group, self.state.group_metadata, 0)
+        return InitializingState(self.state.test_group, self.state.test, 0)
 
     def log(self, data: Mapping[str, Any]) -> None:
         self.logger.log_raw(data)

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from abc import ABC
 from collections import defaultdict
-from typing import Any, ClassVar, Dict, Optional, Set, Type
+from typing import Any, ClassVar, Dict, MutableMapping, Optional, Set, Type
 from urllib.parse import urljoin
 
 from .wptmanifest.parser import atoms
@@ -268,10 +268,8 @@ class Test(ABC):
             known_intermittent = self.known_intermittent(name)
         return self.subtest_result_cls(name, status, message, stack, expected, known_intermittent)
 
-    def update_metadata(self, metadata=None):
-        if metadata is None:
-            metadata = {}
-        return metadata
+    def update_metadata(self, metadata: MutableMapping[str, Any]) -> None:
+        pass
 
     @classmethod
     def from_manifest(cls, manifest_file, manifest_item, inherit_metadata, test_metadata):
@@ -647,7 +645,7 @@ class ReftestTest(Test):
 
         return node
 
-    def update_metadata(self, metadata):
+    def update_metadata(self, metadata: MutableMapping[str, Any]) -> None:
         if "url_count" not in metadata:
             metadata["url_count"] = defaultdict(int)
         for reference, _ in self.references:
@@ -656,7 +654,6 @@ class ReftestTest(Test):
             # for each possible match
             metadata["url_count"][(self.environment["protocol"], reference.url)] += 1
             reference.update_metadata(metadata)
-        return metadata
 
     def get_viewport_size(self, override):
         return override


### PR DESCRIPTION
Rather than using dicts and named tuples, prefer data classes as these are more self-documenting and will integrate better with adding types to the code.