### PR TITLE
script: Remove check for zero request body length in `FetchLater`

### DIFF
--- a/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window.js
+++ b/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window.js
@@ -8,30 +8,13 @@ const {HTTPS_ORIGIN, HTTPS_NOTSAMESITE_ORIGIN} = get_host_info();
 // In a cross-origin iframe, test making a POST request with empty
 // payload, which is not accepted by fetchLater API.
 for (const dataType in BeaconDataType) {
-  if (dataType === BeaconDataType.FormData) {
-    // An empty FormData object serializes to non-empty String. Hence, there
-    // will be no error thrown from fetchLater.
-    parallelPromiseTest(
-        async _ => await loadFetchLaterIframe(HTTPS_NOTSAMESITE_ORIGIN, {
-          activateAfter: 0,
-          method: 'POST',
-          bodyType: dataType,
-          bodySize: 0,
-        }),
-        `fetchLater() accepts a non-empty POST request body of ${
-            dataType} in a default cross-origin iframe.`);
-    continue;
-  }
-
   parallelPromiseTest(
       async _ => await loadFetchLaterIframe(HTTPS_NOTSAMESITE_ORIGIN, {
         activateAfter: 0,
         method: 'POST',
         bodyType: dataType,
         bodySize: 0,
-        expect: new FetchLaterIframeExpectation(
-            FetchLaterExpectationType.ERROR_JS, TypeError),
       }),
-      `fetchLater() does not accept empty POST request body of ${
+      `fetchLater() accepts an empty POST request body of ${
           dataType} in a default cross-origin iframe.`);
 }

--- a/fetch/fetch-later/quota/empty-payload.https.window.js
+++ b/fetch/fetch-later/quota/empty-payload.https.window.js
@@ -14,18 +14,9 @@ for (const dataType in BeaconDataType) {
     body: makeBeaconData('', dataType)
   };
 
-  if (dataType === BeaconDataType.FormData) {
-    // An empty FormData object serializes to non-empty String. Hence, there
-    // will be no error thrown from fetchLater.
-    parallelPromiseTest(async _ => {
-      expectFetchLater(requestInit);
-    }, `fetchLater() accepts a non-empty POST request body of ${dataType}.`);
-    continue;
-  }
-  test(
-      () => assert_throws_js(TypeError, () => fetchLater('/', requestInit)),
-      `fetchLater() does not accept an empty POST request body of ${
-          dataType}.`);
+  parallelPromiseTest(async _ => {
+    expectFetchLater(requestInit);
+  }, `fetchLater() accepts an empty POST request body of ${dataType}.`);
 }
 
 // Test making HTTP non-POST requests, which has no payload and should be

--- a/fetch/fetch-later/quota/same-origin-iframe/empty-payload.https.window.js
+++ b/fetch/fetch-later/quota/same-origin-iframe/empty-payload.https.window.js
@@ -8,30 +8,13 @@ const {HTTPS_ORIGIN, HTTPS_NOTSAMESITE_ORIGIN} = get_host_info();
 // In a same-origin iframe, test making a POST request with empty payload,
 // which is not accepted by fetchLater API.
 for (const dataType in BeaconDataType) {
-  if (dataType === BeaconDataType.FormData) {
-    // An empty FormData object serializes to non-empty String. Hence, there
-    // will be no error thrown from fetchLater.
-    parallelPromiseTest(
-        async _ => await loadFetchLaterIframe(HTTPS_ORIGIN, {
-          activateAfter: 0,
-          method: 'POST',
-          bodyType: dataType,
-          bodySize: 0,
-        }),
-        `fetchLater() accepts a non-empty POST request body of ${
-            dataType} in same-origin iframe.`);
-    continue;
-  }
-
   parallelPromiseTest(
       async _ => await loadFetchLaterIframe(HTTPS_ORIGIN, {
         activateAfter: 0,
         method: 'POST',
         bodyType: dataType,
         bodySize: 0,
-        expect: new FetchLaterIframeExpectation(
-            FetchLaterExpectationType.ERROR_JS, TypeError),
       }),
-      `fetchLater() does not accept empty POST request body of ${
+      `fetchLater() accepts an empty POST request body of ${
           dataType} in same-origin iframe.`);
 }


### PR DESCRIPTION
Per the spec discussion in [1] we should only check for a length of `null` and not zero.

[1]: https://github.com/whatwg/fetch/pull/1902

Testing: Updates WPT test according to spec

Reviewed in servo/servo#43627