### PR TITLE
paint: Use viewport meta tag's `min-scale` and `max-scale` to clamp pinch zoom

### DIFF
--- a/visual-viewport/viewport-scale-clamped.html
+++ b/visual-viewport/viewport-scale-clamped.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Viewport Scale Clamped: Not Pinch Zoomable</title>
+  <link rel=help href="https://github.com/w3c/csswg-drafts/issues/9004">
+  <link rel=help href="https://github.com/servo/servo/issues/40390">
+  <link rel="author" title="Shubham Gupta" href="mailto:shubham13297@gmail.com">
+  <meta name="assert" content="The page can not be pinch-zoom.">
+  <meta name="viewport" content="minimum-scale=1, maximum-scale=1">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+<body>
+  <div style="font-size: 50px;">This page can not be pinch zoomed, it is clamped using meta viewport scale.</div>
+  <script> promise_test(async () => {
+      const x = 200, y = 200;
+      const initialScale = window.visualViewport.scale;
+      // Perform pinch zoom
+      await new test_driver.Actions()
+        .addPointer("f1", "touch")
+        .addPointer("f2", "touch")
+        .pointerMove(x, y, { origin: "viewport", sourceName: "f1" })
+        .pointerMove(x + 100, y + 100, { origin: "viewport", sourceName: "f2" })
+        .pointerDown({ sourceName: "f1" })
+        .pointerDown({ sourceName: "f2" })
+        .pointerMove(x - 100, y - 100, { origin: "viewport", sourceName: "f1", duration: 0 })
+        .pointerMove(x + 100, y + 100, { origin: "viewport", sourceName: "f2", duration: 0 })
+        .pointerUp({ sourceName: "f1" })
+        .pointerUp({ sourceName: "f2" }).send();
+      assert_equals(window.visualViewport.scale, initialScale, "Scale should be same");
+    }) </script>
+</body>
+
+</html>


### PR DESCRIPTION
**Note: Targeting Mobile devices only.**

Clamp Pinch Zoom factor using `viewport`' scale range parsed from `<meta>` tag.

## **Behavior in Servo with this PR**

Zoom Type |  Device Type | Meta Supported |Range 
-- | -- | -- | -- 
Pinch Zoom |  Mobile | Yes |Parsed from <meta> 
Pinch Zoom |  Desktop | No |Default

## **Observed behavior in Chrome**:

Device Type | Viewport Meta Support (pref) | Pinch Zoom (No Reflow)  | Zoom (using keyboard)
-- | -- | -- | --
Mobile (Android) | Yes | Clamped within Viewport Meta Range | Applied to Pinch Zoom*
Desktop (Touch Screen) | No | Clamped within Default Range | Same as Zoom (using menu)

## References from Chromium:
- Defination of [page_scale_delta](https://source.chromium.org/chromium/chromium/src/+/main:cc/trees/layer_tree_host_client.h;drc=56c66e417c83e2096a4e4e8a5c4ab7bbd525c9f3;bpv=1;bpt=1;l=39?gsn=page_scale_delta&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dcc%2Ftrees%2Flayer_tree_host_client.h%23SKME3VsvfEmKrf_3d5aQckyeMEaDxgiGETVRCM1Haac);
- [WebViewImpl::ApplyViewportChanges](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/exported/web_view_impl.cc;drc=56c66e417c83e2096a4e4e8a5c4ab7bbd525c9f3;bpv=1;bpt=1;l=4108?gsn=ApplyViewportChanges&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dthird_party%2Fblink%2Frenderer%2Fcore%2Fexported%2Fweb_view_impl.cc%23ll5snmeunTDzY4PwOwxyrNwNc4EI13SFfZnHIWuBsNw) -> [SetPageScaleFactorAndLocation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/exported/web_view_impl.cc;drc=56c66e417c83e2096a4e4e8a5c4ab7bbd525c9f3;bpv=1;bpt=1;l=2430?gsn=SetPageScaleFactorAndLocation&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dthird_party%2Fblink%2Frenderer%2Fcore%2Fexported%2Fweb_view_impl.cc%23wJPsxPYe-aA-buH8xy-IKLTHLqtZ_IgGsuARSYerlUE) -> [SetScaleAndLocation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/visual_viewport.cc;drc=56c66e417c83e2096a4e4e8a5c4ab7bbd525c9f3;bpv=1;bpt=1;l=513?gsn=SetScaleAndLocation&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dthird_party%2Fblink%2Frenderer%2Fcore%2Fframe%2Fvisual_viewport.cc%23u-DPCmPBwcQcKi3oKJ1duPI83otfHDXzsQI8KMYusaA) -> [DidSetScaleOrLocation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/visual_viewport.cc;drc=56c66e417c83e2096a4e4e8a5c4ab7bbd525c9f3;bpv=1;bpt=1;l=543?gsn=DidSetScaleOrLocation&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dthird_party%2Fblink%2Frenderer%2Fcore%2Fframe%2Fvisual_viewport.cc%23cUPTZHhvInyEDOapVOzXmCPKg9DO_tYGVZY7y0D9EBw) -> [ClampToConstraints](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/page_scale_constraints.cc;drc=56c66e417c83e2096a4e4e8a5c4ab7bbd525c9f3;bpv=1;bpt=1;l=60?gsn=ClampToConstraints&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dthird_party%2Fblink%2Frenderer%2Fcore%2Fframe%2Fpage_scale_constraints.cc%23hQCpRu6_p6TTaFLTpDMnO_d-g3SnRpG-p5UlazTZlK8) 

Testing: New WPT Test Added: `wpt/visual-viewport/viewport-scale-clamped.html`



Fixes: #<!-- nolink -->40390 (Observed Inconsistent behavior with Chrome Android)

Reviewed in servo/servo#40098