### PR TITLE
Fix lazy media in-viewport tests to check loadeddata instead of loadsstart

### DIFF
--- a/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-in-viewport.html
+++ b/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-in-viewport.html
@@ -18,12 +18,11 @@
       windowLoadFired = true;
     });
 
-    audio.addEventListener("loadstart", () => {
-      assert_true(windowLoadFired, "Window load event should fire before loadstart for lazy audio in viewport");
-      t.done();
-    });
+    audio.addEventListener("loadeddata", t.step_func_done(() => {
+      assert_true(windowLoadFired, "Window load event should fire before lazy audio in viewport finishes loading");
+    }));
 
     document.body.appendChild(audio);
-  }, "In-viewport audio with loading='lazy' fires window load before loadstart");
+  }, "In-viewport audio with loading='lazy' does not block window load");
 </script>
 </body>

--- a/html/semantics/embedded-content/the-video-element/video-loading-lazy-in-viewport.html
+++ b/html/semantics/embedded-content/the-video-element/video-loading-lazy-in-viewport.html
@@ -17,12 +17,11 @@
       windowLoadFired = true;
     });
 
-    video.addEventListener("loadstart", () => {
-      assert_true(windowLoadFired, "Window load event should fire before loadstart for lazy video in viewport");
-      t.done();
-    });
+    video.addEventListener("loadeddata", t.step_func_done(() => {
+      assert_true(windowLoadFired, "Window load event should fire before lazy video in viewport finishes loading");
+    }));
 
     document.body.appendChild(video);
-  }, "In-viewport video with loading='lazy' fires window load before loadstart");
+  }, "In-viewport video with loading='lazy' does not block window load");
 </script>
 </body>


### PR DESCRIPTION
The loadstart event has no ordering guarantee relative to the window load event. Intersection observer callbacks can fire before or after the load event, and media elements use their own task source, so loadstart may be dispatched before window load.

The trickle(d2) pipe ensures slow media delivery, so checking loadeddata (which fires after enough data arrives to render the first frame) reliably verifies that window onload is not blocked by lazy media elements.