### PR TITLE
script: Partially implement `IntersectionObserver` compute the intersection algo

### DIFF
--- a/intersection-observer/iframe-root-with-overflow-propagation.html
+++ b/intersection-observer/iframe-root-with-overflow-propagation.html
@@ -2,7 +2,7 @@
 <title>IntersectionObserver observing table with border and overflow scroll</title>
 <link rel="author" href="mailto:steven.novaryo@gmail.com" title="Steven Novaryo">
 <link rel="help" href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-root-intersection-rectangle">
-<link rel="help" href="https://drafts.csswg.org/css-tables/#global-style-overrides">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/intersection-observer-test-utils.js"></script>

--- a/intersection-observer/iframe-root-with-overflow-propagation.html
+++ b/intersection-observer/iframe-root-with-overflow-propagation.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>IntersectionObserver observing table with border and overflow scroll</title>
+<link rel="author" href="mailto:steven.novaryo@gmail.com" title="Steven Novaryo">
+<link rel="help" href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-root-intersection-rectangle">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#global-style-overrides">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+
+<iframe id="target-iframe" width="200" height="200" src="resources/iframe-body-with-overflow-propagation.html">
+</iframe>
+<script>
+var iframe = document.getElementById("target-iframe");
+var target;
+var entries = [];
+
+var rootRect;
+
+iframe.onload = function() {
+  runTestCycle(function() {
+    target = iframe.contentDocument.getElementById("target");
+    assert_true(!!target, "target exists");
+    rootRect = iframe.contentDocument.documentElement.getBoundingClientRect();
+
+    var observer = new IntersectionObserver(function(changes) {
+      entries = entries.concat(changes)
+    }, { root: iframe.contentDocument });
+    observer.observe(target);
+    entries = entries.concat(observer.takeRecords());
+
+    assert_equals(entries.length, 0, "No initial notifications.");
+    runTestCycle(step0, "First rAF.");
+  }, "IntersectionObserver observing an element inside a root table.");
+}
+
+function step0() {
+  var targetRect = target.getBoundingClientRect();
+  iframe.contentDocument.scrollingElement.scrollTop = 1000;
+  runTestCycle(step1, "Scroll the iframe container to show the target element.");
+  checkLastEntry(entries, 0, [
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    0, 0, 0, 0,
+    rootRect.left, rootRect.right, rootRect.top, rootRect.bottom,
+    false
+  ]);
+}
+
+function step1() {
+  var targetRect = target.getBoundingClientRect();
+  checkLastEntry(entries, 1, [
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    rootRect.left, rootRect.right, rootRect.top, rootRect.bottom,
+    true
+  ]);
+}
+
+</script>

--- a/intersection-observer/resources/iframe-body-with-overflow-propagation.html
+++ b/intersection-observer/resources/iframe-body-with-overflow-propagation.html
@@ -1,5 +1,23 @@
 <!DOCTYPE html>
-<body style="overflow-y: auto; width: 100%; height: 200px; margin: 0;">
-    <div id="overflowing-child" style="background-color: red; height: 200%; width: 100%;"></div>
-    <div id="target" style="background-color: green; height: 100%; width: 100%;"></div>
+<style>
+    body {
+        overflow-y: auto;
+        width: 100%;
+        height: 200px;
+        margin: 0;
+    }
+    #overflowing-child {
+        background-color: red;
+        height: 200%;
+        width: 100%;
+    }
+    #target {
+        background-color: green;
+        height: 100%;
+        width: 100%;
+    }
+</style>
+<body>
+    <div id="overflowing-child"></div>
+    <div id="target"></div>
 </body>

--- a/intersection-observer/resources/iframe-body-with-overflow-propagation.html
+++ b/intersection-observer/resources/iframe-body-with-overflow-propagation.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<body style="overflow-y: auto; width: 100%; height: 200px; margin: 0;">
+    <div id="overflowing-child" style="background-color: red; height: 200%; width: 100%;"></div>
+    <div id="target" style="background-color: green; height: 100%; width: 100%;"></div>
+</body>


### PR DESCRIPTION
Depends on #<!-- nolink -->42251 for the overflow query.

Use containing block queries to implement the iteration of step [3.2.7. Compute the Intersection of a Target Element and the Root](https://w3c.github.io/IntersectionObserver/#compute-the-intersection) within `IntersectionObserver` algorithm. 

Contrary to the algorithm in the spec that maps the coordinate space of the element for each iteration, we uses bounding client rect queries to get the appropriate clip rect. And, to handle the mapping between different coordinate spaces of iframes, we use a simple translation. 

Due to the platform limitation, currently it would only handle the same `ScriptThread` browsing context. Therefore innaccuracy any usage with cross origin iframes is expected. 

Testing: Existing and new WPTs.
Part of: https://github.com/servo/servo/issues/35767

Co-authored-by: Josh Matthews [josh@joshmatthews.net](josh@joshmatthews.net)
Reviewed in servo/servo#42204