### PR TITLE
Update mozlog

### DIFF
--- a/tools/flake8.ini
+++ b/tools/flake8.ini
@@ -21,6 +21,7 @@ ignore = E128,E129,E226,E231,E251,E265,E302,E303,E305,E402,E731,W504,W601,N801,N
 exclude =
     .tox,
     third_party,
+    third_party_modified/mozlog,
     wptserve/docs/conf.py,
     wptserve/tests/functional/docroot/invalid.py
     wptserve/wptserve/cgi/

--- a/tools/requirements_tests.txt
+++ b/tools/requirements_tests.txt
@@ -5,4 +5,5 @@ jsonschema==4.23.0; python_version < '3.9'
 pyyaml==6.0.1
 types-pyyaml==6.0.12.20241230
 taskcluster==97.0.1
+mozfile==3.0.0
 mozterm==1.0.0

--- a/tools/third_party_modified/mozlog/mozlog/__init__.py
+++ b/tools/third_party_modified/mozlog/mozlog/__init__.py
@@ -21,7 +21,7 @@ from .structuredlog import get_default_logger, set_default_logger
 
 # Backwards compatibility shim for consumers that use mozlog.structured
 structured = sys.modules[__name__]
-sys.modules["{}.structured".format(__name__)] = structured
+sys.modules[f"{__name__}.structured"] = structured
 
 __all__ = [
     "commandline",

--- a/tools/third_party_modified/mozlog/mozlog/capture.py
+++ b/tools/third_party_modified/mozlog/mozlog/capture.py
@@ -88,7 +88,7 @@ class CaptureIO:
                 while not self.logging_queue.empty():
                     try:
                         self.logger.warning(
-                            "Dropping log message: %r", self.logging_queue.get()
+                            "Dropping log message: %r" % self.logging_queue.get()
                         )
                     except Exception:
                         pass

--- a/tools/third_party_modified/mozlog/mozlog/capture.py
+++ b/tools/third_party_modified/mozlog/mozlog/capture.py
@@ -18,7 +18,7 @@ class LogThread(threading.Thread):
         while True:
             try:
                 msg = self.queue.get()
-            except (EOFError, IOError):
+            except (OSError, EOFError):
                 break
             if msg is None:
                 break
@@ -57,7 +57,7 @@ class LoggingWrapper(BytesIO):
         pass
 
 
-class CaptureIO(object):
+class CaptureIO:
     def __init__(self, logger, do_capture, mp_context=None):
         if mp_context is None:
             import multiprocessing as mp_context
@@ -88,7 +88,7 @@ class CaptureIO(object):
                 while not self.logging_queue.empty():
                     try:
                         self.logger.warning(
-                            "Dropping log message: %r" % self.logging_queue.get()
+                            "Dropping log message: %r", self.logging_queue.get()
                         )
                     except Exception:
                         pass

--- a/tools/third_party_modified/mozlog/mozlog/commandline.py
+++ b/tools/third_party_modified/mozlog/mozlog/commandline.py
@@ -14,22 +14,22 @@ from .structuredlog import StructuredLogger, set_default_logger
 log_formatters = {
     "raw": (
         formatters.JSONFormatter,
-        "Raw structured log messages " "(provided by mozlog)",
+        "Raw structured log messages (provided by mozlog)",
     ),
     "unittest": (
         formatters.UnittestFormatter,
-        "Unittest style output " "(provided by mozlog)",
+        "Unittest style output (provided by mozlog)",
     ),
     "xunit": (
         formatters.XUnitFormatter,
-        "xUnit compatible XML " "(provided by mozlog)",
+        "xUnit compatible XML (provided by mozlog)",
     ),
-    "html": (formatters.HTMLFormatter, "HTML report " "(provided by mozlog)"),
-    "mach": (formatters.MachFormatter, "Human-readable output " "(provided by mozlog)"),
-    "tbpl": (formatters.TbplFormatter, "TBPL style log format " "(provided by mozlog)"),
+    "html": (formatters.HTMLFormatter, "HTML report (provided by mozlog)"),
+    "mach": (formatters.MachFormatter, "Human-readable output (provided by mozlog)"),
+    "tbpl": (formatters.TbplFormatter, "TBPL style log format (provided by mozlog)"),
     "grouped": (
         formatters.GroupingFormatter,
-        "Grouped summary of test results " "(provided by mozlog)",
+        "Grouped summary of test results (provided by mozlog)",
     ),
     "errorsummary": (formatters.ErrorSummaryFormatter, argparse.SUPPRESS),
 }

--- a/tools/third_party_modified/mozlog/mozlog/formatters/errorsummary.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/errorsummary.py
@@ -4,6 +4,8 @@
 
 
 import json
+import math
+import os
 from collections import defaultdict
 
 from .base import BaseFormatter
@@ -12,14 +14,23 @@ from .base import BaseFormatter
 class ErrorSummaryFormatter(BaseFormatter):
     def __init__(self):
         self.test_to_group = {}
+        self.manifest_groups = set()
         self.groups = defaultdict(
             lambda: {
                 "status": None,
-                "start": None,
-                "end": None,
+                "group_start": None,
+                "group_end": None,
+                "all_skipped": True,
+                "test_starts": {},
+                "test_times": [],
             }
         )
+        self.test_time_divisor = 1
         self.line_count = 0
+        self.dump_passing_tests = False
+
+        if os.environ.get("MOZLOG_DUMP_ALL_TESTS"):
+            self.dump_passing_tests = True
 
     def __call__(self, data):
         rv = BaseFormatter.__call__(self, data)
@@ -40,45 +51,65 @@ class ErrorSummaryFormatter(BaseFormatter):
             "expected": item["expected"],
             "message": item.get("message"),
             "stack": item.get("stack"),
+            "modifiers": item.get("extra", {}).get("modifiers", ""),
             "known_intermittent": item.get("known_intermittent", []),
         }
         return self._output("test_result", data)
 
-    def _update_group_result(self, group, item):
-        ginfo = self.groups[group]
+    def _get_group_result(self, group, item):
+        group_info = self.groups[group]
+        result = group_info["status"]
 
-        if item["status"] == "SKIP":
-            if ginfo["status"] is None:
-                ginfo["status"] = "SKIP"
-        elif (
-            ("expected" not in item and item["status"] in ["OK", "PASS"]) or
-            ("expected" in item and item["status"] == item["expected"]) or
-            item["status"] in item.get("known_intermittent", [])
-        ):
-            if ginfo["status"] in (None, "SKIP"):
-                ginfo["status"] = "OK"
+        if result == "ERROR":
+            return result
+
+        # If status == expected, we delete item[expected]
+        test_status = item["status"]
+        test_expected = item.get("expected", test_status)
+        known_intermittent = item.get("known_intermittent", [])
+
+        if test_status == "SKIP":
+            if result is None:
+                result = "SKIP"
         else:
-            ginfo["status"] = "ERROR"
+            self.groups[group]["all_skipped"] = False
+            if test_status == test_expected or test_status in known_intermittent:
+                result = "OK"
+            else:
+                result = "ERROR"
+
+        return result
+
+    def _clean_test_name(self, test):
+        retVal = test
+        # remove extra stuff like "(finished)"
+        if "(finished)" in test:
+            retVal = test.split(" ")[0]
+        return retVal
 
     def suite_start(self, item):
         self.test_to_group = {v: k for k in item["tests"] for v in item["tests"][k]}
+        self.manifest_groups = set(item["tests"].keys())
         # Initialize groups with no tests (missing manifests) with SKIP status
         for group, tests in item["tests"].items():
             if not tests:  # Empty test list
                 self.groups[group] = {
                     "status": "SKIP",
-                    "start": None,
-                    "end": None,
+                    "group_start": None,
+                    "group_end": None,
+                    "all_skipped": True,
+                    "test_starts": {},
+                    "test_times": [],
                 }
         return self._output("test_groups", {"groups": list(item["tests"].keys())})
 
     def suite_end(self, data):
         output = []
         for group, info in self.groups.items():
-            if info["start"] is None or info["end"] is None:
-                duration = None
+            if info["group_start"] is not None and info["group_end"] is not None:
+                duration = info["group_end"] - info["group_start"]
             else:
-                duration = info["end"] - info["start"]
+                duration = sum(info["test_times"])
 
             output.append(
                 self._output(
@@ -93,37 +124,85 @@ class ErrorSummaryFormatter(BaseFormatter):
 
         return "".join(output)
 
+    def group_start(self, item):
+        group = item["name"]
+        if group in self.manifest_groups:
+            self.groups[group]["group_start"] = item["time"]
+        else:
+            extra = item.get("extra") or {}
+            threads = extra.get("threads")
+            if threads and threads > 1:
+                self.test_time_divisor = threads
+
+    def group_end(self, item):
+        group = item["name"]
+        if group in self.manifest_groups and not self.groups[group]["all_skipped"]:
+            self.groups[group]["group_end"] = item["time"]
+        elif group not in self.manifest_groups:
+            self.test_time_divisor = 1
+
     def test_start(self, item):
-        group = self.test_to_group.get(item["test"], None)
-        if group and self.groups[group]["start"] is None:
-            self.groups[group]["start"] = item["time"]
+        test = self._clean_test_name(item["test"])
+        group = item.get("group", self.test_to_group.get(test, None))
+        if group:
+            self.groups[group]["test_starts"][test] = item["time"]
 
     def test_status(self, item):
-        group = self.test_to_group.get(item["test"], None)
+        group = item.get(
+            "group", self.test_to_group.get(self._clean_test_name(item["test"]), None)
+        )
         if group:
-            self._update_group_result(group, item)
+            self.groups[group]["status"] = self._get_group_result(group, item)
 
-        if "expected" not in item:
+        if not self.dump_passing_tests and "expected" not in item:
             return
 
-        return self._output_test(item["test"], item["subtest"], item)
+        if item.get("expected", "") == "":
+            item["expected"] = item["status"]
+
+        return self._output_test(
+            self._clean_test_name(item["test"]), item["subtest"], item
+        )
 
     def test_end(self, item):
-        group = self.test_to_group.get(item["test"], None)
+        test = self._clean_test_name(item["test"])
+        group = item.get("group", self.test_to_group.get(test, None))
         if group:
-            self._update_group_result(group, item)
-            self.groups[group]["end"] = item["time"]
+            self.groups[group]["status"] = self._get_group_result(group, item)
+            start_time = self.groups[group]["test_starts"].pop(test, None)
+            if item["status"] != "SKIP" and start_time is not None:
+                elapsed = item["time"] - start_time
+                self.groups[group]["test_times"].append(
+                    math.ceil(elapsed / self.test_time_divisor)
+                )
 
-        if "expected" not in item:
+        if not self.dump_passing_tests and "expected" not in item:
             return
 
-        return self._output_test(item["test"], None, item)
+        if item.get("expected", "") == "":
+            item["expected"] = item["status"]
+
+        return self._output_test(test, None, item)
 
     def log(self, item):
         if item["level"] not in ("ERROR", "CRITICAL"):
             return
 
         data = {"level": item["level"], "message": item["message"]}
+        return self._output("log", data)
+
+    def shutdown_failure(self, item):
+        data = {"status": "FAIL", "test": item["group"], "message": item["message"]}
+        data["group"] = [g for g in self.groups if item["group"].endswith(g)]
+        if data["group"]:
+            data["group"] = data["group"][0]
+            self.groups[data["group"]]["status"] = "FAIL"
+        else:
+            self.log({
+                "level": "ERROR",
+                "message": "Group '%s' was not found in known groups: %s.  Please look at item: %s"
+                % (item["group"], self.groups, item),
+            })
         return self._output("log", data)
 
     def crash(self, item):
@@ -135,22 +214,24 @@ class ErrorSummaryFormatter(BaseFormatter):
         }
 
         if item.get("test"):
-            data["group"] = self.test_to_group.get(item["test"], "")
+            data["group"] = self.test_to_group.get(
+                self._clean_test_name(item["test"]), ""
+            )
             if data["group"] == "":
                 # item['test'] could be the group name, not a test name
-                if item["test"] in self.groups:
-                    data["group"] = item["test"]
+                if self._clean_test_name(item["test"]) in self.groups:
+                    data["group"] = self._clean_test_name(item["test"])
 
             # unlike test group summary, if we crash expect error unless expected
             if (
                 (
-                    "expected" in item and
-                    "status" in item and
-                    item["status"] in item["expected"]
-                ) or
-                ("expected" in item and "CRASH" == item["expected"]) or
-                "status" in item and
-                item["status"] in item.get("known_intermittent", [])
+                    "expected" in item
+                    and "status" in item
+                    and item["status"] in item["expected"]
+                )
+                or ("expected" in item and "CRASH" == item["expected"])
+                or "status" in item
+                and item["status"] in item.get("known_intermittent", [])
             ):
                 self.groups[data["group"]]["status"] = "PASS"
             else:

--- a/tools/third_party_modified/mozlog/mozlog/formatters/grouping.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/grouping.py
@@ -9,8 +9,8 @@ import sys
 
 from mozlog.formatters import base
 
-DEFAULT_MOVE_UP_CODE = u"\x1b[A"
-DEFAULT_CLEAR_EOL_CODE = u"\x1b[K"
+DEFAULT_MOVE_UP_CODE = "\x1b[A"
+DEFAULT_CLEAR_EOL_CODE = "\x1b[K"
 
 
 class GroupingFormatter(base.BaseFormatter):
