### PR TITLE
script: Use encoding-parse algorithm in Worker::Constructor

### DIFF
--- a/workers/resources/worker-url-encoding.js
+++ b/workers/resources/worker-url-encoding.js
@@ -1,0 +1,1 @@
+postMessage(location.search);

--- a/workers/worker-url-encoding.html
+++ b/workers/worker-url-encoding.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset=windows-1252>
+<title>Worker URL is parsed using document encoding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  async_test(t => {
+    let worker = new Worker("resources/worker-url-encoding.js?\u00DF");
+    worker.onmessage = t.step_func(e => {
+      assert_equals(e.data, "?%DF");
+      t.done();
+    });
+  }, "Worker URL is parsed using document encoding");
+</script>


### PR DESCRIPTION
Updated api base url to encoding_parse_a_url and wrote tests referencing the suggested format

Fixes: #<!-- nolink -->43557 
Testing: new passing test
Reviewed in servo/servo#43588