### PR TITLE
webtransport-test-helpers.sub.js should consistently use substitution

### DIFF
--- a/webtransport/bidirectional-cancel-crash.https.html
+++ b/webtransport/bidirectional-cancel-crash.https.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <html class="test-wait">
-<script src="/common/get-host-info.sub.js"></script>
 <script src="resources/webtransport-test-helpers.sub.js"></script>
 <script type="module">
   const WT_CODE = 127;

--- a/webtransport/close.https.any.js
+++ b/webtransport/close.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 // META: script=/common/utils.js
 

--- a/webtransport/connect.https.any.js
+++ b/webtransport/connect.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 promise_test(async t => {

--- a/webtransport/constructor.https.sub.any.js
+++ b/webtransport/constructor.https.sub.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 // META: script=/common/utils.js
 

--- a/webtransport/csp-fail.https.window.js
+++ b/webtransport/csp-fail.https.window.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 function set_csp(destination) {

--- a/webtransport/csp-pass.https.window.js
+++ b/webtransport/csp-pass.https.window.js
@@ -10,9 +10,10 @@ function set_csp(destination) {
 }
 
 promise_test(async t => {
- let meta = set_csp(`${BASE}`);
+ const handler_url = webtransport_url('custom-response.py?:status=200');
+ let meta = set_csp(new URL(handler_url).origin);
  document.head.appendChild(meta);
 
-  let wt = new WebTransport(webtransport_url('custom-response.py?:status=200'));
+  let wt = new WebTransport(handler_url);
   await wt.ready;
 }, 'WebTransport connection should succeed when CSP connect-src destination is set to the page');

--- a/webtransport/csp-pass.https.window.js
+++ b/webtransport/csp-pass.https.window.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 function set_csp(destination) {

--- a/webtransport/datagram-bad-chunk.https.any.js
+++ b/webtransport/datagram-bad-chunk.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 // META: script=/common/utils.js
 

--- a/webtransport/datagrams.https.any.js
+++ b/webtransport/datagrams.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 // Write datagrams until the producer receives the AbortSignal.

--- a/webtransport/echo-large-bidirectional-streams.https.any.js
+++ b/webtransport/echo-large-bidirectional-streams.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 // META: timeout=long
 

--- a/webtransport/in-removed-iframe.https.html
+++ b/webtransport/in-removed-iframe.https.html
@@ -17,7 +17,6 @@ function iframeOnLoad() {
 
 <iframe id=target onload="iframeOnLoad()" srcdoc="
 <!doctype html>
-<script src=/common/get-host-info.sub.js></script>
 <script src=resources/webtransport-test-helpers.sub.js></script>
 <script>
 window.wt = new WebTransport(webtransport_url('echo.py'));

--- a/webtransport/resources/webtransport-test-helpers.sub.js
+++ b/webtransport/resources/webtransport-test-helpers.sub.js
@@ -1,16 +1,9 @@
-// The file including this must also include /common/get-host-info.sub.js to
-// pick up the necessary constants.
-
-const HOST = get_host_info().ORIGINAL_HOST;
-const PORT = '{{ports[webtransport-h3][0]}}';
-const BASE = `https://${HOST}:${PORT}`;
-
 // Wait for the given number of milliseconds (ms).
 function wait(ms) { return new Promise(res => step_timeout(res, ms)); }
 
 // Create URL for WebTransport session.
 function webtransport_url(handler) {
-  return `${BASE}/webtransport/handlers/${handler}`;
+  return `https://{{host}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/${handler}`;
 }
 
 // Converts WebTransport stream error code to HTTP/3 error code.
@@ -70,13 +63,13 @@ function check_and_remove_standard_headers(headers) {
   delete headers[':scheme'];
   assert_equals(headers[':method'], 'CONNECT');
   delete headers[':method'];
-  assert_equals(headers[':authority'], `${HOST}:${PORT}`);
+  assert_equals(headers[':authority'], '{{host}}:{{ports[webtransport-h3][0]}}');
   delete headers[':authority'];
   assert_equals(headers[':path'], '/webtransport/handlers/echo-request-headers.py');
   delete headers[':path'];
   assert_equals(headers[':protocol'], 'webtransport');
   delete headers[':protocol'];
-  assert_equals(headers['origin'], `${get_host_info().ORIGIN}`);
+  assert_equals(headers['origin'], 'https://{{location[host]}}');
   delete headers['origin'];
 }
 

--- a/webtransport/sendorder.https.any.js
+++ b/webtransport/sendorder.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 // META: script=/common/utils.js
 

--- a/webtransport/sendstream-bad-chunk.https.any.js
+++ b/webtransport/sendstream-bad-chunk.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 // META: script=/common/utils.js
 

--- a/webtransport/server-certificate-hashes.https.any.js
+++ b/webtransport/server-certificate-hashes.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 promise_test(async t => {

--- a/webtransport/stats.https.any.js
+++ b/webtransport/stats.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 function validate_rtt_stats(stats) {

--- a/webtransport/streams-close.https.any.js
+++ b/webtransport/streams-close.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=resources/webtransport-test-helpers.sub.js
 

--- a/webtransport/streams-echo.https.any.js
+++ b/webtransport/streams-echo.https.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
 promise_test(async t => {


### PR DESCRIPTION
This is built on top of https://github.com/web-platform-tests/wpt/pull/58491, and is really cleanup after that.

Prior to that PR, we had HOST and BASE defined in webtransport-test-helpers.sub.js and used by three tests — this PR removes the last remaining case (csp-pass.https.window.js) and eliminates them, because they add very little beyond what already exists.

With webtransport-test-helpers.sub.js already using server-side substituions for some of its definitions, there's little reason for it to use get-host-info.sub.js for others. Thus, we get rid of that.

And with that done, we can drop the get-host-info.sub.js includes in almost all tests (specifically: all except back-forward-cache-with-*, which need it for some of the other scripts they include).

This should have no test result changes.