### PR TITLE
Fix replaceTrack tests using wrong stream for track2

### DIFF
--- a/webrtc/RTCRtpSender-replaceTrack.https.html
+++ b/webrtc/RTCRtpSender-replaceTrack.https.html
@@ -201,7 +201,7 @@ if (rest) {
     const [track1] = stream1.getTracks();
     const stream2 = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
-    const [track2] = stream1.getTracks();
+    const [track2] = stream2.getTracks();
 
     const transceiver = pc.addTransceiver(track1);
     const { sender } = transceiver;
@@ -237,7 +237,7 @@ if (rest) {
     const [track1] = stream1.getTracks();
     const stream2 = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
-    const [track2] = stream1.getTracks();
+    const [track2] = stream2.getTracks();
 
     const transceiver = pc.addTransceiver(track1);
     const { sender } = transceiver;


### PR DESCRIPTION
Two tests in RTCRtpSender-replaceTrack.https.html create stream2 via getNoiseStream() but then extract track2 from stream1 instead of stream2. This means track2 === track1 (same object), so the tests don't actually test replacing with a different track.

In the 'stopped track' test, this means track2 is also stopped (since track1.stop() was called), which accidentally tests replacing with a stopped track rather than replacing a stopped sender's track with a new live track.

Fix: Change stream1.getTracks() to stream2.getTracks() on both lines.