### PR TITLE
script: Report module evaluation errors async.

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html
+++ b/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html
@@ -8,7 +8,7 @@
 
     window.log = [];
 
-    window.addEventListener("error", ev => log.push(ev.error));
+  window.addEventListener("error", ev => {console.log("error handler");log.push(ev.error)});
     window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
@@ -21,7 +21,7 @@
       assert_true(exn.foo);
     }));
 
-    function logLoad() { log.push("load") }
+  function logLoad() { console.log("load handler");log.push("load") }
 
     function unreachable() { log.push("unexpected"); }
 </script>


### PR DESCRIPTION
Per the documentation in https://searchfox.org/firefox-main/rev/36ebbdf6fbbfd0b40a607212ec843992b5d43e92/js/public/Modules.h#255-257, this setting is the expected one for web content.

Testing: This allows a bunch of automated tests to run to completion in debug mozjs builds. Sadly, we don't run those in CI.
Fixes: #<!-- nolink -->34726

Reviewed in servo/servo#39417