### PR TITLE
Fix stability of `tables-inherit-color-from-body-quirk-*`, and don't use green as a failing color

### DIFF
--- a/quirks/tables-inherit-color-from-body-quirk-004.html
+++ b/quirks/tables-inherit-color-from-body-quirk-004.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style>
 html { color-scheme: light; }
-body { color: green; height: min-content; margin: 0; }
+body { color: red; height: min-content; margin: 0; }
 p { color: initial; }
 div { color: red; display: flow-root; margin: 0 8px; }
 table { font: 200px/1 Ahem; }
@@ -22,5 +22,8 @@ table { font: 200px/1 Ahem; }
   </div>
 </body>
 <script>
+  // For stability of the test, compute the color of the body.
+  getComputedStyle(document.body).color;
+
   document.body.replaceWith(document.querySelector("div"));
 </script>

--- a/quirks/tables-inherit-color-from-body-quirk-005.html
+++ b/quirks/tables-inherit-color-from-body-quirk-005.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style>
 html { color-scheme: dark; }
-body { color: green; height: min-content; margin: 0; }
+body { color: red; height: min-content; margin: 0; }
 p { color: initial; }
 div { color: red; display: flow-root; margin: 0 8px; }
 table { font: 200px/1 Ahem; }
@@ -22,5 +22,8 @@ table { font: 200px/1 Ahem; }
   </div>
 </body>
 <script>
+  // For stability of the test, compute the color of the body.
+  getComputedStyle(document.body).color;
+
   document.body.replaceWith(document.querySelector("div"));
 </script>

--- a/quirks/tables-inherit-color-from-body-quirk-006.html
+++ b/quirks/tables-inherit-color-from-body-quirk-006.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style>
 html { color-scheme: light; }
-body { color: green; height: min-content; margin: 0; }
+body { color: red; height: min-content; margin: 0; }
 p { color: initial; }
 div { color: red; display: flow-root; margin: 0 8px; }
 table { font: 200px/1 Ahem; }

--- a/quirks/tables-inherit-color-from-body-quirk-007.html
+++ b/quirks/tables-inherit-color-from-body-quirk-007.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style>
 html { color-scheme: dark; }
-body { color: green; height: min-content; margin: 0; }
+body { color: red; height: min-content; margin: 0; }
 p { color: initial; }
 div { color: red; display: flow-root; margin: 0 8px; }
 table { font: 200px/1 Ahem; }


### PR DESCRIPTION
The checks in #58571 didn't detect it, but some tests didn't have stable results.

Also, use red instead of green as a failing color.