### PR TITLE
[css-multicol] Match reference more closely to test

### DIFF
--- a/css/css-multicol/multicol-scroll-content-ref.html
+++ b/css/css-multicol/multicol-scroll-content-ref.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<div style="overflow: scroll; width: 100px; height: 150px; background: green">
-  <div style="width: 400px; height: 400px"></div>
+<div style="overflow: scroll; width: 100px; height: 150px; background: red">
+  <div style="width: 400px; height: 400px; background: green"></div>
 </div>
 <div style="overflow: scroll; width: 100px; height: 150px;
-            position: relative; top: -50px; left: 100px; background: green">
-  <div style="width: 400px; height: 400px"></div>
+            position: relative; top: -50px; left: 100px; background: red">
+  <div style="width: 400px; height: 400px; background: green"></div>
 </div>


### PR DESCRIPTION
The container background shows through the scrollbar area on MacOS, so we need to recreate the same painting structure in the reference.