### PR TITLE
adds new lint rule for ineffective exclusion patterns in WEB_FEATURES.yml

### DIFF
--- a/css/css-multicol/WEB_FEATURES.yml
+++ b/css/css-multicol/WEB_FEATURES.yml
@@ -135,12 +135,6 @@ features:
   - column-height-003.html
   - column-height-008.html
   - column-height-009.html
-  - "!column-height-010.html"
-  - "!column-height-011.html"
-  - "!column-height-015.html"
-  - "!column-height-021.html"
-  - "!column-height-022.html"
-  - "!column-height-023.html"
   - "!column-rule-002.html"
   - "!columnfill-auto-max-height-*"
   - "!equal-gap-and-rule.html"
@@ -156,7 +150,6 @@ features:
   - "!large-actual-column-count.html"
   - "!multicol-br-inside-avoidcolumn-001.xht"
   - "!multicol-break-*"
-  - "!multicol-breaking-*"
   - "!multicol-breaking-*"
   - "!multicol-containing-003.html"
   - "!multicol-fill-000.xht"
@@ -174,7 +167,6 @@ features:
   - "!multicol-height-*"
   - "!multicol-list-item-008.html"
   - "!multicol-margin-*"
-  - "!multicol-margin-002.xht"
   - multicol-margin-003.html
   - "!multicol-nested-*"
   - multicol-nested-002.xht
@@ -214,8 +206,6 @@ features:
   - "!intrinsic-size-003.html"
   - "!intrinsic-size-004.html"
   - "!intrinsic-size-005.html"
-  - "!multicol-fill-auto-block-children-001.xht"
-  - "!multicol-fill-auto-block-children-002.xht"
   - "!multicol-width-004.html"
   - "!multicol-width-005.html"
   - "!spanning-legend-*"

--- a/css/selectors/parsing/WEB_FEATURES.yml
+++ b/css/selectors/parsing/WEB_FEATURES.yml
@@ -6,7 +6,6 @@ features:
   - '!parse-has.html'
   - '!parse-has-*'
   - '!parse-state.html'
-  - '!parse-has-slotted.tentative.html'
   - '!parse-not.html'
   - '!parse-part.html'
   - '!parse-heading.html'
@@ -22,6 +21,7 @@ features:
   files:
   - parse-has.html
   - parse-has-*
+  - '!parse-has-slotted.tentative.html'
 - name: state
   files:
   - parse-state.html

--- a/html/semantics/embedded-content/the-iframe-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-iframe-element/WEB_FEATURES.yml
@@ -2,6 +2,7 @@ features:
 - name: loading-lazy
   files:
   - iframe-loading-lazy*
+  - "!iframe-loading-lazy-base-url*"
 - name: base
   files:
   - iframe-loading-lazy-base-url*
@@ -22,7 +23,6 @@ features:
   files:
   - "*"
   - "!iframe-loading-lazy*"
-  - "!iframe-loading-lazy-base-url*"
   - "!iframe-with-base.html"
   - "!srcdoc*"
   - "!iframe_sandbox_*"

--- a/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
+++ b/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
@@ -15,7 +15,6 @@ features:
   - "!document-adopt-base-url.html"
   - "!document-base-url.html"
   - "!image-base-url.html"
-  - "!image-loading-lazy-base-url.html"
   # Exclude `srcset`. Keep in sync with `srcset` mappings below.
   - "!responsive-image-select-print.html"
   - "!update-the-source-set.html"
@@ -31,6 +30,7 @@ features:
   - relevant-mutations-lazy.html
   - remove-element-and-scroll.html
   - scrolling-below-viewport-image-lazy-loading-in-iframe.html
