### PR TITLE
script: Notify embedder coalesced events to resolve potential WebDriver deadlock

### DIFF
--- a/uievents/order-of-events/mouse-events/wheel-multiple-sources-deadlock.html
+++ b/uievents/order-of-events/mouse-events/wheel-multiple-sources-deadlock.html
@@ -20,8 +20,7 @@ promise_test(async () => {
     totalDeltaY += e.deltaY;
   });
 
-  // Set pause to 0 to simulate high-frequency events.
-  await new test_driver.Actions(0)
+  await new test_driver.Actions()
     .addWheel("wheel1")
     .addWheel("wheel2")
     .scroll(0, 0, 0, 50, { origin: "viewport", sourceName: "wheel1", duration: 250 })

--- a/uievents/order-of-events/mouse-events/wheel-multiple-sources-deadlock.html
+++ b/uievents/order-of-events/mouse-events/wheel-multiple-sources-deadlock.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Wheel Event Coalescing Deadlock Test</title>
+<link rel=help href="https://github.com/servo/servo/pull/43202">
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<meta name="assert" content="The page should not deadlock when multiple wheel sources are active simultaneously.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+promise_test(async () => {
+  let totalDeltaX = 0;
+  let totalDeltaY = 0;
+
+  document.addEventListener('wheel', (e) => {
+    totalDeltaX += e.deltaX;
+    totalDeltaY += e.deltaY;
+  });
+
+  // Set pause to 0 to simulate high-frequency events.
+  await new test_driver.Actions(0)
+    .addWheel("wheel1")
+    .addWheel("wheel2")
+    .scroll(0, 0, 0, 50, { origin: "viewport", sourceName: "wheel1", duration: 250 })
+    .scroll(0, 0, 50, 0, { origin: "viewport", sourceName: "wheel2", duration: 250 })
+    .send();
+
+  assert_approx_equals(totalDeltaY, 50, 0.1, "Vertical delta from wheel1 must be processed.");
+  assert_approx_equals(totalDeltaX, 50, 0.1, "Horizontal delta from wheel2 must be processed.");
+}, "Simultaneous wheel events in different directions should not deadlock.");
+</script>


### PR DESCRIPTION
Notify embedder the coalesced wheel/mousemove event.

We also stop cloning every single entry in `pending_input_event`.

Testing: This should unblock the potential WebDriver thread deadlock
when receiving simultaneous wheel or pointer inputs from multiple sources.
We added a new test that stably deadlock on https://github.com/servo/servo/commit/74c16ffd8aa7909c55fa70d6098cd745651ff791.
Firefox/Safari/Chrome all pass the new test.
Fixes: https://github.com/servo/servo/issues/43136#issuecomment-4031702204

Reviewed in servo/servo#43202