### PR TITLE
Implement "tables inherit color from body quirk"

### DIFF
--- a/quirks/tables-inherit-color-from-body-quirk-001.html
+++ b/quirks/tables-inherit-color-from-body-quirk-001.html
@@ -1,0 +1,22 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table inside the body</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="../css/reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>

--- a/quirks/tables-inherit-color-from-body-quirk-002.html
+++ b/quirks/tables-inherit-color-from-body-quirk-002.html
@@ -1,0 +1,25 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table after the body</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="../css/reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.after(document.querySelector("div"));
+</script>

--- a/quirks/tables-inherit-color-from-body-quirk-003.html
+++ b/quirks/tables-inherit-color-from-body-quirk-003.html
@@ -1,0 +1,25 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table before the body</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="../css/reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.before(document.querySelector("div"));
+</script>

--- a/quirks/tables-inherit-color-from-body-quirk-004-ref.html
+++ b/quirks/tables-inherit-color-from-body-quirk-004-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Quirks Mode Reference: The tables inherit color from body quirk - Table with body removed, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: light; }
+p { color: initial; }
+table { font: 200px/1 Ahem; color: initial; }
+</style>
+<p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+<table cellspacing="0" cellpadding="0">
+  <tr>
+    <td>X</td>
+  </tr>
+</table>

--- a/quirks/tables-inherit-color-from-body-quirk-004.html
+++ b/quirks/tables-inherit-color-from-body-quirk-004.html
@@ -1,0 +1,26 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table with body removed, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-004-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: light; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.replaceWith(document.querySelector("div"));
+</script>

--- a/quirks/tables-inherit-color-from-body-quirk-005-ref.html
+++ b/quirks/tables-inherit-color-from-body-quirk-005-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Quirks Mode Reference: The tables inherit color from body quirk - Table with body removed, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: dark; }
+p { color: initial; }
+table { font: 200px/1 Ahem; color: initial; }
+</style>
+<p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+<table cellspacing="0" cellpadding="0">
+  <tr>
+    <td>X</td>
+  </tr>
+</table>

--- a/quirks/tables-inherit-color-from-body-quirk-005.html
+++ b/quirks/tables-inherit-color-from-body-quirk-005.html
@@ -1,0 +1,26 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table with body removed, dark mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-005-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: dark; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.replaceWith(document.querySelector("div"));
+</script>

--- a/quirks/tables-inherit-color-from-body-quirk-006.html
+++ b/quirks/tables-inherit-color-from-body-quirk-006.html
@@ -1,0 +1,30 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table without body, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-004-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: light; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<script>
+  // At this point, the <body> has not been created yet.
+  // And replacing the <html> prevents the creation of the <body>.
+  let root = document.documentElement;
+  let div = document.createElement("div");
+  div.innerHTML = `
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  `;
+  root.append(div);
+  document.documentElement.remove();
+  document.append(root.cloneNode(true));
+</script>

--- a/quirks/tables-inherit-color-from-body-quirk-007.html
+++ b/quirks/tables-inherit-color-from-body-quirk-007.html
@@ -1,0 +1,30 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table without body, dark mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-005-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: dark; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<script>
+  // At this point, the <body> has not been created yet.
+  // And replacing the <html> prevents the creation of the <body>.
+  let root = document.documentElement;
+  let div = document.createElement("div");
+  div.innerHTML = `
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  `;
+  root.append(div);
+  document.documentElement.remove();
+  document.append(root.cloneNode(true));
+</script>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/333

Spec: https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk

Testing: Adding 7 new tests. They expose some bugs in other browsers:
 - WebKit and Blink don't use the body color when the table appears before the body
 - Firefox uses the body color even after removing the body

Reviewed in servo/servo#43368