### PR TITLE
[WebTransport] Allow empty buffers

### DIFF
--- a/webtransport/datagram-bad-chunk.https.any.js
+++ b/webtransport/datagram-bad-chunk.https.any.js
@@ -10,5 +10,4 @@ promise_test(async t => {
 
   const writer = wt.datagrams.writable.getWriter();
   await promise_rejects_js(t, TypeError, writer.write("foo"));
-  await promise_rejects_js(t, TypeError, writer.write(new Uint8Array(0)));
 }, 'Datagram should reject when non-buffer-source data is written');

--- a/webtransport/datagrams.https.any.js
+++ b/webtransport/datagrams.https.any.js
@@ -386,3 +386,22 @@ promise_test(async t => {
   wt.datagrams.outgoingHighWaterMark = 0;
   assert_equals(wt.datagrams.outgoingHighWaterMark, 1);
 }, 'Datagram HighWaterMark getters/setters work correctly');
+
+promise_test(async t => {
+  // Establish a WebTransport session.
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+
+  const writer = wt.datagrams.createWritable().getWriter();
+  const reader = wt.datagrams.readable.getReader();
+
+  // Empty buffers are valid BufferSources and should be accepted.
+  await writer.write(new Uint8Array(0));
+
+  // The echo handler echoes back datagrams, so we should receive the empty datagram.
+  const { value: datagram, done } = await reader.read();
+  assert_false(done);
+  assert_equals(datagram.byteLength, 0);
+
+  reader.releaseLock();
+}, 'Datagram should accept and echo empty buffer-source data');

--- a/webtransport/sendstream-bad-chunk.https.any.js
+++ b/webtransport/sendstream-bad-chunk.https.any.js
@@ -13,5 +13,4 @@ promise_test(async t => {
 
   const writer = writable.getWriter();
   await promise_rejects_js(t, TypeError, writer.write("foo"));
-  await promise_rejects_js(t, TypeError, writer.write(new Uint8Array(0)));
 }, 'WebTransportSendStream should reject when non-buffer-source data is written');

--- a/webtransport/streams-echo.https.any.js
+++ b/webtransport/streams-echo.https.any.js
@@ -279,3 +279,24 @@ promise_test(async t => {
 
   await bidi_stream.readable.closed;
 }, 'Closing the stream with no data still resolves the read request');
+
+promise_test(async t => {
+  // Establish a WebTransport session.
+  const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+
+  // Create a bidirectional stream.
+  const bidi_stream = await wt.createBidirectionalStream();
+
+  // Empty buffers are valid BufferSources and should be accepted.
+  const writer = bidi_stream.writable.getWriter();
+  await writer.write(new Uint8Array(0));
+  await writer.close();
+
+  // The echo handler echoes back stream data, so we should receive the empty chunk.
+  const chunks = await read_stream(bidi_stream.readable);
+
+  // Verify we received one chunk and it is empty.
+  assert_equals(chunks.length, 1);
+  assert_equals(chunks[0].byteLength, 0);
+}, 'WebTransportSendStream should accept and echo empty buffer-source data');


### PR DESCRIPTION
_This is a silly PR, for the sake of getting test data on wpt.fyi, to then file a spec bug._

The spec only validates BufferSource type and that buffer length is less than [[OutgoingMaxDatagramSize]].

Therefore: empty Uint8Array(0) is a valid BufferSource and should not be rejected.