### PR TITLE
maps "toggleevent-source" web feature

### DIFF
--- a/html/semantics/interactive-elements/the-details-element/WEB_FEATURES.yml
+++ b/html/semantics/interactive-elements/the-details-element/WEB_FEATURES.yml
@@ -2,3 +2,7 @@ features:
 - name: details-name
   files:
   - name-attribute.html
+- name: toggleevent-source
+  files:
+  - details-toggle-source.html
+  - details-toggle-source-commandfor.tentative.html

--- a/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
+++ b/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
@@ -1,10 +1,28 @@
 features:
 - name: dialog
-  files: "**"
+  files:
+  - "*"
+  # keep exclusions synced with mappings below
+  - "!dialog-cancel-events.html"
+  - "!dialog-canceling.html"
+  - "!dialog-closedby.html"
+  - "!dialog-closedby-*"
+  - "!dialog-popover-closedby-*"
+  - "!dialog-requestclose.html"
+  - "!dialog-requestclose-*"
+  - "!backdrop-*"
+  - "!dialogs-with-no-backdrop.html"
+  - "!modal-dialog-backdrop.html"
+  - "!modal-dialog-backdrop-opacity.html"
+  - "!modal-dialog-display-contents.html"
+  - "!modal-dialog-generated-content.html"
+  - "!dialog-open-pseudo-invalidation.html"
+  - "!dialog-toggle-source.html"
+# keep subsequent mappings synced with exclusions above
 - name: closewatcher
   files:
-  - "dialog-cancel-events.html"
-  - "dialog-canceling.html"
+  - dialog-cancel-events.html
+  - dialog-canceling.html
 - name: dialog-closedby
   files:
   - dialog-closedby.html

--- a/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
+++ b/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
@@ -25,3 +25,6 @@ features:
 - name: open-pseudo
   files:
   - dialog-open-pseudo-invalidation.html
+- name: toggleevent-source
+  files:
+  - dialog-toggle-source.html

--- a/html/semantics/popovers/WEB_FEATURES.yml
+++ b/html/semantics/popovers/WEB_FEATURES.yml
@@ -2,12 +2,15 @@ features:
 - name: popover
   files:
   - "*"
+  # keep exclusions synced with mappings below
   - "!popover-close-request.html"
   - "!popovertarget-disabled-fieldset.html"
   - "!popover-hint-crash.html"
   - "!popover-light-dismiss-hint.html"
   - "!popover-top-layer-nesting-hints.html"
   - "!popover-types-with-hints.html"
+  - "!popover-toggle-source.html"
+# keep subsequent mappings synced with exclusions above
 - name: closewatcher
   files:
   - "popover-close-request.html"
@@ -20,3 +23,6 @@ features:
   - popover-light-dismiss-hint.html
   - popover-top-layer-nesting-hints.html
   - popover-types-with-hints.html
+- name: toggleevent-source
+  files:
+  - popover-toggle-source.html

--- a/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
+++ b/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
@@ -1,3 +1,9 @@
 features:
 - name: invoker-commands
-  files: "**"
+  files:
+  - "*"
+  # keep exclusions synced with mappings below
+  - "!toggleevent-source-attribute-retargeting.html"
+- name: toggleevent-source
+  files:
+  - toggleevent-source-attribute-retargeting.html


### PR DESCRIPTION
web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/toggleevent-source.yml

@foolip I opted to update the mappings in the `the-dialog-element` to avoid overlap with the "dialog" web feature in 8940582cf920b7ff97d9177ad32880c7a641a7a9. You signaled that we should [eventually do this](https://github.com/web-platform-tests/wpt/pull/56727#discussion_r2634381374) when we encountered similar overlap situations on the button element recently. If we should keep dialog as is though, I can revert the commit.

cc @jcscottiii @jugglinmike 

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)