### PR TITLE
Fix flaky wpt test: html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html

### DIFF
--- a/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html
+++ b/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html
@@ -35,6 +35,7 @@ promise_test(async () => {
   shadowButton.click();
   await new Promise(requestAnimationFrame);
   await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
 
   for (const eventName of eventNames) {
     const event = eventNameToEvent[eventName];


### PR DESCRIPTION
The subtest 'ToggleEvent.source should be retargeted during and after event dispatch' is flaky on WPE.

Adding an extra 'requestAnimationFrame' call solves the issue.