### PR TITLE
[Digital Credentials] Implement check order and mixed protocol handling updates

### DIFF
--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -236,6 +236,7 @@
 
     for (const badValue of throwingValues) {
       const options = makeCreateOptions({ data: badValue });
+      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         TypeError,
@@ -256,4 +257,30 @@
       "Should throw for invalid form element"
     );
   }, "Throws when form element does not contain password.");
+
+  promise_test(async (t) => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const options = {
+      digital: {
+        requests: [
+          {
+            protocol: "unknown-protocol",
+            data: BigInt(1), // malformed/non-serializable
+          },
+          {
+            protocol: "openid4vci",
+            data: { some: "data" }, // proper data
+          },
+        ],
+      },
+      signal,
+    };
+
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.create(options);
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.create() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail.");
 </script>

--- a/digital-credentials/get.https.html
+++ b/digital-credentials/get.https.html
@@ -243,6 +243,7 @@ promise_test(async t => {
 
   for (const badValue of throwingValues) {
     const options = makeGetOptions({ data: badValue });
+    await test_driver.bless("user activation");
     await promise_rejects_js(
       t,
       TypeError,
@@ -258,4 +259,30 @@ promise_test(async (t) => {
       TypeError,
       navigator.credentials.get({digital: {}}));
   }, "`requests` field is required in the options object.");
+
+  promise_test(async (t) => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const options = {
+      digital: {
+        requests: [
+          {
+            protocol: "unknown-protocol",
+            data: BigInt(1), // malformed/non-serializable
+          },
+          {
+            protocol: "openid4vp-v1-unsigned",
+            data: { some: "data" }, // proper data
+          },
+        ],
+      },
+      signal,
+    };
+
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.get(options);
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail.");
 </script>

--- a/digital-credentials/get.https.html
+++ b/digital-credentials/get.https.html
@@ -281,4 +281,67 @@ promise_test(async (t) => {
     controller.abort();
     await promise_rejects_dom(t, "AbortError", promise);
   }, "navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail.");
+
+  promise_test(async (t) => {
+    const options = {
+      digital: {
+        requests: [
+          { protocol: "bogus-1", data: BigInt(1) },
+          { protocol: "bogus-2", data: BigInt(2) },
+          { protocol: "bogus-3", data: BigInt(3) },
+        ],
+      },
+    };
+
+    await test_driver.bless("user activation");
+    await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+  }, "navigator.credentials.get() with only bogus requests should reject with TypeError.");
+
+  promise_test(async (t) => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const [openidReq] = makeGetOptions({ protocol: "openid4vp-v1-unsigned" }).digital.requests;
+    const [mdocReq] = makeGetOptions({ protocol: "org-iso-mdoc" }).digital.requests;
+
+    const options = makeGetOptions({
+      protocol: [], // disable defaults
+      requests: [
+        openidReq,
+        { protocol: "bogus-1", data: BigInt(1) },
+        { protocol: "bogus-2", data: BigInt(2) },
+        mdocReq,
+      ],
+      signal,
+    });
+
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.get(options);
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail.");
+
+  promise_test(async (t) => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const [openidReq] = makeGetOptions({ protocol: "openid4vp-v1-unsigned" }).digital.requests;
+    const [mdocReq] = makeGetOptions({ protocol: "org-iso-mdoc" }).digital.requests;
+
+    const options = makeGetOptions({
+      protocol: [], // disable automatic protocol requests
+      requests: [
+        { protocol: "bogus-1", data: BigInt(1) },
+        openidReq,
+        mdocReq,
+        { protocol: "bogus-2", data: BigInt(2) },
+      ],
+      signal,
+    });
+
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.get(options);
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.get() with bogus requests at both ends should skip them and not fail.");
 </script>

--- a/digital-credentials/get.https.html
+++ b/digital-credentials/get.https.html
@@ -264,21 +264,17 @@ promise_test(async (t) => {
     const controller = new AbortController();
     const signal = controller.signal;
 
-    const options = {
-      digital: {
-        requests: [
-          {
-            protocol: "unknown-protocol",
-            data: BigInt(1), // malformed/non-serializable
-          },
-          {
-            protocol: "openid4vp-v1-unsigned",
-            data: { some: "data" }, // proper data
-          },
-        ],
-      },
+    // makeGetOptions() with a manual request in `requests` will create a mix
+    // of that request plus the default canonical ones (openid4vp, org-iso-mdoc).
+    const options = makeGetOptions({
+      requests: [
+        {
+          protocol: "unknown-protocol",
+          data: BigInt(1), // malformed/non-serializable
+        },
+      ],
       signal,
-    };
+    });
 
     await test_driver.bless("user activation");
     const promise = navigator.credentials.get(options);

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -27,6 +27,19 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
+    const options = makeCreateOptions({ data: BigInt(1) });
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      navigator.credentials.create(options),
+    );
+  }, "navigator.credentials.create() with non-serializable data and no user activation should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active",
+    );
     const options = makeCreateOptions({ protocol: [] });
     await promise_rejects_js(
       t,

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -27,6 +27,19 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
+    const options = makeGetOptions({ data: BigInt(1) });
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      navigator.credentials.get(options),
+    );
+  }, "navigator.credentials.get() with non-serializable data and no user activation should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    assert_false(
+      navigator.userActivation.isActive,
+      "User activation should not be active",
+    );
     const options = makeGetOptions({ protocol: [] });
     await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
     assert_false(


### PR DESCRIPTION
   This PR updates the Digital Credentials Web Platform Tests to align with the latest specification changes regarding the order of execution checks and the handling of multiple credential requests.

   ### Key Changes

   #### 1. Check Order Prioritization
   Updated `navigator.credentials.get()` and `navigator.credentials.create()` tests to reflect that **User Activation** must be checked before **Data Serialization** as a side effect of the PR.
   - **New Test Cases**: Added tests in `user-activation-get.https.html` and `user-activation-create.tentative.https.html` using non-serializable data (`BigInt`) to verify that `NotAllowedError` is thrown instead of `TypeError` when transient activation is missing.
   - **Updated Existing Tests**: Updated existing serialization tests in `get.https.html` and `create.tentative.https.html` to include `test_driver.bless()`, ensuring they correctly validate serialization logic after passing the activation check.

   #### 2. Mixed Protocol Handling
   Added tests to verify that the API gracefully handles a list of requests containing unknown or malformed protocols such  that the "malformed" unknown protocol is skipped and does not cause the entire promise to reject with a `TypeError`.