### PR TITLE
layout: Fix `first-paint` detection

### DIFF
--- a/paint-timing/first-paint-only/first-paint-bg-color.html
+++ b/paint-timing/first-paint-only/first-paint-bg-color.html
@@ -1,11 +1,19 @@
 <!DOCTYPE html>
 <head>
 <title>Performance Paint Timing Test: FP due to background color</title>
+<style>html{background: yellow}</style>
 </head>
 <body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/utils.js"></script>
+<style>
+body {
+    background: red;
+    opacity: 0.5;
+    height: 100px;
+}
+</style>
 <div id="main"></div>
 </body>
 


### PR DESCRIPTION
This PR comprises
1. Segregates `paintable` and `contentful`.
2. Adds Checking of non-default background for eligibility to mark `first-paint`.
3. Adds a bool `is_paintable` to `display_list` and use same for marking `first-paint`.

TODO: This doesn't consider `iframes`. Will add PR after fixing WPT tests.

Testing: Updated WPT tests expectations.

Reviewed in servo/servo#42975