### PR TITLE
wdspec: `tagName` IDL attribute should be upper case when in html

### DIFF
--- a/webdriver/tests/classic/get_element_tag_name/get.py
+++ b/webdriver/tests/classic/get_element_tag_name/get.py
@@ -92,4 +92,4 @@ def test_get_element_tag_name(session, inline):
     element = session.find.css("input", all=False)
 
     result = get_element_tag_name(session, element.id)
-    assert_success(result, "input")
+    assert_success(result, "INPUT")


### PR DESCRIPTION
[Spec for `tagName`](https://dom.spec.whatwg.org/#element-html-uppercased-qualified-name). 

The expectation should use upper case here, as the test document is definitely in HTML:
https://github.com/servo/servo/blob/bc62b7475cb9ccb65f14e21974f9c111d743f151/tests/wpt/tests/webdriver/tests/support/fixtures.py#L149

https://github.com/servo/servo/blob/bc62b7475cb9ccb65f14e21974f9c111d743f151/tests/wpt/tests/webdriver/tests/support/inline.py#L33-L34


Testing: New passing WPT.

Reviewed in servo/servo#43673