### PR TITLE
WebTransport no longer defines wt.datagrams.writable

### DIFF
--- a/webtransport/datagram-bad-chunk.https.any.js
+++ b/webtransport/datagram-bad-chunk.https.any.js
@@ -9,7 +9,7 @@ promise_test(async t => {
   t.add_cleanup(() => wt.close());
   await wt.ready;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   await promise_rejects_js(t, TypeError, writer.write("foo"));
   await promise_rejects_js(t, TypeError, writer.write(new Uint8Array(0)));
 }, 'Datagram should reject when non-buffer-source data is written');

--- a/webtransport/datagrams.https.any.js
+++ b/webtransport/datagrams.https.any.js
@@ -100,7 +100,7 @@ promise_test(async t => {
   const wt = new WebTransport(webtransport_url('echo.py'));
   await wt.ready;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const reader = wt.datagrams.readable.getReader();
 
   const controller = new AbortController();
@@ -123,7 +123,7 @@ promise_test(async t => {
   const wt = new WebTransport(webtransport_url('echo.py'));
   await wt.ready;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const reader = wt.datagrams.readable.getReader({ mode: 'byob' });
 
   const controller = new AbortController();
@@ -150,7 +150,7 @@ promise_test(async t => {
   const wt = new WebTransport(webtransport_url('echo.py'));
   await wt.ready;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const reader = wt.datagrams.readable.getReader({ mode: 'byob' });
 
   const controller = new AbortController();
@@ -174,7 +174,7 @@ promise_test(async t => {
   const wt = new WebTransport(webtransport_url('echo_datagram_length.py'));
   await wt.ready;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const reader = wt.datagrams.readable.getReader();
 
   // Write and read max-size datagram.
@@ -196,7 +196,7 @@ promise_test(async t => {
   const wt = new WebTransport(webtransport_url('echo.py'));
   await wt.ready;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const reader = wt.datagrams.readable.getReader();
 
   let maxDatagramSize = wt.datagrams.maxDatagramSize;
@@ -223,7 +223,7 @@ promise_test(async t => {
   // Make a WebTransport connection, but session is not necessarily established.
   const wt = new WebTransport(webtransport_url('echo.py'));
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const reader = wt.datagrams.readable.getReader();
 
   const controller = new AbortController();
@@ -253,7 +253,7 @@ promise_test(async t => {
   const N = 5;
   wt.datagrams.outgoingHighWaterMark = N;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const encoder = new TextEncoder();
 
   // Write N-1 datagrams.
@@ -298,7 +298,7 @@ promise_test(async t => {
   const N = 5;
   wt.datagrams.incomingHighWaterMark = N;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const encoder = new TextEncoder();
 
   // Write 10*N datagrams.

--- a/webtransport/historical.https.sub.any.js
+++ b/webtransport/historical.https.sub.any.js
@@ -1,0 +1,13 @@
+// META: global=window,worker
+// META: script=/common/get-host-info.sub.js
+// META: script=resources/webtransport-test-helpers.sub.js
+
+promise_test(async t => {
+  // https://github.com/w3c/webtransport/commit/3e37d39bb4399935f8c88018fe3008698cad7862
+  const wt = new WebTransport(webtransport_url('{{domains[nonexistent]}}'));
+  // `ready` and `closed` promises will be rejected due to connection error.
+  // Catches them to avoid unhandled rejections.
+  wt.ready.catch(() => {});
+  wt.closed.catch(() => {});
+  assert_false('writable' in wt.datagrams);
+}, 'WebTransportDatagramDuplexStream#writable');

--- a/webtransport/stats.https.any.js
+++ b/webtransport/stats.https.any.js
@@ -82,7 +82,7 @@ promise_test(async t => {
   const numDatagrams = 64;
   wt.datagrams.incomingHighWaterMark = 4;
 
-  const writer = wt.datagrams.writable.getWriter();
+  const writer = wt.datagrams.createWritable().getWriter();
   const encoder = new TextEncoder();
   const promises = [];
   while (promises.length < numDatagrams) {


### PR DESCRIPTION
This was removed from the spec in https://github.com/w3c/webtransport/commit/3e37d39bb4399935f8c88018fe3008698cad7862.

This also adds a historical test for non-support.
