### PR TITLE
script: Use encoding-parse algorithm when handling iframe and Document URL attributes

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-src-encoding.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-src-encoding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset=windows-1252>
+<title>iframe src URL is parsed using document encoding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+async_test(t => {
+  let frame = document.createElement('iframe');
+  frame.src = "resources/frame-encoding.html?\u00DF";
+  document.body.appendChild(frame);
+  frame.onload = t.step_func(() => {
+    assert_equals(frame.contentWindow.location.search, "?%DF");
+    assert_equals(frame.contentWindow.test.textContent, "?%DF");
+    assert_equals(frame.src, new URL("resources/frame-encoding.html?%DF", location.href).href);
+    t.done();
+  });
+});
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/resources/frame-encoding.html
+++ b/html/semantics/embedded-content/the-iframe-element/resources/frame-encoding.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<div id=test></div>
+<script>
+test.textContent = location.search;
+</script>


### PR DESCRIPTION
This PR fixes iframe URL parsing to use document encoding, so non-UTF-8 pages reflect iframe.src  correctly, and adds a WPT test for it.

Testing: added Test file 
Fixes: #<!-- nolink -->43559 
Reviewed in servo/servo#43572