### PR TITLE
fullscreen/rendering/backdrop-object.html continues to be flaky

### DIFF
--- a/fullscreen/rendering/backdrop-object.html
+++ b/fullscreen/rendering/backdrop-object.html
@@ -19,14 +19,17 @@ object {
 <script>
 const object = document.querySelector("object");
 
-Promise.all([
-  new Promise((resolve) => {
-    object.addEventListener("load", resolve);
-    object.data = "/images/100px-green-rect.svg";
-  }),
-  new Promise((resolve) => {
-    document.addEventListener("fullscreenchange", resolve);
-    test_driver.bless('fullscreen', () => object.requestFullscreen());
-  }),
-]).then(() => document.documentElement.classList.remove('reftest-wait'));
+document.addEventListener("fullscreenchange", async () => {
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  document.documentElement.classList.remove('reftest-wait');
+});
+
+new Promise((resolve) => {
+  object.addEventListener("load", resolve);
+  object.data = "/images/100px-green-rect.svg";
+}).then(() => {
+  test_driver.bless('fullscreen', () => object.requestFullscreen());
+});
 </script>

--- a/fullscreen/rendering/backdrop-object.html
+++ b/fullscreen/rendering/backdrop-object.html
@@ -20,16 +20,13 @@ object {
 const object = document.querySelector("object");
 
 document.addEventListener("fullscreenchange", async () => {
+  // Await fullscreen animation. It seems to always be done within 3 frames.
   await new Promise(requestAnimationFrame);
   await new Promise(requestAnimationFrame);
   await new Promise(requestAnimationFrame);
   document.documentElement.classList.remove('reftest-wait');
 });
 
-new Promise((resolve) => {
-  object.addEventListener("load", resolve);
-  object.data = "/images/100px-green-rect.svg";
-}).then(() => {
-  test_driver.bless('fullscreen', () => object.requestFullscreen());
-});
+object.onload = () => test_driver.bless('fullscreen', () => object.requestFullscreen());
+object.data = "/images/100px-green-rect.svg";
 </script>


### PR DESCRIPTION
The problem is that test_driver.bless creates a button and presses on it, but that button might be shifted due to the <object> loading while the press is happening. An additional issue is that the fullscreen animation might not have finished by the time fullscreenchange fires so we want a couple of additional frames there.