### PR TITLE
webdriver: Support interspersed scroll actions via event queue

### DIFF
--- a/webdriver/tests/classic/perform_actions/perform.py
+++ b/webdriver/tests/classic/perform_actions/perform.py
@@ -53,3 +53,33 @@ def test_input_source_action_sequence_pointer_parameters_not_processed(
     ]
     response = perform_actions(session, actions)
     assert_success(response)
+
+
+def test_interspersed_wheel_pointermove(session, wheel_chain, mouse_chain, inline):
+    session.url = inline("""
+        <div id='target' style='width: 200px; height: 200px; background: red; overflow: scroll;'>
+            <div style='height: 1000px;'></div>
+        </div>
+        <script>
+            window.events = [];
+            window.onwheel = () => window.events.push('wheel');
+            window.onmousemove = () => window.events.push('move');
+        </script>
+    """)
+
+    target = session.find.css("#target", all=False)
+
+    wheel_chain.scroll(0, 0, 0, 150, duration=500, origin=target)
+    mouse_chain.pointer_move(80, 80, duration=500, origin=target)
+
+    session.actions.perform([wheel_chain.dict, mouse_chain.dict])
+
+    events = session.execute_script("return window.events")
+
+    assert "wheel" in events
+    assert "move" in events
+
+    first_move = events.index("move")
+    last_wheel = len(events) - 1 - events[::-1].index("wheel")
+
+    assert first_move < last_wheel, f"Events were not interspersed: {events}"


### PR DESCRIPTION
Scroll and PointerMove is quite similar. We did so for `PointeMove` in https://github.com/servo/servo/pull/42289 + https://github.com/servo/servo/pull/42946.

Imagine having 3 non-zero duration scroll actions with origin at different Elements. 
Previously we would wait for one to be fully dispatched before moving to next action,
instead of interspersed.

We also consolidate `PendingPointerMove` and
newly added `PendingScroll` into `enum PendingActions`.

Testing: 
[Existing tests behaviour not changing.](https://github.com/servo/servo/actions/runs/22887005716). Added a wdspec test.
Previously: `['wheel', 'wheel', 'wheel', 'wheel', 'wheel', 'wheel', 'wheel', 'wheel', 'wheel', 'move']`
Now: `['wheel', 'move', 'wheel', 'move', 'wheel', 'move', 'move', 'wheel', 'wheel', 'move', 'move', 'wheel', 'wheel', 'move', 'move', 'wheel']`

Reviewed in servo/servo#43126