@@ -18,7 +18,7 @@ class GroupingFormatter(base.BaseFormatter):
     together in a readable format."""
 
     def __init__(self):
-        super(GroupingFormatter, self).__init__()
+        super().__init__()
         self.number_of_tests = 0
         self.completed_tests = 0
         self.need_to_erase_last_line = False
@@ -72,8 +72,8 @@ class GroupingFormatter(base.BaseFormatter):
             "CRASH": [],
         }
 
-        # Follows the format of {(<subsuite>, <test>, <subtest>): <data>}, where
-        # (<subsuite>, <test>, None) represents a top level test.
+        # Follows the format of {(<test>, <subtest>): <data>}, where
+        # (<test>, None) represents a top level test.
         self.known_intermittent_results = {}
 
     def _enable_show_logs(self):
@@ -127,41 +127,39 @@ class GroupingFormatter(base.BaseFormatter):
             else:
                 max_width = sys.maxsize
             return (
-                new_display +
-                ("\n%s" % indent).join(
-                    f"{self.get_test_name_output(subsuite, test_name)}"[:max_width]
-                    for subsuite, test_name in self.running_tests.values()
-                ) + "\n"
+                new_display
+                + ("\n%s" % indent).join(
+                    val[:max_width] for val in self.running_tests.values()
+                )
+                + "\n"
             )
         else:
             return new_display + "No tests running.\n"
 
     def suite_start(self, data):
-        self.number_of_tests = sum(
-            len(tests) for tests in data["tests"].values()
-        )
+        self.number_of_tests = sum(len(tests) for tests in data["tests"].values())
         self.start_time = data["time"]
 
         if self.number_of_tests == 0:
-            return "Running tests in %s\n\n" % data[u"source"]
+            return "Running tests in %s\n\n" % data["source"]
         else:
             return "Running %i tests in %s\n\n" % (
                 self.number_of_tests,
-                data[u"source"],
+                data["source"],
             )
 
     def test_start(self, data):
-        self.running_tests[data["thread"]] = (data.get("subsuite"), data["test"])
+        self.running_tests[data["thread"]] = data["test"]
         return self.generate_output(text=None, new_display=self.build_status_line())
 
     def wrap_and_indent_lines(self, lines, indent):
         assert len(lines) > 0
 
-        output = indent + u"\u25B6 %s\n" % lines[0]
+        output = indent + "\u25b6 %s\n" % lines[0]
         for line in lines[1:-1]:
-            output += indent + u"\u2502 %s\n" % line
+            output += indent + "\u2502 %s\n" % line
         if len(lines) > 1:
-            output += indent + u"\u2514 %s\n" % lines[-1]
+            output += indent + "\u2514 %s\n" % lines[-1]
         return output
 
     def get_lines_for_unexpected_result(
@@ -172,13 +170,13 @@ class GroupingFormatter(base.BaseFormatter):
         test_name = test_name.encode("unicode-escape").decode("utf-8")
 
         if expected:
-            expected_text = u" [expected %s]" % expected
+            expected_text = " [expected %s]" % expected
         else:
-            expected_text = u""
+            expected_text = ""
 
-        lines = [u"%s%s %s" % (status, expected_text, test_name)]
+        lines = ["%s%s %s" % (status, expected_text, test_name)]
         if message:
-            lines.append(u"  \u2192 %s" % message)
+            lines.append("  \u2192 %s" % message)
         if stack:
             lines.append("")
             lines += [stackline for stackline in stack.splitlines()]
@@ -187,7 +185,7 @@ class GroupingFormatter(base.BaseFormatter):
     def get_lines_for_known_intermittents(self, known_intermittent_results):
         lines = []
 
-        for (subsuite, test, subtest), data in self.known_intermittent_results.items():
+        for (test, subtest), data in self.known_intermittent_results.items():
             status = data["status"]
             known_intermittent = ", ".join(data["known_intermittent"])
             expected = " [expected %s, known intermittent [%s]" % (
@@ -195,24 +193,18 @@ class GroupingFormatter(base.BaseFormatter):
                 known_intermittent,
             )
             lines += [
-                u"%s%s %s%s"
+                "%s%s %s%s"
                 % (
                     status,
                     expected,
-                    self.get_test_name_output(subsuite, test),
+                    test,
                     (", %s" % subtest) if subtest is not None else "",
                 )
             ]
         output = self.wrap_and_indent_lines(lines, "  ") + "\n"
         return output
 
-    def get_test_name_output(self, subsuite, test_name):
-        # Generate human readable test name from subsuite and test_name.
-        # Vendors can override this function to produce output in a different
-        # format that suites their need.
-        return f"{subsuite}:{test_name}" if subsuite else test_name
-
-    def get_output_for_unexpected_subtests(self, subsuite, test_name, unexpected_subtests):
+    def get_output_for_unexpected_subtests(self, test_name, unexpected_subtests):
         if not unexpected_subtests:
             return ""
 
@@ -225,9 +217,8 @@ class GroupingFormatter(base.BaseFormatter):
                 stack,
             )
 
-        def make_subtests_failure(subsuite, test_name, subtests, stack=None):
-            lines = [u"Unexpected subtest result in %s:"
-                     % self.get_test_name_output(subsuite, test_name)]
+        def make_subtests_failure(test_name, subtests, stack=None):
+            lines = ["Unexpected subtest result in %s:" % test_name]
             for subtest in subtests[:-1]:
                 add_subtest_failure(lines, subtest, None)
             add_subtest_failure(lines, subtests[-1], stack)
@@ -241,21 +232,20 @@ class GroupingFormatter(base.BaseFormatter):
         for failure in unexpected_subtests:
             # Print stackless results first. They are all separate.
             if "stack" not in failure:
-                output += make_subtests_failure(subsuite, test_name, [failure], None)
+                output += make_subtests_failure(test_name, [failure], None)
             else:
                 failures_by_stack[failure["stack"]].append(failure)
 
-        for (stack, failures) in failures_by_stack.items():
-            output += make_subtests_failure(subsuite, test_name, failures, stack)
+        for stack, failures in failures_by_stack.items():
+            output += make_subtests_failure(test_name, failures, stack)
         return output
 
     def test_end(self, data):
         self.completed_tests += 1
         test_status = data["status"]
         test_name = data["test"]
-        subsuite = data.get("subsuite")
         known_intermittent_statuses = data.get("known_intermittent", [])
-        subtest_failures = self.subtest_failures.pop((subsuite, test_name), [])
+        subtest_failures = self.subtest_failures.pop(test_name, [])
         if "expected" in data and test_status not in known_intermittent_statuses:
             had_unexpected_test_result = True
         else:
@@ -270,18 +260,17 @@ class GroupingFormatter(base.BaseFormatter):
                 return self.generate_output(text=None, new_display=new_display)
             else:
                 return self.generate_output(
-                    text="  %s\n" % self.get_test_name_output(subsuite, test_name),
-                    new_display=new_display
+                    text="  %s\n" % test_name, new_display=new_display
                 )
 
         if test_status in known_intermittent_statuses:
-            self.known_intermittent_results[(subsuite, test_name, None)] = data
+            self.known_intermittent_results[(test_name, None)] = data
 
         # If the test crashed or timed out, we also include any process output,
         # because there is a good chance that the test produced a stack trace
         # or other error messages.
         if test_status in ("CRASH", "TIMEOUT"):
-            stack = self.test_output[(subsuite, test_name)] + data.get("stack", "")
+            stack = self.test_output[test_name] + data.get("stack", "")
         else:
             stack = data.get("stack", None)
 
@@ -289,7 +278,7 @@ class GroupingFormatter(base.BaseFormatter):
         if had_unexpected_test_result:
             self.unexpected_tests[test_status].append(data)
             lines = self.get_lines_for_unexpected_result(
-                self.get_test_name_output(subsuite, test_name),
+                test_name,
                 test_status,
                 data.get("expected", None),
                 data.get("message", None),
@@ -298,9 +287,9 @@ class GroupingFormatter(base.BaseFormatter):
             output += self.wrap_and_indent_lines(lines, "  ") + "\n"
 
         if subtest_failures:
-            self.tests_with_failing_subtests.append((subsuite, test_name))
+            self.tests_with_failing_subtests.append(test_name)
             output += self.get_output_for_unexpected_subtests(
-                subsuite, test_name, subtest_failures
+                test_name, subtest_failures
             )
         self.test_failure_text += output
 
@@ -310,53 +299,51 @@ class GroupingFormatter(base.BaseFormatter):
         if "expected" in data and data["status"] not in data.get(
             "known_intermittent", []
         ):
-            key = (data.get("subsuite"), data["test"])
-            self.subtest_failures[key].append(data)
+            self.subtest_failures[data["test"]].append(data)
         elif data["status"] in data.get("known_intermittent", []):
-            key = (data.get("subsuite"), data["test"], data["subtest"])
-            self.known_intermittent_results[key] = data
+            self.known_intermittent_results[(data["test"], data["subtest"])] = data
 
     def suite_end(self, data):
         self.end_time = data["time"]
 
         if not self.interactive:
-            output = u"\n"
+            output = "\n"
         else:
             output = ""
 
-        output += u"Ran %i tests finished in %.1f seconds.\n" % (
+        output += "Ran %i tests finished in %.1f seconds.\n" % (
             self.completed_tests,
             (self.end_time - self.start_time) / 1000.0,
         )
-        output += u"  \u2022 %i ran as expected. %i tests skipped.\n" % (
+        output += "  \u2022 %i ran as expected. %i tests skipped.\n" % (
             sum(self.expected.values()),
             self.expected["SKIP"],
         )
         if self.known_intermittent_results:
-            output += u"  \u2022 %i known intermittent results.\n" % (
+            output += "  \u2022 %i known intermittent results.\n" % (
                 len(self.known_intermittent_results)
             )
 
         def text_for_unexpected_list(text, section):
             tests = self.unexpected_tests[section]
             if not tests:
-                return u""
-            return u"  \u2022 %i tests %s\n" % (len(tests), text)
+                return ""
+            return "  \u2022 %i tests %s\n" % (len(tests), text)
 
-        output += text_for_unexpected_list(u"crashed unexpectedly", "CRASH")
-        output += text_for_unexpected_list(u"had errors unexpectedly", "ERROR")
-        output += text_for_unexpected_list(u"failed unexpectedly", "FAIL")
+        output += text_for_unexpected_list("crashed unexpectedly", "CRASH")
+        output += text_for_unexpected_list("had errors unexpectedly", "ERROR")
+        output += text_for_unexpected_list("failed unexpectedly", "FAIL")
         output += text_for_unexpected_list(
-            u"precondition failed unexpectedly", "PRECONDITION_FAILED"
+            "precondition failed unexpectedly", "PRECONDITION_FAILED"
         )
-        output += text_for_unexpected_list(u"timed out unexpectedly", "TIMEOUT")
-        output += text_for_unexpected_list(u"passed unexpectedly", "PASS")
-        output += text_for_unexpected_list(u"unexpectedly okay", "OK")
+        output += text_for_unexpected_list("timed out unexpectedly", "TIMEOUT")
+        output += text_for_unexpected_list("passed unexpectedly", "PASS")
+        output += text_for_unexpected_list("unexpectedly okay", "OK")
 
         num_with_failing_subtests = len(self.tests_with_failing_subtests)
         if num_with_failing_subtests:
             output += (
-                u"  \u2022 %i tests had unexpected subtest results\n"
+                "  \u2022 %i tests had unexpected subtest results\n"
                 % num_with_failing_subtests
             )
         output += "\n"
@@ -364,21 +351,21 @@ class GroupingFormatter(base.BaseFormatter):
         # Repeat failing test output, so that it is easier to find, since the
         # non-interactive version prints all the test names.
         if not self.interactive and self.test_failure_text:
-            output += u"Tests with unexpected results:\n" + self.test_failure_text
+            output += "Tests with unexpected results:\n" + self.test_failure_text
 
         if self.known_intermittent_results:
             results = self.get_lines_for_known_intermittents(
                 self.known_intermittent_results
             )
-            output += u"Tests with known intermittent results:\n" + results
+            output += "Tests with known intermittent results:\n" + results
 
         return self.generate_output(text=output, new_display="")
 
     def process_output(self, data):
         if data["thread"] not in self.running_tests:
             return
-        test_key = self.running_tests[data["thread"]]
-        self.test_output[test_key] += data["data"] + "\n"
+        test_name = self.running_tests[data["thread"]]
+        self.test_output[test_name] += data["data"] + "\n"
 
     def log(self, data):
         if data.get("component"):

--- a/tools/third_party_modified/mozlog/mozlog/formatters/grouping.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/grouping.py
@@ -72,8 +72,8 @@ class GroupingFormatter(base.BaseFormatter):
             "CRASH": [],
         }
 
-        # Follows the format of {(<test>, <subtest>): <data>}, where
-        # (<test>, None) represents a top level test.
+        # Follows the format of {(<subsuite>, <test>, <subtest>): <data>}, where
+        # (<subsuite>, <test>, None) represents a top level test.
         self.known_intermittent_results = {}
 
     def _enable_show_logs(self):
@@ -127,11 +127,11 @@ class GroupingFormatter(base.BaseFormatter):
             else:
                 max_width = sys.maxsize
             return (
-                new_display
-                + ("\n%s" % indent).join(
-                    val[:max_width] for val in self.running_tests.values()
-                )
-                + "\n"
+                new_display +
+                ("\n%s" % indent).join(
+                    f"{self.get_test_name_output(subsuite, test_name)}"[:max_width]
+                    for subsuite, test_name in self.running_tests.values()
+                ) + "\n"
             )
         else:
             return new_display + "No tests running.\n"
@@ -149,7 +149,7 @@ class GroupingFormatter(base.BaseFormatter):
             )
 
     def test_start(self, data):
-        self.running_tests[data["thread"]] = data["test"]
+        self.running_tests[data["thread"]] = (data.get("subsuite"), data["test"])
         return self.generate_output(text=None, new_display=self.build_status_line())
 
     def wrap_and_indent_lines(self, lines, indent):
@@ -185,7 +185,7 @@ class GroupingFormatter(base.BaseFormatter):
     def get_lines_for_known_intermittents(self, known_intermittent_results):
         lines = []
 
-        for (test, subtest), data in self.known_intermittent_results.items():
+        for (subsuite, test, subtest), data in self.known_intermittent_results.items():
             status = data["status"]
             known_intermittent = ", ".join(data["known_intermittent"])
             expected = " [expected %s, known intermittent [%s]" % (
@@ -197,14 +197,20 @@ class GroupingFormatter(base.BaseFormatter):
                 % (
                     status,
                     expected,
-                    test,
+                    self.get_test_name_output(subsuite, test),
                     (", %s" % subtest) if subtest is not None else "",
                 )
             ]
         output = self.wrap_and_indent_lines(lines, "  ") + "\n"
         return output
 
-    def get_output_for_unexpected_subtests(self, test_name, unexpected_subtests):
+    def get_test_name_output(self, subsuite, test_name):
+        # Generate human readable test name from subsuite and test_name.
+        # Vendors can override this function to produce output in a different
+        # format that suites their need.
+        return f"{subsuite}:{test_name}" if subsuite else test_name
+
+    def get_output_for_unexpected_subtests(self, subsuite, test_name, unexpected_subtests):
         if not unexpected_subtests:
             return ""
 
@@ -217,8 +223,9 @@ class GroupingFormatter(base.BaseFormatter):
                 stack,
             )
 
-        def make_subtests_failure(test_name, subtests, stack=None):
-            lines = ["Unexpected subtest result in %s:" % test_name]
+        def make_subtests_failure(subsuite, test_name, subtests, stack=None):
+            lines = [u"Unexpected subtest result in %s:"
+                     % self.get_test_name_output(subsuite, test_name)]
             for subtest in subtests[:-1]:
                 add_subtest_failure(lines, subtest, None)
             add_subtest_failure(lines, subtests[-1], stack)
@@ -232,20 +239,22 @@ class GroupingFormatter(base.BaseFormatter):
         for failure in unexpected_subtests:
             # Print stackless results first. They are all separate.
             if "stack" not in failure:
-                output += make_subtests_failure(test_name, [failure], None)
+                output += make_subtests_failure(subsuite, test_name, [failure], None)
             else:
                 failures_by_stack[failure["stack"]].append(failure)
 
         for stack, failures in failures_by_stack.items():
-            output += make_subtests_failure(test_name, failures, stack)
+            output += make_subtests_failure(subsuite, test_name, failures, stack)
+
         return output
 
     def test_end(self, data):
         self.completed_tests += 1
         test_status = data["status"]
         test_name = data["test"]
+        subsuite = data.get("subsuite")
         known_intermittent_statuses = data.get("known_intermittent", [])
-        subtest_failures = self.subtest_failures.pop(test_name, [])
+        subtest_failures = self.subtest_failures.pop((subsuite, test_name), [])
         if "expected" in data and test_status not in known_intermittent_statuses:
             had_unexpected_test_result = True
         else:
@@ -260,17 +269,18 @@ class GroupingFormatter(base.BaseFormatter):
                 return self.generate_output(text=None, new_display=new_display)
             else:
                 return self.generate_output(
-                    text="  %s\n" % test_name, new_display=new_display
+                    text="  %s\n" % self.get_test_name_output(subsuite, test_name),
+                    new_display=new_display
                 )
 
         if test_status in known_intermittent_statuses:
-            self.known_intermittent_results[(test_name, None)] = data
+            self.known_intermittent_results[(subsuite, test_name, None)] = data
 
         # If the test crashed or timed out, we also include any process output,
         # because there is a good chance that the test produced a stack trace
         # or other error messages.
         if test_status in ("CRASH", "TIMEOUT"):
-            stack = self.test_output[test_name] + data.get("stack", "")
+            stack = self.test_output[(subsuite, test_name)] + data.get("stack", "")
         else:
             stack = data.get("stack", None)
 
@@ -278,7 +288,7 @@ class GroupingFormatter(base.BaseFormatter):
         if had_unexpected_test_result:
             self.unexpected_tests[test_status].append(data)
             lines = self.get_lines_for_unexpected_result(
-                test_name,
+                self.get_test_name_output(subsuite, test_name),
                 test_status,
                 data.get("expected", None),
                 data.get("message", None),
@@ -287,9 +297,9 @@ class GroupingFormatter(base.BaseFormatter):
             output += self.wrap_and_indent_lines(lines, "  ") + "\n"
 
         if subtest_failures:
-            self.tests_with_failing_subtests.append(test_name)
+            self.tests_with_failing_subtests.append((subsuite, test_name))
             output += self.get_output_for_unexpected_subtests(
-                test_name, subtest_failures
+                subsuite, test_name, subtest_failures
             )
         self.test_failure_text += output
 
@@ -299,9 +309,11 @@ class GroupingFormatter(base.BaseFormatter):
         if "expected" in data and data["status"] not in data.get(
             "known_intermittent", []
         ):
-            self.subtest_failures[data["test"]].append(data)
+            key = (data.get("subsuite"), data["test"])
+            self.subtest_failures[key].append(data)
         elif data["status"] in data.get("known_intermittent", []):
-            self.known_intermittent_results[(data["test"], data["subtest"])] = data
+            key = (data.get("subsuite"), data["test"], data["subtest"])
+            self.known_intermittent_results[key] = data
 
     def suite_end(self, data):
         self.end_time = data["time"]
@@ -364,8 +376,8 @@ class GroupingFormatter(base.BaseFormatter):
     def process_output(self, data):
         if data["thread"] not in self.running_tests:
             return
-        test_name = self.running_tests[data["thread"]]
-        self.test_output[test_name] += data["data"] + "\n"
+        test_key = self.running_tests[data["thread"]]
+        self.test_output[test_key] += data["data"] + "\n"
 
     def log(self, data):
         if data.get("component"):

--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
@@ -6,7 +6,7 @@ import base64
 import json
 import os
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .. import base
 
@@ -239,7 +239,7 @@ class HTMLFormatter(base.BaseFormatter):
         )
 
     def generate_html(self):
-        generated = datetime.utcnow()
+        generated = datetime.now(timezone.utc)
         with open(os.path.join(base_path, "main.js")) as main_f:
             doc = html.html(
                 self.head,

--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -6,7 +7,7 @@ import base64
 import json
 import os
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime
 
 from .. import base
 
@@ -83,12 +84,10 @@ class HTMLFormatter(base.BaseFormatter):
                 if version_info.get("application_repository"):
                     self.env["Gecko revision"] = html.a(
                         version_info.get("application_changeset"),
-                        href="/rev/".join(
-                            [
-                                version_info.get("application_repository"),
-                                version_info.get("application_changeset"),
-                            ]
-                        ),
+                        href="/rev/".join([
+                            version_info.get("application_repository"),
+                            version_info.get("application_changeset"),
+                        ]),
                         target="_blank",
                     )
 
@@ -217,14 +216,13 @@ class HTMLFormatter(base.BaseFormatter):
                 separator = line.startswith(" " * 10)
                 if separator:
                     log.append(line[:80])
+                elif (
+                    line.lower().find("error") != -1
+                    or line.lower().find("exception") != -1
+                ):
+                    log.append(html.span(raw(escape(line)), class_="error"))
                 else:
-                    if (
-                        line.lower().find("error") != -1 or
-                        line.lower().find("exception") != -1
-                    ):
-                        log.append(html.span(raw(escape(line)), class_="error"))
-                    else:
-                        log.append(raw(escape(line)))
+                    log.append(raw(escape(line)))
                 log.append(html.br())
             additional_html.append(log)
 
@@ -242,7 +240,7 @@ class HTMLFormatter(base.BaseFormatter):
         )
 
     def generate_html(self):
-        generated = datetime.now(timezone.utc)
+        generated = datetime.utcnow()
         with open(os.path.join(base_path, "main.js")) as main_f:
             doc = html.html(
                 self.head,
@@ -269,7 +267,8 @@ class HTMLFormatter(base.BaseFormatter):
                         "%i tests ran in %.1f seconds."
                         % (
                             sum(self.test_count.values()),
-                            (self.suite_times["end"] - self.suite_times["start"]) / 1000.0,
+                            (self.suite_times["end"] - self.suite_times["start"])
+                            / 1000.0,
                         ),
                         html.br(),
                         html.span("%i passed" % self.test_count["PASS"], class_="pass"),
@@ -310,20 +309,16 @@ class HTMLFormatter(base.BaseFormatter):
                     html.table(
                         [
                             html.thead(
-                                html.tr(
-                                    [
-                                        html.th(
-                                            "Result", class_="sortable", col="result"
-                                        ),
-                                        html.th("Test", class_="sortable", col="name"),
-                                        html.th(
-                                            "Duration",
-                                            class_="sortable numeric",
-                                            col="duration",
-                                        ),
-                                        html.th("Links"),
-                                    ]
-                                ),
+                                html.tr([
+                                    html.th("Result", class_="sortable", col="result"),
+                                    html.th("Test", class_="sortable", col="name"),
+                                    html.th(
+                                        "Duration",
+                                        class_="sortable numeric",
+                                        col="duration",
+                                    ),
+                                    html.th("Links"),
+                                ]),
                                 id="results-table-head",
                             ),
                             html.tbody(self.result_rows, id="results-table-body"),
@@ -333,4 +328,4 @@ class HTMLFormatter(base.BaseFormatter):
                 ),
             )
 
-        return u"<!DOCTYPE html>\n" + doc.unicode(indent=2)
+        return "<!DOCTYPE html>\n" + doc.unicode(indent=2)

--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/main.js
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/main.js
@@ -52,7 +52,7 @@ addEventListener("DOMContentLoaded", function () {
   });
 
   find_all(".sortable").forEach(function (elem) {
-    elem.addEventListener("click", function (event) {
+    elem.addEventListener("click", function () {
       toggle_sort_states(elem);
       var colIndex = toArray(elem.parentNode.childNodes).indexOf(elem);
       var key = elem.classList.contains("numeric") ? key_num : key_alpha;

--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/style.css
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/style.css
@@ -3,26 +3,26 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 body {
-	font-family: Helvetica, Arial, sans-serif;
-	font-size: 12px;
-	min-width: 1200px;
-	color: #999;
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  min-width: 1200px;
+  color: #999;
 }
 h2 {
-	font-size: 16px;
-	color: black;
+  font-size: 16px;
+  color: black;
 }
 
 p {
-    color: black;
+  color: black;
 }
 
 a {
-	color: #999;
+  color: #999;
 }
 
 table {
-	border-collapse: collapse;
+  border-collapse: collapse;
 }
 
 /******************************
@@ -30,32 +30,42 @@ table {
  ******************************/
 
 #environment td {
-	padding: 5px;
-	border: 1px solid #E6E6E6;
+  padding: 5px;
+  border: 1px solid #e6e6e6;
 }
 
 #environment tr:nth-child(odd) {
-	background-color: #f6f6f6;
+  background-color: #f6f6f6;
 }
 
 /******************************
  * TEST RESULT COLORS
  ******************************/
-span.pass, .pass .col-result {
-	color: green;
+span.pass,
+.pass .col-result {
+  color: green;
 }
-span.expected_fail, .expected_fail .col-result,
-span.expected_skip, .expected_skip .col-result,
-span.skip, .skip .col-result,
-span.known_intermittent, .known_intermittent .col-result {
-	color: orange;
+span.expected_fail,
+.expected_fail .col-result,
+span.expected_skip,
+.expected_skip .col-result,
+span.skip,
+.skip .col-result,
+span.known_intermittent,
+.known_intermittent .col-result {
+  color: orange;
 }
-span.error, .error .col-result,
-span.fail, .fail .col-result,
-span.unexpected_error, .unexpected_error .col-result,
-span.unexpected_fail, .unexpected_fail .col-result,
-span.unexpected_pass, .unexpected_pass .col-result {
-	color: red;
+span.error,
+.error .col-result,
+span.fail,
+.fail .col-result,
+span.unexpected_error,
+.unexpected_error .col-result,
+span.unexpected_fail,
+.unexpected_fail .col-result,
+span.unexpected_pass,
+.unexpected_pass .col-result {
+  color: red;
 }
 
 /******************************
@@ -72,19 +82,20 @@ span.unexpected_pass, .unexpected_pass .col-result {
  *------------------*/
 
 #results-table {
-	border: 1px solid #e6e6e6;
-	color: #999;
-	font-size: 12px;
-	width: 100%
+  border: 1px solid #e6e6e6;
+  color: #999;
+  font-size: 12px;
+  width: 100%;
 }
 
-#results-table th, #results-table td {
-	padding: 5px;
-	border: 1px solid #E6E6E6;
-	text-align: left
+#results-table th,
+#results-table td {
+  padding: 5px;
+  border: 1px solid #e6e6e6;
+  text-align: left;
 }
 #results-table th {
-	font-weight: bold
+  font-weight: bold;
 }
 
 /*------------------
@@ -92,64 +103,65 @@ span.unexpected_pass, .unexpected_pass .col-result {
  *------------------*/
 
 .log:only-child {
-	height: inherit
+  height: inherit;
 }
 .log {
-	background-color: #e6e6e6;
-	border: 1px solid #e6e6e6;
-	color: black;
-	display: block;
-	font-family: "Courier New", Courier, monospace;
-	height: 230px;
-	overflow-y: scroll;
-	padding: 5px;
-	white-space: pre-wrap
+  background-color: #e6e6e6;
+  border: 1px solid #e6e6e6;
+  color: black;
+  display: block;
+  font-family: "Courier New", Courier, monospace;
+  height: 230px;
+  overflow-y: scroll;
+  padding: 5px;
+  white-space: pre-wrap;
 }
 div.screenshot {
-	border: 1px solid #e6e6e6;
-	float: left;
-	margin-left: 5px;
-	height: 220px
+  border: 1px solid #e6e6e6;
+  float: left;
+  margin-left: 5px;
+  height: 220px;
 }
 div.screenshot img {
-	height: 220px
+  height: 220px;
 }
 
 /*if the result is passed or xpassed don't show debug row*/
-.passed + .debug, .unexpected.pass + .debug {
-	display: none;
+.passed + .debug,
+.unexpected.pass + .debug {
+  display: none;
 }
 
 /*------------------
  * 3. Sorting items
  *------------------*/
 .sortable {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 .sort-icon {
-	font-size: 0px;
-	float: left;
-	margin-right: 5px;
-	margin-top: 5px;
-	/*triangle*/
-	width: 0;
-	height: 0;
-	border-left: 8px solid transparent;
-	border-right: 8px solid transparent;
+  font-size: 0;
+  float: left;
+  margin-right: 5px;
+  margin-top: 5px;
+  /*triangle*/
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
 }
 
 .inactive .sort-icon {
-	/*finish triangle*/
-	border-top: 8px solid #E6E6E6;
+  /*finish triangle*/
+  border-top: 8px solid #e6e6e6;
 }
 
 .asc.active .sort-icon {
-	/*finish triangle*/
-	border-bottom: 8px solid #999;
+  /*finish triangle*/
+  border-bottom: 8px solid #999;
 }
 
 .desc.active .sort-icon {
-	/*finish triangle*/
-	border-top: 8px solid #999;
+  /*finish triangle*/
+  border-top: 8px solid #999;
 }

--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/xmlgen.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/xmlgen.py
@@ -23,30 +23,20 @@ by holger krekel, holger at merlinux eu. 2009
 """
 
 import re
