### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309916

### DIFF
--- a/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-003-ref.html
+++ b/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-003-ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<style>
+  html { color-scheme: dark; }
+</style>
+<p>You should not see any white boxes.</p>

--- a/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-003.sub.html
+++ b/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-003.sub.html
@@ -1,0 +1,25 @@
+<!doctype html>
+
+<title>CSS Color Adjustment Test: Cross-origin frame with light color-scheme should not get opaque background when embedding element is also light, even though the parent document is dark</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="match" href="color-scheme-iframe-background-mismatch-opaque-cross-origin-003-ref.html">
+
+<style>
+  html {
+    color-scheme: dark;
+  }
+
+  iframe {
+    margin: 0;
+    border: 0;
+    padding: 0;
+    width: 200px;
+    height: 200px;
+    display: block;
+    color-scheme: light;
+  }
+</style>
+
+<p>You should not see any white boxes.</p>
+<iframe src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-empty.html"></iframe>

--- a/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-empty.html
+++ b/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-empty.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<style>
+  :root { color-scheme: light }
+</style>


### PR DESCRIPTION
WebKit export from bug: [RemoteFrameLayoutInfo::useDarkAppearance should come from the owner element of the frame](https://bugs.webkit.org/show_bug.cgi?id=309916)