### PR TITLE
adds lint rules for non-test files in web-feature files

### DIFF
--- a/html/browsers/the-window-object/open-close/resources/WEB_FEATURES.yml
+++ b/html/browsers/the-window-object/open-close/resources/WEB_FEATURES.yml
@@ -1,4 +1,0 @@
-features:
-- name: barprop
-  files:
-  - is-popup-barprop.html

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/WEB_FEATURES.yml
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/WEB_FEATURES.yml
@@ -15,4 +15,3 @@ features:
   - window-serviceworker-failure.https.html
   - window-sharedworker-failure.https.html
   - window-simple-success.https.html
-  - window-simple-success.https.html.headers

--- a/html/semantics/forms/the-form-element/resources/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-form-element/resources/WEB_FEATURES.yml
@@ -1,5 +1,0 @@
-features:
-- name: base
-  files:
-  - form-no-action-with-base.html
-  - form-with-action-and-base.sub.html

--- a/streams/readable-streams/crashtests/WEB_FEATURES.yml
+++ b/streams/readable-streams/crashtests/WEB_FEATURES.yml
@@ -1,7 +1,7 @@
 features:
 - name: streams
   files:
-    - strategy-worker.js
+    - strategy-worker-terminate.html
 - name: readablestream-from
   files:
     - from-cross-realm.https.html

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -756,6 +756,27 @@ def check_meta_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Err
     return []
 
 
+# Non-test directory indicators, mirroring SourceFile in manifest/sourcefile.py.
+_NON_TEST_DIRS = {"resources", "support", "tools"}
+
+
+def _path_in_non_test_dir(path: str) -> bool:
+    """Check if a path is inside a non-test directory."""
+    parts = path.split(os.path.sep)
+    if parts[0] == "common":
+        return True
+    return bool(_NON_TEST_DIRS & set(parts))
+
+
+def check_web_features_file_path(repo_root: Text, path: Text) -> List[rules.Error]:
+    if os.path.basename(path) != WEB_FEATURES_YML_FILENAME:
+        return []
+    dir_path = os.path.dirname(path)
+    if dir_path and _path_in_non_test_dir(dir_path):
+        return [rules.WebFeaturesFileInNonTestDirectory.error(path, (dir_path,))]
+    return []
+
+
 def check_web_features_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]:
     if os.path.basename(path) != WEB_FEATURES_YML_FILENAME:
         return []
@@ -1106,7 +1127,8 @@ def lint(repo_root: Text,
 
 
 path_lints = [check_file_type, check_path_length, check_worker_collision, check_ahem_copy,
-              check_mojom_js, check_tentative_directories, check_gitignore_file]
+              check_mojom_js, check_tentative_directories, check_gitignore_file,
+              check_web_features_file_path]
 file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata,
               check_ahem_system_font, check_meta_file, check_web_features_file]
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -756,23 +756,12 @@ def check_meta_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Err
     return []
 
 
-# Non-test directory indicators, mirroring SourceFile in manifest/sourcefile.py.
-_NON_TEST_DIRS = {"resources", "support", "tools"}
-
-
-def _path_in_non_test_dir(path: str) -> bool:
-    """Check if a path is inside a non-test directory."""
-    parts = path.split(os.path.sep)
-    if parts[0] == "common":
-        return True
-    return bool(_NON_TEST_DIRS & set(parts))
-
-
 def check_web_features_file_path(repo_root: Text, path: Text) -> List[rules.Error]:
     if os.path.basename(path) != WEB_FEATURES_YML_FILENAME:
         return []
-    dir_path = os.path.dirname(path)
-    if dir_path and _path_in_non_test_dir(dir_path):
+    source_file = SourceFile(repo_root, path, "/")
+    if source_file.in_non_test_dir():
+        dir_path = os.path.dirname(path)
         return [rules.WebFeaturesFileInNonTestDirectory.error(path, (dir_path,))]
     return []
 
