### PR TITLE
Improve and expand WPT tests for <textPath> `side` attribute

### DIFF
--- a/svg/text/reftests/textpath-side-001-ref.svg
+++ b/svg/text/reftests/textpath-side-001-ref.svg
@@ -1,55 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg id="svg-root"
-  width="100%" height="100%" viewBox="0 0 480 360"
+<svg width="400" height="300" viewBox="0 0 400 300"
   xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
-  <g id="testmeta">
-    <title>TextPath Side — 001</title>
-    <html:link rel="author"
-          title="Tavmjong Bah"
-          href="mailto:tavmjong@free.fr"/>
-  </g>
-
-  <style id="test-font" type="text/css">
-    /* Standard Font (if needed). */
-    @font-face {
-      font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
-           local("FreeSans");
-    }
-    text { font-family: FreeSans, sans-serif }
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
   </style>
-
-  <style id="test-style" type="text/css">
-    /* Style that is being tested (if needed). */
-    text { font-family: FreeSans, sans-serif }
-  </style>
-
   <defs>
-    <path id="TextPath" d="m 90,150 c 100,-100 200,100 300,0"/>
-    <path id="TextPathReversed" d="m 390,150 c -100,100 -200,-100 -300,0"/>
+    <path id="path" d="M 50,80 Q 200,20 350,80"/>
+    <!-- Reversed path: geometrically equivalent to side="right" on the forward path -->
+    <path id="path-reversed" d="M 350,80 Q 200,20 50,80"/>
   </defs>
-
-  <g id="test-body-content" style="font-size:24px">
-    <g transform="translate(0,0)">
-      <use xlink:href="#TextPath" style="fill:none;stroke:lightblue"/>
-      <text>
-        <textPath xlink:href="#TextPath">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</textPath>
-      </text>
-    </g>
-    <g transform="translate(0,75)">
-      <use xlink:href="#TextPath" style="fill:none;stroke:lightblue"/>
-      <text>
-        <textPath xlink:href="#TextPath">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</textPath>
-      </text>
-    </g>
-    <g transform="translate(0,150)">
-      <use xlink:href="#TextPath" style="fill:none;stroke:lightblue"/>
-      <text>
-        <textPath xlink:href="#TextPathReversed">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</textPath>
-      </text>
-    </g>
+  <!-- Row 1: no side attribute (default = left) -->
+  <g transform="translate(0,0)">
+    <use href="#path" style="fill:none;stroke:lightblue"/>
+    <text>
+      <textPath href="#path">ABCD</textPath>
+    </text>
   </g>
-
+  <!-- Row 2: same as row 1 (side="left" == default) -->
+  <g transform="translate(0,80)">
+    <use href="#path" style="fill:none;stroke:lightblue"/>
+    <text>
+      <textPath href="#path">ABCD</textPath>
+    </text>
+  </g>
+  <!-- Row 3: reversed path = equivalent to side="right" -->
+  <g transform="translate(0,160)">
+    <use href="#path" style="fill:none;stroke:lightblue"/>
+    <text>
+      <textPath href="#path-reversed">ABCD</textPath>
+    </text>
+  </g>
 </svg>

--- a/svg/text/reftests/textpath-side-001.svg
+++ b/svg/text/reftests/textpath-side-001.svg
@@ -1,57 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg id="svg-root"
-  width="100%" height="100%" viewBox="0 0 480 360"
+<svg width="400" height="300" viewBox="0 0 400 300"
   xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
-  <g id="testmeta">
-    <title>TextPath Side — 001</title>
-    <html:link rel="author"
-          title="Tavmjong Bah"
-          href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextPathAttributes"/>
-    <html:link rel="match"  href="textpath-side-001-ref.svg" />
-  </g>
-
-  <style id="test-font" type="text/css">
-    /* Standard Font (if needed). */
-    @font-face {
-      font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
-           local("FreeSans");
-    }
-    text { font-family: FreeSans, sans-serif }
+  <metadata>
+    <html:link rel="author" title="Tavmjong Bah" href="mailto:tavmjong@free.fr"/>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
+    <html:link rel="match" href="textpath-side-001-ref.svg"/>
+    <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100"/>
+  </metadata>
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
   </style>
-
-  <style id="test-style" type="text/css">
-    /* Style that is being tested (if needed). */
-    text { font-family: FreeSans, sans-serif }
-  </style>
-
   <defs>
-    <path id="TextPath" d="m 90,150 c 100,-100 200,100 300,0"/>
+    <path id="path" d="M 50,80 Q 200,20 350,80"/>
   </defs>