-import sys
-
-if sys.version_info >= (3, 0):
-
-    def u(s):
-        return s
-
-    def unicode(x):
-        if hasattr(x, "__unicode__"):
-            return x.__unicode__()
-        return str(x)
 
 
-else:
+def u(s):
+    return s
 
-    def u(s):
-        return unicode(s)
 
-    # pylint: disable=W1612
-    unicode = unicode
+def unicode(x):
+    if hasattr(x, "__unicode__"):
+        return x.__unicode__()
+    return str(x)
 
 
 class NamespaceMetaclass(type):
-    def __getattr__(self, name):  # noqa: N804
+    def __getattr__(self, name):
         if name[:1] == "_":
             raise AttributeError(name)
         if self == Namespace:
@@ -63,12 +53,12 @@ class NamespaceMetaclass(type):
 
 
 class Tag(list):
-    class Attr(object):
+    class Attr:
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
     def __init__(self, *args, **kwargs):
-        super(Tag, self).__init__(args)
+        super().__init__(args)
         self.attr = self.Attr(**kwargs)
 
     def __unicode__(self):
@@ -77,9 +67,9 @@ class Tag(list):
     __str__ = __unicode__
 
     def unicode(self, indent=2):
-        lv = []
-        SimpleUnicodeVisitor(lv.append, indent).visit(self)
-        return u("").join(lv)
+        l = []
+        SimpleUnicodeVisitor(l.append, indent).visit(self)
+        return u("").join(l)
 
     def __repr__(self):
         name = self.__class__.__name__
@@ -99,9 +89,9 @@ Namespace = NamespaceMetaclass(
 
 class HtmlTag(Tag):
     def unicode(self, indent=2):
-        lv = []
-        HtmlVisitor(lv.append, indent, shortempty=False).visit(self)
-        return u("").join(lv)
+        l = []
+        HtmlVisitor(l.append, indent, shortempty=False).visit(self)
+        return u("").join(l)
 
 
 # exported plain html namespace
@@ -110,33 +100,31 @@ class HtmlTag(Tag):
 class html(Namespace):
     __tagclass__ = HtmlTag
     __stickyname__ = True
-    __tagspec__ = dict(
-        [
-            (x, 1)
-            for x in (
-                "a,abbr,acronym,address,applet,area,b,bdo,big,blink,"
-                "blockquote,body,br,button,caption,center,cite,code,col,"
-                "colgroup,comment,dd,del,dfn,dir,div,dl,dt,em,embed,"
-                "fieldset,font,form,frameset,h1,h2,h3,h4,h5,h6,head,html,"
-                "i,iframe,img,input,ins,kbd,label,legend,li,link,listing,"
-                "map,marquee,menu,meta,multicol,nobr,noembed,noframes,"
-                "noscript,object,ol,optgroup,option,p,pre,q,s,script,"
-                "select,small,span,strike,strong,style,sub,sup,table,"
-                "tbody,td,textarea,tfoot,th,thead,title,tr,tt,u,ul,xmp,"
-                "base,basefont,frame,hr,isindex,param,samp,var"
-            ).split(",")
-            if x
-        ]
-    )
+    __tagspec__ = dict([
+        (x, 1)
+        for x in (
+            "a,abbr,acronym,address,applet,area,b,bdo,big,blink,"
+            "blockquote,body,br,button,caption,center,cite,code,col,"
+            "colgroup,comment,dd,del,dfn,dir,div,dl,dt,em,embed,"
+            "fieldset,font,form,frameset,h1,h2,h3,h4,h5,h6,head,html,"
+            "i,iframe,img,input,ins,kbd,label,legend,li,link,listing,"
+            "map,marquee,menu,meta,multicol,nobr,noembed,noframes,"
+            "noscript,object,ol,optgroup,option,p,pre,q,s,script,"
+            "select,small,span,strike,strong,style,sub,sup,table,"
+            "tbody,td,textarea,tfoot,th,thead,title,tr,tt,u,ul,xmp,"
+            "base,basefont,frame,hr,isindex,param,samp,var"
+        ).split(",")
+        if x
+    ])
 
-    class Style(object):
+    class Style:
         def __init__(self, **kw):
             for x, y in kw.items():
                 x = x.replace("_", "-")
                 setattr(self, x, y)
 
 
-class raw(object):
+class raw:
     """just a box that can contain a unicode string that will be
     included directly in the output"""
 
@@ -144,7 +132,7 @@ class raw(object):
         self.uniobj = uniobj
 
 
-class SimpleUnicodeVisitor(object):
+class SimpleUnicodeVisitor:
     """recursive visitor to write unicode."""
 
     def __init__(self, write, indent=0, curindent=0, shortempty=True):
@@ -216,13 +204,13 @@ class SimpleUnicodeVisitor(object):
         # serialize attributes
         attrlist = dir(tag.attr)
         attrlist.sort()
-        lv = []
+        l = []
         for name in attrlist:
             res = self.repr_attribute(tag.attr, name)
             if res is not None:
-                lv.append(res)
-        lv.extend(self.getstyle(tag))
-        return u("").join(lv)
+                l.append(res)
+        l.extend(self.getstyle(tag))
+        return u("").join(l)
 
     def repr_attribute(self, attrs, name):
         if name[:2] != "__":
@@ -255,32 +243,25 @@ class SimpleUnicodeVisitor(object):
 
 
 class HtmlVisitor(SimpleUnicodeVisitor):
-
-    single = dict(
-        [
-            (x, 1)
-            for x in ("br,img,area,param,col,hr,meta,link,base," "input,frame").split(
-                ","
-            )
-        ]
-    )
-    inline = dict(
-        [
-            (x, 1)
-            for x in (
-                "a abbr acronym b basefont bdo big br cite code dfn em font "
-                "i img input kbd label q s samp select small span strike "
-                "strong sub sup textarea tt u var".split(" ")
-            )
-        ]
-    )
+    single = dict([
+        (x, 1)
+        for x in ("br,img,area,param,col,hr,meta,link,base,input,frame").split(",")
+    ])
+    inline = dict([
+        (x, 1)
+        for x in (
+            "a abbr acronym b basefont bdo big br cite code dfn em font "
+            "i img input kbd label q s samp select small span strike "
+            "strong sub sup textarea tt u var".split(" ")
+        )
+    ])
 
     def repr_attribute(self, attrs, name):
         if name == "class_":
             value = getattr(attrs, name)
             if value is None:
                 return
-        return super(HtmlVisitor, self).repr_attribute(attrs, name)
+        return super().repr_attribute(attrs, name)
 
     def _issingleton(self, tagname):
         return tagname in self.single

--- a/tools/third_party_modified/mozlog/mozlog/formatters/machformatter.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/machformatter.py
@@ -41,7 +41,7 @@ def format_seconds(total):
     return "%2d:%05.2f" % (minutes, seconds)
 
 
-class TerminalColors(object):
+class TerminalColors:
     def __init__(self, term, color_dict):
         for key, value in color_dict.items():
             attribute = getattr(term, value)
@@ -75,9 +75,9 @@ class MachFormatter(base.BaseFormatter):
         summary_on_shutdown=False,
         verbose=False,
         enable_screenshot=False,
-        **kwargs
+        **kwargs,
     ):
