### PR TITLE
[Navigation API] navigate-history-traversal-during-onnavigate-should-reject.html has incorrect URL

### DIFF
--- a/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html
+++ b/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html
@@ -9,7 +9,7 @@ promise_test(async t => {
   await new Promise(resolve => w.onload = resolve);
 
   await test_driver.bless("navigate", async function() {
-    w.navigation.navigate("resources/navigate-during-onnavigate-should-reject-helper.html");
+    w.navigation.navigate("../navigation-api/navigate-event/resources/navigate-during-onnavigate-should-reject-helper.html");
   });
 
   await new Promise(resolve => onmessage = resolve);


### PR DESCRIPTION
This test is failing on Chrome, Firefox, and Safari because it uses a URL that doesn't exist:

It calls w.navigation.navigate("resources/..."), which resolves against the popup's document URL "/common/blank.html". This results in "/common/resources/navigate-during-onnavigate-should-reject-helper.html", which doesn't exist.