### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309976

### DIFF
--- a/svg/animations/invalid-attribute-type-does-not-block-begin-event.html
+++ b/svg/animations/invalid-attribute-type-does-not-block-begin-event.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>beginEvent must fire for a delayed animation when an invalid attribute type group exists</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg>
+  <!-- Invalid animation: attributeType="CSS" on a non-CSS attribute. -->
+  <rect>
+    <animate attributeName="href" attributeType="CSS" values="foo"/>
+  </rect>
+
+  <!-- Valid animation with a delayed begin. -->
+  <rect width="100" height="100" fill="red">
+    <animate id="valid" attributeName="fill" values="green" begin="0.05s"/>
+  </rect>
+</svg>
+<script>
+async_test(t => {
+  document.getElementById("valid").addEventListener("beginEvent", t.step_func_done(() => {
+    assert_true(true, "beginEvent fired for delayed animation");
+  }));
+});
+</script>

--- a/svg/animations/invalid-attribute-type-does-not-block-other-animations.html
+++ b/svg/animations/invalid-attribute-type-does-not-block-other-animations.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>An invalid attribute type in one animation group must not block other animation groups</title>
+<link rel="match" href="../struct/reftests/reference/green-100x100.html">
+<svg>
+  <!-- Invalid animation: attributeType="CSS" on a non-CSS attribute. -->
+  <rect>
+    <animate attributeName="href" attributeType="CSS" values="foo" dur="1s"/>
+  </rect>
+
+  <!-- Valid animation: should still run despite the earlier invalid group. -->
+  <rect width="100" height="100" fill="red">
+    <set attributeName="fill" to="green" fill="freeze"/>
+  </rect>
+</svg>

--- a/svg/animations/invalid-attribute-type-does-not-block-same-group-animation.html
+++ b/svg/animations/invalid-attribute-type-does-not-block-same-group-animation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>An invalid attributeType on one animate must not block a subsequent animate in the same group</title>
+<link rel="match" href="../struct/reftests/reference/green-100x100.html">
+<svg>
+  <rect width="100" height="100" fill="red">
+    <animate attributeType="CSS" attributeName="fill" fill="freeze" begin="0" dur="0.05s" to="blue"/>
+    <set attributeName="fill" to="green" fill="freeze"/>
+  </rect>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [Invalid attribute type in one animation group prevents all subsequent animation groups from running](https://bugs.webkit.org/show_bug.cgi?id=309976)