-        super(MachFormatter, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if start_time is None:
             start_time = time.time()
@@ -115,7 +115,7 @@ class MachFormatter(base.BaseFormatter):
     def __call__(self, data):
         self.summary(data)
 
-        s = super(MachFormatter, self).__call__(data)
+        s = super().__call__(data)
         if s is None:
             return
 
@@ -174,18 +174,18 @@ class MachFormatter(base.BaseFormatter):
             if expected not in ("PASS", "OK"):
                 color = self.color_formatter.log_test_status_fail
                 status = "EXPECTED-%s" % status
+        elif status in known_intermittent:
+            color = self.color_formatter.log_test_status_known_intermittent
+            status = "KNOWN-INTERMITTENT-%s" % status
         else:
-            if status in known_intermittent:
-                color = self.color_formatter.log_test_status_known_intermittent
-                status = "KNOWN-INTERMITTENT-%s" % status
-            else:
-                color = self.color_formatter.log_test_status_fail
-                if status in ("PASS", "OK"):
-                    status = "UNEXPECTED-%s" % status
+            color = self.color_formatter.log_test_status_fail
+            if status in ("PASS", "OK"):
+                status = "UNEXPECTED-%s" % status
         return color(status)
 
     def _format_status(self, test, data):
-        name = data.get("subtest", test)
+        subtest = data.get("subtest")
+        name = subtest if subtest is not None else test
         rv = "%s %s" % (
             self._format_expected(
                 data["status"],
@@ -220,9 +220,7 @@ class MachFormatter(base.BaseFormatter):
         rv.append(
             "Ran {} checks ({})".format(
                 sum(checks.values()),
-                ", ".join(
-                    ["{} {}s".format(v, k) for k, v in sorted(checks.items()) if v]
-                ),
+                ", ".join([f"{v} {k}s" for k, v in sorted(checks.items()) if v]),
             )
         )
 
@@ -232,34 +230,29 @@ class MachFormatter(base.BaseFormatter):
             "known_intermittent", count, include_skip=False
         )
         intermittents = sum(intermittent_checks.values())
-        known = (
-            " ({} known intermittents)".format(intermittents) if intermittents else ""
-        )
-        rv.append("Expected results: {}{}".format(sum(checks.values()), known))
+        known = f" ({intermittents} known intermittents)" if intermittents else ""
+        rv.append(f"Expected results: {sum(checks.values())}{known}")
 
         # Format skip counts
         skip_tests = count["test"]["expected"]["skip"]
         skip_subtests = count["subtest"]["expected"]["skip"]
         if skip_tests:
-            skipped = "Skipped: {} tests".format(skip_tests)
+            skipped = f"Skipped: {skip_tests} tests"
             if skip_subtests:
-                skipped = "{}, {} subtests".format(skipped, skip_subtests)
+                skipped = f"{skipped}, {skip_subtests} subtests"
             rv.append(skipped)
 
         # Format unexpected counts
         checks = self.summary.aggregate("unexpected", count)
         unexpected_count = sum(checks.values())
-        rv.append("Unexpected results: {}".format(unexpected_count))
+        rv.append(f"Unexpected results: {unexpected_count}")
         if unexpected_count:
             for key in ("test", "subtest", "assert"):
                 if not count[key]["unexpected"]:
                     continue
-                status_str = ", ".join(
-                    [
-                        "{} {}".format(n, s)
-                        for s, n in sorted(count[key]["unexpected"].items())
-                    ]
-                )
+                status_str = ", ".join([
+                    f"{n} {s}" for s, n in sorted(count[key]["unexpected"].items())
+                ])
                 rv.append(
                     "  {}: {} ({})".format(
                         key, sum(count[key]["unexpected"].values()), status_str
@@ -269,13 +262,11 @@ class MachFormatter(base.BaseFormatter):
         # Format intermittents
         if intermittents > 0:
             heading = "Known Intermittent Results"
-            rv.extend(
-                [
-                    "",
-                    self.color_formatter.heading(heading),
-                    self.color_formatter.heading("-" * len(heading)),
-                ]
-            )
+            rv.extend([
+                "",
+                self.color_formatter.heading(heading),
+                self.color_formatter.heading("-" * len(heading)),
+            ])
             if count["subtest"]["count"]:
                 for test_id, results in intermittent_logs.items():
                     test = self._get_file_name(test_id)
@@ -297,14 +288,12 @@ class MachFormatter(base.BaseFormatter):
             rv.append(self.color_formatter.log_test_status_pass("OK"))
         else:
             # Format test failures
-            heading = "Unexpected Results"
-            rv.extend(
-                [
-                    "",
-                    self.color_formatter.heading(heading),
-                    self.color_formatter.heading("-" * len(heading)),
-                ]
-            )
+            heading = "Error Summary"
+            rv.extend([
+                "",
+                self.color_formatter.heading(heading),
+                self.color_formatter.heading("-" * len(heading)),
+            ])
             if count["subtest"]["count"]:
                 for test_id, results in logs.items():
                     test = self._get_file_name(test_id)
@@ -379,6 +368,9 @@ class MachFormatter(base.BaseFormatter):
             for d in intermittents:
                 rv += self._format_status(data["test"], d)
 
+        if data["status"] == "SKIP" and data.get("message"):
+            rv += f" ({data['message']})"
+
         if "expected" not in data and not bool(subtests["unexpected"]):
             color = self.color_formatter.log_test_status_pass
         else:
@@ -452,7 +444,7 @@ class MachFormatter(base.BaseFormatter):
                 )
 
             status = self.color_formatter.log_test_status_pass("FAIL")
-            return "%s leakcheck: " "%s missing output line for total leaks!\n" % (
+            return "%s leakcheck: %s missing output line for total leaks!\n" % (
                 status,
                 data["process"],
             )
@@ -587,8 +579,14 @@ class MachFormatter(base.BaseFormatter):
 
     def log(self, data):
         level = data.get("level").upper()
+        message = data["message"]
 
-        if level in ("CRITICAL", "ERROR"):
+        # Handle TEST-EXPECTED-FAIL specially
+        if level == "ERROR" and message.startswith("TEST-EXPECTED-FAIL"):
+            level = self.color_formatter.warning("TODO")
+            # Replace the TEST-EXPECTED-FAIL prefix with empty string
+            message = message[len("TEST-EXPECTED-FAIL") :].strip()
+        elif level in ("CRITICAL", "ERROR"):
             level = self.color_formatter.error(level)
         elif level == "WARNING":
             level = self.color_formatter.warning(level)
@@ -596,9 +594,9 @@ class MachFormatter(base.BaseFormatter):
             level = self.color_formatter.log_process_output(level)
 
         if data.get("component"):
-            rv = " ".join([data["component"], level, data["message"]])
+            rv = " ".join([data["component"], level, message])
         else:
-            rv = "%s %s" % (level, data["message"])
+            rv = "%s %s" % (level, message)
 
         if "stack" in data:
             rv += "\n%s" % data["stack"]
@@ -614,9 +612,11 @@ class MachFormatter(base.BaseFormatter):
             path=data["path"],
             normal=self.color_formatter.normal,
             c1=self.color_formatter.grey,
-            c2=self.color_formatter.error
-            if data["level"] == "error"
-            else (self.color_formatter.log_test_status_fail),
+            c2=(
+                self.color_formatter.error
+                if data["level"] == "error"
+                else (self.color_formatter.log_test_status_fail)
+            ),
             lineno=str(data["lineno"]),
             column=(":" + str(data["column"])) if data.get("column") else "",
             level=data["level"],

--- a/tools/third_party_modified/mozlog/mozlog/formatters/process.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/process.py
@@ -20,12 +20,10 @@ def strsig(n):
         _SIG_NAME = {}
         for k in dir(signal):
             if (
-                k.startswith("SIG") and
-                not k.startswith("SIG_") and
-                k != "SIGCLD" and
-                k != "SIGPOLL"
+                k.startswith("SIG")
+                and not k.startswith("SIG_")
+                and k not in {"SIGCLD", "SIGPOLL"}
             ):
-
                 _SIG_NAME[getattr(signal, k)] = k
 
         # Realtime signals mostly have no names
@@ -50,7 +48,7 @@ def strstatus(status):
     if os.name != "posix":
         # Windows error codes are easier to look up if printed in hexadecimal
         if status < 0:
-            status += 2 ** 32
+            status += 2**32
         return "exit %x" % status
     elif status >= 0:
         return "exit %d" % status

--- a/tools/third_party_modified/mozlog/mozlog/formatters/tbplformatter.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/tbplformatter.py
@@ -29,7 +29,7 @@ class TbplFormatter(BaseFormatter):
     """
 
     def __init__(self, compact=False, summary_on_shutdown=False, **kwargs):
-        super(TbplFormatter, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.suite_start_time = None
         self.test_start_times = {}
         self.buffer = None
@@ -42,7 +42,7 @@ class TbplFormatter(BaseFormatter):
     def __call__(self, data):
         if self.summary_on_shutdown:
             self.summary(data)
-        return super(TbplFormatter, self).__call__(data)
+        return super().__call__(data)
 
     @property
     def compact(self):
@@ -61,9 +61,11 @@ class TbplFormatter(BaseFormatter):
         if subtract_context:
             count -= len(self.buffer)
         self.subtests_count = 0
-        return self._log(
-            {"level": "INFO", "message": "." * count, "component": component}
-        )
+        return self._log({
+            "level": "INFO",
+            "message": "." * count,
+            "component": component,
+        })
 
     @output_subtests
     def log(self, data):
@@ -99,14 +101,27 @@ class TbplFormatter(BaseFormatter):
         return "TEST-INFO | %s: %s\n" % (data["process"], strstatus(data["exitcode"]))
 
     @output_subtests
+    def shutdown_failure(self, data):
+        return "TEST-UNEXPECTED-FAIL | %s | %s\n" % (data["group"], data["message"])
+
+    @output_subtests
     def crash(self, data):
         id = data["test"] if "test" in data else "pid: %s" % data["process"]
+        quiet = data.get("quiet", False)
+        crash_prefix = "INFO crashed process" if quiet else "PROCESS-CRASH"
+
+        # Add minidump name to crash prefix for treeherder linking
+        if data.get("minidump_path"):
+            import os
+
+            minidump_name = os.path.splitext(os.path.basename(data["minidump_path"]))[0]
+            crash_prefix = crash_prefix + " | " + minidump_name
 
         if data.get("java_stack"):
             # use "<exception> at <top frame>" as a crash signature for java exception
             sig = data["java_stack"].split("\n")
             sig = " ".join(sig[0:2])
-            rv = ["PROCESS-CRASH | %s | %s\n[%s]" % (id, sig, data["java_stack"])]
+            rv = ["%s | %s | %s\n[%s]" % (crash_prefix, id, sig, data["java_stack"])]
 
             if data.get("reason"):
                 rv.append("Mozilla crash reason: %s" % data["reason"])
@@ -117,7 +132,7 @@ class TbplFormatter(BaseFormatter):
         else:
             signature = data["signature"] if data["signature"] else "unknown top frame"
             reason = data.get("reason", "application crashed")
-            rv = ["PROCESS-CRASH | %s [%s] | %s " % (reason, signature, id)]
+            rv = ["%s | %s [%s] | %s " % (crash_prefix, reason, signature, id)]
 
             if data.get("process_type"):
                 rv.append("Process type: {}".format(data["process_type"]))
@@ -202,7 +217,7 @@ class TbplFormatter(BaseFormatter):
         )
 
     def _format_status(self, data):
-        message = "- " + data["message"] if "message" in data else ""
+        message = data.get("message", "")
         if "stack" in data:
             message += "\n%s" % data["stack"]
         if message and message[-1] == "\n":
@@ -210,28 +225,43 @@ class TbplFormatter(BaseFormatter):
 
         status = data["status"]
 
+        subtest = data["subtest"]
+
         if "expected" in data:
             if status in data.get("known_intermittent", []):
                 status = "KNOWN-INTERMITTENT-%s" % status
             else:
                 if not message:
-                    message = "- expected %s" % data["expected"]
-                failure_line = "TEST-UNEXPECTED-%s | %s | %s %s\n" % (
+                    message = "expected %s" % data["expected"]
+                # When there's a subtest, format as: "subtest - message"
+                # Otherwise just use the message as-is
+                if subtest:
+                    subtest_msg = subtest + " - " + message
+                else:
+                    subtest_msg = message
+                failure_line = "TEST-UNEXPECTED-%s | %s | %s\n" % (
                     status,
                     data["test"],
-                    data["subtest"],
-                    message,
+                    subtest_msg,
                 )
                 if data["expected"] != "PASS":
                     info_line = "TEST-INFO | expected %s\n" % data["expected"]
                     return failure_line + info_line
                 return failure_line
 
-        return "TEST-%s | %s | %s %s\n" % (
+        # When there's a subtest, format as: "subtest - message"
+        # Otherwise just use the message as-is
+        if subtest:
+            subtest_msg = subtest
+            if message:
+                subtest_msg += " - " + message
+        else:
+            subtest_msg = message
+
+        return "TEST-%s | %s | %s\n" % (
             status,
             data["test"],
-            data["subtest"],
-            message,
+            subtest_msg,
         )
 
     def test_end(self, data):
@@ -389,19 +419,34 @@ class TbplFormatter(BaseFormatter):
         if data["bytes"] == 0:
             return "TEST-PASS | leakcheck | %s no leaks detected!\n" % data["process"]
 
+        message = ""
+        bigLeakers = [
+            "nsGlobalWindowInner",
+            "nsGlobalWindowOuter",
+            "Document",
+            "nsDocShell",
+            "BrowsingContext",
+            "SystemGlobal",
+        ]
+        for bigLeakName in bigLeakers:
+            if bigLeakName in data["objects"]:
+                message = "leakcheck large %s | %s" % (bigLeakName, data["scope"])
+                break
+
         # Create a comma delimited string of the first N leaked objects found,
         # to aid with bug summary matching in TBPL. Note: The order of the objects
         # had no significance (they're sorted alphabetically).
-        max_objects = 5
-        object_summary = ", ".join(data["objects"][:max_objects])
-        if len(data["objects"]) > max_objects:
-            object_summary += ", ..."
+        if message == "":
+            max_objects = 5
+            object_summary = ", ".join(data["objects"][:max_objects])
+            if len(data["objects"]) > max_objects:
+                object_summary += ", ..."
 
-        message = "leakcheck | %s %d bytes leaked (%s)\n" % (
-            data["process"],
-            data["bytes"],
-            object_summary,
-        )
+            message = "leakcheck | %s %d bytes leaked (%s)\n" % (
+                data["process"],
+                data["bytes"],
+                object_summary,
+            )
 
         # data["bytes"] will include any expected leaks, so it can be off
         # by a few thousand bytes.
@@ -420,24 +465,20 @@ class TbplFormatter(BaseFormatter):
         intermittents = sum(
             self.summary.aggregate("known_intermittent", counts).values()
         )
-        known = (
-            " ({} known intermittent tests)".format(intermittents)
-            if intermittents
-            else ""
-        )
-        status_str = "{}/{}{}".format(expected, total, known)
-        rv = ["{}: {}".format(suite, status_str)]
+        known = f" ({intermittents} known intermittent tests)" if intermittents else ""
+        status_str = f"{expected}/{total}{known}"
+        rv = [f"{suite}: {status_str}"]
 
         for results in logs.values():
             for data in results:
-                rv.append("  {}".format(self._format_status(data)))
+                rv.append(f"  {self._format_status(data)}")
 
         if intermittent_logs:
             rv.append("Known Intermittent tests:")
             for results in intermittent_logs.values():
                 for data in results:
                     data["subtest"] = data.get("subtest", "")
-                    rv.append("  {}".format(self._format_status(data)))
+                    rv.append(f"  {self._format_status(data)}")
 
         return "\n".join(rv)
 

--- a/tools/third_party_modified/mozlog/mozlog/formatters/unittest.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/unittest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tools/third_party_modified/mozlog/mozlog/formatters/unittest.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/unittest.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -31,7 +32,7 @@ class UnittestFormatter(base.BaseFormatter):
                 status
             ]
 
-            if status == "FAIL" or status == "PRECONDITION_FAILED":
+            if status in {"FAIL", "PRECONDITION_FAILED"}:
                 self.fails.append(data)
             elif status == "ERROR":
                 self.errors.append(data)
@@ -45,15 +46,13 @@ class UnittestFormatter(base.BaseFormatter):
             char = "X"
         elif data["count"] > data["max_expected"]:
             char = "F"
-            self.fails.append(
-                {
-                    "test": data["test"],
-                    "message": (
-                        "assertion count %i is greated than %i"
-                        % (data["count"], data["max_expected"])
-                    ),
-                }
-            )
+            self.fails.append({
+                "test": data["test"],
+                "message": (
+                    "assertion count %i is greated than %i"
+                    % (data["count"], data["max_expected"])
+                ),
+            })
         elif data["count"] > 0:
             char = "."
         else:
@@ -63,9 +62,11 @@ class UnittestFormatter(base.BaseFormatter):
 
     def suite_end(self, data):
         self.end_time = data["time"]
-        summary = "\n".join(
-            [self.output_fails(), self.output_errors(), self.output_summary()]
-        )
+        summary = "\n".join([
+            self.output_fails(),
+            self.output_errors(),
+            self.output_summary(),
+        ])
         return "\n%s\n" % summary
 
     def output_fails(self):

--- a/tools/third_party_modified/mozlog/mozlog/formatters/xunit.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/xunit.py
@@ -97,15 +97,13 @@ class XUnitFormatter(base.BaseFormatter):
         self._create_result(data)
 
     def suite_end(self, data):
-        self.root.attrib.update(
-            {
-                "tests": str(self.tests_run),
-                "errors": str(self.errors),
-                "failures": str(self.failures),
-                "skips": str(self.skips),
-                "time": "%.2f" % ((data["time"] - self.suite_start_time) / 1000.0),
-            }
-        )
+        self.root.attrib.update({
+            "tests": str(self.tests_run),
+            "errors": str(self.errors),
+            "failures": str(self.failures),
+            "skips": str(self.skips),
+            "time": "%.2f" % ((data["time"] - self.suite_start_time) / 1000.0),
+        })
         xml_string = ElementTree.tostring(self.root, encoding="utf8")
         # pretty printing can not be done from xml.etree
         from xml.dom import minidom

--- a/tools/third_party_modified/mozlog/mozlog/handlers/__init__.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/__init__.py
@@ -4,6 +4,7 @@
 
 from .base import BaseHandler, LogLevelFilter, StreamHandler
 from .bufferhandler import BufferHandler
+from .resourcehandler import ResourceHandler
 from .statushandler import StatusHandler
 from .summaryhandler import SummaryHandler
 from .valgrindhandler import ValgrindHandler
@@ -12,6 +13,7 @@ __all__ = [
     "LogLevelFilter",
     "StreamHandler",
     "BaseHandler",
+    "ResourceHandler",
     "StatusHandler",
     "SummaryHandler",
     "BufferHandler",

--- a/tools/third_party_modified/mozlog/mozlog/handlers/base.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/base.py
@@ -17,7 +17,7 @@ class BaseHandler:
     def __init__(self, inner):
         self.message_handler = MessageHandler()
         if hasattr(inner, "message_handler"):
-            self.message_handler.wrapped.append(inner)
+            self.message_handler.wrapped.append(inner.message_handler)
 
 
 class LogLevelFilter(BaseHandler):

--- a/tools/third_party_modified/mozlog/mozlog/handlers/base.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/base.py
@@ -3,14 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import locale
-import tempfile
 from threading import Lock
 
 from mozlog.handlers.messagehandler import MessageHandler
 from mozlog.structuredlog import log_levels
 
 
-class BaseHandler(object):
+class BaseHandler:
     """A base handler providing message handling facilities to
     derived classes.
     """
@@ -18,7 +17,7 @@ class BaseHandler(object):
     def __init__(self, inner):
         self.message_handler = MessageHandler()
         if hasattr(inner, "message_handler"):
-            self.message_handler.wrapped.append(inner.message_handler)
+            self.message_handler.wrapped.append(inner)
 
 
 class LogLevelFilter(BaseHandler):
@@ -65,6 +64,8 @@ class StreamHandler(BaseHandler):
         with self._lock:
             import io
 
+            import mozfile
+
             source_enc = "utf-8"
             target_enc = "utf-8"
             if isinstance(self.stream, io.BytesIO):
@@ -74,13 +75,11 @@ class StreamHandler(BaseHandler):
             if target_enc is None:
                 target_enc = locale.getpreferredencoding()
 
-            if isinstance(self.stream, io.StringIO) and isinstance(
-                formatted, bytes
-            ):
+            if isinstance(self.stream, io.StringIO) and isinstance(formatted, bytes):
                 formatted = formatted.decode(source_enc, "replace")
             elif (
-                isinstance(self.stream, io.BytesIO) or
-                isinstance(self.stream, tempfile._TemporaryFileWrapper)
+                isinstance(self.stream, io.BytesIO)
+                or isinstance(self.stream, mozfile.NamedTemporaryFile)
             ) and isinstance(formatted, str):
                 formatted = formatted.encode(target_enc, "replace")
             elif isinstance(formatted, str):
@@ -96,7 +95,7 @@ class StreamHandler(BaseHandler):
             # consequences for the executed tests, anyways).
             try:
                 self.stream.write(formatted)
-            except (UnicodeEncodeError):
+            except UnicodeEncodeError:
                 return
 
             self.stream.flush()

--- a/tools/third_party_modified/mozlog/mozlog/handlers/bufferhandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/bufferhandler.py
@@ -77,7 +77,7 @@ class BufferHandler(BaseHandler):
 
     def _flush_buffered(self):
         """Logs the contents of the current buffer"""
-        for msg in self._buffer[self._buffer_pos:]:
+        for msg in self._buffer[self._buffer_pos :]:
             if msg is not None:
                 self.inner(msg)
         for msg in self._buffer[: self._buffer_pos]:

--- a/tools/third_party_modified/mozlog/mozlog/handlers/messagehandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/messagehandler.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-class MessageHandler(object):
+class MessageHandler:
     """A message handler providing message handling facilities to
     classes derived from BaseHandler and BaseFormatter. This is a
     composition class, to ensure handlers and formatters remain separate.

--- a/tools/third_party_modified/mozlog/mozlog/handlers/resourcehandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/resourcehandler.py
@@ -1,0 +1,75 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os
+
+from ..reader import LogHandler
+
+
+class ResourceHandler(LogHandler):
+    """Handler class for recording a resource usage profile."""
+
+    def __init__(self, command_context, **kwargs):
+        super().__init__(**kwargs)
+
+        from mozbuild.util import construct_log_filename
+        from mozsystemmonitor.resourcemonitor import SystemResourceMonitor
+
+        # Get command name for log subdirectory
+        handler = getattr(command_context, "handler", None)
+        command_name = handler.name if handler else "test"
+        log_subdir = os.path.join("logs", command_name)
+
+        # Ensure log directory exists and create timestamped profile filename
+        command_context._ensure_state_subdir_exists(log_subdir)
+        self.build_resources_profile_path = command_context._get_state_filename(
+            construct_log_filename("profile"), subdir=log_subdir
+        )
+        self.resources = SystemResourceMonitor(
+            poll_interval=0.1,
+        )
+        self.resources.start()
+
+    def shutdown(self, data):
+        if not self.resources:
+            return
+
+        self.resources.stop()
+        with open(
+            self.build_resources_profile_path, "w", encoding="utf-8", newline="\n"
+        ) as fh:
+            to_write = json.dumps(self.resources.as_profile(), separators=(",", ":"))
+            fh.write(to_write)
+
+    def suite_start(self, data):
+        self.current_suite = data.get("name")
+        self.resources.begin_marker("suite", self.current_suite)
+
+    def suite_end(self, data):
+        self.resources.end_marker("suite", self.current_suite)
+
+    def group_start(self, data):
+        self.resources.begin_marker("test", data["name"])
+
+    def group_end(self, data):
+        self.resources.end_marker("test", data["name"])
+
+    def test_start(self, data):
+        self.resources.begin_test(data)
+
+    def test_end(self, data):
+        self.resources.end_test(data)
+
+    def test_status(self, data):
+        self.resources.test_status(data)
+
+    def log(self, data):
+        self.resources.test_status(data)
+
+    def process_output(self, data):
+        self.resources.test_status(data)
+
+    def crash(self, data):
+        self.resources.crash(data)

--- a/tools/third_party_modified/mozlog/mozlog/handlers/statushandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/statushandler.py
@@ -16,7 +16,7 @@ RunSummary = namedtuple(
 )
 
 
-class StatusHandler(object):
+class StatusHandler:
     """A handler used to determine an overall status for a test run according
     to a sequence of log messages."""
 
@@ -33,11 +33,24 @@ class StatusHandler(object):
         self.log_level_counts = defaultdict(int)
         # The count of "No tests run" error messages seen
         self.no_tests_run_count = 0
+        # Track tests that have already had a crash counted to avoid counting
+        # multiple crashes for the same test
+        self.tests_with_counted_crash = set()
 
     def __call__(self, data):
         action = data["action"]
         known_intermittent = data.get("known_intermittent", [])
-        self.action_counts[action] += 1
+
+        # Handle crash actions specially to only count once per test
+        if action == "crash":
+            test_name = data.get("test")
+            # Only count the first crash per test, or always count if no test name
+            if test_name is None or test_name not in self.tests_with_counted_crash:
+                self.action_counts["crash"] += 1
+                if test_name is not None:
+                    self.tests_with_counted_crash.add(test_name)
+        else:
+            self.action_counts[action] += 1
 
         if action == "log":
             if data["level"] == "ERROR" and data["message"] == "No tests ran":
@@ -54,6 +67,10 @@ class StatusHandler(object):
                 # Count known_intermittent as expected and intermittent.
                 if status in known_intermittent:
                     self.known_intermittent_statuses[status] += 1
+
+        # Clean up crash tracking when test ends to handle retry scenarios
+        if action == "test_end":
+            self.tests_with_counted_crash.discard(data.get("test"))
 
         if action == "assertion_count":
             if data["count"] < data["min_expected"]:

--- a/tools/third_party_modified/mozlog/mozlog/handlers/summaryhandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/summaryhandler.py
@@ -18,7 +18,7 @@ class SummaryHandler(LogHandler):
     """
 
     def __init__(self, **kwargs):
-        super(SummaryHandler, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.summary = OrderedDict()
         self.current_suite = None
@@ -74,8 +74,7 @@ class SummaryHandler(LogHandler):
         Yields a tuple of (suite, summary). The summary returned is
         the same format as returned by 'get'.
         """
-        for suite, data in self.summary.items():
-            yield suite, data
+        yield from self.summary.items()
 
     @classmethod
     def aggregate(cls, key, counts, include_skip=True):
@@ -95,7 +94,7 @@ class SummaryHandler(LogHandler):
         return res
 
     def suite_start(self, data):
-        self.current_suite = data.get("name", "suite {}".format(len(self.summary) + 1))
+        self.current_suite = data.get("name", f"suite {len(self.summary) + 1}")
         if self.current_suite not in self.summary:
             self.summary[self.current_suite] = {
                 "counts": {

--- a/tools/third_party_modified/mozlog/mozlog/handlers/valgrindhandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/valgrindhandler.py
@@ -19,7 +19,7 @@ class ValgrindHandler(BaseHandler):
             self.inner(tmp)
 
 
-class ValgrindFilter(object):
+class ValgrindFilter:
     """
     A class for handling Valgrind output.
 
@@ -31,7 +31,7 @@ class ValgrindFilter(object):
     ==60741==    by 0x63AEF65: PR_Calloc (prmem.c:443)
     ==60741==    by 0x69F236E: PORT_ZAlloc_Util (secport.c:117)
     ==60741==    by 0x69F1336: SECITEM_AllocItem_Util (secitem.c:28)
-    ==60741==    by 0xA04280B: ffi_call_unix64 (in /builds/worker/m-in-l64-valgrind-000000000000/objdir/toolkit/library/libxul.so) # noqa
+    ==60741==    by 0xA04280B: ffi_call_unix64 (in /builds/slave/m-in-l64-valgrind-000000000000/objdir/toolkit/library/libxul.so) # noqa
     ==60741==    by 0xA042443: ffi_call (ffi64.c:485)
 
     For each such error, this class extracts most or all of the first (error
@@ -57,19 +57,19 @@ class ValgrindFilter(object):
         # Valgrind is English-only, so we don't have to worry about
         # localization.
         self.re_error = re.compile(
-            r"==\d+== (" +
-            r"(Use of uninitialised value of size \d+)|" +
-            r"(Conditional jump or move depends on uninitialised value\(s\))|" +
-            r"(Syscall param .* contains uninitialised byte\(s\))|" +
-            r"(Syscall param .* points to (unaddressable|uninitialised) byte\(s\))|" +
-            r"((Unaddressable|Uninitialised) byte\(s\) found during client check request)|" +
-            r"(Invalid free\(\) / delete / delete\[\] / realloc\(\))|" +
-            r"(Mismatched free\(\) / delete / delete \[\])|" +
-            r"(Invalid (read|write) of size \d+)|" +
-            r"(Jump to the invalid address stated on the next line)|" +
-            r"(Source and destination overlap in .*)|" +
-            r"(.* bytes in .* blocks are .* lost)" +
-            r")"
+            r"==\d+== ("
+            + r"(Use of uninitialised value of size \d+)|"
+            + r"(Conditional jump or move depends on uninitialised value\(s\))|"
+            + r"(Syscall param .* contains uninitialised byte\(s\))|"
+            + r"(Syscall param .* points to (unaddressable|uninitialised) byte\(s\))|"
+            + r"((Unaddressable|Uninitialised) byte\(s\) found during client check request)|"
+            + r"(Invalid free\(\) / delete / delete\[\] / realloc\(\))|"
+            + r"(Mismatched free\(\) / delete / delete \[\])|"
+            + r"(Invalid (read|write) of size \d+)|"
+            + r"(Jump to the invalid address stated on the next line)|"
+            + r"(Source and destination overlap in .*)|"
+            + r"(.* bytes in .* blocks are .* lost)"
+            + r")"
         )
         # Match identifer chars, plus ':' for namespaces, and '\?' in order to
         # match "???" which Valgrind sometimes produces.
@@ -120,14 +120,14 @@ class ValgrindFilter(object):
                 # fields from the incoming message, since there's nowhere
                 # else to get them from.
                 output_message = {  # Mandatory fields
-                    u"action": "valgrind_error",
-                    u"time": msg["time"],
-                    u"thread": msg["thread"],
-                    u"pid": msg["pid"],
-                    u"source": msg["source"],
+                    "action": "valgrind_error",
+                    "time": msg["time"],
+                    "thread": msg["thread"],
+                    "pid": msg["pid"],
+                    "source": msg["source"],
                     # valgrind_error specific fields
-                    u"primary": self.curr_failure_msg,
-                    u"secondary": self.buffered_lines,
+                    "primary": self.curr_failure_msg,
+                    "secondary": self.buffered_lines,
                 }
                 self.curr_failure_msg = ""
                 self.buffered_lines = []

--- a/tools/third_party_modified/mozlog/mozlog/handlers/valgrindhandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/valgrindhandler.py
@@ -31,7 +31,7 @@ class ValgrindFilter:
     ==60741==    by 0x63AEF65: PR_Calloc (prmem.c:443)
     ==60741==    by 0x69F236E: PORT_ZAlloc_Util (secport.c:117)
     ==60741==    by 0x69F1336: SECITEM_AllocItem_Util (secitem.c:28)
-    ==60741==    by 0xA04280B: ffi_call_unix64 (in /builds/slave/m-in-l64-valgrind-000000000000/objdir/toolkit/library/libxul.so) # noqa
+    ==60741==    by 0xA04280B: ffi_call_unix64 (in /builds/worker/m-in-l64-valgrind-000000000000/objdir/toolkit/library/libxul.so) # noqa
     ==60741==    by 0xA042443: ffi_call (ffi64.c:485)
 
     For each such error, this class extracts most or all of the first (error

--- a/tools/third_party_modified/mozlog/mozlog/logtypes.py
+++ b/tools/third_party_modified/mozlog/mozlog/logtypes.py
@@ -9,7 +9,7 @@ missing = object()
 no_default = object()
 
 
-class log_action(object):
+class log_action:
     def __init__(self, *args):
         self.args = {}
 
@@ -112,7 +112,7 @@ class log_action(object):
         return self.convert(**known_kwargs)
 
 
-class DataType(object):
+class DataType:
     def __init__(self, name, default=no_default, optional=False):
         self.name = name
         self.default = default
@@ -164,8 +164,12 @@ class ContainerType(DataType):
 
 class Unicode(DataType):
     def convert(self, data):
+        if data is None:
+            return None
         if isinstance(data, str):
             return data
+        if isinstance(data, str):
+            return data.decode("utf8", "replace")
         return str(data)
 
 
@@ -219,7 +223,7 @@ class SubStatus(Status):
 
 class Dict(ContainerType):
     def _format_item_type(self, item_type):
-        superfmt = super(Dict, self)._format_item_type
+        superfmt = super()._format_item_type
 
         if isinstance(item_type, dict):
             if len(item_type) != 1:
@@ -274,7 +278,7 @@ class Boolean(DataType):
 
 class Tuple(ContainerType):
     def _format_item_type(self, item_type):
-        superfmt = super(Tuple, self)._format_item_type
+        superfmt = super()._format_item_type
 
         if isinstance(item_type, (tuple, list)):
             return [superfmt(t) for t in item_type]

--- a/tools/third_party_modified/mozlog/mozlog/proxy.py
+++ b/tools/third_party_modified/mozlog/mozlog/proxy.py
@@ -7,7 +7,7 @@ from threading import Thread
 from .structuredlog import StructuredLogger, get_default_logger
 
 
-class ProxyLogger(object):
+class ProxyLogger:
     """
     A ProxyLogger behaves like a
     :class:`mozlog.structuredlog.StructuredLogger`.
@@ -73,7 +73,7 @@ class LogQueueThread(Thread):
         while True:
             try:
                 msg = self.queue.get()
-            except (EOFError, IOError):
+            except (OSError, EOFError):
                 break
             if msg is None:
                 break

--- a/tools/third_party_modified/mozlog/mozlog/pytest_mozlog/plugin.py
+++ b/tools/third_party_modified/mozlog/mozlog/pytest_mozlog/plugin.py
@@ -15,15 +15,13 @@ def pytest_addoption(parser):
     group = parser.getgroup("mozlog")
 
     for name, (_class, _help) in mozlog.commandline.log_formatters.items():
-        group.addoption("--log-{0}".format(name), action="append", help=_help)
+        group.addoption(f"--log-{name}", action="append", help=_help)
 
     formatter_options = mozlog.commandline.fmt_options.items()
     for name, (_class, _help, formatters, action) in formatter_options:
         for formatter in formatters:
             if formatter in mozlog.commandline.log_formatters:
-                group.addoption(
-                    "--log-{0}-{1}".format(formatter, name), action=action, help=_help
-                )
+                group.addoption(f"--log-{formatter}-{name}", action=action, help=_help)
 
 
 def pytest_configure(config):
@@ -32,7 +30,7 @@ def pytest_configure(config):
         config.pluginmanager.register(MozLog())
 
 
-class MozLog(object):
+class MozLog:
     def __init__(self):
         self._started = False
         self.results = {}
@@ -99,7 +97,7 @@ class MozLog(object):
             elif hasattr(longrepr, "reprcrash"):
                 # For failures, longrepr is a ReprExceptionInfo
                 crash = longrepr.reprcrash
-                message = "{0} (line {1})".format(crash.message, crash.lineno)
+                message = f"{crash.message} (line {crash.lineno})"
                 stack = longrepr.reprtraceback
             elif hasattr(longrepr, "errorstring"):
                 message = longrepr.errorstring

--- a/tools/third_party_modified/mozlog/mozlog/reader.py
+++ b/tools/third_party_modified/mozlog/mozlog/reader.py
@@ -51,7 +51,7 @@ def each_log(log_iter, action_map):
             action_map[item["action"]](item)
 
 
-class LogHandler(object):
+class LogHandler:
     """Base class for objects that act as log handlers. A handler is a callable
     that takes a log entry as the only argument.
 
@@ -62,7 +62,7 @@ class LogHandler(object):
 
       class StartIdHandler(LogHandler):
           def test_start(data):
-              #For simplicity in the example pretend the id is always a string
+              # For simplicity in the example pretend the id is always a string
               return data["test"]
     """
 

--- a/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
+++ b/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
@@ -5,9 +5,9 @@
 
 import argparse
 
-import format as formatlog
-import logmerge
-import unstable
+from . import format as formatlog
+from . import logmerge
+from . import unstable
 
 
 def get_parser():

--- a/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
+++ b/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
+++ b/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -5,9 +6,9 @@
 
 import argparse
 
-from . import format as formatlog
-from . import logmerge
-from . import unstable
+import format as formatlog
+import logmerge
+import unstable
 
 
 def get_parser():

--- a/tools/third_party_modified/mozlog/mozlog/scripts/logmerge.py
+++ b/tools/third_party_modified/mozlog/mozlog/scripts/logmerge.py
@@ -69,7 +69,7 @@ def main(**kwargs):
         output = sys.stdout
     else:
         output = open(kwargs["output"], "w")
-    readers = [read(open(filename, "r")) for filename in kwargs["files"]]
+    readers = [read(open(filename)) for filename in kwargs["files"]]
     start_events = [process_until_suite_start(reader, output) for reader in readers]
     validate_start_events(start_events)
     merged_start_event = merge_start_events(start_events)

--- a/tools/third_party_modified/mozlog/mozlog/scripts/unstable.py
+++ b/tools/third_party_modified/mozlog/mozlog/scripts/unstable.py
@@ -132,11 +132,10 @@ def main(**kwargs):
 
     if kwargs["json"]:
         print(json.dumps(unstable))
+    elif not kwargs["group"]:
+        print_results(unstable)
     else:
-        if not kwargs["group"]:
-            print_results(unstable)
-        else:
-            print_run(unstable)
+        print_run(unstable)
 
 
 if __name__ == "__main__":

--- a/tools/third_party_modified/mozlog/mozlog/stdadapter.py
+++ b/tools/third_party_modified/mozlog/mozlog/stdadapter.py
@@ -17,7 +17,7 @@ class UnstructuredHandler(logging.Handler):
             log_func = getattr(self.structured, record.levelname.lower())
         else:
             log_func = self.logger.debug
-        log_func(record.msg)
+        log_func(record.getMessage())
 
     def handle(self, record):
         self.emit(record)

--- a/tools/third_party_modified/mozlog/mozlog/stdadapter.py
+++ b/tools/third_party_modified/mozlog/mozlog/stdadapter.py
@@ -17,13 +17,13 @@ class UnstructuredHandler(logging.Handler):
             log_func = getattr(self.structured, record.levelname.lower())
         else:
             log_func = self.logger.debug
-        log_func(record.getMessage())
+        log_func(record.msg)
 
     def handle(self, record):
         self.emit(record)
 
 
-class LoggingWrapper(object):
+class LoggingWrapper:
     def __init__(self, wrapped):
         self.wrapped = wrapped
         self.wrapped.addHandler(

--- a/tools/third_party_modified/mozlog/mozlog/structuredlog.py
+++ b/tools/third_party_modified/mozlog/mozlog/structuredlog.py
@@ -38,12 +38,19 @@ Allowed actions, and subfields:
       name - Name for the subsuite (must be unique)
       run_info - Updates to the suite run_info (optional)
 
+  group_start
+      name - Name for the test group
+
+  group_end
+      name - Name for the test group
+
   suite_end
 
   test_start
       test - ID for the test
       path - Relative path to test (optional)
       subsuite - Name of the subsuite to which test belongs (optional)
+      group - Name of the test group for the incoming test (optional)
 
   test_end
       test - ID for the test
@@ -55,6 +62,7 @@ Allowed actions, and subfields:
       known_intermittent - List of known intermittent statuses that should
                            not fail a test. eg. ['FAIL', 'TIMEOUT']
       subsuite - Name of the subsuite to which test belongs (optional)
+      group - Name of the test group for the incoming test (optional)
 
   test_status
       test - ID for the test
@@ -66,6 +74,7 @@ Allowed actions, and subfields:
       known_intermittent - List of known intermittent statuses that should
                            not fail a test. eg. ['FAIL', 'TIMEOUT']
       subsuite - Name of the subsuite to which test belongs (optional)
+      group - Name of the test group for the incoming test (optional)
 
   process_output
       process - PID of the process
@@ -126,8 +135,6 @@ def get_default_logger(component=None):
 
     :param component: The component name to tag log messages with
     """
-    global _default_logger_name
-
     if not _default_logger_name:
         return None
 
@@ -167,7 +174,7 @@ class LoggerShutdownError(Exception):
     """Raised when attempting to log after logger.shutdown() has been called."""
 
 
-class LoggerState(object):
+class LoggerState:
     def __init__(self):
         self.reset()
 
@@ -180,12 +187,12 @@ class LoggerState(object):
         self.has_shutdown = False
 
 
-class ComponentState(object):
+class ComponentState:
     def __init__(self):
         self.filter_ = None
 
 
-class StructuredLogger(object):
+class StructuredLogger:
     _lock = Lock()
     _logger_states = {}
     """Create a structured logger with the given name
@@ -221,9 +228,9 @@ class StructuredLogger(object):
         are removed, running tests are discarded and components are reset.
         """
         self._state.reset()
-        self._component_state = self._state.component_states[
-            self.component
-        ] = ComponentState()
+        self._component_state = self._state.component_states[self.component] = (
+            ComponentState()
+        )
 
     def send_message(self, topic, command, *args):
         """Send a message to each handler configured for this logger. This
@@ -240,6 +247,11 @@ class StructuredLogger(object):
             if hasattr(handler, "message_handler"):
                 rv += handler.message_handler.handle_message(topic, command, *args)
         return rv
+
+    @property
+    def has_shutdown(self):
+        """Property indicating whether the logger has been shutdown"""
+        return self._state.has_shutdown
 
     @property
     def handlers(self):
@@ -263,8 +275,8 @@ class StructuredLogger(object):
         converted_data = convertor_registry[action].convert_known(**raw_data)
         for k, v in raw_data.items():
             if (
-                k not in converted_data and
-                k not in convertor_registry[action].optional_args
+                k not in converted_data
+                and k not in convertor_registry[action].optional_args
             ):
                 converted_data[k] = v
 
@@ -272,9 +284,9 @@ class StructuredLogger(object):
 
         if action in ("test_status", "test_end"):
             if (
-                data["expected"] == data["status"] or
-                data["status"] == "SKIP" or
-                "expected" not in raw_data
+                data["expected"] == data["status"]
+                or data["status"] == "SKIP"
+                or "expected" not in raw_data
             ):
                 del data["expected"]
 
@@ -336,16 +348,16 @@ class StructuredLogger(object):
             if self._state.suite_started:
                 # limit data to reduce unnecessary log bloat
                 self.error(
-                    "Got second suite_start message before suite_end. " +
-                    "Logged with data: {}".format(json.dumps(data)[:100])
+                    "Got second suite_start message before suite_end. "
+                    + f"Logged with data: {json.dumps(data)[:100]}"
                 )
                 return False
             self._state.suite_started = True
         elif action == "suite_end":
             if not self._state.suite_started:
                 self.error(
-                    "Got suite_end message before suite_start. " +
-                    "Logged with data: {}".format(json.dumps(data))
+                    "Got suite_end message before suite_start. "
+                    + f"Logged with data: {json.dumps(data)}"
                 )
                 return False
             self._state.suite_started = False
@@ -394,6 +406,28 @@ class StructuredLogger(object):
         self._state.subsuites.add(data["name"])
         self._log_data("add_subsuite", data)
 
+    @log_action(
+        Unicode("name"),
+        Dict(Any, "extra", default=None, optional=True),
+    )
+    def group_start(self, data):
+        """Log a group_start message
+
+        :param str name: Name to identify the test group.
+        :param dict extra: Extra metadata, e.g. thread count for parallel groups.
+        """
+        self._log_data("group_start", data)
+
+    @log_action(
+        Unicode("name"),
+    )
+    def group_end(self, data):
+        """Log a group_end message
+
+        :param str name: Name to identify the test group.
+        """
+        self._log_data("group_end", data)
+
     @log_action(Dict(Any, "extra", default=None, optional=True))
     def suite_end(self, data):
         """Log a suite_end message"""
@@ -408,6 +442,7 @@ class StructuredLogger(object):
         TestId("test"),
         Unicode("path", default=None, optional=True),
         Unicode("subsuite", default=None, optional=True),
+        Unicode("group", default=None, optional=True),
     )
     def test_start(self, data):
         """Log a test_start message
@@ -416,6 +451,8 @@ class StructuredLogger(object):
         :param path: Path to test relative to some base (typically the root of
                      the source tree).
         :param subsuite: Optional name of the subsuite to which the test belongs.
+        :param group: Optional name of the test group or manifest name (useful
+                     when running in paralle)
         """
         if not self._state.suite_started:
             self.error(
@@ -439,6 +476,7 @@ class StructuredLogger(object):
         Dict(Any, "extra", default=None, optional=True),
         List(SubStatus, "known_intermittent", default=None, optional=True),
         Unicode("subsuite", default=None, optional=True),
+        Unicode("group", default=None, optional=True),
     )
     def test_status(self, data):
         """
@@ -454,6 +492,8 @@ class StructuredLogger(object):
         :param extra: Optional suite-specific data associated with the test result.
         :param known_intermittent: Optional list of string expected intermittent statuses
         :param subsuite: Optional name of the subsuite to which the test belongs.
+        :param group: Optional name of the test group or manifest name (useful
+                     when running in paralle)
         """
 
         if data["expected"] == data["status"] or data["status"] == "SKIP":
@@ -478,6 +518,7 @@ class StructuredLogger(object):
         Dict(Any, "extra", default=None, optional=True),
         List(Status, "known_intermittent", default=None, optional=True),
         Unicode("subsuite", default=None, optional=True),
+        Unicode("group", default=None, optional=True),
     )
     def test_end(self, data):
         """
@@ -493,6 +534,8 @@ class StructuredLogger(object):
         :param stack: Optional stack trace encountered during test execution.
         :param extra: Optional suite-specific data associated with the test result.
         :param subsuite: Optional name of the subsuite to which the test belongs.
+        :param group: Optional name of the test group or manifest name (useful
+                     when running in paralle)
         """
 
         if data["expected"] == data["status"] or data["status"] == "SKIP":
@@ -541,13 +584,19 @@ class StructuredLogger(object):
         Unicode("java_stack", default=None, optional=True),
         Unicode("process_type", default=None, optional=True),
         List(Unicode, "stackwalk_errors", default=None),
+        List(Any, "crashing_thread_stack", default=None, optional=True),
         Unicode("subsuite", default=None, optional=True),
+        Boolean("quiet", default=False, optional=True),
     )
     def crash(self, data):
         if data["stackwalk_errors"] is None:
             data["stackwalk_errors"] = []
 
         self._log_data("crash", data)
+
+    @log_action(Unicode("group", default=None), Unicode("message", default=None))
+    def shutdown_failure(self, data):
+        self._log_data("shutdown_failure", data)
 
     @log_action(
         Unicode("primary", default=None), List(Unicode, "secondary", default=None)
@@ -740,7 +789,7 @@ for level_name in lint_levels:
     setattr(StructuredLogger, name, _lint_func(level_name))
 
 
-class StructuredLogFileLike(object):
+class StructuredLogFileLike:
     """Wrapper for file-like objects to redirect writes to logger
     instead. Each call to `write` becomes a single log entry of type `log`.
 

--- a/tools/third_party_modified/mozlog/mozlog/unstructured/loggingmixin.py
+++ b/tools/third_party_modified/mozlog/mozlog/unstructured/loggingmixin.py
@@ -5,7 +5,7 @@
 from .logger import Logger, getLogger
 
 
-class LoggingMixin(object):
+class LoggingMixin:
     """Expose a subset of logging functions to an inheriting class."""
 
     def set_logger(self, logger_instance=None, name=None):

--- a/tools/third_party_modified/mozlog/setup.py
+++ b/tools/third_party_modified/mozlog/setup.py
@@ -9,6 +9,8 @@ PACKAGE_VERSION = "8.0.0"
 DEPS = [
     "blessed>=1.19.1",
     "mozterm",
+    "mozfile",
+    "mozsystemmonitor",
 ]
 
 
@@ -32,9 +34,17 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     package_data={"mozlog": ["formatters/html/main.js", "formatters/html/style.css"]},
     entry_points={"console_scripts": ["structlog = mozlog.scripts:main"]},
+    python_requires=">=3.8",
 )

--- a/tools/third_party_modified/mozlog/tests/conftest.py
+++ b/tools/third_party_modified/mozlog/tests/conftest.py
@@ -1,7 +1,6 @@
 from io import StringIO
 
 import pytest
-
 from mozlog.formatters import ErrorSummaryFormatter, MachFormatter
 from mozlog.handlers import StreamHandler
 from mozlog.structuredlog import StructuredLogger

--- a/tools/third_party_modified/mozlog/tests/test_capture.py
+++ b/tools/third_party_modified/mozlog/tests/test_capture.py
@@ -1,7 +1,6 @@
 import sys
 import unittest
 
-import mozunit
 from mozlog import capture, structuredlog
 from test_structured import TestHandler
 
@@ -34,4 +33,5 @@ class TestCaptureIO(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_capture.py
+++ b/tools/third_party_modified/mozlog/tests/test_capture.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 
 from mozlog import capture, structuredlog
-from test_structured import TestHandler
+from test_structured import Handler
 
 
 class TestCaptureIO(unittest.TestCase):
@@ -10,7 +10,7 @@ class TestCaptureIO(unittest.TestCase):
 
     def setUp(self):
         self.logger = structuredlog.StructuredLogger("test")
-        self.handler = TestHandler()
+        self.handler = Handler()
         self.logger.add_handler(self.handler)
 
     def test_captureio_log(self):

--- a/tools/third_party_modified/mozlog/tests/test_capture.py
+++ b/tools/third_party_modified/mozlog/tests/test_capture.py
@@ -1,8 +1,9 @@
 import sys
 import unittest
 
+import mozunit
 from mozlog import capture, structuredlog
-from test_structured import LogHandler
+from test_structured import TestHandler
 
 
 class TestCaptureIO(unittest.TestCase):
@@ -10,7 +11,7 @@ class TestCaptureIO(unittest.TestCase):
 
     def setUp(self):
         self.logger = structuredlog.StructuredLogger("test")
-        self.handler = LogHandler()
+        self.handler = TestHandler()
         self.logger.add_handler(self.handler)
 
     def test_captureio_log(self):
@@ -29,9 +30,8 @@ class TestCaptureIO(unittest.TestCase):
         self.assertIn("STDOUT: message 1", messages)
         self.assertIn("STDOUT: message 2", messages)
         self.assertIn("STDERR: message 3", messages)
-        self.assertIn(u"STDOUT: \xff", messages)
+        self.assertIn("STDOUT: \xff", messages)
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_errorsummary.py
+++ b/tools/third_party_modified/mozlog/tests/test_errorsummary.py
@@ -3,7 +3,6 @@
 import json
 import time
 
-import mozunit
 import pytest
 
 # flake8: noqa
@@ -384,4 +383,5 @@ def test_errorsummary(monkeypatch, get_logger, logs, expected):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_errorsummary.py
+++ b/tools/third_party_modified/mozlog/tests/test_errorsummary.py
@@ -3,6 +3,7 @@
 import json
 import time
 
+import mozunit
 import pytest
 
 # flake8: noqa
@@ -32,8 +33,8 @@ import pytest
             ],
             """
                 {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
-                {"test": "test_baz", "subtest": null, "group": "manifestA", "status": "PASS", "expected": "FAIL", "message": null, "stack": null, "known_intermittent": [], "action": "test_result", "line": 8}
-                {"group": "manifestA", "status": "ERROR", "duration": 70, "action": "group_result", "line": 9}
+                {"test": "test_baz", "subtest": null, "group": "manifestA", "status": "PASS", "expected": "FAIL", "message": null, "stack": null, "modifiers": "", "known_intermittent": [], "action": "test_result", "line": 8}
+                {"group": "manifestA", "status": "ERROR", "duration": 20, "action": "group_result", "line": 9}
                 {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 9}
             """.strip(),
             id="basic",
@@ -46,7 +47,7 @@ import pytest
             ],
             """
                 {"groups": ["manifest"], "action": "test_groups", "line": 0}
-                {"group": "manifest", "status": null, "duration": null, "action": "group_result", "line": 2}
+                {"group": "manifest", "status": null, "duration": 0, "action": "group_result", "line": 2}
             """.strip(),
             id="missing_test_end",
         ),
@@ -85,11 +86,273 @@ import pytest
             ],
             """
                 {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
-                {"test": "test_bar", "subtest": null, "group": "manifestA", "status": "CRASH", "expected": "OK", "message": null, "stack": null, "known_intermittent": [], "action": "test_result", "line": 4}
-                {"group": "manifestA", "status": "ERROR", "duration": 70, "action": "group_result", "line": 9}
+                {"test": "test_bar", "subtest": null, "group": "manifestA", "status": "CRASH", "expected": "OK", "message": null, "stack": null, "modifiers": "", "known_intermittent": [], "action": "test_result", "line": 4}
+                {"group": "manifestA", "status": "ERROR", "duration": 20, "action": "group_result", "line": 9}
                 {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 9}
             """.strip(),
             id="crash_and_group_status",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar", "test_baz"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "OK"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("test_start", "test_baz"),
+                ("test_status", "test_baz", "subtest", "FAIL", "FAIL"),
+                ("test_end", "test_baz", "OK"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"group": "manifestA", "status": "OK", "duration": 29, "action": "group_result", "line": 10}
+                {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 10}
+            """.strip(),
+            id="fail_expected_fail",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar", "test_baz"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "OK"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("test_start", "test_baz"),
+                ("test_status", "test_baz", "Test timed out", "FAIL", "PASS"),
+                ("test_status", "test_baz", "", "TIMEOUT", "PASS"),
+                ("crash", "", "signature", "manifestA"),
+                ("test_end", "test_baz", "OK"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"test": "test_baz", "subtest": "Test timed out", "group": "manifestA", "status": "FAIL", "expected": "PASS", "message": null, "stack": null, "modifiers": "", "known_intermittent": [], "action": "test_result", "line": 8}
+                {"test": "test_baz", "subtest": "", "group": "manifestA", "status": "TIMEOUT", "expected": "PASS", "message": null, "stack": null, "modifiers": "", "known_intermittent": [], "action": "test_result", "line": 9}
+                {"test": "manifestA", "group": "manifestA", "signature": "signature", "stackwalk_stderr": null, "stackwalk_stdout": null, "action": "crash", "line": 10}
+                {"group": "manifestA", "status": "ERROR", "duration": 49, "action": "group_result", "line": 12}
+                {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 12}
+            """.strip(),
+            id="timeout_and_crash",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar", "test_baz"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "CRASH", "CRASH"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("test_start", "test_baz"),
+                ("test_end", "test_baz", "FAIL", "FAIL"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"group": "manifestA", "status": "OK", "duration": 20, "action": "group_result", "line": 9}
+                {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 9}
+            """.strip(),
+            id="crash_expected_crash",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar", "test_baz"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "OK"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("test_start", "test_baz"),
+                ("test_end", "test_baz", "FAIL", "FAIL"),
+                ("crash", "", "", "manifestA"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"test": "manifestA", "group": "manifestA", "signature": "", "stackwalk_stderr": null, "stackwalk_stdout": null, "action": "crash", "line": 9}
+                {"group": "manifestA", "status": "ERROR", "duration": 20, "action": "group_result", "line": 10}
+                {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 10}
+            """.strip(),
+            id="assertion_crash_on_shutdown",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar", "test_baz"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "OK"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("test_start", "test_baz"),
+                ("test_end", "test_baz", "FAIL"),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"test": "test_baz", "group": "manifestA", "status": "FAIL", "expected": "OK", "subtest": null, "message": null, "stack": null, "modifiers": "", "known_intermittent": [], "action": "test_result", "line": 8}
+            """.strip(),
+            id="timeout_no_group_status",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar", "test_baz"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("group_start", "manifestA"),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "OK"),
+                ("test_start", "test_baz"),
+                ("test_end", "test_baz", "PASS", "FAIL"),
+                ("group_end", "manifestA"),
+                ("group_start", "manifestB"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("group_end", "manifestB"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"test": "test_baz", "subtest": null, "group": "manifestA", "status": "PASS", "expected": "FAIL", "message": null, "stack": null, "modifiers": "", "known_intermittent": [], "action": "test_result", "line": 7}
+                {"group": "manifestA", "status": "ERROR", "duration": 70, "action": "group_result", "line": 13}
+                {"group": "manifestB", "status": "OK", "duration": 30, "action": "group_result", "line": 13}
+            """.strip(),
+            id="group_start_end_duration",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo", "test_bar"],
+                    },
+                ),
+                ("group_start", "manifestA"),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "SKIP"),
+                ("test_start", "test_bar"),
+                ("test_end", "test_bar", "SKIP"),
+                ("group_end", "manifestA"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA"], "action": "test_groups", "line": 0}
+                {"group": "manifestA", "status": "SKIP", "duration": 0, "action": "group_result", "line": 7}
+            """.strip(),
+            id="group_start_end_all_skipped",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_foo"],
+                        "manifestB": ["test_something"],
+                    },
+                ),
+                ("group_start", "parallel"),
+                ("test_start", "test_foo"),
+                ("test_end", "test_foo", "OK"),
+                ("test_start", "test_something"),
+                ("test_end", "test_something", "OK"),
+                ("group_end", "parallel"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"group": "manifestA", "status": "OK", "duration": 10, "action": "group_result", "line": 7}
+                {"group": "manifestB", "status": "OK", "duration": 10, "action": "group_result", "line": 7}
+            """.strip(),
+            id="non_manifest_group_names_ignored",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_a1", "test_a2"],
+                        "manifestB": ["test_b1"],
+                    },
+                ),
+                ("group_start", "parallel", {"threads": 2}),
+                ("test_start", "test_a1"),
+                ("test_end", "test_a1", "OK"),
+                ("test_start", "test_b1"),
+                ("test_end", "test_b1", "OK"),
+                ("group_end", "parallel"),
+                ("group_start", "sequential"),
+                ("test_start", "test_a2"),
+                ("test_end", "test_a2", "OK"),
+                ("group_end", "sequential"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA", "manifestB"], "action": "test_groups", "line": 0}
+                {"group": "manifestA", "status": "OK", "duration": 14, "action": "group_result", "line": 11}
+                {"group": "manifestB", "status": "OK", "duration": 5, "action": "group_result", "line": 11}
+            """.strip(),
+            id="parallel_threads_divide_time",
+        ),
+        pytest.param(
+            [
+                (
+                    "suite_start",
+                    {
+                        "manifestA": ["test_a1", "test_a2"],
+                    },
+                ),
+                ("test_start", "test_a1"),
+                ("test_start", "test_a2"),
+                ("test_end", "test_a2", "SKIP"),
+                ("test_end", "test_a1", "OK"),
+                ("suite_end",),
+            ],
+            """
+                {"groups": ["manifestA"], "action": "test_groups", "line": 0}
+                {"group": "manifestA", "status": "OK", "duration": 30, "action": "group_result", "line": 5}
+            """.strip(),
+            id="parallel_skip_does_not_clear_other_test_time",
         ),
     ),
 )
@@ -121,5 +384,4 @@ def test_errorsummary(monkeypatch, get_logger, logs, expected):
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_formatters.py
+++ b/tools/third_party_modified/mozlog/tests/test_formatters.py
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -7,9 +5,11 @@
 import os
 import signal
 import unittest
-import xml.etree.ElementTree as Et
+import xml.etree.ElementTree as ET
+from io import StringIO
 from textwrap import dedent
 
+import mozunit
 import pytest
 from mozlog.formatters import (
     GroupingFormatter,
@@ -20,7 +20,6 @@ from mozlog.formatters import (
 )
 from mozlog.handlers import StreamHandler
 from mozlog.structuredlog import StructuredLogger
-from six import StringIO, ensure_text, unichr
 
 FORMATS = {
     # A list of tuples consisting of (name, options, expected string).
@@ -100,8 +99,8 @@ FORMATS = {
               test: 2 (1 fail, 1 pass)
               subtest: 2 (1 fail, 1 timeout)
 
-            Unexpected Results
-            ------------------
+            Error Summary
+            -------------
             test_foo
               FAIL test_foo - expected 0 got 1
             test_bar
@@ -140,8 +139,8 @@ FORMATS = {
               test: 2 (1 fail, 1 pass)
               subtest: 2 (1 fail, 1 timeout)
 
-            Unexpected Results
-            ------------------
+            Error Summary
+            -------------
             test_foo
               FAIL test_foo - expected 0 got 1
             test_bar
@@ -177,8 +176,8 @@ FORMATS = {
               test: 1 (1 precondition_failed)
               subtest: 1 (1 precondition_failed)
 
-            Unexpected Results
-            ------------------
+            Error Summary
+            -------------
             test_foo
               PRECONDITION_FAILED test_foo
             test_bar
@@ -208,8 +207,8 @@ FORMATS = {
               test: 1 (1 precondition_failed)
               subtest: 1 (1 precondition_failed)
 
-            Unexpected Results
-            ------------------
+            Error Summary
+            -------------
             test_foo
               PRECONDITION_FAILED test_foo
             test_bar
@@ -291,10 +290,10 @@ FORMATS = {
 def ids(test):
     ids = []
     for value in FORMATS[test]:
-        args = ", ".join(["{}={}".format(k, v) for k, v in value[1].items()])
+        args = ", ".join([f"{k}={v}" for k, v in value[1].items()])
         if args:
-            args = "-{}".format(args)
-        ids.append("{}{}".format(value[0], args))
+            args = f"-{args}"
+        ids.append(f"{value[0]}{args}")
     return ids
 
 
@@ -332,9 +331,7 @@ def test_fail(get_logger, name, opts, expected):
     stack = """
     SimpleTest.is@SimpleTest/SimpleTest.js:312:5
     @caps/tests/mochitest/test_bug246699.html:53:1
-""".strip(
-        "\n"
-    )
+""".strip("\n")
 
     logger = get_logger(name, **opts)
 
@@ -428,7 +425,7 @@ class FormatterTest(unittest.TestCase):
     @property
     def loglines(self):
         self.output_file.seek(self.position)
-        return [ensure_text(line.rstrip()) for line in self.output_file.readlines()]
+        return [line.rstrip() for line in self.output_file.readlines()]
 
 
 class TestHTMLFormatter(FormatterTest):
@@ -445,7 +442,7 @@ class TestHTMLFormatter(FormatterTest):
     def test_base64_unicode(self):
         self.logger.suite_start([])
         self.logger.test_start("unicode_test")
-        self.logger.test_end("unicode_test", "FAIL", extra={"data": unichr(0x02A9)})
+        self.logger.test_end("unicode_test", "FAIL", extra={"data": chr(0x02A9)})
         self.logger.suite_end()
         self.assertIn("data:text/html;charset=utf-8;base64,yqk=", self.loglines[-3])
 
@@ -669,6 +666,33 @@ Unexpected results: 3
         self.logger.process_exit(1234, -signal.SIGTERM)
         self.assertIn("1234: killed by SIGTERM", self.loglines[0])
 
+    def test_expected_fail_log_conversion(self):
+        """Test that ERROR TEST-EXPECTED-FAIL messages are converted to TODO"""
+        self.set_position()
+
+        # Test a log message that starts with TEST-EXPECTED-FAIL
+        self.logger.error("TEST-EXPECTED-FAIL | some test failed")
+
+        # Test a regular ERROR message (should not be converted)
+        self.logger.error("Regular error message")
+
+        # Test a message containing but not starting with TEST-EXPECTED-FAIL (should not be converted)
+        self.logger.error("Some prefix TEST-EXPECTED-FAIL suffix")
+
+        # Check that the TEST-EXPECTED-FAIL message was converted to TODO
+        # and the prefix was removed
+        output = "\n".join(self.loglines)
+        self.assertIn("TODO | some test failed", output)
+
+        # Check that regular ERROR messages are unchanged
+        self.assertIn("ERROR Regular error message", output)
+
+        # Check that messages not starting with TEST-EXPECTED-FAIL are unchanged
+        self.assertIn("ERROR Some prefix TEST-EXPECTED-FAIL suffix", output)
+
+        # Ensure the original ERROR TEST-EXPECTED-FAIL format doesn't appear
+        self.assertNotIn("ERROR TEST-EXPECTED-FAIL", output)
+
 
 class TestGroupingFormatter(FormatterTest):
     def get_formatter(self):
@@ -699,9 +723,9 @@ class TestGroupingFormatter(FormatterTest):
         self.assertIn("  \u2022 1 ran as expected. 0 tests skipped.", self.loglines)
         self.assertIn("  \u2022 1 known intermittent results.", self.loglines)
         self.assertIn("  \u2022 1 tests failed unexpectedly", self.loglines)
-        self.assertIn("  \u25B6 FAIL [expected OK] test2", self.loglines)
+        self.assertIn("  \u25b6 FAIL [expected OK] test2", self.loglines)
         self.assertIn(
-            "  \u25B6 FAIL [expected PASS, known intermittent [FAIL] test2, subtest2",
+            "  \u25b6 FAIL [expected PASS, known intermittent [FAIL] test2, subtest2",
             self.loglines,
         )
 
@@ -711,7 +735,7 @@ class TestXUnitFormatter(FormatterTest):
         return XUnitFormatter()
 
     def log_as_xml(self):
-        return Et.fromstring("\n".join(self.loglines))
+        return ET.fromstring("\n".join(self.loglines))
 
     def test_stacktrace_is_present(self):
         self.logger.suite_start([])
@@ -757,11 +781,10 @@ class TestXUnitFormatter(FormatterTest):
         )
         xml_string = formatter.suite_end(dict(time=55559))
 
-        root = Et.fromstring(xml_string)
+        root = ET.fromstring(xml_string)
         self.assertEqual(root.get("time"), "0.56")
         self.assertEqual(root.find("testcase").get("time"), "0.46")
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_formatters.py
+++ b/tools/third_party_modified/mozlog/tests/test_formatters.py
@@ -9,7 +9,6 @@ import xml.etree.ElementTree as ET
 from io import StringIO
 from textwrap import dedent
 
-import mozunit
 import pytest
 from mozlog.formatters import (
     GroupingFormatter,
@@ -787,4 +786,5 @@ class TestXUnitFormatter(FormatterTest):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_logger.py
+++ b/tools/third_party_modified/mozlog/tests/test_logger.py
@@ -35,13 +35,13 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(default_logger.handlers), 1)
         self.assertTrue(isinstance(default_logger.handlers[0], mozlog.StreamHandler))
 
-        f = mozfile.NamedTemporaryFile()
-        list_logger = mozlog.getLogger(
-            "file.logger", handler=mozlog.FileHandler(f.name)
-        )
-        self.assertEqual(len(list_logger.handlers), 1)
-        self.assertTrue(isinstance(list_logger.handlers[0], mozlog.FileHandler))
-        f.close()
+        with mozfile.NamedTemporaryFile() as f:
+            list_logger = mozlog.getLogger(
+                "file.logger", handler=mozlog.FileHandler(f.name)
+            )
+            self.assertEqual(len(list_logger.handlers), 1)
+            self.assertTrue(isinstance(list_logger.handlers[0], mozlog.FileHandler))
+            list_logger.handlers[0].close()
 
         self.assertRaises(
             ValueError, mozlog.getLogger, "file.logger", handler=ListHandler()

--- a/tools/third_party_modified/mozlog/tests/test_logger.py
+++ b/tools/third_party_modified/mozlog/tests/test_logger.py
@@ -9,7 +9,9 @@ import threading
 import time
 import unittest
 
+import mozfile
 import mozlog.unstructured as mozlog
+import mozunit
 
 
 class ListHandler(mozlog.Handler):
@@ -34,12 +36,16 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(default_logger.handlers), 1)
         self.assertTrue(isinstance(default_logger.handlers[0], mozlog.StreamHandler))
 
-        list_logger = mozlog.getLogger("list.logger", handler=ListHandler())
+        f = mozfile.NamedTemporaryFile()
+        list_logger = mozlog.getLogger(
+            "file.logger", handler=mozlog.FileHandler(f.name)
+        )
         self.assertEqual(len(list_logger.handlers), 1)
-        self.assertTrue(isinstance(list_logger.handlers[0], ListHandler))
+        self.assertTrue(isinstance(list_logger.handlers[0], mozlog.FileHandler))
+        f.close()
 
         self.assertRaises(
-            ValueError, mozlog.getLogger, "list.logger", handler=mozlog.StreamHandler()
+            ValueError, mozlog.getLogger, "file.logger", handler=ListHandler()
         )
 
     def test_timestamps(self):
@@ -73,7 +79,7 @@ class TestStructuredLogging(unittest.TestCase):
         The actual message should contain no fields other than the timestamp
         field and those present in expected."""
 
-        self.assertTrue(isinstance(actual["_time"], int))
+        self.assertTrue(isinstance(actual["_time"], (int,)))
 
         for k, v in expected.items():
             self.assertEqual(v, actual[k])
@@ -189,46 +195,40 @@ class TestStructuredLogging(unittest.TestCase):
 
     def test_log_listener(self):
         connection = "127.0.0.1", 0
-        log_server = mozlog.LogMessageServer(
+        self.log_server = mozlog.LogMessageServer(
             connection, self.logger, message_callback=self.message_callback, timeout=0.5
         )
 
-        message_string_one = json.dumps(
-            {
-                "_message": "socket message one",
-                "action": "test_message",
-                "_level": "DEBUG",
-            }
-        )
-        message_string_two = json.dumps(
-            {
-                "_message": "socket message two",
-                "action": "test_message",
-                "_level": "DEBUG",
-            }
-        )
+        message_string_one = json.dumps({
+            "_message": "socket message one",
+            "action": "test_message",
+            "_level": "DEBUG",
+        })
+        message_string_two = json.dumps({
+            "_message": "socket message two",
+            "action": "test_message",
+            "_level": "DEBUG",
+        })
 
-        message_string_three = json.dumps(
-            {
-                "_message": "socket message three",
-                "action": "test_message",
-                "_level": "DEBUG",
-            }
-        )
+        message_string_three = json.dumps({
+            "_message": "socket message three",
+            "action": "test_message",
+            "_level": "DEBUG",
+        })
 
         message_string = (
-            message_string_one +
-            "\n" +
-            message_string_two +
-            "\n" +
-            message_string_three +
-            "\n"
+            message_string_one
+            + "\n"
+            + message_string_two
+            + "\n"
+            + message_string_three
+            + "\n"
         )
 
-        server_thread = threading.Thread(target=log_server.handle_request)
+        server_thread = threading.Thread(target=self.log_server.handle_request)
         server_thread.start()
 
-        host, port = log_server.server_address
+        host, port = self.log_server.server_address
 
         sock = socket.socket()
         sock.connect((host, port))
@@ -245,8 +245,6 @@ class TestStructuredLogging(unittest.TestCase):
         time.sleep(0.01)
         sock.sendall(message_string[128:].encode())
 
-        sock.close()
-        log_server.server_close()
         server_thread.join()
 
 
@@ -295,5 +293,4 @@ class TestLoggingMixin(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_logger.py
+++ b/tools/third_party_modified/mozlog/tests/test_logger.py
@@ -11,7 +11,6 @@ import unittest
 
 import mozfile
 import mozlog.unstructured as mozlog
-import mozunit
 
 
 class ListHandler(mozlog.Handler):
@@ -293,4 +292,5 @@ class TestLoggingMixin(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_logger.py
+++ b/tools/third_party_modified/mozlog/tests/test_logger.py
@@ -229,22 +229,22 @@ class TestStructuredLogging(unittest.TestCase):
 
         host, port = self.log_server.server_address
 
-        sock = socket.socket()
-        sock.connect((host, port))
+        with socket.socket() as sock:
+            sock.connect((host, port))
 
-        # Sleeps prevent listener from receiving entire message in a single call
-        # to recv in order to test reconstruction of partial messages.
-        sock.sendall(message_string[:8].encode())
-        time.sleep(0.01)
-        sock.sendall(message_string[8:32].encode())
-        time.sleep(0.01)
-        sock.sendall(message_string[32:64].encode())
-        time.sleep(0.01)
-        sock.sendall(message_string[64:128].encode())
-        time.sleep(0.01)
-        sock.sendall(message_string[128:].encode())
+            # Sleeps prevent listener from receiving entire message in a single call
+            # to recv in order to test reconstruction of partial messages.
+            sock.sendall(message_string[:8].encode())
+            time.sleep(0.01)
+            sock.sendall(message_string[8:32].encode())
+            time.sleep(0.01)
+            sock.sendall(message_string[32:64].encode())
+            time.sleep(0.01)
+            sock.sendall(message_string[64:128].encode())
+            time.sleep(0.01)
+            sock.sendall(message_string[128:].encode())
 
-        server_thread.join()
+            server_thread.join()
 
 
 class Loggable(mozlog.LoggingMixin):

--- a/tools/third_party_modified/mozlog/tests/test_logtypes.py
+++ b/tools/third_party_modified/mozlog/tests/test_logtypes.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from mozlog.logtypes import Any, Dict, Int, List, TestList, Tuple, Unicode
+from mozlog.logtypes import Any, Dict, Int, List, TestList as TypeTestList, Tuple, Unicode
 
 
 class TestContainerTypes(unittest.TestCase):
@@ -88,7 +88,7 @@ class TestContainerTypes(unittest.TestCase):
 
 class TestDataTypes(unittest.TestCase):
     def test_test_list(self):
-        t = TestList("name")
+        t = TypeTestList("name")
         with self.assertRaises(ValueError):
             t("foo")
 

--- a/tools/third_party_modified/mozlog/tests/test_logtypes.py
+++ b/tools/third_party_modified/mozlog/tests/test_logtypes.py
@@ -4,7 +4,8 @@
 
 import unittest
 
-from mozlog.logtypes import Any, Dict, Int, List, TestList as LogTypeTestList, Tuple, Unicode
+import mozunit
+from mozlog.logtypes import Any, Dict, Int, List, TestList, Tuple, Unicode
 
 
 class TestContainerTypes(unittest.TestCase):
@@ -40,25 +41,25 @@ class TestContainerTypes(unittest.TestCase):
         d({"foo": {"bar": [1]}})  # doesn't raise
 
     def test_list_type_basic(self):
-        lst = List("name")
+        l = List("name")
         with self.assertRaises(ValueError):
-            lst(["foo"])
+            l(["foo"])
 
-        lst = List(Any, "name")
-        lst(["foo", 1])  # doesn't raise
+        l = List(Any, "name")
+        l(["foo", 1])  # doesn't raise
 
     def test_list_type_with_recursive_item_types(self):
-        lst = List(Dict(List(Tuple((Unicode, Int)))), "name")
+        l = List(Dict(List(Tuple((Unicode, Int)))), "name")
         with self.assertRaises(ValueError):
-            lst(["foo"])
+            l(["foo"])
 
         with self.assertRaises(ValueError):
-            lst([{"foo": "bar"}])
+            l([{"foo": "bar"}])
 
         with self.assertRaises(ValueError):
-            lst([{"foo": ["bar"]}])
+            l([{"foo": ["bar"]}])
 
-        lst([{"foo": [("bar", 1)]}])  # doesn't raise
+        l([{"foo": [("bar", 1)]}])  # doesn't raise
 
     def test_tuple_type_basic(self):
         t = Tuple("name")
@@ -88,7 +89,7 @@ class TestContainerTypes(unittest.TestCase):
 
 class TestDataTypes(unittest.TestCase):
     def test_test_list(self):
-        t = LogTypeTestList("name")
+        t = TestList("name")
         with self.assertRaises(ValueError):
             t("foo")
 
@@ -98,9 +99,8 @@ class TestDataTypes(unittest.TestCase):
         d1 = t({"default": ["bar"]})  # doesn't raise
         d2 = t(["bar"])  # doesn't raise
 
-        self.assertEqual(d1, d2)
+        self.assertLessEqual(d1.items(), d2.items())
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_logtypes.py
+++ b/tools/third_party_modified/mozlog/tests/test_logtypes.py
@@ -4,7 +4,6 @@
 
 import unittest
 
-import mozunit
 from mozlog.logtypes import Any, Dict, Int, List, TestList, Tuple, Unicode
 
 
@@ -103,4 +102,5 @@ class TestDataTypes(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_structured.py
+++ b/tools/third_party_modified/mozlog/tests/test_structured.py
@@ -7,7 +7,6 @@ import unittest
 from io import StringIO
 
 import mozfile
-import mozunit
 from mozlog import commandline, formatters, handlers, reader, stdadapter, structuredlog
 
 
@@ -1168,4 +1167,5 @@ class TestReader(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_structured.py
+++ b/tools/third_party_modified/mozlog/tests/test_structured.py
@@ -875,13 +875,9 @@ class TestComponentFilter(BaseStructuredTest):
 
 
 class TestCommandline(unittest.TestCase):
-    def setUp(self):
-        self.logfile = mozfile.NamedTemporaryFile()
-
-    @property
-    def loglines(self):
-        self.logfile.seek(0)
-        return [line.rstrip() for line in self.logfile.readlines()]
+    def log_lines(self, log_file):
+        log_file.seek(0)
+        return [line.rstrip() for line in log_file.readlines()]
 
     def test_setup_logging(self):
         parser = argparse.ArgumentParser()
@@ -926,44 +922,50 @@ class TestCommandline(unittest.TestCase):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
 
-        args = parser.parse_args(["--log-tbpl=%s" % self.logfile.name])
-        logger = commandline.setup_logging("test_fmtopts", args, {})
-        logger.info("INFO message")
-        logger.debug("DEBUG message")
-        logger.error("ERROR message")
-        # The debug level is not logged by default.
-        self.assertEqual([b"INFO message", b"ERROR message"], self.loglines)
+        with mozfile.NamedTemporaryFile() as log_file:
+            args = parser.parse_args(["--log-tbpl=%s" % log_file.name])
+            logger = commandline.setup_logging("test_fmtopts", args, {})
+            logger.info("INFO message")
+            logger.debug("DEBUG message")
+            logger.error("ERROR message")
+            # The debug level is not logged by default.
+            self.assertEqual([b"INFO message", b"ERROR message"], self.log_lines(log_file))
+            logger.handlers[0].stream.close()
 
     def test_logging_errorlevel(self):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
-        args = parser.parse_args([
-            "--log-tbpl=%s" % self.logfile.name,
-            "--log-tbpl-level=error",
-        ])
-        logger = commandline.setup_logging("test_fmtopts", args, {})
-        logger.info("INFO message")
-        logger.debug("DEBUG message")
-        logger.error("ERROR message")
+        with mozfile.NamedTemporaryFile() as log_file:
+            args = parser.parse_args([
+                "--log-tbpl=%s" % log_file.name,
+                "--log-tbpl-level=error",
+            ])
+            logger = commandline.setup_logging("test_fmtopts", args, {})
+            logger.info("INFO message")
+            logger.debug("DEBUG message")
+            logger.error("ERROR message")
 
-        # Only the error level and above were requested.
-        self.assertEqual([b"ERROR message"], self.loglines)
+            # Only the error level and above were requested.
+            self.assertEqual([b"ERROR message"], self.log_lines(log_file))
+            logger.handlers[0].stream.close()
 
     def test_logging_debuglevel(self):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
-        args = parser.parse_args([
-            "--log-tbpl=%s" % self.logfile.name,
-            "--log-tbpl-level=debug",
-        ])
-        logger = commandline.setup_logging("test_fmtopts", args, {})
-        logger.info("INFO message")
-        logger.debug("DEBUG message")
-        logger.error("ERROR message")
-        # Requesting a lower log level than default works as expected.
-        self.assertEqual(
-            [b"INFO message", b"DEBUG message", b"ERROR message"], self.loglines
-        )
+        with mozfile.NamedTemporaryFile() as log_file:
+            args = parser.parse_args([
+                "--log-tbpl=%s" % log_file.name,
+                "--log-tbpl-level=debug",
+            ])
+            logger = commandline.setup_logging("test_fmtopts", args, {})
+            logger.info("INFO message")
+            logger.debug("DEBUG message")
+            logger.error("ERROR message")
+            # Requesting a lower log level than default works as expected.
+            self.assertEqual(
+                [b"INFO message", b"DEBUG message", b"ERROR message"], self.log_lines(log_file)
+            )
+            logger.handlers[0].stream.close()
 
     def test_unused_options(self):
         parser = argparse.ArgumentParser()

--- a/tools/third_party_modified/mozlog/tests/test_structured.py
+++ b/tools/third_party_modified/mozlog/tests/test_structured.py
@@ -10,7 +10,7 @@ import mozfile
 from mozlog import commandline, formatters, handlers, reader, stdadapter, structuredlog
 
 
-class TestHandler:
+class Handler:
     def __init__(self):
         self.items = []
 
@@ -29,7 +29,7 @@ class TestHandler:
 class BaseStructuredTest(unittest.TestCase):
     def setUp(self):
         self.logger = structuredlog.StructuredLogger("test")
-        self.handler = TestHandler()
+        self.handler = Handler()
         self.logger.add_handler(self.handler)
 
     def pop_last_item(self):
@@ -608,7 +608,7 @@ class TestStructuredLog(BaseStructuredTest):
             logging.root.setLevel(old_level)
 
     def test_add_remove_handlers(self):
-        handler = TestHandler()
+        handler = Handler()
         self.logger.add_handler(handler)
         self.logger.info("test1")
 
@@ -994,7 +994,7 @@ class TestBuffer(BaseStructuredTest):
 
     def setUp(self):
         self.logger = structuredlog.StructuredLogger("testBuffer")
-        self.handler = handlers.BufferHandler(TestHandler(), message_limit=4)
+        self.handler = handlers.BufferHandler(Handler(), message_limit=4)
         self.logger.add_handler(self.handler)
 
     def tearDown(self):

--- a/tools/third_party_modified/mozlog/tests/test_structured.py
+++ b/tools/third_party_modified/mozlog/tests/test_structured.py
@@ -1,19 +1,17 @@
-# -*- coding: utf-8 -*-
-
 import argparse
-import contextlib
 import json
 import optparse
 import os
 import sys
-import tempfile
 import unittest
 from io import StringIO
 
+import mozfile
+import mozunit
 from mozlog import commandline, formatters, handlers, reader, stdadapter, structuredlog
 
 
-class LogHandler:
+class TestHandler:
     def __init__(self):
         self.items = []
 
@@ -32,7 +30,7 @@ class LogHandler:
 class BaseStructuredTest(unittest.TestCase):
     def setUp(self):
         self.logger = structuredlog.StructuredLogger("test")
-        self.handler = LogHandler()
+        self.handler = TestHandler()
         self.logger.add_handler(self.handler)
 
     def pop_last_item(self):
@@ -54,7 +52,7 @@ class BaseStructuredTest(unittest.TestCase):
 
 class TestStatusHandler(BaseStructuredTest):
     def setUp(self):
-        super(TestStatusHandler, self).setUp()
+        super().setUp()
         self.handler = handlers.StatusHandler()
         self.logger.add_handler(self.handler)
 
@@ -108,10 +106,79 @@ class TestStatusHandler(BaseStructuredTest):
         self.assertIn("OK", summary.expected_statuses)
         self.assertEqual(2, summary.expected_statuses["OK"])
 
+    def test_crash_with_expected_crash_status(self):
+        # Test that crashes are accounted for when test ends with expected CRASH status
+        self.logger.suite_start([])
+        self.logger.test_start("test1")
+        self.logger.crash(
+            test="test1",
+            process=1234,
+            signature="test_signature",
+            minidump_path="/path/to/dump",
+        )
+        self.logger.crash(
+            test="test1",
+            process=5678,
+            signature="test_signature2",
+            minidump_path="/path/to/dump2",
+        )
+        self.logger.test_end("test1", "CRASH", expected="CRASH")
+        self.logger.suite_end()
+        summary = self.handler.summarize()
+        # Extra crashes were subtracted, keeping 1 to match the CRASH status
+        self.assertEqual(1, summary.action_counts.get("crash", 0))
+        # Test had expected CRASH status
+        self.assertEqual(1, summary.expected_statuses["CRASH"])
+
+    def test_crash_with_retry_pass(self):
+        # Simulates xpcshell retry: test crashes producing 2 dumps, then passes on retry
+        self.logger.suite_start([])
+        # First run: test crashes
+        self.logger.test_start("test1")
+        self.logger.crash(
+            test="test1",
+            process=1234,
+            signature="test_signature",
+            minidump_path="/path/to/dump",
+        )
+        self.logger.crash(
+            test="test1",
+            process=5678,
+            signature="test_signature2",
+            minidump_path="/path/to/dump2",
+        )
+        self.logger.test_end("test1", "CRASH", expected="CRASH")
+        # Retry: test passes
+        self.logger.test_start("test1")
+        self.logger.test_end("test1", "PASS", expected="PASS")
+        self.logger.suite_end()
+        summary = self.handler.summarize()
+        # Extra crashes were subtracted, keeping 1 to match the CRASH status
+        self.assertEqual(1, summary.action_counts.get("crash", 0))
+        # Both test runs are counted
+        self.assertEqual(1, summary.expected_statuses["CRASH"])
+        self.assertEqual(1, summary.expected_statuses["PASS"])
+
+    def test_crash_without_test_name(self):
+        # Orphaned crash (e.g., shutdown crash) without associated test
+        self.logger.suite_start([])
+        self.logger.test_start("test1")
+        self.logger.test_end("test1", "PASS", expected="PASS")
+        self.logger.crash(
+            process=9999,
+            signature="shutdown_crash",
+            minidump_path="/path/to/dump",
+        )
+        self.logger.suite_end()
+        summary = self.handler.summarize()
+        # Crash without test name remains unaccounted
+        self.assertEqual(1, summary.action_counts["crash"])
+        self.assertEqual(1, summary.expected_statuses["PASS"])
+
 
 class TestSummaryHandler(BaseStructuredTest):
     def setUp(self):
-        super(TestSummaryHandler, self).setUp()
+        super().setUp()
         self.handler = handlers.SummaryHandler()
         self.logger.add_handler(self.handler)
 
@@ -168,9 +235,11 @@ class TestSummaryHandler(BaseStructuredTest):
 class TestStructuredLog(BaseStructuredTest):
     def test_suite_start(self):
         self.logger.suite_start(["test"], "logtest")
-        self.assert_log_equals(
-            {"action": "suite_start", "name": "logtest", "tests": {"default": ["test"]}}
-        )
+        self.assert_log_equals({
+            "action": "suite_start",
+            "name": "logtest",
+            "tests": {"default": ["test"]},
+        })
         self.logger.suite_end()
 
     def test_suite_end(self):
@@ -181,13 +250,11 @@ class TestStructuredLog(BaseStructuredTest):
     def test_add_subsuite(self):
         self.logger.suite_start([])
         self.logger.add_subsuite("other")
-        self.assert_log_equals(
-            {
-                "action": "add_subsuite",
-                "name": "other",
-                "run_info": {"subsuite": "other"},
-            }
-        )
+        self.assert_log_equals({
+            "action": "add_subsuite",
+            "name": "other",
+            "run_info": {"subsuite": "other"},
+        })
         self.logger.suite_end()
 
     def test_add_subsuite_duplicate(self):
@@ -195,13 +262,11 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.add_subsuite("other")
         # This should be a no-op
         self.logger.add_subsuite("other")
-        self.assert_log_equals(
-            {
-                "action": "add_subsuite",
-                "name": "other",
-                "run_info": {"subsuite": "other"},
-            }
-        )
+        self.assert_log_equals({
+            "action": "add_subsuite",
+            "name": "other",
+            "run_info": {"subsuite": "other"},
+        })
         self.assert_log_equals({"action": "suite_start", "tests": {"default": []}})
 
         self.logger.suite_end()
@@ -212,26 +277,22 @@ class TestStructuredLog(BaseStructuredTest):
         self.assert_log_equals({"action": "test_start", "test": "test1"})
 
         self.logger.test_start(("test1", "==", "test1-ref"), path="path/to/test")
-        self.assert_log_equals(
-            {
-                "action": "test_start",
-                "test": ("test1", "==", "test1-ref"),
-                "path": "path/to/test",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_start",
+            "test": ("test1", "==", "test1-ref"),
+            "path": "path/to/test",
+        })
         self.logger.suite_end()
 
     def test_start_inprogress(self):
         self.logger.suite_start([])
         self.logger.test_start("test1")
         self.logger.test_start("test1")
-        self.assert_log_equals(
-            {
-                "action": "log",
-                "message": "test_start for test1 logged while in progress.",
-                "level": "ERROR",
-            }
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "message": "test_start for test1 logged while in progress.",
+            "level": "ERROR",
+        })
         self.logger.suite_end()
 
     def test_start_inprogress_subsuite(self):
@@ -239,13 +300,11 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.add_subsuite("other")
         self.logger.test_start("test1")
         self.logger.test_start("test1", subsuite="other")
-        self.assert_log_equals(
-            {
-                "action": "test_start",
-                "test": "test1",
-                "subsuite": "other",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_start",
+            "test": "test1",
+            "subsuite": "other",
+        })
         self.logger.suite_end()
 
     def test_status(self):
@@ -254,15 +313,13 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.test_status(
             "test1", "subtest name", "fail", expected="FAIL", message="Test message"
         )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "subtest": "subtest name",
-                "status": "FAIL",
-                "message": "Test message",
-                "test": "test1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "subtest": "subtest name",
+            "status": "FAIL",
+            "message": "Test message",
+            "test": "test1",
+        })
         self.logger.test_end("test1", "OK")
         self.logger.suite_end()
 
@@ -270,15 +327,13 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.suite_start([])
         self.logger.test_start("test1")
         self.logger.test_status("test1", "subtest name", "fail")
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "subtest": "subtest name",
-                "status": "FAIL",
-                "expected": "PASS",
-                "test": "test1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "subtest": "subtest name",
+            "status": "FAIL",
+            "expected": "PASS",
+            "test": "test1",
+        })
         self.logger.test_end("test1", "OK")
         self.logger.suite_end()
 
@@ -297,16 +352,14 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.test_status(
             "test1", "subtest name", "FAIL", expected="PASS", extra={"data": 42}
         )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "subtest": "subtest name",
-                "status": "FAIL",
-                "expected": "PASS",
-                "test": "test1",
-                "extra": {"data": 42},
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "subtest": "subtest name",
+            "status": "FAIL",
+            "expected": "PASS",
+            "test": "test1",
+            "extra": {"data": 42},
+        })
         self.logger.test_end("test1", "OK")
         self.logger.suite_end()
 
@@ -320,16 +373,14 @@ class TestStructuredLog(BaseStructuredTest):
             expected="PASS",
             stack="many\nlines\nof\nstack",
         )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "subtest": "subtest name",
-                "status": "FAIL",
-                "expected": "PASS",
-                "test": "test1",
-                "stack": "many\nlines\nof\nstack",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "subtest": "subtest name",
+            "status": "FAIL",
+            "expected": "PASS",
+            "test": "test1",
+            "stack": "many\nlines\nof\nstack",
+        })
         self.logger.test_end("test1", "OK")
         self.logger.suite_end()
 
@@ -339,16 +390,14 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.test_status(
             "test1", "subtest name", "fail", known_intermittent=["FAIL"]
         )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "subtest": "subtest name",
-                "status": "FAIL",
-                "expected": "PASS",
-                "known_intermittent": ["FAIL"],
-                "test": "test1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "subtest": "subtest name",
+            "status": "FAIL",
+            "expected": "PASS",
+            "known_intermittent": ["FAIL"],
+            "test": "test1",
+        })
         self.logger.test_end("test1", "OK")
         self.logger.suite_end()
 
@@ -366,15 +415,13 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.test_status(
             "test1", "subtest name", "fail", message=None, stack=None
         )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "subtest": "subtest name",
-                "status": "FAIL",
-                "expected": "PASS",
-                "test": "test1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "subtest": "subtest name",
+            "status": "FAIL",
+            "expected": "PASS",
+            "test": "test1",
+        })
         self.logger.test_end("test1", "OK")
         self.logger.suite_end()
 
@@ -387,29 +434,25 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.suite_start([])
         self.logger.test_start("test1")
         self.logger.test_end("test1", "fail", message="Test message")
-        self.assert_log_equals(
-            {
-                "action": "test_end",
-                "status": "FAIL",
-                "expected": "OK",
-                "message": "Test message",
-                "test": "test1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_end",
+            "status": "FAIL",
+            "expected": "OK",
+            "message": "Test message",
+            "test": "test1",
+        })
         self.logger.suite_end()
 
     def test_end_1(self):
         self.logger.suite_start([])
         self.logger.test_start("test1")
         self.logger.test_end("test1", "PASS", expected="PASS", extra={"data": 123})
-        self.assert_log_equals(
-            {
-                "action": "test_end",
-                "status": "PASS",
-                "extra": {"data": 123},
-                "test": "test1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_end",
+            "status": "PASS",
+            "extra": {"data": 123},
+            "test": "test1",
+        })
         self.logger.suite_end()
 
     def test_end_2(self):
@@ -421,14 +464,12 @@ class TestStructuredLog(BaseStructuredTest):
         self.logger.test_end(
             "test1", "PASS", expected="PASS", stack="many\nlines\nof\nstack"
         )
-        self.assert_log_equals(
-            {
-                "action": "test_end",
-                "status": "PASS",
-                "test": "test1",
-                "stack": "many\nlines\nof\nstack",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_end",
+            "status": "PASS",
+            "test": "test1",
+            "stack": "many\nlines\nof\nstack",
+        })
         self.logger.suite_end()
 
     def test_end_no_start(self):
@@ -451,23 +492,23 @@ class TestStructuredLog(BaseStructuredTest):
             )
         )
         self.logger.test_end("test1", "OK", subsuite="other")
