### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=299902

### DIFF
--- a/css/css-text/letter-spacing/letter-spacing-ligatures-005.html
+++ b/css/css-text/letter-spacing/letter-spacing-ligatures-005.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-9" />
+<title>letter-spacing with cursive content</title>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#letter-spacing-property'>
+<link rel='match' href='reference/letter-spacing-ligatures-005-ref.html'>
+<meta name="assert" content="letter-spacing should not introduce gaps between adjacent content here.">
+<style>
+div {
+  font-size: 50px;
+  font-family: Monospace;
+  width: max-content;
+  border: 1px solid green;
+  letter-spacing: 10px;
+}
+</style>
+<div><span>ت</span><span>ف</span><span>ا</span><span>ح</span>ة</div>

--- a/css/css-text/letter-spacing/reference/letter-spacing-ligatures-005-ref.html
+++ b/css/css-text/letter-spacing/reference/letter-spacing-ligatures-005-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>letter-spacing with cursive content</title>
+<style>
+div {
+  font-size: 50px;
+  font-family: Monospace;
+  width: max-content;
+  border: 1px solid green;
+}
+</style>
+<div>تفاحة</div>


### PR DESCRIPTION
WebKit export from bug: [\[text shaping\] Letter spacing introduces gaps between shaped glyphs](https://bugs.webkit.org/show_bug.cgi?id=299902)