### PR TITLE
Digital Credentials: Add WebDriver automation commands and tests

### DIFF
--- a/digital-credentials/webdriver/create.https.html
+++ b/digital-credentials/webdriver/create.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>Digital Credential API: create() webdriver tests.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeCreateOptions } from "../support/helper.js";
+
+  promise_test(async (t) => {
+    const responseData = "test-create-response-data";
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vci", { "value": responseData });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeCreateOptions({ protocol: "openid4vci" });
+    const result = await navigator.credentials.create(options);
+
+    assert_equals(result.protocol, "openid4vci");
+    assert_equals(result.data.value, responseData);
+  }, "navigator.credentials.create() with respond mode should resolve with the specified data.");
+
+  promise_test(async (t) => {
+    const complexData = { "a": 1, "b": [2, 3], "c": { "d": 4 } };
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vci", complexData);
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeCreateOptions({ protocol: "openid4vci" });
+    const result = await navigator.credentials.create(options);
+
+    assert_equals(result.protocol, "openid4vci");
+    assert_equals(result.data.a, 1);
+    assert_array_equals(result.data.b, [2, 3]);
+    assert_equals(result.data.c.d, 4);
+  }, "navigator.credentials.create() with complex data response should resolve with structured data.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("decline");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeCreateOptions({ protocol: "openid4vci" });
+    await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.create(options));
+  }, "navigator.credentials.create() with decline mode should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const controller = new AbortController();
+    const options = makeCreateOptions({ protocol: "openid4vci", signal: controller.signal });
+    const promise = navigator.credentials.create(options);
+
+    // Give it some time to make sure it's pending.
+    await new Promise(resolve => t.step_timeout(resolve, 100));
+
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.create() with wait mode should remain pending until aborted.");
+</script>

