### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309778

### DIFF
--- a/mediacapture-streams/MediaStreamTrack-transfer-video.https.html
+++ b/mediacapture-streams/MediaStreamTrack-transfer-video.https.html
@@ -17,7 +17,7 @@ promise_test(async () => {
     };
   });
   iframe.addEventListener("load", () => {
-    iframe.contentWindow.postMessage(track);
+    iframe.contentWindow.postMessage(track, "*", [track]);
   });
   iframe.src = "support/iframe-MediaStreamTrack-transfer-video.html";
   document.body.appendChild(iframe);


### PR DESCRIPTION
WebKit export from bug: [MediaStreamTrack/MediaStreamTrackHandle need to be in postMessage transfer list](https://bugs.webkit.org/show_bug.cgi?id=309778)