### PR TITLE
Safari on macOS 26.4 supports WebTransport

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import os
+import platform
 import plistlib
 from packaging.version import Version
 from shutil import which
@@ -72,7 +73,14 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {}
+    rv = {}
+
+    version, _, _ = platform.mac_ver()
+    if version:
+        if Version(macos_version_str) >= Version("26.4"):
+            rv["enable_webtransport_h3"] = True
+
+    return rv
 
 
 def run_info_extras(logger, **kwargs):

--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -77,7 +77,7 @@ def env_options():
 
     version, _, _ = platform.mac_ver()
     if version:
-        if Version(macos_version_str) >= Version("26.4"):
+        if Version(version) >= Version("26.4"):
             rv["enable_webtransport_h3"] = True
 
     return rv


### PR DESCRIPTION
Thus we should enable the WebTransport H3 server.

See <https://developer.apple.com/documentation/safari-release-notes/safari-26_4-release-notes#Networking>.