--- a/digital-credentials/webdriver/get.https.html
+++ b/digital-credentials/webdriver/get.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() webdriver tests.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeGetOptions } from "../support/helper.js";
+
+  promise_test(async (t) => {
+    const responseData = "test-response-data";
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vp-v1-unsigned", { "value": responseData });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "openid4vp-v1-unsigned");
+    assert_equals(result.data.value, responseData);
+  }, "navigator.credentials.get() with respond mode should resolve with the specified data.");
+
+  promise_test(async (t) => {
+    const complexData = { "a": 1, "b": [2, 3], "c": { "d": 4 } };
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vp-v1-unsigned", complexData);
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "openid4vp-v1-unsigned");
+    assert_equals(result.data.a, 1);
+    assert_array_equals(result.data.b, [2, 3]);
+    assert_equals(result.data.c.d, 4);
+  }, "navigator.credentials.get() with complex data response should resolve with structured data.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("decline");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.get(options));
+  }, "navigator.credentials.get() with decline mode should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const controller = new AbortController();
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned", signal: controller.signal });
+    const promise = navigator.credentials.get(options);
+
+    // Give it some time to make sure it's pending.
+    await new Promise(resolve => t.step_timeout(resolve, 100));
+
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.get() with wait mode should remain pending until aborted.");
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1988,8 +1988,9 @@
         /**
          * Sets the behavior for the virtual wallet.
          *
-         * Matches the `Set Virtual Wallet Behavior`
-         * WebDriver BiDi command in Digital Credentials spec.
+         * Matches the `Set Virtual Wallet Behavior
+         * <https://w3c-fedid.github.io/digital-credentials/#automated-testing>`_
+         * WebDriver command.
          *
          * @param {String} action - The action to take ("decline", "respond", "wait", "clear").
          * @param {String} [protocol=null] - The protocol requested (required for "respond").

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1986,6 +1986,24 @@
         },
 
         /**
+         * Sets the behavior for the virtual wallet.
+         *
+         * Matches the `Set Virtual Wallet Behavior`
+         * WebDriver BiDi command in Digital Credentials spec.
+         *
+         * @param {String} action - The action to take ("decline", "respond", "wait", "clear").
+         * @param {String} [protocol=null] - The protocol requested (required for "respond").
+         * @param {Object} [response=null] - The response data (optional for "respond").
+         * @param {WindowProxy} [context=null] - Browsing context in which to run the call.
+         *
+         * @returns {Promise} Fulfilled after the behavior has been set.
+         */
+        set_virtual_wallet_behavior: function(action, protocol=null, response=null, context=null) {
+          return window.test_driver_internal.set_virtual_wallet_behavior(action, protocol, response, context);
+        },
+
+
+        /**
          * Creates a virtual sensor for use with the Generic Sensors APIs.
          *
          * Matches the `Create Virtual Sensor
@@ -2694,6 +2712,11 @@
         async reset_fedcm_cooldown(context=null) {
             throw new Error("reset_fedcm_cooldown() is not implemented by testdriver-vendor.js");
         },
+
+        async set_virtual_wallet_behavior(action, protocol=null, response=null, context=null) {
+            throw new Error("set_virtual_wallet_behavior() is not implemented by testdriver-vendor.js");
+        },
+
 
         async create_virtual_sensor(sensor_type, sensor_params, context=null) {
             throw new Error("create_virtual_sensor() is not implemented by testdriver-vendor.js");

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -441,21 +441,6 @@ class ResetFedCMCooldownAction:
         return self.protocol.fedcm.reset_fedcm_cooldown()
 
 
-class SetVirtualWalletBehaviorAction:
-    name = "set_virtual_wallet_behavior"
-
-    def __init__(self, logger, protocol):
-        self.logger = logger
-        self.protocol = protocol
-
-    def __call__(self, payload):
-        action = payload["action"]
-        protocol = payload.get("protocol")
-        response = payload.get("response")
-        self.logger.debug("Setting virtual wallet behavior to %s" % action)
-        return self.protocol.digital_credentials.set_virtual_wallet_behavior(action, protocol, response)
-
-
 class CreateVirtualSensorAction:
     name = "create_virtual_sensor"
 
@@ -668,7 +653,6 @@ actions = [ClickAction,
            GetFedCMDialogTypeAction,
            SetFedCMDelayEnabledAction,
            ResetFedCMCooldownAction,
-           SetVirtualWalletBehaviorAction,
            CreateVirtualSensorAction,
            UpdateVirtualSensorAction,
            RemoveVirtualSensorAction,

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -441,6 +441,21 @@ class ResetFedCMCooldownAction:
         return self.protocol.fedcm.reset_fedcm_cooldown()
 
 
+class SetVirtualWalletBehaviorAction:
+    name = "set_virtual_wallet_behavior"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        action = payload["action"]
+        protocol = payload.get("protocol")
+        response = payload.get("response")
+        self.logger.debug("Setting virtual wallet behavior to %s" % action)
+        return self.protocol.digital_credentials.set_virtual_wallet_behavior(action, protocol, response)
+
+
 class CreateVirtualSensorAction:
     name = "create_virtual_sensor"
 
@@ -653,6 +668,7 @@ actions = [ClickAction,
            GetFedCMDialogTypeAction,
            SetFedCMDelayEnabledAction,
            ResetFedCMCooldownAction,
+           SetVirtualWalletBehaviorAction,
            CreateVirtualSensorAction,
            UpdateVirtualSensorAction,
            RemoveVirtualSensorAction,

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -342,6 +342,22 @@ class BidiPermissionsSetPermissionAction:
                                                                    embedded_origin)
 
 
+class BidiDigitalCredentialsSetVirtualWalletBehaviorAction:
+    name = "set_virtual_wallet_behavior"
+
+    def __init__(self, logger, protocol):
+        do_delayed_imports()
+        self.logger = logger
+        self.protocol = protocol
+
+    async def execute(self, context: str, payload: Mapping[str, Any]) -> Any:
+        action = payload["action"]
+        protocol = payload.get("protocol")
+        response = payload.get("response")
+        self.logger.debug("Setting virtual wallet behavior to %s" % action)
+        return await self.protocol.digital_credentials.set_virtual_wallet_behavior(action, protocol, response, context)
+
+
 async_actions = [
     BidiBluetoothHandleRequestDevicePrompt,
     BidiBluetoothSimulateAdapterAction,
@@ -362,4 +378,5 @@ async_actions = [
     BidiPermissionsSetPermissionAction,
     BidiSessionSubscribeAction,
     BidiSessionUnsubscribeAction,
-    BidiPermissionsSetPermissionAction]
+    BidiPermissionsSetPermissionAction,
+    BidiDigitalCredentialsSetVirtualWalletBehaviorAction]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import asyncio
+import logging
 import json
 import os
 import socket
@@ -36,6 +37,7 @@ from .protocol import (BaseProtocolPart,
                        SPCTransactionsProtocolPart,
                        RPHRegistrationsProtocolPart,
                        FedCMProtocolPart,
+                       DigitalCredentialsProtocolPart,
                        VirtualSensorProtocolPart,
                        BidiBluetoothProtocolPart,
                        BidiBrowsingContextProtocolPart,
@@ -965,6 +967,24 @@ class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
         return self.webdriver.send_session_command("DELETE", "deviceposture")
 
 
+class WebDriverDigitalCredentialsPart(DigitalCredentialsProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+        self.logger = logging.getLogger(__name__)
+
+    async def set_virtual_wallet_behavior(self, action, protocol=None, response=None, context=None):
+        if context is None:
+            context = self.webdriver.current_window_handle
+
+        params = {"action": action, "context": context}
+        if protocol is not None:
+            params["protocol"] = protocol
+        if response is not None:
+            params["response"] = response
+
+        return await self.webdriver.bidi_session.send_command("digitalCredentials.setVirtualWalletBehavior", params)
+
+
 class WebDriverStorageProtocolPart(StorageProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -1056,6 +1076,7 @@ class WebDriverProtocol(Protocol):
                   WebDriverSPCTransactionsProtocolPart,
                   WebDriverRPHRegistrationsProtocolPart,
                   WebDriverFedCMProtocolPart,
+                  WebDriverDigitalCredentialsPart,
                   WebDriverDebugProtocolPart,
                   WebDriverVirtualSensorPart,
                   WebDriverDevicePostureProtocolPart,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -966,7 +966,7 @@ class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
         return self.webdriver.send_session_command("DELETE", "deviceposture")
 
 
-class WebDriverDigitalCredentialsPart(DigitalCredentialsProtocolPart):
+class WebDriverBidiDigitalCredentialsProtocolPart(DigitalCredentialsProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
@@ -1074,7 +1074,6 @@ class WebDriverProtocol(Protocol):
                   WebDriverSPCTransactionsProtocolPart,
                   WebDriverRPHRegistrationsProtocolPart,
                   WebDriverFedCMProtocolPart,
-                  WebDriverDigitalCredentialsPart,
                   WebDriverDebugProtocolPart,
                   WebDriverVirtualSensorPart,
                   WebDriverDevicePostureProtocolPart,
@@ -1162,6 +1161,7 @@ class WebDriverBidiProtocol(WebDriverProtocol):
                   WebDriverBidiScriptProtocolPart,
                   WebDriverBidiWebExtensionsProtocolPart,
                   WebDriverBidiUserAgentClientHintsProtocolPart,
+                  WebDriverBidiDigitalCredentialsProtocolPart,
                   *(part for part in WebDriverProtocol.implements)
                   ]
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 
 import asyncio
-import logging
 import json
 import os
 import socket
@@ -970,7 +969,6 @@ class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
 class WebDriverDigitalCredentialsPart(DigitalCredentialsProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
-        self.logger = logging.getLogger(__name__)
 
     async def set_virtual_wallet_behavior(self, action, protocol=None, response=None, context=None):
         if context is None:

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1145,6 +1145,22 @@ class FedCMProtocolPart(ProtocolPart):
         pass
 
 
+class DigitalCredentialsProtocolPart(ProtocolPart):
+    """Protocol part for Digital Credentials"""
+    __metaclass__ = ABCMeta
+
+    name = "digital_credentials"
+
+    @abstractmethod
+    async def set_virtual_wallet_behavior(self, action, protocol=None, response=None, context=None):
+        """Set the virtual wallet behavior
+
+        :param str action: The action to take ("decline", "respond", "wait", "clear")
+        :param str protocol: The protocol requested (required for "respond")
+        :param dict response: The response data (optional for "respond")"""
+        pass
+
+
 class PrintProtocolPart(ProtocolPart):
     """Protocol part for rendering to a PDF."""
     __metaclass__ = ABCMeta

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -655,6 +655,10 @@
         return create_context_action("reset_fedcm_cooldown", context, {});
     };
 
+    window.test_driver_internal.set_virtual_wallet_behavior = function(action, protocol=null, response=null, context=null) {
+        return create_context_action("set_virtual_wallet_behavior", context, {action, protocol, response});
+    };
+
     window.test_driver_internal.create_virtual_sensor = function(sensor_type, sensor_params={}, context=null) {
         return create_context_action("create_virtual_sensor", context, {sensor_type, sensor_params});
     };


### PR DESCRIPTION

This PR adds WebDriver BiDi automation support for the Digital Credentials API in Web Platform Tests (WPT), implementing the spec changes proposed in [w3c-fedid/digital-credentials#381](https://github.com/w3c-fedid/digital-credentials/pull/381).
### Summary of Changes
#### Infrastructure Support
- **WebDriver BiDi Integration**: Implements support for the `digitalCredentials.setVirtualWalletBehavior` command as defined in the Digital Credentials specification.
- **wptrunner Updates**: Adds necessary protocol parts and actions in `protocol.py`, `actions.py`, and `executorwebdriver.py` to handle the BiDi command via the browser's BiDi session.
- **testdriver.js Extensions**: Exposes `test_driver.set_virtual_wallet_behavior` to tests, allowing them to configure the simulated wallet's response to API calls.
#### Tests
- **WebDriver Tests**: Introduces automated tests for `navigator.credentials.get()` and `navigator.credentials.create()` in the `digital-credentials/webdriver/` directory.
- **Test Coverage**:
  - **Respond**: Verifies that the API resolves successfully with the data provided by the mock wallet (supporting both simple strings and complex structured objects).
  - **Decline**: Verifies that the API rejects with `NotAllowedError` when the mock wallet simulates a user decline.
  - **Wait**: Verifies that the API remains pending when the mock wallet is set to wait, and correctly handles abort signals.
- **State Isolation**: Tests include cleanup steps to reset the virtual wallet behavior, ensuring no side effects on subsequent tests.