-        self.assert_log_equals(
-            {
-                "action": "test_end",
-                "status": "OK",
-                "test": "test1",
-                "subsuite": "other",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_end",
+            "status": "OK",
+            "test": "test1",
+            "subsuite": "other",
+        })
         self.logger.suite_end()
 
     def test_end_twice(self):
         self.logger.suite_start([])
         self.logger.test_start("test2")
         self.logger.test_end("test2", "PASS", expected="PASS")
-        self.assert_log_equals(
-            {"action": "test_end", "status": "PASS", "test": "test2"}
-        )
+        self.assert_log_equals({
+            "action": "test_end",
+            "status": "PASS",
+            "test": "test2",
+        })
         self.logger.test_end("test2", "PASS", expected="PASS")
         last_item = self.pop_last_item()
         self.assertEqual(last_item["action"], "log")
@@ -517,9 +558,11 @@ class TestStructuredLog(BaseStructuredTest):
 
     def test_process(self):
         self.logger.process_output(1234, "test output")
-        self.assert_log_equals(
-            {"action": "process_output", "process": "1234", "data": "test output"}
-        )
+        self.assert_log_equals({
+            "action": "process_output",
+            "process": "1234",
+            "data": "test output",
+        })
 
     def test_process_start(self):
         self.logger.process_start(1234)
