### PR TITLE
Sanitizer: Fix formatting of a few tests

### DIFF
--- a/sanitizer-api/sanitizer-basic-filtering.tentative.html
+++ b/sanitizer-api/sanitizer-basic-filtering.tentative.html
@@ -236,8 +236,8 @@ a <!-- comment --> b
 { "elements": [{ "name": "svg", "namespace": "http://www.w3.org/2000/svg" }]}
 #document
 | <svg svg>
-|   xml space="default"
 |   xlink href="about:blank"
+|   xml space="default"
 |   xmlns:foo="barspace"
 
 #data

--- a/sanitizer-api/sanitizer-javascript-url.html
+++ b/sanitizer-api/sanitizer-javascript-url.html
@@ -109,7 +109,6 @@
 | <svg svg>
 |   <svg animateTransform>
 
-
 #data
 <svg><set attributeName="href"></svg>
 #document
@@ -128,14 +127,14 @@
 <a nothref="javascript:alert(1)"></a>
 #document
 | <a>
-|  nothref="javascript:alert(1)"
+|   nothref="javascript:alert(1)"
 
 #data
 <svg><a xlink:href="data:text/html,foobar"></a></svg>
 #document
 | <svg svg>
-|  <svg a>
-|    xlink href="data:text/html,foobar"
+|   <svg a>
+|     xlink href="data:text/html,foobar"
 
 #data
 <svg><set attributeName=" href "></svg>

--- a/sanitizer-api/sanitizer-parseHTML.tentative.html
+++ b/sanitizer-api/sanitizer-parseHTML.tentative.html
@@ -118,22 +118,20 @@ TypeError
 #config
 {"elements": [{ "name":"p", "attributes":["onclick"] }, "html", "body"], "attributes":[]}
 #document
-#document
 | <html>
 |   <body>
 |     <p>
-|      "Click handler!"
+|       "Click handler!"
 
 #data
 <p onclick="alert(document.cookie)">Click handler!</p>
 #config
 {"elements": [{ "name":"p", "attributes":["onclick"] }, "html", "body"]}
 #document
-#document
 | <html>
 |   <body>
 |     <p>
-|      "Click handler!"
+|       "Click handler!"
 
 </script>
 <script id="unsafe" type="html5lib-testcases">

--- a/sanitizer-api/sethtml-safety.sub.dat
+++ b/sanitizer-api/sethtml-safety.sub.dat
@@ -61,4 +61,3 @@ script
 <p data-x="1" data-y="2" data-z="3">
 #document
 | <p>
-

--- a/sanitizer-api/sethtml-unsafety.sub.dat
+++ b/sanitizer-api/sethtml-unsafety.sub.dat
@@ -46,8 +46,8 @@ script
 #document
 | <a>
 |   href="https://{{host}}/"
-|   one="two"
 |   onclick="2+2"
+|   one="two"
 
 #data
 <a href="https://{{host}}/" onclick="2+2" one="two">
@@ -76,4 +76,3 @@ script
 |   data-x="1"
 |   data-y="2"
 |   data-z="3"
-


### PR DESCRIPTION
This fixes the formatting of a few tests where the `#document`  section is inconsistent with the format of the html5lib tree construction tests. In particular this addresses:

- Extra blank lines between tests or at the end of files
- A duplicated `#document` line
- Attributes inconsistently sorted (html5lib tests always sort attributes by ascending name)
- Inconsistent indention (should be two spaces for every level of depth)

This has no effect on the execution of tests in a browser, but it did lead to some spurious failures in the testing of my own Sanitizer implementation after adapting an existing HTML tree construction test harness I had, so I might not be the only one who ran into speed bumps with this.