### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309977

### DIFF
--- a/css/css-tables/collapsed-border-background-inset-notref.html
+++ b/css/css-tables/collapsed-border-background-inset-notref.html
@@ -2,13 +2,13 @@
 <title>CSS Test Reference (mismatch): collapsed border cell background fills full width</title>
 <style>
 th {
-    border: 0px solid red;
+    border: 0px solid transparent;
 }
 tr.green {
     background: green;
 }
 td {
-    border: 50px solid red;
+    border: 50px solid transparent;
     padding: 6px 12px;
     text-align: left;
     vertical-align: top;

--- a/css/css-tables/collapsed-border-background-inset.html
+++ b/css/css-tables/collapsed-border-background-inset.html
@@ -4,11 +4,11 @@
 <link rel="mismatch" href="collapsed-border-background-inset-notref.html">
 <style>
 th {
-    border: 0px solid red;
+    border: 0px solid transparent;
     background: green;
 }
 td {
-    border: 50px solid red;
+    border: 50px solid transparent;
     padding: 6px 12px;
     text-align: left;
     vertical-align: top;


### PR DESCRIPTION
WebKit export from bug: [\[css-tables\] Fix collapsed-border-background-inset WPT mismatch test to use transparent borders](https://bugs.webkit.org/show_bug.cgi?id=309977)