@@ -527,16 +570,20 @@ class TestStructuredLog(BaseStructuredTest):
 
     def test_process_exit(self):
         self.logger.process_exit(1234, 0)
-        self.assert_log_equals(
-            {"action": "process_exit", "process": "1234", "exitcode": 0}
-        )
+        self.assert_log_equals({
+            "action": "process_exit",
+            "process": "1234",
+            "exitcode": 0,
+        })
 
     def test_log(self):
         for level in ["critical", "error", "warning", "info", "debug"]:
             getattr(self.logger, level)("message")
-            self.assert_log_equals(
-                {"action": "log", "level": level.upper(), "message": "message"}
-            )
+            self.assert_log_equals({
+                "action": "log",
+                "level": level.upper(),
+                "message": "message",
+            })
 
     def test_logging_adapter(self):
         import logging
@@ -553,14 +600,16 @@ class TestStructuredLog(BaseStructuredTest):
         try:
             for level in ["critical", "error", "warning", "info", "debug"]:
                 getattr(logger, level)("message")
-                self.assert_log_equals(
-                    {"action": "log", "level": level.upper(), "message": "message"}
-                )
+                self.assert_log_equals({
+                    "action": "log",
+                    "level": level.upper(),
+                    "message": "message",
+                })
         finally:
             logging.root.setLevel(old_level)
 
     def test_add_remove_handlers(self):
