### PR TITLE
wptserve: register image/jxl content type

### DIFF
--- a/tools/wptserve/wptserve/constants.py
+++ b/tools/wptserve/wptserve/constants.py
@@ -15,6 +15,7 @@ content_types = utils.invert_dict({
     "image/bmp": ["bmp"],
     "image/gif": ["gif"],
     "image/jpeg": ["jpg", "jpeg"],
+    "image/jxl": ["jxl"],
     "image/png": ["png"],
     "image/svg+xml": ["svg"],
     "text/cache-manifest": ["manifest"],


### PR DESCRIPTION
Add a .jxl extension mapping to image/jxl in wptserve's content type table.

This lets WPT resources with the .jxl extension be served with the correct MIME type by default.

Chromium CL: https://chromium-review.googlesource.com/c/chromium/src/+/7572466