### PR TITLE
Increase testharness chunks from 16 to 24 in test.yml

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -16,7 +16,7 @@ components:
           textArtifactName: public/results/checkrun.md
 
   wpt-testharness:
-    chunks: 16
+    chunks: 24
     maxRunTime: 14400
     vars:
       test-type: testharness


### PR DESCRIPTION
This is a temporary fix to hopefully solve the issue where chunk 6 is stuck for Firefox runs.