-        handler = LogHandler()
+        handler = TestHandler()
         self.logger.add_handler(handler)
         self.logger.info("test1")
 
@@ -605,9 +654,12 @@ class TestStructuredLog(BaseStructuredTest):
         log = structuredlog.StructuredLogger("test 1")
         log.add_handler(self.handler)
         log.info("line 1")
-        self.assert_log_equals(
-            {"action": "log", "level": "INFO", "message": "line 1", "source": "test 1"}
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "level": "INFO",
+            "message": "line 1",
+            "source": "test 1",
+        })
         log.shutdown()
         self.assert_log_equals({"action": "shutdown", "source": "test 1"})
         with self.assertRaises(structuredlog.LoggerShutdownError):
@@ -625,14 +677,12 @@ class TestStructuredLog(BaseStructuredTest):
         with structuredlog.StructuredLogger("test 2") as log:
             log.add_handler(self.handler)
             log.info("line 2")
-            self.assert_log_equals(
-                {
-                    "action": "log",
-                    "level": "INFO",
-                    "message": "line 2",
-                    "source": "test 2",
-                }
-            )
+            self.assert_log_equals({
+                "action": "log",
+                "level": "INFO",
+                "message": "line 2",
+                "source": "test 2",
+            })
         self.assert_log_equals({"action": "shutdown", "source": "test 2"})
 
         # shutdown prevents logging across instances
