### PR TITLE
constellation(storage): validate storage event source and scope session fanout by webview

### DIFF
--- a/webstorage/event_local_window_open_oldvalue.html
+++ b/webstorage/event_local_window_open_oldvalue.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>WebStorage Test: localStorage event - window open oldValue</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+    <h1>event_local_window_open_oldValue</h1>
+    <div id="log"></div>
+    <script>
+        async_test(function(t) {
+            localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear(); });
+
+            var expected = [null, 'user1', null];
+            function onStorageEvent(event) {
+                assert_equals(event.oldValue, expected.shift());
+                if (!expected.length) {
+                    t.done();
+                }
+            }
+
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
+
+            var win = window.open("resources/local_change_item_window.html");
+            t.add_cleanup(function() { win.close(); });
+        }, "oldValue property test of local event from window.open() - Local event is fired due to an invocation of the setItem(), clear() methods.");
+    </script>
+ </body>
+</html>

--- a/webstorage/event_local_window_open_oldvalue.html
+++ b/webstorage/event_local_window_open_oldvalue.html
@@ -13,6 +13,9 @@
             localStorage.clear();
             t.add_cleanup(function() { localStorage.clear(); });
 
+            // The opened window does setItem("name", "user1"), then
+            // setItem("name", "user2"), then clear(). The clear() event has
+            // oldValue == null, so the expected sequence is null -> user1 -> null.
             var expected = [null, 'user1', null];
             function onStorageEvent(event) {
                 assert_equals(event.oldValue, expected.shift());

--- a/webstorage/event_session_window_open_scope.html
+++ b/webstorage/event_session_window_open_scope.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>WebStorage Test: sessionStorage event - window scope</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+    <h1>event_session_window_open_scope</h1>
+    <div id="log"></div>
+    <script>
+        async_test(function(t) {
+            sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear(); });
+
+            var events = [];
+            window.addEventListener('storage', t.step_func(function(event) {
+                events.push(event);
+            }), false);
+
+            var win = window.open("resources/session_change_item_window.html");
+            t.add_cleanup(function() { win.close(); });
+
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data && e.data.error) {
+                    assert_unreached(e.data.error);
+                    return;
+                }
+                if (e.data && e.data.done) {
+                    t.step_timeout(function() {
+                        assert_equals(events.length, 0,
+                            "sessionStorage events from a new window should not fire in the opener (different session scope)");
+                        t.done();
+                    }, 500);
+                }
+            }));
+        }, "sessionStorage events from a new window opened via window.open() should not fire in the opener");
+    </script>
+ </body>
+</html>

--- a/webstorage/resources/local_change_item_window.html
+++ b/webstorage/resources/local_change_item_window.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script>
+if (('localStorage' in window) && window.localStorage !== null) {
+    try {
+        localStorage.setItem("name", "user1");
+        localStorage.setItem("name", "user2");
+    } catch (e) {
+        window.opener.postMessage({error: "setItem method is failed."}, '*');
+    }
+    localStorage.clear();
+} else {
+    window.opener.postMessage({error: "localStorage is not supported."}, '*');
+}
+</script>
+</body>
+</html>

--- a/webstorage/resources/session_change_item_window.html
+++ b/webstorage/resources/session_change_item_window.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script>
+if (('sessionStorage' in window) && window.sessionStorage !== null) {
+    try {
+        sessionStorage.setItem("name", "user1");
+        sessionStorage.setItem("name", "user2");
+    } catch (e) {
+        window.opener.postMessage({error: "setItem method is failed."}, '*');
+    }
+    sessionStorage.clear();
+} else {
+    window.opener.postMessage({error: "sessionStorage is not supported."}, '*');
+}
+window.opener.postMessage({done: true}, '*');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Follow the spec and tightenings storage event routing in Constellation by validating that a BroadcastStorageEvent comes from the same origin as its source pipeline, while preserving existing localStorage fanout behavior.



Reviewed in servo/servo#43096