+  - "!image-loading-lazy-base-url.html"
 - name: base
   files:
   # Keep in sync with `img` mappings.

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -760,8 +760,8 @@ def check_web_features_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[r
         return []
     try:
         web_features_file: WebFeaturesFile = WebFeaturesFile(load_data_to_dict(f))
-    except Exception:
-        return [rules.InvalidWebFeaturesFile.error(path)]
+    except Exception as e:
+        return [rules.InvalidWebFeaturesFile.error(path, (str(e),))]
     errors = []
     base_dir = os.path.join(repo_root, os.path.dirname(path))
     files_in_directory = [

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -33,7 +33,8 @@ from ..manifest.sourcefile import SourceFile, js_meta_re, python_meta_re, space_
 
 from ..metadata.yaml.load import load_data_to_dict
 from ..metadata.meta.schema import META_YML_FILENAME, MetaFile
-from ..metadata.webfeatures.schema import WEB_FEATURES_YML_FILENAME, WebFeaturesFile
+from ..metadata.webfeatures.schema import (WEB_FEATURES_YML_FILENAME, WebFeaturesFile,
+                                          FileMatchingMode)
 
 # The Ignorelist is a two level dictionary. The top level is indexed by
 # error names (e.g. 'TRAILING WHITESPACE'). Each of those then has a map of
@@ -768,9 +769,20 @@ def check_web_features_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[r
         f for f in os.listdir(base_dir) if os.path.isfile(os.path.join(base_dir, f))]
     for feature in web_features_file.features:
         if isinstance(feature.files, list):
+            # Resolve inclusion patterns to files, then subtract exclusions.
+            included: Set[str] = set()
             for file in feature.files:
-                if not file.match_files(files_in_directory):
-                    errors.append(rules.MissingTestInWebFeaturesFile.error(path, (file)))
+                matched = file.match_files(files_in_directory)
+                if file.matching_mode == FileMatchingMode.INCLUDE:
+                    if not matched:
+                        errors.append(rules.MissingTestInWebFeaturesFile.error(path, (file)))
+                    included.update(matched)
+                elif file.matching_mode == FileMatchingMode.EXCLUDE:
+                    excluded = set(matched) & included
+                    if not excluded:
+                        errors.append(rules.UnnecessaryExclusionInWebFeaturesFile.error(path, (
+                            f"'{file}' in feature '{feature.name}'",)))
+                    included -= excluded
 
     return errors
 

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -382,8 +382,7 @@ class MissingTestInWebFeaturesFile(Rule):
 class UnnecessaryExclusionInWebFeaturesFile(Rule):
     name = "UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE"
     description = collapse("""
-        The WEB_FEATURES.yml file contains an exclusion pattern
-        that does not exclude any included files: %s
+        The WEB_FEATURES.yml file contains a redundant or inoperable exclusion pattern: %s
     """)
 
 

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -369,7 +369,7 @@ class InvalidMetaFile(Rule):
 
 class InvalidWebFeaturesFile(Rule):
     name = "INVALID-WEB-FEATURES-FILE"
-    description = "The WEB_FEATURES.yml file contains an invalid structure"
+    description = "The WEB_FEATURES.yml file contains an invalid structure: %s"
 
 
 class MissingTestInWebFeaturesFile(Rule):

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -379,6 +379,14 @@ class MissingTestInWebFeaturesFile(Rule):
     """)
 
 
+class UnnecessaryExclusionInWebFeaturesFile(Rule):
+    name = "UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE"
+    description = collapse("""
+        The WEB_FEATURES.yml file contains an exclusion pattern
+        that does not exclude any included files: %s
+    """)
+
+
 EXTENSIONS = {
     "html": [".html", ".htm"],
     "xhtml": [".xht", ".xhtml"],

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1205,6 +1205,46 @@ features:
 """,
         []
     ),
+    (
+        ["file1.txt", "file2.txt", "file3.txt"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - "*"
+  - "!file3.txt"
+""",
+        []
+    ),
+    (
+        ["foobar.txt", "foo.txt", "bar.txt"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - "*foo*"
+  - "!*bar*"
+""",
+        []
+    ),
+    (
+        ["foo-1.txt", "bar-1.txt"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - foo-*
+  - "!bar-*"
+""",
+        [
+            ("UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file contains an exclusion pattern "
+             "that does not exclude any included files: "
+             "'!bar-*' in feature 'feature1'",
+             "css/WEB_FEATURES.yml",
+             None),
+        ]
+    ),
 ])
 def test_valid_web_features_file(monkeypatch, files, yml, expected_errors):
     def listdir(dir):

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1238,8 +1238,7 @@ features:
 """,
         [
             ("UNNECESSARY-EXCLUSION-IN-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file contains an exclusion pattern "
-             "that does not exclude any included files: "
+             "The WEB_FEATURES.yml file contains a redundant or inoperable exclusion pattern: "
              "'!bar-*' in feature 'feature1'",
              "css/WEB_FEATURES.yml",
              None),

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1231,7 +1231,7 @@ def test_valid_web_features_file(monkeypatch, files, yml, expected_errors):
 """,
         [
             ('INVALID-WEB-FEATURES-FILE',
-            'The WEB_FEATURES.yml file contains an invalid structure',
+            "The WEB_FEATURES.yml file contains an invalid structure: Input value ['test'] is not a dict",
             "css/WEB_FEATURES.yml",
             None),
         ]
@@ -1245,7 +1245,7 @@ features:
 """,
         [
             ('INVALID-WEB-FEATURES-FILE',
-            'The WEB_FEATURES.yml file contains an invalid structure',
+            'The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 contains "**" in a list. It should be `files: "**"`',
             "css/WEB_FEATURES.yml",
             None),
         ]
@@ -1282,7 +1282,7 @@ features:
 
     assert errors == [
         ('INVALID-WEB-FEATURES-FILE',
-         'The WEB_FEATURES.yml file contains an invalid structure',
+         "The WEB_FEATURES.yml file contains an invalid structure: Duplicate 'features' key found in YAML.",
          "css/WEB_FEATURES.yml",
          None),
     ]


### PR DESCRIPTION
This adds functionality to the WPT linter to cross-check files listed in an exclusion pattern in a WEB_FEATURES.yml (e.g. "!some-file.html" or "!some-file-*") and raises an error if it finds a redundant or simply ineffective exclusion pattern. 

Keeping track of exclusions can be a problem on WEB_FEATURES.yml files with lots of different web features with lots of potential unexpected overlap (there's good examples of this complexity in the newly raised lint errors fixed in this [commit](https://github.com/web-platform-tests/wpt/commit/8fa388717af23787f53a4b449e80f62a1e0f9e6e).)

cc @jcscottiii @jugglinmike @foolip 