### PR TITLE
maps "arianotify" web feature

### DIFF
--- a/core-aam/arianotify/WEB_FEATURES.yml
+++ b/core-aam/arianotify/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: arianotify
+  files: "**"


### PR DESCRIPTION
aria-notify web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/arianotify.yml

maps manual tests in [`core-aam/arianotify`](https://github.com/web-platform-tests/wpt/tree/master/core-aam/arianotify)

cc @jugglinmike for review!

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)