### PR TITLE
Align the test's expectation with the latest spec.

### DIFF
--- a/html/semantics/scripting-1/the-script-element/execution-timing/148.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/148.html
@@ -32,7 +32,7 @@ t.step(function() {
 });
 
 onload = t.step_func(function() {
-  assert_array_equals(eventOrder, ["inline script #1", "inline script #2", "inline script #3", "inline script #4"]);
+  assert_array_equals(eventOrder, ["inline script #1", "inline script #2", "inline script #4"]);
   t.done();
 });
 </script>


### PR DESCRIPTION
To "prepare the script element" [1] exits early when the element is disconnected. In this test, the script element represented by frag_script_2 which logs "inline script #3" is disconnected in the preceeding script (frag_script_1 / "inline script #2"). Since post-connection steps [2] are executed in the tree order, by the time we are to "prepare the script element" on frag_script_2 / "inline script #3", the script element is already disconnected and the script will not be executed.

This test failing in Chrome and Safari but passing in Firefox. After the change, the test passes in Chrome and Safari and fails in Firefox.

[1] https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
[2] https://dom.spec.whatwg.org/#concept-node-post-connection-ext