### PR TITLE
Use matches :modal instead of element from point in moveBefore dialog…

### DIFF
--- a/dom/nodes/moveBefore/modal-dialog.html
+++ b/dom/nodes/moveBefore/modal-dialog.html
@@ -13,7 +13,8 @@
 promise_test(async t => {
     const dialog = document.querySelector("#dialog");
     dialog.showModal();
+    assert_true(dialog.matches(':modal'));
     document.querySelector("#new_parent").moveBefore(dialog, null);
-    assert_equals(document.elementFromPoint(0, 0), dialog);
+    assert_true(dialog.matches(':modal'));
 }, "when reparenting a modal dialog, the dialog should stay modal");
 </script>


### PR DESCRIPTION
… test

This feels cleaner than relying on the backdrop hit test from elementFromPoint. This also makes it pass in servo which doesn't yet support backdrop but does support moveBefore.