### PR TITLE
Web Feature ID: `scoped-custom-element-registries` generated tests

### DIFF
--- a/custom-elements/registries/Document-createElement.html
+++ b/custom-elements/registries/Document-createElement.html
@@ -3,6 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-api">
+<link rel="help" href="https://dom.spec.whatwg.org/#element-custom-element-registry">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -94,6 +96,18 @@ test(() => {
     assert_equals(abElement.customElementRegistry, scopedRegistry);
     assert_false(abElement instanceof ScopedABElement);
 }, 'createElement on a non-HTML document should still handle registries correctly');
+
+test(() => {
+    assert_throws_dom("NotSupportedError", () => {
+        document.createElement('div', { is: 'my-div', customElementRegistry: scopedRegistry });
+    });
+}, 'createElement should throw a NotSupportedError when options dictionary contains both customElementRegistry and is members');
+
+test(() => {
+    assert_throws_dom("NotSupportedError", () => {
+        document.createElement('div', { is: 'my-div', customElementRegistry: window.customElements });
+    });
+}, 'createElement should throw a NotSupportedError when options dictionary contains both customElementRegistry (global) and is members');
 
 </script>
 </body>

--- a/custom-elements/registries/Document-createElementNS.html
+++ b/custom-elements/registries/Document-createElementNS.html
@@ -2,6 +2,8 @@
 <html>
 <head>
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-api">
+<link rel="help" href="https://dom.spec.whatwg.org/#element-custom-element-registry">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -93,6 +95,18 @@ test(() => {
     assert_equals(abElement.customElementRegistry, scopedRegistry);
     assert_false(abElement instanceof ScopedABElement);
 }, 'createElementNS on a non-HTML document should still handle registries correctly');
+
+test(() => {
+    assert_throws_dom("NotSupportedError", () => {
+        document.createElementNS('http://www.w3.org/1999/xhtml', 'div', { is: 'my-div', customElementRegistry: scopedRegistry });
+    });
+}, 'createElementNS should throw a NotSupportedError when options dictionary contains both customElementRegistry and is members');
+
+test(() => {
+    assert_throws_dom("NotSupportedError", () => {
+        document.createElementNS('http://www.w3.org/1999/xhtml', 'div', { is: 'my-div', customElementRegistry: window.customElements });
+    });
+}, 'createElementNS should throw a NotSupportedError when options dictionary contains both customElementRegistry (global) and is members');
 
 </script>
 </body>

--- a/custom-elements/registries/scoped-registry-define-extends.html
+++ b/custom-elements/registries/scoped-registry-define-extends.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Custom Elements: Scoped registry define throws with extends</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-api">
+<link rel="help" href="https://dom.spec.whatwg.org/#element-custom-element-registry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const extendsValues = [
+  'button',
+  'div',
+  'custom-name',
+  '',
+  'unknown'
+];
+
+for (const ext of extendsValues) {
+  test(() => {
+    const registry = new CustomElementRegistry();
+    assert_throws_dom('NotSupportedError', () => {
+      registry.define(`test-element-${ext || 'empty'}`, class extends HTMLElement {}, { extends: ext });
+    });
+  }, `CustomElementRegistry.define() on a scoped registry throws NotSupportedError if extends is "${ext}"`);
+}
+</script>


### PR DESCRIPTION
Requirements that were missing tests:
```
1. If `CustomElementRegistry.define()` is called on a scoped registry (where `is scoped` is true) and the `extends` option is provided, a `NotSupportedError` `DOMException` must be thrown.
2. If `Document.createElement()` is called with an options dictionary containing both `customElementRegistry` and `is` members, a `NotSupportedError` `DOMException` must be thrown.
3. If `Document.createElementNS()` is called with an options dictionary containing both `customElementRegistry` and `is` members, a `NotSupportedError` `DOMException` must be thrown.
4. If `Document.createElement()` is called with both `customElementRegistry` and `is` options supplied, it must throw a `NotSupportedError` `DOMException`.
5. If `Document.createElementNS()` is called with both `customElementRegistry` and `is` options supplied, it must throw a `NotSupportedError` `DOMException`.
```