@@ -646,27 +696,25 @@ class TestStructuredLog(BaseStructuredTest):
 class TestTypeConversions(BaseStructuredTest):
     def test_raw(self):
         self.logger.log_raw({"action": "suite_start", "tests": [1], "time": "1234"})
-        self.assert_log_equals(
-            {"action": "suite_start", "tests": {"default": ["1"]}, "time": 1234}
-        )
+        self.assert_log_equals({
+            "action": "suite_start",
+            "tests": {"default": ["1"]},
+            "time": 1234,
+        })
         self.logger.suite_end()
 
     def test_tuple(self):
         self.logger.suite_start([])
-        self.logger.test_start(
-            (
-                b"\xf0\x90\x8d\x84\xf0\x90\x8c\xb4\xf0\x90"
-                b"\x8d\x83\xf0\x90\x8d\x84".decode(),
-                42,
-                u"\u16a4",
-            )
-        )
-        self.assert_log_equals(
-            {
-                "action": "test_start",
-                "test": (u"\U00010344\U00010334\U00010343\U00010344", u"42", u"\u16a4"),
-            }
-        )
+        self.logger.test_start((
+            b"\xf0\x90\x8d\x84\xf0\x90\x8c\xb4\xf0\x90"
+            b"\x8d\x83\xf0\x90\x8d\x84".decode(),
+            42,
+            "\u16a4",
+        ))
+        self.assert_log_equals({
+            "action": "test_start",
+            "test": ("\U00010344\U00010334\U00010343\U00010344", "42", "\u16a4"),
+        })
         self.logger.suite_end()
 
     def test_non_string_messages(self):
@@ -674,18 +722,16 @@ class TestTypeConversions(BaseStructuredTest):
         self.logger.info(1)
         self.assert_log_equals({"action": "log", "message": "1", "level": "INFO"})
         self.logger.info([1, (2, "3"), "s", "s" + chr(255)])
-        self.assert_log_equals(
-            {
-                "action": "log",
-                "message": "[1, (2, '3'), 's', 's\xff']",
-                "level": "INFO",
-            }
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "message": "[1, (2, '3'), 's', 's\xff']",
+            "level": "INFO",
+        })
 
         self.logger.suite_end()
 
     def test_utf8str_write(self):
-        with tempfile.NamedTemporaryFile() as logfile:
+        with mozfile.NamedTemporaryFile() as logfile:
             _fmt = formatters.TbplFormatter()
             _handler = handlers.StreamHandler(logfile, _fmt)
             self.logger.add_handler(_handler)
@@ -702,29 +748,27 @@ class TestTypeConversions(BaseStructuredTest):
         self.assert_log_equals({"action": "log", "message": "test", "level": "INFO"})
 
         self.logger.suite_start([], run_info={})
-        self.assert_log_equals(
-            {"action": "suite_start", "tests": {"default": []}, "run_info": {}}
-        )
+        self.assert_log_equals({
+            "action": "suite_start",
+            "tests": {"default": []},
+            "run_info": {},
+        })
         self.logger.test_start(test="test1")
         self.logger.test_status("subtest1", "FAIL", test="test1", status="PASS")
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "test": "test1",
-                "subtest": "subtest1",
-                "status": "PASS",
-                "expected": "FAIL",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "test": "test1",
+            "subtest": "subtest1",
+            "status": "PASS",
+            "expected": "FAIL",
+        })
         self.logger.process_output(123, "data", "test")
-        self.assert_log_equals(
-            {
-                "action": "process_output",
-                "process": "123",
-                "command": "test",
-                "data": "data",
-            }
-        )
+        self.assert_log_equals({
+            "action": "process_output",
+            "process": "123",
+            "command": "test",
+            "data": "data",
+        })
         self.assertRaises(
             TypeError,
             self.logger.test_status,
@@ -737,6 +781,7 @@ class TestTypeConversions(BaseStructuredTest):
             self.logger.test_status,
             "test1",
             "subtest1",
+            "group1",
             "PASS",
             "FAIL",
             "message",
@@ -764,14 +809,12 @@ class TestComponentFilter(BaseStructuredTest):
 
         component_logger.info("Test 1")
         self.assertFalse(self.handler.empty)
-        self.assert_log_equals(
-            {
-                "action": "log",
-                "level": "INFO",
-                "message": "Test 1",
-                "component": "test_component",
-            }
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "level": "INFO",
+            "message": "Test 1",
+            "component": "test_component",
+        })
 
         component_logger.debug("Test 2")
         self.assertTrue(self.handler.empty)
@@ -780,14 +823,12 @@ class TestComponentFilter(BaseStructuredTest):
 
         component_logger.debug("Test 3")
         self.assertFalse(self.handler.empty)
-        self.assert_log_equals(
-            {
-                "action": "log",
-                "level": "DEBUG",
-                "message": "Test 3",
-                "component": "test_component",
-            }
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "level": "DEBUG",
+            "message": "Test 3",
+            "component": "test_component",
+        })
 
     def test_filter_default_component(self):
         component_logger = structuredlog.StructuredLogger(
@@ -805,14 +846,12 @@ class TestComponentFilter(BaseStructuredTest):
 
         component_logger.debug("Test 2")
         self.assertFalse(self.handler.empty)
-        self.assert_log_equals(
-            {
-                "action": "log",
-                "level": "DEBUG",
-                "message": "Test 2",
-                "component": "test_component",
-            }
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "level": "DEBUG",
+            "message": "Test 2",
+            "component": "test_component",
+        })
 
         self.logger.component_filter = None
 
@@ -828,35 +867,22 @@ class TestComponentFilter(BaseStructuredTest):
 
         self.logger.component_filter = filter_mutate
         self.logger.debug("Test")
-        self.assert_log_equals(
-            {"action": "log", "level": "DEBUG", "message": "FILTERED! Test"}
-        )
+        self.assert_log_equals({
+            "action": "log",
+            "level": "DEBUG",
+            "message": "FILTERED! Test",
+        })
         self.logger.component_filter = None
 
 
 class TestCommandline(unittest.TestCase):
-    @contextlib.contextmanager
-    def get_logfile(self):
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
-        temp_file.close()
-        try:
-            yield temp_file
-        finally:
-            # This will fail on Windows, because file is not closed
-            # in StreamHandler.
-            os.unlink(temp_file.name)
+    def setUp(self):
+        self.logfile = mozfile.NamedTemporaryFile()
 
-    def loglines(self, logfile):
-        close = False
-        if logfile.closed:
-            close = True
-            logfile = open(logfile.name, "rb")
-        try:
-            logfile.seek(0)
-            return [line.rstrip() for line in logfile.readlines()]
-        finally:
-            if close:
-                logfile.close()
+    @property
+    def loglines(self):
+        self.logfile.seek(0)
+        return [line.rstrip() for line in self.logfile.readlines()]
 
     def test_setup_logging(self):
         parser = argparse.ArgumentParser()
@@ -891,65 +917,61 @@ class TestCommandline(unittest.TestCase):
     def test_setup_logging_optparse_unicode(self):
         parser = optparse.OptionParser()
         commandline.add_logging_group(parser)
-        args, _ = parser.parse_args([u"--log-raw=-"])
+        args, _ = parser.parse_args(["--log-raw=-"])
         logger = commandline.setup_logging("test_optparse_unicode", args, {})
         self.assertEqual(len(logger.handlers), 1)
         self.assertEqual(logger.handlers[0].stream, sys.stdout)
         self.assertIsInstance(logger.handlers[0], handlers.StreamHandler)
 
-    @unittest.skip("Failed on Windows")
     def test_logging_defaultlevel(self):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
 
-        with self.get_logfile() as logfile:
-            args = parser.parse_args(["--log-tbpl=%s" % logfile.name])
-            logger = commandline.setup_logging("test_logging_defaultlevel", args, {})
-            logger.info("INFO message")
-            logger.debug("DEBUG message")
-            logger.error("ERROR message")
-            # The debug level is not logged by default.
-            self.assertEqual([b"INFO message", b"ERROR message"], self.loglines(logfile))
+        args = parser.parse_args(["--log-tbpl=%s" % self.logfile.name])
+        logger = commandline.setup_logging("test_fmtopts", args, {})
+        logger.info("INFO message")
+        logger.debug("DEBUG message")
+        logger.error("ERROR message")
+        # The debug level is not logged by default.
+        self.assertEqual([b"INFO message", b"ERROR message"], self.loglines)
 
-    @unittest.skip("Failed on Windows")
     def test_logging_errorlevel(self):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
-        with self.get_logfile() as logfile:
-            args = parser.parse_args(
-                ["--log-tbpl=%s" % logfile.name, "--log-tbpl-level=error"]
-            )
-            logger = commandline.setup_logging("test_logging_errorlevel", args, {})
-            logger.info("INFO message")
-            logger.debug("DEBUG message")
-            logger.error("ERROR message")
+        args = parser.parse_args([
+            "--log-tbpl=%s" % self.logfile.name,
+            "--log-tbpl-level=error",
+        ])
+        logger = commandline.setup_logging("test_fmtopts", args, {})
+        logger.info("INFO message")
+        logger.debug("DEBUG message")
+        logger.error("ERROR message")
 
-            # Only the error level and above were requested.
-            self.assertEqual([b"ERROR message"], self.loglines(logfile))
+        # Only the error level and above were requested.
+        self.assertEqual([b"ERROR message"], self.loglines)
 
-    @unittest.skip("Failed on Windows")
     def test_logging_debuglevel(self):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
-        with self.get_logfile() as logfile:
-            args = parser.parse_args(
-                ["--log-tbpl=%s" % logfile.name, "--log-tbpl-level=debug"]
-            )
-            logger = commandline.setup_logging("test_logging_debuglevel", args, {})
-            logger.info("INFO message")
-            logger.debug("DEBUG message")
-            logger.error("ERROR message")
-            # Requesting a lower log level than default works as expected.
-            self.assertEqual(
-                [b"INFO message", b"DEBUG message", b"ERROR message"], self.loglines(logfile)
-            )
+        args = parser.parse_args([
+            "--log-tbpl=%s" % self.logfile.name,
+            "--log-tbpl-level=debug",
+        ])
+        logger = commandline.setup_logging("test_fmtopts", args, {})
+        logger.info("INFO message")
+        logger.debug("DEBUG message")
+        logger.error("ERROR message")
+        # Requesting a lower log level than default works as expected.
+        self.assertEqual(
+            [b"INFO message", b"DEBUG message", b"ERROR message"], self.loglines
+        )
 
     def test_unused_options(self):
         parser = argparse.ArgumentParser()
         commandline.add_logging_group(parser)
         args = parser.parse_args(["--log-tbpl-level=error"])
         self.assertRaises(
-            ValueError, commandline.setup_logging, "test_unused_options", args, {}
+            ValueError, commandline.setup_logging, "test_fmtopts", args, {}
         )
 
 
@@ -973,7 +995,7 @@ class TestBuffer(BaseStructuredTest):
 
     def setUp(self):
         self.logger = structuredlog.StructuredLogger("testBuffer")
-        self.handler = handlers.BufferHandler(LogHandler(), message_limit=4)
+        self.handler = handlers.BufferHandler(TestHandler(), message_limit=4)
         self.logger.add_handler(self.handler)
 
     def tearDown(self):
@@ -989,14 +1011,12 @@ class TestBuffer(BaseStructuredTest):
         self.logger.test_status("test1", "sub1", status="PASS")
         # Even for buffered actions, the buffer does not interfere if
         # buffering is turned off.
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "test": "test1",
-                "status": "PASS",
-                "subtest": "sub1",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "test": "test1",
+            "status": "PASS",
+            "subtest": "sub1",
+        })
         self.logger.send_message("buffer", "on")
         self.logger.test_status("test1", "sub2", status="PASS")
         self.logger.test_status("test1", "sub3", status="PASS")
@@ -1031,40 +1051,32 @@ class TestBuffer(BaseStructuredTest):
         self.assertEqual([4], self.logger.send_message("buffer", "flush"))
 
         # When the buffer is dumped, the failure is the last thing logged
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "test": "test1",
-                "subtest": "sub8",
-                "status": "FAIL",
-                "expected": "PASS",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "test": "test1",
+            "subtest": "sub8",
+            "status": "FAIL",
+            "expected": "PASS",
+        })
         # Three additional messages should have been retained for context
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "test": "test1",
-                "status": "PASS",
-                "subtest": "sub7",
-            }
-        )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "test": "test1",
-                "status": "PASS",
-                "subtest": "sub6",
-            }
-        )
-        self.assert_log_equals(
-            {
-                "action": "test_status",
-                "test": "test1",
-                "status": "PASS",
-                "subtest": "sub5",
-            }
-        )
+        self.assert_log_equals({
+            "action": "test_status",
+            "test": "test1",
+            "status": "PASS",
+            "subtest": "sub7",
+        })
+        self.assert_log_equals({
+            "action": "test_status",
+            "test": "test1",
+            "status": "PASS",
+            "subtest": "sub6",
+        })
+        self.assert_log_equals({
+            "action": "test_status",
+            "test": "test1",
+            "status": "PASS",
+            "subtest": "sub5",
+        })
         self.assert_log_equals({"action": "suite_start", "tests": {"default": []}})
 
 
@@ -1135,7 +1147,7 @@ class TestReader(unittest.TestCase):
 
         test = self
 
-        class ReaderHandler(reader.LogHandler):
+        class ReaderTestHandler(reader.LogHandler):
             def __init__(self):
                 self.action_0_count = 0
                 self.action_1_count = 0
@@ -1148,7 +1160,7 @@ class TestReader(unittest.TestCase):
                 test.assertEqual(item["action"], "action_1")
                 self.action_1_count += 1
 
-        handler = ReaderHandler()
+        handler = ReaderTestHandler()
         reader.handle_log(reader.read(f), handler)
 
         self.assertEqual(handler.action_0_count, 1)
@@ -1156,5 +1168,4 @@ class TestReader(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_terminal_colors.py
+++ b/tools/third_party_modified/mozlog/tests/test_terminal_colors.py
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -7,6 +5,7 @@
 import sys
 from io import StringIO
 
+import mozunit
 import pytest
 from mozterm import Terminal
 
@@ -19,7 +18,7 @@ def terminal():
     try:
         term = Terminal(stream=StringIO(), force_styling=True, kind=kind)
     except blessed.curses.error:
-        pytest.skip("terminal '{}' not found".format(kind))
+        pytest.skip(f"terminal '{kind}' not found")
 
     return term
 
@@ -58,5 +57,4 @@ def test_terminal_colors(terminal):
 
 
 if __name__ == "__main__":
-    import mozunit
     mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_terminal_colors.py
+++ b/tools/third_party_modified/mozlog/tests/test_terminal_colors.py
@@ -5,7 +5,6 @@
 import sys
 from io import StringIO
 
-import mozunit
 import pytest
 from mozterm import Terminal
 
@@ -57,4 +56,5 @@ def test_terminal_colors(terminal):
 
 
 if __name__ == "__main__":
+    import mozunit
     mozunit.main()


### PR DESCRIPTION
Update to the latest mozlog from firefox/main

To do this, copy the latest code over and then reapply the patches we've subsequently made, along with some additional fixes for test failures that only happen in our CI setup.