### PR TITLE
Add WPT tests for Error Stack Accessor proposal web platform integration

### DIFF
--- a/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack.window.js
+++ b/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack.window.js
@@ -1,0 +1,103 @@
+// https://tc39.es/proposal-error-stack-accessor/
+// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+//
+// The [[Stack]] internal slot is now normatively serialized and deserialized
+// as part of the structured clone algorithm for Error objects.
+
+"use strict";
+
+test(() => {
+  const error = new Error("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on Error");
+
+test(() => {
+  const error = new TypeError("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on TypeError");
+
+test(() => {
+  const error = new RangeError("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on RangeError");
+
+test(() => {
+  const error = new EvalError("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on EvalError");
+
+test(() => {
+  const error = new ReferenceError("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on ReferenceError");
+
+test(() => {
+  const error = new SyntaxError("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on SyntaxError");
+
+test(() => {
+  const error = new URIError("some message");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on URIError");
+
+test(() => {
+  const error = new DOMException("some message", "SyntaxError");
+  assert_equals(typeof error.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(error);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, error.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on DOMException");
+
+test(() => {
+  let caught;
+  try {
+    document.createElement("");
+  } catch (e) {
+    caught = e;
+  }
+  assert_true(caught instanceof DOMException, "must be a DOMException");
+  assert_equals(typeof caught.stack, "string", "original stack must be a string");
+
+  const cloned = structuredClone(caught);
+  assert_equals(typeof cloned.stack, "string", "cloned stack must be a string");
+  assert_equals(cloned.stack, caught.stack, "cloned stack must equal original stack");
+}, "structuredClone() preserves .stack on a thrown DOMException");
+
+test(() => {
+  const error = new Error("some message");
+  const cloned = structuredClone(error);
+  assert_false(cloned.hasOwnProperty("stack"),
+    "cloned error must not have an own stack property");
+  assert_equals(cloned.stack, error.stack,
+    "cloned stack must still be accessible via the accessor");
+}, "structuredClone() preserves .stack via [[Stack]] internal slot, not as own property");

--- a/webidl/ecmascript-binding/es-exceptions/DOMException-stack-accessor.any.js
+++ b/webidl/ecmascript-binding/es-exceptions/DOMException-stack-accessor.any.js
@@ -1,0 +1,80 @@
+// META: global=window,dedicatedworker,shadowrealm
+
+// https://tc39.es/proposal-error-stack-accessor/
+// https://github.com/whatwg/webidl/pull/1421
+
+"use strict";
+
+test(() => {
+  const e = new DOMException("some message", "SyntaxError");
+  assert_equals(typeof e.stack, "string", "stack must be a string");
+}, "new DOMException() has a stack property that is a string");
+
+test(() => {
+  const e = new DOMException();
+  assert_equals(typeof e.stack, "string", "stack must be a string");
+}, "new DOMException() with no arguments has a stack property that is a string");
+
+if (typeof document !== "undefined") {
+  test(() => {
+    let caught;
+    try {
+      document.createElement("");
+    } catch (e) {
+      caught = e;
+    }
+    assert_true(caught instanceof DOMException, "must be a DOMException");
+    assert_equals(typeof caught.stack, "string", "stack must be a string");
+  }, "thrown DOMException from DOM API has a stack property that is a string");
+}
+
+test(() => {
+  const e = new DOMException("some message", "SyntaxError");
+  assert_false(e.hasOwnProperty("stack"), "stack must not be an own property of the instance");
+}, "DOMException instance does not have an own stack property");
+
+test(() => {
+  assert_false(DOMException.prototype.hasOwnProperty("stack"),
+    "DOMException.prototype must not have an own stack property");
+}, "DOMException.prototype does not have an own stack property");
+
+test(() => {
+  const desc = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+  assert_not_equals(desc, undefined, "Error.prototype must have a stack property descriptor");
+  assert_equals(typeof desc.get, "function", "stack must have a getter");
+  assert_equals(typeof desc.set, "function", "stack must have a setter");
+  assert_false(desc.enumerable, "stack must not be enumerable");
+  assert_true(desc.configurable, "stack must be configurable");
+}, "Error.prototype.stack is an accessor property with correct attributes");
+
+test(() => {
+  const getter = Object.getOwnPropertyDescriptor(Error.prototype, "stack").get;
+  const e = new DOMException("some message", "SyntaxError");
+  const stack = getter.call(e);
+  assert_equals(typeof stack, "string", "getter must return a string for DOMException");
+  assert_equals(stack, e.stack, "getter result must match e.stack");
+}, "Error.prototype.stack getter works on DOMException instances");
+
+test(() => {
+  const setter = Object.getOwnPropertyDescriptor(Error.prototype, "stack").set;
+  const e = new DOMException("some message", "SyntaxError");
+  setter.call(e, "custom stack");
+  assert_true(e.hasOwnProperty("stack"), "after setter, stack must be an own property");
+  assert_equals(e.stack, "custom stack", "own stack property must have the set value");
+
+  const desc = Object.getOwnPropertyDescriptor(e, "stack");
+  assert_equals(desc.value, "custom stack", "must be a data property");
+  assert_true(desc.writable, "must be writable");
+  assert_true(desc.enumerable, "must be enumerable");
+  assert_true(desc.configurable, "must be configurable");
+}, "Error.prototype.stack setter installs own data property on DOMException instances");
+
+test(() => {
+  const setter = Object.getOwnPropertyDescriptor(Error.prototype, "stack").set;
+  // SetterThatIgnoresPrototypeProperties should not install a property on Error.prototype itself
+  const originalStack = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+  setter.call(Error.prototype, "custom stack");
+  const afterStack = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+  assert_equals(typeof afterStack.get, "function",
+    "Error.prototype.stack must still be an accessor after calling setter on it");
+}, "Error.prototype.stack setter ignores Error.prototype itself");


### PR DESCRIPTION
Add tests for DOMException .stack behavior per the TC39 Error Stack Accessor proposal (https://tc39.es/proposal-error-stack-accessor/) and the WebIDL [[ErrorData]] integration (whatwg/webidl#1421):

- DOMException instances get .stack as a string via Error.prototype.stack accessor
- Error.prototype.stack property descriptor has correct accessor attributes
- Error.prototype.stack getter works on DOMException instances
- Error.prototype.stack setter (SetterThatIgnoresPrototypeProperties) behavior
- DOMException.prototype does not have an own stack property

Add tests for structured clone serialization/deserialization of [[Stack]]:

- structuredClone() preserves .stack on Error and all NativeError subtypes
- structuredClone() preserves .stack on DOMException (constructed and thrown)
- Cloned .stack is accessed via the accessor, not as an own property

See https://github.com/tc39/proposal-error-stack-accessor/issues/9 and https://github.com/tc39/proposal-error-stack-accessor/issues/8