### PR TITLE
WebTransport defines incomingMaxAge/outgoingMaxAge initial values to be null

### DIFF
--- a/webtransport/datagrams.https.any.js
+++ b/webtransport/datagrams.https.any.js
@@ -340,8 +340,8 @@ promise_test(async t => {
   const wt = new WebTransport(webtransport_url('echo.py'));
   await wt.ready;
 
-  assert_equals(wt.datagrams.incomingMaxAge, Infinity);
-  assert_equals(wt.datagrams.outgoingMaxAge, Infinity);
+  assert_equals(wt.datagrams.incomingMaxAge, null);
+  assert_equals(wt.datagrams.outgoingMaxAge, null);
 
   wt.datagrams.incomingMaxAge = 5;
   assert_equals(wt.datagrams.incomingMaxAge, 5);
@@ -354,9 +354,9 @@ promise_test(async t => {
   assert_throws_js(RangeError, () => { wt.datagrams.outgoingMaxAge = NaN; });
 
   wt.datagrams.incomingMaxAge = 0;
-  assert_equals(wt.datagrams.incomingMaxAge, Infinity);
+  assert_equals(wt.datagrams.incomingMaxAge, null);
   wt.datagrams.outgoingMaxAge = 0;
-  assert_equals(wt.datagrams.outgoingMaxAge, Infinity);
+  assert_equals(wt.datagrams.outgoingMaxAge, null);
 }, 'Datagram MaxAge getters/setters work correctly');
 
 promise_test(async t => {


### PR DESCRIPTION
Per https://github.com/w3c/webtransport/commit/7292d72165673ac953d8790dc1852da569edf16c, `incomingMaxAge` and `outgoingMaxAge` are now nullable again with null as the initial value. Setting to 0 also maps to null per the setter algorithm.