@@ -792,12 +781,21 @@ def check_web_features_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[r
         if isinstance(feature.files, list):
             # Resolve inclusion patterns to files, then subtract exclusions.
             included: Set[str] = set()
+            dir_path = os.path.dirname(path)
             for file in feature.files:
                 matched = file.match_files(files_in_directory)
                 if file.matching_mode == FileMatchingMode.INCLUDE:
                     if not matched:
                         errors.append(rules.MissingTestInWebFeaturesFile.error(path, (file)))
                     included.update(matched)
+                    # Only check explicitly named files (no wildcards).
+                    if "*" not in str(file):
+                        for filename in matched:
+                            rel_path = os.path.join(dir_path, filename)
+                            source_file = SourceFile(repo_root, rel_path, "/")
+                            if source_file.possible_types == {"support"}:
+                                errors.append(rules.NonTestFileInWebFeaturesFile.error(path, (
+                                    filename, feature.name)))
                 elif file.matching_mode == FileMatchingMode.EXCLUDE:
                     excluded = set(matched) & included
                     if not excluded:

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -386,6 +386,13 @@ class UnnecessaryExclusionInWebFeaturesFile(Rule):
     """)
 
 
+class WebFeaturesFileInNonTestDirectory(Rule):
+    name = "WEB-FEATURES-FILE-IN-NON-TEST-DIRECTORY"
+    description = collapse("""
+        WEB_FEATURES.yml is located in a non-test directory: '%s'
+    """)
+
+
 EXTENSIONS = {
     "html": [".html", ".htm"],
     "xhtml": [".xht", ".xhtml"],

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -393,6 +393,13 @@ class WebFeaturesFileInNonTestDirectory(Rule):
     """)
 
 
+class NonTestFileInWebFeaturesFile(Rule):
+    name = "NON-TEST-FILE-IN-WEB-FEATURES-FILE"
+    description = collapse("""
+        The WEB_FEATURES.yml file references a non-test file: '%s' in feature '%s'
+    """)
+
+
 EXTENSIONS = {
     "html": [".html", ".htm"],
     "xhtml": [".xht", ".xhtml"],

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1244,6 +1244,66 @@ features:
              None),
         ]
     ),
