### PR TITLE
Enhanced <select>: make ::target-text test work

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html
@@ -26,12 +26,12 @@ select::picker(select)::target-text {
 </select>
 
 <script>
-window.location.hash = "#:~:text=Hello";
-
 (async () => {
   await test_driver.bless();
   document.querySelector("select").showPicker();
   await new Promise(requestAnimationFrame);
+  window.location.hash = "#:~:text=Hello";
+  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
   document.documentElement.classList.remove("reftest-wait");
 })();
 </script>


### PR DESCRIPTION
If you search for text that isn't rendered yet it might well take a while. So only start searching for it after it's being displayed.