### PR TITLE
maps "origin" web feature

### DIFF
--- a/html/browsers/origin/api/WEB_FEATURES.yml
+++ b/html/browsers/origin/api/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: origin
+  files: "**"


### PR DESCRIPTION
"Origin" web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/origin.yml

I interpreted this to strictly refer to the Origin interface, so I limited the mapping to tests in [`html/browsers/origin/api`](https://github.com/web-platform-tests/wpt/tree/master/html/browsers/origin/api) here. 

cc @jugglinmike for review

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)