### PR TITLE
wpt: Add a delay to load to valid image to overcome false positive `PASS`

### DIFF
--- a/largest-contentful-paint/broken-image-icon.html
+++ b/largest-contentful-paint/broken-image-icon.html
@@ -9,7 +9,7 @@
 
 <body>
   <img src="../non-existent-image.jpg">
-  <img src="/css/css-images/support/colors-16x8.png">
+  <img src="/css/css-images/support/colors-16x8.png?pipe=trickle(d2)">
 
   <script>
     promise_test(async () => {


### PR DESCRIPTION
This adds a delay of 2 seconds for loading a valid image. This is added to potentially overcome the race condition happening while reporting LCP, to save from false positive result.

Testing: WPT tests is `TIMED OUT` as expected.

Reviewed in servo/servo#43357