-
-  <g id="test-body-content" style="font-size:24px">
-    <g transform="translate(0,0)">
-      <use xlink:href="#TextPath" style="fill:none;stroke:lightblue"/>
-      <text>
-        <textPath xlink:href="#TextPath">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</textPath>
-      </text>
-    </g>
-    <g transform="translate(0,75)">
-      <use xlink:href="#TextPath" style="fill:none;stroke:lightblue"/>
-      <text>
-        <textPath xlink:href="#TextPath" side="left">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</textPath>
-      </text>
-    </g>
-    <g transform="translate(0,150)">
-      <use xlink:href="#TextPath" style="fill:none;stroke:lightblue"/>
-      <text>
-        <textPath xlink:href="#TextPath" side="right">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</textPath>
-      </text>
-    </g>
+  <!-- Row 1: no side attribute (default) -->
+  <g transform="translate(0,0)">
+    <use href="#path" style="fill:none;stroke:lightblue"/>
+    <text>
+      <textPath href="#path">ABCD</textPath>
+    </text>
   </g>
-
+  <!-- Row 2: side="left" (should match default) -->
+  <g transform="translate(0,80)">
+    <use href="#path" style="fill:none;stroke:lightblue"/>
+    <text>
+      <textPath href="#path" side="left">ABCD</textPath>
+    </text>
+  </g>
+  <!-- Row 3: side="right" (text on opposite side of curve) -->
+  <g transform="translate(0,160)">
+    <use href="#path" style="fill:none;stroke:lightblue"/>
+    <text>
+      <textPath href="#path" side="right">ABCD</textPath>
+    </text>
+  </g>
 </svg>

--- a/svg/text/reftests/textpath-side-002-ref.svg
+++ b/svg/text/reftests/textpath-side-002-ref.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="200" viewBox="0 0 400 200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <path id="curve" d="M 50,80 Q 200,10 350,80"/>
+  </defs>
+  <!-- Reference: both use no side attribute (default = left) -->
+  <g transform="translate(0,0)">
+    <text fill="blue">
+      <textPath href="#curve">ABCDE</textPath>
+    </text>
+  </g>
+  <g transform="translate(0,80)">
+    <text fill="green">
+      <textPath href="#curve">ABCDE</textPath>
+    </text>
+  </g>
+</svg>

--- a/svg/text/reftests/textpath-side-002.svg
+++ b/svg/text/reftests/textpath-side-002.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="200" viewBox="0 0 400 200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
+    <html:link rel="match" href="textpath-side-002-ref.svg"/>
+  </metadata>
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <path id="curve" d="M 50,80 Q 200,10 350,80"/>
+  </defs>
+  <!-- side="left" should render identically to the default (no side attribute) -->
+  <g transform="translate(0,0)">
+    <text fill="blue">
+      <textPath href="#curve" side="left">ABCDE</textPath>
+    </text>
+  </g>
+  <g transform="translate(0,80)">
+    <text fill="green">
+      <textPath href="#curve" side="left">ABCDE</textPath>
+    </text>
+  </g>
+</svg>

--- a/svg/text/reftests/textpath-side-003-ref.svg
+++ b/svg/text/reftests/textpath-side-003-ref.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="200" viewBox="0 0 400 200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <!-- Reversed path: equivalent to side="right" on the original curve -->
+    <path id="curve-reversed" d="M 350,100 Q 200,30 50,100"/>
+  </defs>
+  <!-- Reference: reversed path without side attr = same as side="right" on original -->
+  <text fill="black">
+    <textPath href="#curve-reversed">ABCDE</textPath>
+  </text>
+</svg>

--- a/svg/text/reftests/textpath-side-003.svg
+++ b/svg/text/reftests/textpath-side-003.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="200" viewBox="0 0 400 200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
+    <html:link rel="match" href="textpath-side-003-ref.svg"/>
+    <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100"/>
+  </metadata>
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <path id="curve" d="M 50,100 Q 200,30 350,100"/>
+  </defs>
+  <!-- side="right" places text on the opposite side of the path -->
+  <text fill="black">
+    <textPath href="#curve" side="right">ABCDE</textPath>
+  </text>
+</svg>

--- a/svg/text/reftests/textpath-side-004-ref.svg
+++ b/svg/text/reftests/textpath-side-004-ref.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="200" viewBox="0 0 400 200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <path id="curve" d="M 50,80 Q 200,10 350,80"/>
+  </defs>
+  <!-- Reference: no side attribute (default = left) for both -->
+  <g transform="translate(0,0)">
+    <text fill="blue">
+      <textPath href="#curve">ABCDE</textPath>
+    </text>
+  </g>
+  <g transform="translate(0,80)">
+    <text fill="green">
+      <textPath href="#curve">ABCDE</textPath>
+    </text>
+  </g>
+</svg>

