### PR TITLE
Correct expectation in custom-property-animation-transform-list-multiple-values.html

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html
@@ -52,7 +52,7 @@ animation_test({
 }, {
   iterationComposite: "accumulate",
   keyframes: ["translateX(0px) scale(3)", "translateX(100px) scale(4)"],
-  expected: "translateX(250px) scale(11.5)"
+  expected: "translateX(250px) scale(9.5)"
 }, 'Animating a custom property of type <transform-list> containing multiple values with iterationComposite');
 
 animation_test({


### PR DESCRIPTION
Scale is a one-based value, so it accumulates following:

    Vresult = Va + Vb - 1

This particular test defines an animation from scale(3) to scale(4), and accumulates it for 2.5 iterations.

At the end of the 1st iteration, 

    scale = Va = 4

At the end of the 2nd iteration, Vb = 4, so 

    scale = Va + Vb - 1 = 4 + 4 - 1 = 7

A half-way partial iteration from from scale(3) to scale(4) contributes an additional 3.5

Therefore, accumulating with the result from the end of the second iteration yields:

    7 + 3.5 - 1 = 9.5

https://www.w3.org/TR/css-transforms-2/#combining-transform-lists