### PR TITLE
Let wpt-pr-bot assign reviewers for wasm workflow

### DIFF
--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cd wpt
           git push --set-upstream origin $BRANCH_NAME
-          gh pr create --title "$COMMIT_TITLE" --body "$PR_BODY" --reviewer jcscottiii,dschuff
+          gh pr create --title "$COMMIT_TITLE" --body "$PR_BODY" --reviewer wpt-pr-bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_TITLE: "Update Wasm tests"

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cd wpt
           git push --set-upstream origin $BRANCH_NAME
-          gh pr create --title "$COMMIT_TITLE" --body "$PR_BODY" --reviewer wpt-pr-bot
+          gh pr create --title "$COMMIT_TITLE" --body "$PR_BODY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_TITLE: "Update Wasm tests"


### PR DESCRIPTION
As pointed out by @jgraham, this can be very surprising.

https://github.com/web-platform-tests/wpt/pull/56843#discussion_r2947314024

[wpt-pr-bot](https://github.com/web-platform-tests/wpt-pr-bot) will take the PR event and assign reviewers.