### PR TITLE
maps "view-transitions-element-scoped" web feature

### DIFF
--- a/css/css-view-transitions/scoped/WEB_FEATURES.yml
+++ b/css/css-view-transitions/scoped/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: view-transitions-element-scoped
+  files: "**"


### PR DESCRIPTION
web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/view-transitions-element-scoped.yml

@foolip I opted to preserve the existing overlap of new view-transition-related features with the [original view-transition mapping](https://github.com/web-platform-tests/wpt/pull/43390/changes#diff-09ebadcec3bb17676dfb64b0c0682a85553a5f564a7b44dbb5168c1449ccfde8R1-R3) here, as that seems intentional (like in [this PR](https://github.com/web-platform-tests/wpt/pull/51658/changes) for example). Let me know if we should actually be excluding the sub-features here instead, and I can make those changes in this PR. 

cc @jcscottiii @jugglinmike 

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)