### PR TITLE
Credential Management: Test rejection of incompatible types in get()

### DIFF
--- a/credential-management/credentialscontainer-get-basics.https.html
+++ b/credential-management/credentialscontainer-get-basics.https.html
@@ -55,6 +55,40 @@
     );
   }, "Calling navigator.credentials.get() without a valid matching interface.");
 
+  promise_test(async (t) => {
+    const invalidCombinations = [
+      { password: true, publicKey: { challenge: new Uint8Array() } },
+      { password: true, otp: { transport: ["sms"] } },
+      { password: true, identity: { providers: [] } },
+      { federated: { providers: ['https://idp.example.com'] }, publicKey: { challenge: new Uint8Array() } },
+      { federated: { providers: ['https://idp.example.com'] }, otp: { transport: ["sms"] } },
+      { federated: { providers: ['https://idp.example.com'] }, identity: { providers: [] } },
+      { publicKey: { challenge: new Uint8Array() }, otp: { transport: ["sms"] } },
+      { publicKey: { challenge: new Uint8Array() }, identity: { providers: [] } },
+      { otp: { transport: ["sms"] }, identity: { providers: [] } },
+    ];
+
+    for (const options of invalidCombinations) {
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        navigator.credentials.get(options)
+      );
+    }
+  }, "Calling navigator.credentials.get() with invalid combinations of credential types.");
+
+  promise_test(async (t) => {
+    try {
+      await navigator.credentials.get({
+        password: true,
+        federated: { providers: ['https://idp.example.com'] }
+      });
+    } catch (e) {
+      assert_not_equals(e.name, "NotSupportedError",
+        "Valid combination (password + federated) should not throw NotSupportedError");
+    }
+  }, "Calling navigator.credentials.get() with valid combination (password + federated).");
+
   promise_test(function(t) {
     const controller = new AbortController();
     controller.abort("custom reason");

--- a/credential-management/credentialscontainer-get-basics.https.html
+++ b/credential-management/credentialscontainer-get-basics.https.html
@@ -78,15 +78,17 @@
   }, "Calling navigator.credentials.get() with invalid combinations of credential types.");
 
   promise_test(async (t) => {
-    try {
-      await navigator.credentials.get({
+    // Valid combination (password + federated) is allowed by the spec. It should reach the
+    // fetching phase, where it will fail with NotAllowedError due to lack of user activation,
+    // but crucially NOT NotSupportedError.
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      navigator.credentials.get({
         password: true,
         federated: { providers: ['https://idp.example.com'] }
-      });
-    } catch (e) {
-      assert_not_equals(e.name, "NotSupportedError",
-        "Valid combination (password + federated) should not throw NotSupportedError");
-    }
+      })
+    );
   }, "Calling navigator.credentials.get() with valid combination (password + federated).");
 
   promise_test(function(t) {


### PR DESCRIPTION
This PR adds Web Platform Tests for the restrictions introduced in https://github.com/w3c/webappsec-credential-management/pull/261.

  The specification now requires that navigator.credentials.get() must reject with a
  NotSupportedError if it is called with a combination of credential types that are not
  explicitly allowed to be mixed in the same request. 

  Changes:
   - Updated credential-management/credentialscontainer-get-basics.https.html to include a
     new test suite for invalid type combinations.
   - Verified that requesting combinations such as password + publicKey, otp + identity, and
     others result in a promise rejected with NotSupportedError.
   - The test covers the following credential types: 
     - PasswordCredential
     - FederatedCredential
     - PublicKeyCredential
     - OTPCredential
     - IdentityCredential (FedCM)

  This ensures that implementations correctly validate the "types allowed in the same get()
  request" registry column as defined in the updated spec.