+    (
+        ["test.html", "META.yml"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - META.yml
+""",
+        [
+            ("INVALID-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: 'META.yml'",
+             "css/WEB_FEATURES.yml",
+             None),
+        ]
+    ),
+    (
+        ["test.html", "test.html.headers"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - test.html.headers
+""",
+        [
+            ("INVALID-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: 'test.html.headers'",
+             "css/WEB_FEATURES.yml",
+             None),
+        ]
+    ),
+    (
+        ["test.html", ".hidden"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - .hidden
+""",
+        [
+            ("INVALID-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: '.hidden'",
+             "css/WEB_FEATURES.yml",
+             None),
+        ]
+    ),
+    (
+        ["test.html", "MANIFEST.json"],
+        b"""\
+features:
+- name: feature1
+  files:
+  - MANIFEST.json
+""",
+        [
+            ("INVALID-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: 'MANIFEST.json'",
+             "css/WEB_FEATURES.yml",
+             None),
+        ]
+    ),
 ])
 def test_valid_web_features_file(monkeypatch, files, yml, expected_errors):
     def listdir(dir):

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1130,74 +1130,74 @@ def test_invalid_meta_file():
 
 @pytest.mark.parametrize("files,yml,expected_errors", [
     (
-        ["file1.txt", "file2.txt", "file3.txt"],
+        ["file1.html", "file2.html", "file3.html"],
         b"""\
 features:
 - name: feature1
   files:
-  - file1.txt
+  - file1.html
 """,
         []
     ),
     (
-        ["file1.txt", "file2.txt", "file3.txt"],
+        ["file1.html", "file2.html", "file3.html"],
         b"""\
 features:
 - name: feature1
   files:
-  - file*.txt
+  - file*.html
 """,
         []
     ),
     (
-        ["file1.txt", "file2.txt", "file3.txt"],
+        ["file1.html", "file2.html", "file3.html"],
         b"""\
 features:
 - name: feature1
   files:
-  - file*.txt
-  - foo.txt
+  - file*.html
+  - foo.html
 """,
         [
             ("MISSING-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a test that does not exist: 'foo.txt'",
+             "The WEB_FEATURES.yml file references a test that does not exist: 'foo.html'",
              "css/WEB_FEATURES.yml",
              None),
         ]
     ),
     (
-        ["bar1.txt", "bar2.txt", "bar3.txt"],
+        ["bar1.html", "bar2.html", "bar3.html"],
         b"""\
 features:
 - name: feature1
   files:
-  - file*.txt
-  - bar*.txt
+  - file*.html
+  - bar*.html
 """,
         [
             ("MISSING-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a test that does not exist: 'file*.txt'",
+             "The WEB_FEATURES.yml file references a test that does not exist: 'file*.html'",
              "css/WEB_FEATURES.yml",
              None),
         ]
     ),
     (
-        ["file1.txt", "file2.txt", "file3.txt"],
+        ["file1.html", "file2.html", "file3.html"],
         b"""\
 features:
 - name: feature1
   files:
-  - foo.txt
+  - foo.html
 """,
         [
             ("MISSING-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file references a test that does not exist: 'foo.txt'",
+             "The WEB_FEATURES.yml file references a test that does not exist: 'foo.html'",
              "css/WEB_FEATURES.yml",
              None),
         ]
     ),
     (
-        ["file1.txt", "file2.txt", "file3.txt"],
+        ["file1.html", "file2.html", "file3.html"],
         b"""\
 features:
 - name: feature1
@@ -1206,18 +1206,18 @@ features:
         []
     ),
     (
-        ["file1.txt", "file2.txt", "file3.txt"],
+        ["file1.html", "file2.html", "file3.html"],
         b"""\
 features:
 - name: feature1
   files:
   - "*"
-  - "!file3.txt"
+  - "!file3.html"
 """,
         []
     ),
     (
-        ["foobar.txt", "foo.txt", "bar.txt"],
+        ["foobar.html", "foo.html", "bar.html"],
         b"""\
 features:
 - name: feature1
@@ -1228,7 +1228,7 @@ features:
         []
     ),
     (
-        ["foo-1.txt", "bar-1.txt"],
+        ["foo-1.html", "bar-1.html"],
         b"""\
 features:
 - name: feature1
@@ -1253,8 +1253,8 @@ features:
   - META.yml
 """,
         [
-            ("INVALID-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: 'META.yml'",
+            ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file references a non-test file: 'META.yml' in feature 'feature1'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1268,8 +1268,8 @@ features:
   - test.html.headers
 """,
         [
-            ("INVALID-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: 'test.html.headers'",
+            ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file references a non-test file: 'test.html.headers' in feature 'feature1'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1283,8 +1283,8 @@ features:
   - .hidden
 """,
         [
-            ("INVALID-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: '.hidden'",
+            ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file references a non-test file: '.hidden' in feature 'feature1'",
              "css/WEB_FEATURES.yml",
              None),
         ]
@@ -1298,8 +1298,8 @@ features:
   - MANIFEST.json
 """,
         [
-            ("INVALID-WEB-FEATURES-FILE",
-             "The WEB_FEATURES.yml file contains an invalid structure: Feature feature1 references a non-test file pattern: 'MANIFEST.json'",
+            ("NON-TEST-FILE-IN-WEB-FEATURES-FILE",
+             "The WEB_FEATURES.yml file references a non-test file: 'MANIFEST.json' in feature 'feature1'",
              "css/WEB_FEATURES.yml",
              None),
         ]

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -162,3 +162,27 @@ def test_unique_case_insensitive_paths(paths, errors):
     for (name, _, path, _), expected_path in zip(got_errors, errors):
         assert name == "DUPLICATE-CASE-INSENSITIVE-PATH"
         assert path == expected_path
+
+
+@pytest.mark.parametrize("path", [
+    os.path.join("css", "resources", "WEB_FEATURES.yml"),
+    os.path.join("css", "support", "WEB_FEATURES.yml"),
+    os.path.join("html", "tools", "WEB_FEATURES.yml"),
+    os.path.join("common", "WEB_FEATURES.yml"),
+    os.path.join("html", "semantics", "resources", "sub", "WEB_FEATURES.yml"),
+])
+def test_web_features_file_in_non_test_directory(path):
+    errors = check_path("/foo/", path)
+    assert len(errors) == 1
+    assert errors[0][0] == "WEB-FEATURES-FILE-IN-NON-TEST-DIRECTORY"
+
+
+@pytest.mark.parametrize("path", [
+    os.path.join("css", "css-images", "WEB_FEATURES.yml"),
+    os.path.join("html", "semantics", "WEB_FEATURES.yml"),
+    os.path.join("css", "WEB_FEATURES.yml"),
+    os.path.join("html", "semantics", "the-button-element", "WEB_FEATURES.yml"),
+])
+def test_web_features_file_in_non_test_directory_negative(path):
+    errors = check_path("/foo/", path)
+    assert not any(e[0] == "WEB-FEATURES-FILE-IN-NON-TEST-DIRECTORY" for e in errors)

--- a/tools/metadata/webfeatures/schema.py
+++ b/tools/metadata/webfeatures/schema.py
@@ -14,6 +14,24 @@ WEB_FEATURES_YML_FILENAME = "WEB_FEATURES.yml"
 # File prefix to indicate that this FeatureFile should run in EXCLUDE mode.
 EXCLUSION_PREFIX = "!"
 
+# Non-test file indicators, mirroring SourceFile in manifest/sourcefile.py.
+_NON_TEST_FILE_PREFIXES = ("MANIFEST",)
+_NON_TEST_FILENAMES = {"META.yml", WEB_FEATURES_YML_FILENAME}
+_NON_TEST_FILE_EXTENSIONS = {".headers", ".ini", ".yml", ".yaml"}
+
+
+def _is_non_test_filename(filename: str) -> bool:
+    """Check if a filename is obviously not a test, using name-only heuristics."""
+    if any(filename.startswith(p) for p in _NON_TEST_FILE_PREFIXES):
+        return True
+    if filename in _NON_TEST_FILENAMES:
+        return True
+    if filename.startswith("."):
+        return True
+    if any(filename.endswith(ext) for ext in _NON_TEST_FILE_EXTENSIONS):
+        return True
+    return False
+
 
 class SpecialFileEnum(Enum):
     """All files recursively"""
@@ -82,6 +100,14 @@ class FeatureEntry:
         # If "**" is used, it should be the only item. Not in a list.
         if isinstance(self.files, list) and SpecialFileEnum.RECURSIVE.value in self.files:
             raise ValueError(f'Feature {self.name} contains "**" in a list. It should be `files: "**"`')
+        # Non-test files should not be referenced in WEB_FEATURES.yml.
+        if isinstance(self.files, list):
+            for f in self.files:
+                if f.matching_mode == FileMatchingMode.EXCLUDE:
+                    continue
+                if _is_non_test_filename(f.processed_filename):
+                    raise ValueError(
+                        f"Feature {self.name} references a non-test file pattern: '{f}'")
 
 
     def does_feature_apply_recursively(self) -> bool:

--- a/tools/metadata/webfeatures/schema.py
+++ b/tools/metadata/webfeatures/schema.py
@@ -14,24 +14,6 @@ WEB_FEATURES_YML_FILENAME = "WEB_FEATURES.yml"
 # File prefix to indicate that this FeatureFile should run in EXCLUDE mode.
 EXCLUSION_PREFIX = "!"
 
-# Non-test file indicators, mirroring SourceFile in manifest/sourcefile.py.
-_NON_TEST_FILE_PREFIXES = ("MANIFEST",)
-_NON_TEST_FILENAMES = {"META.yml", WEB_FEATURES_YML_FILENAME}
-_NON_TEST_FILE_EXTENSIONS = {".headers", ".ini", ".yml", ".yaml"}
-
-
-def _is_non_test_filename(filename: str) -> bool:
-    """Check if a filename is obviously not a test, using name-only heuristics."""
-    if any(filename.startswith(p) for p in _NON_TEST_FILE_PREFIXES):
-        return True
-    if filename in _NON_TEST_FILENAMES:
-        return True
-    if filename.startswith("."):
-        return True
-    if any(filename.endswith(ext) for ext in _NON_TEST_FILE_EXTENSIONS):
-        return True
-    return False
-
 
 class SpecialFileEnum(Enum):
     """All files recursively"""
@@ -100,14 +82,6 @@ class FeatureEntry:
         # If "**" is used, it should be the only item. Not in a list.
         if isinstance(self.files, list) and SpecialFileEnum.RECURSIVE.value in self.files:
             raise ValueError(f'Feature {self.name} contains "**" in a list. It should be `files: "**"`')
-        # Non-test files should not be referenced in WEB_FEATURES.yml.
-        if isinstance(self.files, list):
-            for f in self.files:
-                if f.matching_mode == FileMatchingMode.EXCLUDE:
-                    continue
-                if _is_non_test_filename(f.processed_filename):
-                    raise ValueError(
-                        f"Feature {self.name} references a non-test file pattern: '{f}'")
 
 
     def does_feature_apply_recursively(self) -> bool:


### PR DESCRIPTION
This adds a new lint rule and extends `webfeatures/schema.py` to check for the _explicit_ inclusion of non-test files in a WEB_FEATURES.yml. (This doesn't affect the usage of `**`.) The rules are based on some of the checks happening in [`tools/manifest/sourcefile.py`](https://github.com/web-platform-tests/wpt/blob/master/tools/manifest/sourcefile.py). 

I opted _not_ to parse file content here to avoid slowing down the linter, but I'm open to suggestions if folks think these filename-and-directory-based heuristics are too rough or broad.

Here's the new rules for "non-test files":
**Directory-level checks**:
- checks if file is in `common/`, `resources/`, `support/`, `tools/` 

**File-level checks**
- Starts with `MANIFEST`
- Is named `META.yml` or `WEB_FEATURES.yml`
- Starts with `.`
- Ends with `.headers`, `.ini`, `.yml`, `.yaml`

Example of new lint errors caught with these additions are in [this commit](https://github.com/web-platform-tests/wpt/commit/85118703e1d8e8e9abbbefc5deb4b145e8df983e)

cc @jcscottiii @foolip @jugglinmike for review!