### PR TITLE
[WebTransport] Use host substitution instead of hardcoded example.com

### DIFF
--- a/webtransport/constructor.https.sub.any.js
+++ b/webtransport/constructor.https.sub.any.js
@@ -7,11 +7,11 @@ const BAD_URLS = [
   null,
   '',
   'no-scheme',
-  'http://example.com/' /* scheme is wrong */,
-  'quic-transport://example.com/' /* scheme is wrong */,
+  'http://{{domains[nonexistent]}}/' /* scheme is wrong */,
+  'quic-transport://{{domains[nonexistent]}}/' /* scheme is wrong */,
   'https:///' /* no host  specified */,
-  'https://example.com/#failing' /* has fragment */,
-  `https://${HOST}:999999/` /* invalid port */,
+  'https://{{domains[nonexistent]}}/#failing' /* has fragment */,
+  'https://{{host}}:999999/' /* invalid port */,
 ];
 
 for (const url of BAD_URLS) {
@@ -60,7 +60,7 @@ for (const options of OPTIONS) {
 }
 
 promise_test(async t => {
-  const wt = new WebTransport(`https://${HOST}:0/`);
+  const wt = new WebTransport('https://{{host}}:0/');
 
   // Sadly we cannot use promise_rejects_dom as the error constructor is
   // WebTransportError rather than DOMException.

--- a/webtransport/datagram-cancel-crash.https.sub.window.js
+++ b/webtransport/datagram-cancel-crash.https.sub.window.js
@@ -4,7 +4,7 @@
 test(() => {
   const iframeTag = document.createElement('iframe');
   document.body.appendChild(iframeTag);
-  const wt = new iframeTag.contentWindow.WebTransport('https://example.com/');
+  const wt = new iframeTag.contentWindow.WebTransport('https://{{domains[nonexistent]}}/');
   iframeTag.remove();
   const datagrams = wt.datagrams;
   const reader = datagrams.readable;

--- a/webtransport/idlharness.https.sub.any.js
+++ b/webtransport/idlharness.https.sub.any.js
@@ -15,7 +15,7 @@ idl_test(
       // SendStream
       // ReceiveStream
     });
-    self.webTransport = new WebTransport("https://example.com/");
+    self.webTransport = new WebTransport("https://{{domains[nonexistent]}}/");
     // `ready` and `closed` promises will be rejected due to connection error.
     // Catches them to avoid unhandled rejections.
     self.webTransport.ready.catch(() => {});


### PR DESCRIPTION
This gives us a stronger guarantee that we don't accidentally try to connect to example.com, which we really don't want to do.

This should have no test result changes, given Firefox doesn't seem to hit its blocking of remote access.