### PR TITLE
Rename incomingHighWaterMark/outgoingHighWaterMark to incomingMaxBufferedDatagrams/outgoingMaxBufferedDatagrams

### DIFF
--- a/webtransport/datagrams.https.any.js
+++ b/webtransport/datagrams.https.any.js
@@ -230,7 +230,7 @@ promise_test(async t => {
 
   // Write and read datagrams.
   const N = 5;
-  wt.datagrams.outgoingHighWaterMark = N;
+  wt.datagrams.outgoingMaxBufferedDatagrams = N;
   const [sentTokens, receivedTokens] = await Promise.all([
       write_N_datagrams(writer, N),
       read_datagrams(reader, controller, N)
@@ -250,7 +250,7 @@ promise_test(async t => {
   await wt.ready;
 
   const N = 5;
-  wt.datagrams.outgoingHighWaterMark = N;
+  wt.datagrams.outgoingMaxBufferedDatagrams = N;
 
   const writer = wt.datagrams.createWritable().getWriter();
   const encoder = new TextEncoder();
@@ -287,7 +287,7 @@ promise_test(async t => {
 
   // Make sure writer.ready is resolved eventually.
   await writer.ready;
-}, 'Datagram\'s outgoingHighWaterMark correctly regulates written datagrams');
+}, 'Datagram\'s outgoingMaxBufferedDatagrams correctly regulates written datagrams');
 
 promise_test(async t => {
   // Establish a WebTransport session.
@@ -295,7 +295,7 @@ promise_test(async t => {
   await wt.ready;
 
   const N = 5;
-  wt.datagrams.incomingHighWaterMark = N;
+  wt.datagrams.incomingMaxBufferedDatagrams = N;
 
   const writer = wt.datagrams.createWritable().getWriter();
   const encoder = new TextEncoder();
@@ -330,9 +330,9 @@ promise_test(async t => {
   }
 
   // Check that the receivedDatagrams is less than or equal to the
-  // incomingHighWaterMark.
+  // incomingMaxBufferedDatagrams.
   assert_less_than_equal(receivedDatagrams, N);
-}, 'Datagrams read is less than or equal to the incomingHighWaterMark');
+}, 'Datagrams read is less than or equal to the incomingMaxBufferedDatagrams');
 
 promise_test(async t => {
   // Establish a WebTransport session.
@@ -364,25 +364,32 @@ promise_test(async t => {
   await wt.ready;
 
   // Initial values are implementation-defined
-  assert_greater_than_equal(wt.datagrams.incomingHighWaterMark, 1);
-  assert_greater_than_equal(wt.datagrams.outgoingHighWaterMark, 1);
+  assert_greater_than_equal(wt.datagrams.incomingMaxBufferedDatagrams, 1);
+  assert_greater_than_equal(wt.datagrams.outgoingMaxBufferedDatagrams, 1);
 
-  wt.datagrams.incomingHighWaterMark = 5;
-  assert_equals(wt.datagrams.incomingHighWaterMark, 5);
-  wt.datagrams.outgoingHighWaterMark = 5;
-  assert_equals(wt.datagrams.outgoingHighWaterMark, 5);
+  wt.datagrams.incomingMaxBufferedDatagrams = 5;
+  assert_equals(wt.datagrams.incomingMaxBufferedDatagrams, 5);
+  wt.datagrams.outgoingMaxBufferedDatagrams = 5;
+  assert_equals(wt.datagrams.outgoingMaxBufferedDatagrams, 5);
 
-  assert_throws_js(RangeError, () => { wt.datagrams.incomingHighWaterMark = -1; });
-  assert_throws_js(RangeError, () => { wt.datagrams.outgoingHighWaterMark = -1; });
-  assert_throws_js(RangeError, () => { wt.datagrams.incomingHighWaterMark = NaN; });
-  assert_throws_js(RangeError, () => { wt.datagrams.outgoingHighWaterMark = NaN; });
+  // With unsigned long type, -1 coerces to 2^32 - 1 (4294967295)
+  wt.datagrams.incomingMaxBufferedDatagrams = -1;
+  assert_equals(wt.datagrams.incomingMaxBufferedDatagrams, 4294967295);
+  wt.datagrams.outgoingMaxBufferedDatagrams = -1;
+  assert_equals(wt.datagrams.outgoingMaxBufferedDatagrams, 4294967295);
 
-  wt.datagrams.incomingHighWaterMark = 0.5;
-  assert_equals(wt.datagrams.incomingHighWaterMark, 1);
-  wt.datagrams.outgoingHighWaterMark = 0.5;
-  assert_equals(wt.datagrams.outgoingHighWaterMark, 1);
-  wt.datagrams.incomingHighWaterMark = 0;
-  assert_equals(wt.datagrams.incomingHighWaterMark, 1);
-  wt.datagrams.outgoingHighWaterMark = 0;
-  assert_equals(wt.datagrams.outgoingHighWaterMark, 1);
-}, 'Datagram HighWaterMark getters/setters work correctly');
+  // NaN coerces to 0, then clamped to 1
+  wt.datagrams.incomingMaxBufferedDatagrams = NaN;
+  assert_equals(wt.datagrams.incomingMaxBufferedDatagrams, 1);
+  wt.datagrams.outgoingMaxBufferedDatagrams = NaN;
+  assert_equals(wt.datagrams.outgoingMaxBufferedDatagrams, 1);
+
+  wt.datagrams.incomingMaxBufferedDatagrams = 0.5;
+  assert_equals(wt.datagrams.incomingMaxBufferedDatagrams, 1);
+  wt.datagrams.outgoingMaxBufferedDatagrams = 0.5;
+  assert_equals(wt.datagrams.outgoingMaxBufferedDatagrams, 1);
+  wt.datagrams.incomingMaxBufferedDatagrams = 0;
+  assert_equals(wt.datagrams.incomingMaxBufferedDatagrams, 1);
+  wt.datagrams.outgoingMaxBufferedDatagrams = 0;
+  assert_equals(wt.datagrams.outgoingMaxBufferedDatagrams, 1);
+}, 'Datagram MaxBufferedDatagrams getters/setters work correctly');

--- a/webtransport/historical.https.sub.any.js
+++ b/webtransport/historical.https.sub.any.js
@@ -2,12 +2,29 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=resources/webtransport-test-helpers.sub.js
 
-promise_test(async t => {
-  // https://github.com/w3c/webtransport/commit/3e37d39bb4399935f8c88018fe3008698cad7862
+async function get_wt() {
   const wt = new WebTransport(webtransport_url('{{domains[nonexistent]}}'));
   // `ready` and `closed` promises will be rejected due to connection error.
   // Catches them to avoid unhandled rejections.
   wt.ready.catch(() => {});
   wt.closed.catch(() => {});
+  return wt;
+}
+
+promise_test(async t => {
+  // https://github.com/w3c/webtransport/commit/3e37d39bb4399935f8c88018fe3008698cad7862
+  const wt = await get_wt();
   assert_false('writable' in wt.datagrams);
-}, 'WebTransportDatagramDuplexStream#writable');
+}, 'WebTransportDatagramDuplexStream#writable is removed');
+
+promise_test(async t => {
+  // https://github.com/w3c/webtransport/commit/56eb7e184c1c91fda932557f3ccfc44fc2187503
+  const wt = await get_wt();
+  assert_false('incomingHighWaterMark' in wt.datagrams);
+}, 'WebTransportDatagramDuplexStream#incomingHighWaterMark is removed');
+
+promise_test(async t => {
+  // https://github.com/w3c/webtransport/commit/5e10b91e73bd409a8577a4d2264c53b8dcfdb353
+  const wt = await get_wt();
+  assert_false('outgoingHighWaterMark' in wt.datagrams);
+}, 'WebTransportDatagramDuplexStream#outgoingHighWaterMark is removed');

--- a/webtransport/stats.https.any.js
+++ b/webtransport/stats.https.any.js
@@ -79,7 +79,7 @@ promise_test(async t => {
   await wt.ready;
 
   const numDatagrams = 64;
-  wt.datagrams.incomingHighWaterMark = 4;
+  wt.datagrams.incomingMaxBufferedDatagrams = 4;
 
   const writer = wt.datagrams.createWritable().getWriter();
   const encoder = new TextEncoder();
@@ -101,5 +101,5 @@ promise_test(async t => {
   }
   assert_greater_than(stats.datagrams.droppedIncoming, 0);
   assert_less_than_equal(stats.datagrams.droppedIncoming,
-                         numDatagrams - wt.datagrams.incomingHighWaterMark);
+                         numDatagrams - wt.datagrams.incomingMaxBufferedDatagrams);
 }, "WebTransport client should be able to provide droppedIncoming values for datagrams");


### PR DESCRIPTION
This both renames them, and changes their type, following https://github.com/w3c/webtransport/commit/56eb7e184c1c91fda932557f3ccfc44fc2187503 and https://github.com/w3c/webtransport/commit/5e10b91e73bd409a8577a4d2264c53b8dcfdb353