### PR TITLE
WebTransport defines sendOrder to be non-nullable

### DIFF
--- a/webtransport/sendorder.https.any.js
+++ b/webtransport/sendorder.https.any.js
@@ -32,10 +32,13 @@ promise_test(async t => {
 
   // Create a bidirectional stream with sendorder
   const {readable, writable} = await wt.createBidirectionalStream();
-  assert_equals(writable.sendOrder, null);
+  assert_equals(writable.sendOrder, 0);
   // modify it
   writable.sendOrder = 4;
   assert_equals(writable.sendOrder, 4);
+  // Test null coercion: long long converts null via ToNumber(null) = +0
+  writable.sendOrder = null;
+  assert_equals(writable.sendOrder, 0);
 }, 'WebTransport client should be able to modify unset sendOrder after stream creation');
 
 promise_test(async t => {
@@ -49,8 +52,8 @@ promise_test(async t => {
   // modify it
   writable.sendOrder = 5;
   assert_equals(writable.sendOrder, 5);
-  writable.sendOrder = null;
-  assert_equals(writable.sendOrder, null);
+  writable.sendOrder = 0;
+  assert_equals(writable.sendOrder, 0);
   // Note: this doesn't verify the underlying stack actually changes priority, just the API
   // for controlling sendOrder
 }, 'WebTransport client should be able to modify existing sendOrder after stream creation');


### PR DESCRIPTION
Per https://github.com/w3c/webtransport/commit/37d1d28db7137cef981ea805d762fbe803ce4f51 `sendOrder` is no longer nullable. `WebTransportSendOptions.sendOrder` now defaults to `0`.