--- a/svg/text/reftests/textpath-side-004.svg
+++ b/svg/text/reftests/textpath-side-004.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="200" viewBox="0 0 400 200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
+    <html:link rel="match" href="textpath-side-004-ref.svg"/>
+  </metadata>
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <path id="curve" d="M 50,80 Q 200,10 350,80"/>
+  </defs>
+  <!-- Invalid side values should be treated as the default ("left") -->
+  <g transform="translate(0,0)">
+    <text fill="blue">
+      <textPath href="#curve" side="invalid">ABCDE</textPath>
+    </text>
+  </g>
+  <g transform="translate(0,80)">
+    <text fill="green">
+      <textPath href="#curve" side="">ABCDE</textPath>
+    </text>
+  </g>
+</svg>

--- a/svg/text/reftests/textpath-side-005-ref.svg
+++ b/svg/text/reftests/textpath-side-005-ref.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="500" viewBox="0 0 400 500"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <!-- Clockwise circle, starting at 3 o'clock (230,100) -->
+    <path id="circle-cw" d="M 230,100 A 80,80 0 0,1 70,100 A 80,80 0 0,1 230,100"/>
+    <!-- Counter-clockwise circle from same start point: reversed CW = side="right" -->
+    <path id="circle-ccw" d="M 230,100 A 80,80 0 0,0 70,100 A 80,80 0 0,0 230,100"/>
+    <!-- Visual guide -->
+    <circle id="guide" cx="150" cy="100" r="80"/>
+  </defs>
+  <!-- Row 1: default (left) on CW circle -->
+  <g transform="translate(0,0)">
+    <use href="#guide" style="fill:none;stroke:lightblue"/>
+    <text fill="blue">
+      <textPath href="#circle-cw">ABCD</textPath>
+    </text>
+  </g>
+  <!-- Row 2: CCW circle = equivalent to side="right" on CW -->
+  <g transform="translate(0,220)">
+    <use href="#guide" style="fill:none;stroke:lightblue"/>
+    <text fill="green">
+      <textPath href="#circle-ccw">ABCD</textPath>
+    </text>
+  </g>
+</svg>

--- a/svg/text/reftests/textpath-side-005.svg
+++ b/svg/text/reftests/textpath-side-005.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="400" height="500" viewBox="0 0 400 500"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
+    <html:link rel="match" href="textpath-side-005-ref.svg"/>
+    <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-200"/>
+  </metadata>
+  <html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <style>
+    text { font-family: Ahem; font-size: 16px; }
+  </style>
+  <defs>
+    <!-- Clockwise circle as path, starting at 3 o'clock (230,100) -->
+    <path id="circle-cw" d="M 230,100 A 80,80 0 0,1 70,100 A 80,80 0 0,1 230,100"/>
+    <!-- Visual guide -->
+    <circle id="guide" cx="150" cy="100" r="80"/>
+  </defs>
+  <!-- Row 1: side="left" on CW circle (text on outside) -->
+  <g transform="translate(0,0)">
+    <use href="#guide" style="fill:none;stroke:lightblue"/>
+    <text fill="blue">
+      <textPath href="#circle-cw" side="left">ABCD</textPath>
+    </text>
+  </g>
+  <!-- Row 2: side="right" on CW circle (text on inside) -->
+  <g transform="translate(0,220)">
+    <use href="#guide" style="fill:none;stroke:lightblue"/>
+    <text fill="green">
+      <textPath href="#circle-cw" side="right">ABCD</textPath>
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
The SVG WG resolved to keep the `side` attribute on `<textPath>` (https://www.w3.org/2026/03/12-svg-minutes.html), [w3c/svgwg#1068](https://github.com/w3c/svgwg/issues/1068)). The existing test (`textpath-side-001`) was failing in Firefox (which implements `side`) due to pixel fuzziness from font/path choices, not a bug.

**Changes**
Rewritten: `textpath-side-001`

- Replaced missing `FreeSans` font with Ahem for deterministic rendering
- Shortened text from 58-char Lorem Ipsum to `ABCD` (4 glyphs)
- Simplified path from S-shaped cubic Bézier to a quadratic curve
- Used exact geometric reversal for the `side="right"` reference
- Added tight fuzzy tolerance (`maxDifference=0-1; totalPixels=0-100`)

**New tests:**

1. `textpath-side-002` - `side="left"` renders identically to the default (no attribute)
2. `textpath-side-003` - `side="right"` places text on the opposite side, matching a reversed path
3. `textpath-side-004` - Invalid `side` values (`"invalid"`, `""`) fall back to the default `"left"`
4. `textpath-side-005` - `side` on circular paths, `left` = outside, `right` = inside

All tests use Ahem font, short text, and simple geometry to minimize cross-browser rendering differences.

**Expected results**
Firefox: All 5 tests pass (implements `side`)
Chrome/Safari: Tests 002 and 004 pass (don't depend on `side="right"`); tests 001, 003, 005 fail on `side="right"` rows until side is implemented.