### PR TITLE
webdriver: Improve error reporting for Cookie Addition

### DIFF
--- a/webdriver/tests/classic/add_cookie/add.py
+++ b/webdriver/tests/classic/add_cookie/add.py
@@ -305,3 +305,17 @@ def test_add_cookie_with_invalid_samesite_type(session, url, same_site):
 
     response = add_cookie(session, new_cookie)
     assert_error(response, "invalid argument")
+
+
+@pytest.mark.parametrize("expiry", [2 ** 53, -1, 0.5])
+def test_add_cookie_with_invalid_expiry(session, url, expiry):
+    new_cookie = {
+        "name": "hello",
+        "value": "world",
+        "expiry": expiry
+    }
+
+    session.url = url("/common/blank.html")
+
+    response = add_cookie(session, new_cookie)
+    assert_error(response, "invalid argument")


### PR DESCRIPTION
Improve the error reporting for [cookie addition](https://w3c.github.io/webdriver/#add-cookie).
Most notably, when
- expiry time exceeds maximum safe integer
- cookie domain is not equal to session's current browsing context's active document's domain

There is a bug with spec: https://github.com/servo/servo/pull/43690#discussion_r2994771111.
We fix spec in https://github.com/w3c/webdriver/pull/1955 and
make sure Servo behaves consistently with other browsers.

Testing: Added one test for invalid expiry time. New passing with existing.
Reviewed in servo/servo#43690