### PR TITLE
Fix missing Firefox Android tasks by updating Taskcluster

### DIFF
--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -274,6 +274,8 @@ def create_tc_task(event, task, taskgroup_id, depends_on_ids, env_extra=None):
         if "capabilities" not in task_data["payload"]:
             task_data["payload"]["capabilities"] = {}
         task_data["payload"]["capabilities"]["privileged"] = True
+    if "scopes" in task_data:
+        task_data["scopes"] = [s.replace("docker-worker:capability:privileged", "generic-worker:docker-privileged") for s in task_data["scopes"]]
     if env_extra:
         task_data["payload"]["env"].update(env_extra)
     if depends_on_ids:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -113,7 +113,7 @@ components:
   browser-firefox_android:
     privileged: true
     scopes:
-      - "docker-worker:capability:privileged"
+      - "generic-worker:docker-privileged"
     chunks-override:
       testharness: 30
 


### PR DESCRIPTION
Fixes #57838

**Description:**
This PR fixes an issue where Firefox Android test runs have been silently dropped from the Taskcluster queue since the `taskcluster` python client upgrade to v96.
