### PR TITLE
[wasm] fix moduleSource toStringTag brand check

### DIFF
--- a/wasm/jsapi/module/moduleSource.tentative.any.js
+++ b/wasm/jsapi/module/moduleSource.tentative.any.js
@@ -31,5 +31,5 @@ test(() => {
   const toStringTag = Object.getOwnPropertyDescriptor(AbstractModuleSource.prototype, Symbol.toStringTag).get;
 
   assert_equals(toStringTag.call(module), "WebAssembly.Module");
-  assert_throws_js(TypeError, () => toStringTag.call({}));
+  assert_equals(toStringTag.call({}), undefined);
 }, "AbstractModuleSourceProto toStringTag brand check");


### PR DESCRIPTION
The source phase imports proposal specifies the `get %AbstractModuleSource%.prototype[@@toStringTag]` brand check getter as:

```
1. If O is not an Object, return undefined.
2. Let module be HostGetModuleSourceModuleRecord(O).
3. If module is ~not-a-source~, return undefined.
4. Return module.GetModuleSourceKind().
```

This old test expects a TypeError in the `~not-a-source~` case instead of the undefined return, and was landed incorrectly.

This fixes the test to conform to the specification.