### PR TITLE
layout: Fix `first-paint` detection

### DIFF
--- a/paint-timing/first-paint-only/first-paint-bg-color.html
+++ b/paint-timing/first-paint-only/first-paint-bg-color.html
@@ -14,6 +14,9 @@
 setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_equals(performance.getEntriesByType('paint').length, 0, "There should be no Paint Entry");
+
+    // Changing background color should fire FP.
     document.body.style.backgroundColor = "#AA0000";
 
     assertFirstPaint(t, 20);


### PR DESCRIPTION
This PR comprises
1. Segregate `paintable` and `contentful`.
2. Adds Checking of non-default background for eligibility to mark `first-paint`.
3. Adds a bool `is_paintable` to `display_list` and use same for marking `first-paint`.

TODO: This doesn't consider `iframes`. Will add PR after fixing WPT tests.

Raised an issue for some incomplete definitions: https://github.com/w3c/paint-timing/issues/122




Testing: 
- `wpt/tests/paint-timing/first-paint-only/first-paint-bg-color.html`
- Updated WPT tests expectations.
  - `wpt/paint-timing/first-image-child.html`
  - `wpt/paint-timing/first-paint-only/sibling-painting-first-image.html`
- Unit Test: `servo/tests/performance_paint_timings.rs`. Following Tests Cases are covered: 

Background Pref |Root Background|FP|TC
--|--|--|--
|Default|Unset|:x: | `test_default_pref_with_unset_background`
|Non-Default|Unset|:x: | `test_non_default_pref_with_unset_background`
|Default|Transparent|:x:|`test_default_pref_with_transparent_background`
|Non-Default|Unset|:x:|`test_non_default_pref_with_transparent_background`
|Default|Set|:white_check_mark:|`test_default_pref_with_background`
|Non-Default|Set|:white_check_mark:|`test_non_default_pref_with_background`
|Non-Default|Set (same as pref)|:x:|`test_non_default_pref_with_same_background`

Fixes: #<!-- nolink -->42148

Reviewed in servo/servo#42975