### PR TITLE
Clean up focusing in `dialog-closedby-start-open.html`

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
@@ -31,7 +31,7 @@ promise_test(async (t) => {
 
 <dl>
   <dt contenteditable></dt>
-  <dialog id=test2 open></dialog>
+  <dialog id=test2></dialog>
 </dl>
 
 <script>
@@ -51,6 +51,8 @@ promise_test(async (t) => {
   // the dialog to be closed.
   const dialog = document.querySelector('dialog#test2');
   const controller = new AbortController();
+  document.querySelector('dt').focus();
+  dialog.open = true;
   document.querySelector('dl').addEventListener("focusin", () => {
     dialog.showModal();
   },{signal:controller.signal});
@@ -59,7 +61,6 @@ promise_test(async (t) => {
   dialog.open = false;
   await new Promise(resolve => {
     document.defaultView.requestIdleCallback(() => {
-      window.getSelection().addRange(document.createRange());
       dialog.close();
       resolve();
     });


### PR DESCRIPTION
The test claims that setting `open = false` restores focus to the previous element but I think it is actually the mysteriously-placed `window.getSelection().addRange(document.createRange());` that's doing that (at least, right now it's passing on Chrome stable even though restoring focus with `open = false` is not implemented there).
(Arguably this should be a tentative test since https://github.com/whatwg/html/pull/10124 is not merged but I don't know how strict people are about that…)