### PR TITLE
canvas: Support all Unicode variation selectors in text runs

### DIFF
--- a/html/canvas/element/text/2d.text.variationSelectors.html
+++ b/html/canvas/element/text/2d.text.variationSelectors.html
@@ -3,12 +3,14 @@
 <link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="/css/css-fonts/support/css/variation-sequences.css">
+<link rel="help" href="https://github.com/servo/servo/issues/43650">
 <canvas id="canvas" width="400" height="200"></canvas>
 <script>
 test(() => {
     const canvas = document.getElementById('canvas');
     const ctx = canvas.getContext('2d');
-
+    ctx.font = '32px ColorEmojiFont';
     // Anchor: U+2693
     const base = '\u2693';
     const vs15 = '\uFE0E'; // text selector

--- a/html/canvas/element/text/2d.text.variationSelectors.html
+++ b/html/canvas/element/text/2d.text.variationSelectors.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Canvas text: Variation selectors affect glyph width</title>
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<canvas id="canvas" width="400" height="200"></canvas>
+<script>
+test(() => {
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+
+    // Anchor: U+2693
+    const base = '\u2693';
+    const vs15 = '\uFE0E'; // text selector
+    const vs16 = '\uFE0F'; // emoji selector
+
+    const widthText = ctx.measureText(base + vs15).width;
+    const widthEmoji = ctx.measureText(base + vs16).width;
+
+    // Emoji should be wider.
+    assert_not_equals(widthText, widthEmoji, 'Widths with VS15 and VS16 should differ');
+}, 'Variation selectors (VS15/VS16) affect text width');
+</script>


### PR DESCRIPTION
Initially I just want to update the legacy comment, since raqote backend is gone.

This also enforces other variation selectors properly: see anchor ⚓ below, 
which ignored our text selector previously.

Fixes: https://github.com/servo/servo/issues/43448
Fixes: https://github.com/servo/servo/issues/43650
Testing: Added a test that all other browsers pass as well.

| Before | After |
|----------|----------|
| <img width="483" height="211" alt="image" src="https://github.com/user-attachments/assets/436493bc-ec42-4641-bcf8-c39afac6cfdc" /> | <img width="461" height="186" alt="image" src="https://github.com/user-attachments/assets/348375a8-45a4-4fde-aea6-9657cac211d3" />  |
| <img width="669" height="449" alt="image" src="https://github.com/user-attachments/assets/c791e840-9791-43b6-9147-1c250ea37721" /> | <img width="653" height="433" alt="image" src="https://github.com/user-attachments/assets/4fd06581-ac62-48f1-8135-d3c287e898cf" /> |
Reviewed in servo/servo#43449