### PR TITLE
URL: add a few UTF-16 pitfalls

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -4268,6 +4268,36 @@
     "search": "",
     "hash": ""
   },
+  {
+    "input": "https://localhost?q=🔥",
+    "base": null,
+    "href": "https://localhost/?q=%F0%9F%94%A5",
+    "origin": "https://localhost",
+    "protocol": "https:",
+    "username": "",
+    "password": "",
+    "host": "localhost",
+    "hostname": "localhost",
+    "port": "",
+    "pathname": "/",
+    "search": "?q=%F0%9F%94%A5",
+    "hash": ""
+  },
+  {
+    "input": "https://localhost#🔥",
+    "base": null,
+    "href": "https://localhost/#%F0%9F%94%A5",
+    "origin": "https://localhost",
+    "protocol": "https:",
+    "username": "",
+    "password": "",
+    "host": "localhost",
+    "hostname": "localhost",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": "#%F0%9F%94%A5"
+  },
   "# resolving a fragment against any scheme succeeds",
   {
     "input": "#",


### PR DESCRIPTION
hii
i've added a few pitfalls that may occur when processing in UTF-16
the fire emoji is defined as a single Unicode codepoint, but encoded using two UTF-16 code units
previously, the tests would not detect an incorrect surrogate pair encoding in the query and fragment 