### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309488

### DIFF
--- a/css/css-tables/collapsed-border-background-inset-notref.html
+++ b/css/css-tables/collapsed-border-background-inset-notref.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<title>CSS Test Reference (mismatch): collapsed border cell background fills full width</title>
+<style>
+th {
+    border: 0px solid red;
+}
+tr.green {
+    background: green;
+}
+td {
+    border: 50px solid red;
+    padding: 6px 12px;
+    text-align: left;
+    vertical-align: top;
+}
+.table {
+    overflow-x: auto;
+    max-width: 810px;
+}
+table {
+    border-collapse: collapse;
+    border: none;
+}
+</style>
+<div class="table-wrapper">
+    <div class="table">
+        <table>
+            <thead>
+                <tr class="green">
+                    <th>Key</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Key</td>
+                    <td>
+                        <p>If you group based on datetime and the filter creates a
+                            time period, potential missing values are automatically
+                            substituted by default values.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/css/css-tables/collapsed-border-background-inset.html
+++ b/css/css-tables/collapsed-border-background-inset.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<title>CSS Test: collapsed border cell background does not extend into other cells' border space</title>
+<link rel="help" href="https://drafts.csswg.org/css2/tables.html#collapsing-borders">
+<link rel="mismatch" href="collapsed-border-background-inset-notref.html">
+<style>
+th {
+    border: 0px solid red;
+    background: green;
+}
+td {
+    border: 50px solid red;
+    padding: 6px 12px;
+    text-align: left;
+    vertical-align: top;
+}
+.table {
+    overflow-x: auto;
+    max-width: 810px;
+}
+table {
+    border-collapse: collapse;
+    border: none;
+}
+</style>
+<div class="table-wrapper">
+    <div class="table">
+        <table>
+            <thead>
+                <tr>
+                    <th>Key</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Key</td>
+                    <td>
+                        <p>If you group based on datetime and the filter creates a
+                            time period, potential missing values are automatically
+                            substituted by default values.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [Cell background in collapsed-border table extends into adjacent cells' border space at table edges](https://bugs.webkit.org/show_bug.cgi?id=309488)