Full audit worksheet:
```
<audit_worksheet>
[Existence]
R1: The `CustomElementRegistry` interface must be constructible via a parameterless constructor (`new CustomElementRegistry()`). -> [COVERED by CustomElementRegistry-define.html]
R2: The `CustomElementRegistry` interface must expose an `initialize` method. -> [COVERED by CustomElementRegistry-initialize.html]
R3: The `Document` interface must expose a `customElementRegistry` readonly property. -> [COVERED by Document-customElementRegistry.html]
R4: The `ShadowRoot` interface must expose a `customElementRegistry` readonly property. -> [COVERED by ShadowRoot-init-customElementRegistry.html]
R5: The `Element` interface must expose a `customElementRegistry` readonly property. -> [COVERED by Element-customElementRegistry.html]

[Common Use Cases]
R6: When the `CustomElementRegistry()` constructor is invoked, it must create a new `CustomElementRegistry` object with its internal `is scoped` flag set to true. -> [COVERED by CustomElementRegistry-define.html]
R7: When `define()` is called on a scoped `CustomElementRegistry`, it must upgrade matching elements within all documents present in the registry's scoped document set. -> [COVERED by scoped-registry-define-upgrade-criteria.html]
R8: When `initialize(root)` is called on a scoped `CustomElementRegistry` and the root is a `Document` node with a null custom element registry, the document's custom element registry must be set to the scoped registry. -> [COVERED by CustomElementRegistry-initialize.html]
R9: When `initialize(root)` is called on a scoped `CustomElementRegistry` and the root is a `ShadowRoot` node with a null custom element registry, the shadow root's custom element registry must be set to the scoped registry. -> [COVERED by CustomElementRegistry-initialize.html]
R10: When `initialize(root)` is called on a scoped `CustomElementRegistry`, for each inclusive descendant of the root with a null custom element registry, the descendant's custom element registry must be set to the scoped registry. -> [COVERED by CustomElementRegistry-initialize.html]
R11: When `initialize(root)` is called on a scoped `CustomElementRegistry`, for each inclusive descendant of the root whose custom element registry is updated to the scoped registry, the descendant's node document must be appended to the registry's scoped document set. -> [COVERED by scoped-registry-define-upgrade-criteria.html]
R12: When `initialize(root)` is called on a scoped `CustomElementRegistry`, it must attempt to upgrade each inclusive descendant of the root whose custom element registry matches the scoped registry. -> [COVERED by scoped-registry-initialize-upgrades.html]
R13: When `attachShadow()` is called with a `customElementRegistry` property in its initialization dictionary, the created shadow root's custom element registry must be set to the provided scoped registry. -> [COVERED by ShadowRoot-init-customElementRegistry.html]
R14: When `createElement()` is called with a `customElementRegistry` property in its options dictionary, the created element's custom element registry must be set to the provided scoped registry. -> [COVERED by Document-createElement.html]
R15: When `createElementNS()` is called with a `customElementRegistry` property in its options dictionary, the created element's custom element registry must be set to the provided scoped registry. -> [COVERED by Document-createElementNS.html]
R16: When `importNode()` is called with a `customElementRegistry` property in its options dictionary, the cloned node must use the provided scoped registry as its fallback registry. -> [COVERED by Document-importNode.html]
R17: When adopting a node into a new document, if an inclusive descendant element has a scoped custom element registry, its custom element registry must not be overridden by the new document's global registry. -> [COVERED by adoption.window.js]

[Error Scenarios]
R18: If `CustomElementRegistry.define()` is called on a scoped registry (where `is scoped` is true) and the `extends` option is provided, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by scoped-registry-define-extends.html]
R19: If `CustomElementRegistry.initialize()` is called on a global registry (where `is scoped` is false) and the root argument is a `Document` node, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by CustomElementRegistry-initialize.html]
R20: If `CustomElementRegistry.initialize()` is called on a global registry (where `is scoped` is false) and the root argument's node document's custom element registry is not the registry being initialized, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by global.window.js]
R21: If `Document.createElement()` is called with an options dictionary containing both `customElementRegistry` and `is` members, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by Document-createElement.html]
[Error Scenarios]
R22: If `Document.createElementNS()` is called with an options dictionary containing both `customElementRegistry` and `is` members, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by Document-createElementNS.html]
R23: If `Document.createElement()` is called with a `customElementRegistry` option that is a global registry (not scoped) and is not the document's own custom element registry, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by global.window.js]
R24: If `Document.createElementNS()` is called with a `customElementRegistry` option that is a global registry (not scoped) and is not the document's own custom element registry, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by global.window.js]
R25: If `Element.attachShadow()` is called with a `customElementRegistry` option that is a global registry (not scoped) and is not the element's node document's custom element registry, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by global.window.js]
R26: If `Document.importNode()` is called with a `customElementRegistry` option that is a global registry (not scoped) and is not the document's own custom element registry, a `NotSupportedError` `DOMException` must be thrown. -> [COVERED by global.window.js]

[Invalidation]
R27: When `initialize(root)` is invoked, if the root is a Document node or ShadowRoot node with a null custom element registry, its custom element registry must be updated to the invoked CustomElementRegistry object. -> [COVERED by CustomElementRegistry-initialize.html]
R28: When `initialize(root)` is invoked, every inclusive descendant of the root that is an Element node with a null custom element registry must have its custom element registry updated to the invoked CustomElementRegistry object. -> [COVERED by CustomElementRegistry-initialize.html]
R29: When `initialize(root)` is invoked, if an inclusive descendant Element node already has a non-null custom element registry, its custom element registry must not be changed. -> [COVERED by CustomElementRegistry-initialize.html]
R30: When `define()` successfully defines a custom element, if the registry's when-defined promise map contains an entry for the element's name, the promise must be resolved with the constructor and the entry must be removed from the map. -> [COVERED by CustomElementRegistry.html]
R31: When `whenDefined(name)` is invoked for a valid custom element name that is not yet defined, if the registry's when-defined promise map does not already contain an entry for the name, a new promise must be created, cached in the map, and returned. -> [COVERED by CustomElementRegistry.html]
R32: When `define()` is invoked, the registry's internal 'element definition is running' flag must be set to true during execution and restored to false upon completion, including when exceptions are thrown, to prevent reentrant invocations. -> [COVERED by CustomElementRegistry.html]

[Integration]
R33: If `Document.createElement()` is called with a `customElementRegistry` option that is not scoped and is not the document's custom element registry, it must throw a `NotSupportedError` `DOMException`. -> [COVERED by global.window.js]
R34: If `Document.createElement()` is called with both `customElementRegistry` and `is` options supplied, it must throw a `NotSupportedError` `DOMException`. -> [COVERED by Document-createElement.html]
R35: If `Document.createElementNS()` is called with a `customElementRegistry` option that is not scoped and is not the document's custom element registry, it must throw a `NotSupportedError` `DOMException`. -> [COVERED by global.window.js]
R36: If `Document.createElementNS()` is called with both `customElementRegistry` and `is` options supplied, it must throw a `NotSupportedError` `DOMException`. -> [COVERED by Document-createElementNS.html]
R37: If `Element.attachShadow()` is called with a `customElementRegistry` option that is not scoped and is not the node document's custom element registry, it must throw a `NotSupportedError` `DOMException`. -> [COVERED by global.window.js]
R38: If `Document.importNode()` is called with a `customElementRegistry` option that is not scoped and is not the document's custom element registry, it must throw a `NotSupportedError` `DOMException`. -> [COVERED by global.window.js]
R39: When `Document.adoptNode()` is called, if an inclusive descendant is a shadow root whose custom element registry is a global custom element registry, its custom element registry must be set to the adopting document's effective global custom element registry. -> [COVERED by adoption.window.js]
R40: When `Document.adoptNode()` is called, if an inclusive descendant is an element whose custom element registry is not scoped, its custom element registry must be set to the adopting document's effective global custom element registry. -> [COVERED by adoption.window.js]
R41: When cloning a node that is a shadow host with a clonable shadow root, if the original shadow root's custom element registry is a global custom element registry, the cloned shadow root must be attached using the document's effective global custom element registry. -> [COVERED by Document-importNode-cross-document.window.js]
</audit_worksheet>

```