### PR TITLE
URL: add parse-ipv4-number test

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -6095,6 +6095,21 @@
     "search": "",
     "hash": ""
   },
+  {
+    "input": "https://0000000000000000000000000000000000000000177.0.0.1",
+    "base": null,
+    "href": "https://127.0.0.1/",
+    "origin": "https://127.0.0.1",
+    "protocol": "https:",
+    "username": "",
+    "password": "",
+    "host": "127.0.0.1",
+    "hostname": "127.0.0.1",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
   "More IPv4 parsing (via https://github.com/jsdom/whatwg-url/issues/92)",
   {
     "input": "https://0x100000000/test",


### PR DESCRIPTION
Hii! 
I'm the developer of a [WHATWG URL implementation](https://github.com/Dubzer/Dubzer.WhatwgUrl) for .NET

I accidentally stumbled upon a bug where, if you pass an IPv4 address with a lot of zeroes in the first octet, my library could mistakenly return a parsing error

This wasn't covered by the existing tests, so I've decided to add one!