### PR TITLE
maps "input-file-webkit" web feature

### DIFF
--- a/entries-api/WEB_FEATURES.yml
+++ b/entries-api/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: input-file-webkitdirectory
+  files:
+  - file-webkitRelativePath-manual.html

--- a/html/semantics/forms/the-input-element/WEB_FEATURES.yml
+++ b/html/semantics/forms/the-input-element/WEB_FEATURES.yml
@@ -12,6 +12,8 @@ features:
   - '!date*'
   - '!time*'
   - '!input-valueasdate*'
+  - '!files.html'
+  - '!file-manual.html'
   - '!type-change-file-to-text-crash.html'
   - '!input-value-invalidstateerr.html'
   - '!change-to-empty-value.html'
@@ -54,6 +56,8 @@ features:
   - input-valueasdate*
 - name: input-file
   files:
+  - files.html
+  - file-manual.html
   - type-change-file-to-text-crash.html
   - input-value-invalidstateerr.html
 - name: change-event


### PR DESCRIPTION
web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/input-file-webkitdirectory.yml

cc @jugglinmike for review. Incidental to this PR, I found some additional tests that I think should be mapped to "[input-file"](https://github.com/web-platform-dx/web-features/blob/main/features/input-file.yml) and added them in b9497c909e73d914222252307ff0ae769f115e99. If you disagree, I can revert.

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)