### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=310874

### DIFF
--- a/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes-ref.html
+++ b/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    rotate: 90deg;
+}
+
+div:after {
+    position: absolute;
+    content: "";
+    width: 50px;
+    height: 50px;
+    background-color: gray;
+}
+
+#unspecifed-to {
+    rotate: 270deg;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes.html
+++ b/css/css-transforms/animation/rotate-explicit-and-implicit-keyframes.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "rotate" property with explicit and implicit keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="rotate-explicit-and-implicit-keyframes-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    animation: none 100000s -25000s linear forwards;
+}
+
+div:after {
+    position: absolute;
+    content: "";
+    width: 50px;
+    height: 50px;
+    background-color: gray;
+}
+
+@keyframes explicit-from-and-to {
+    from { rotate: 80deg }
+    to   { rotate: 120deg}
+}
+
+@keyframes unspecified-from {
+    to { rotate: 360deg }
+}
+
+@keyframes base-value-from {
+    to { rotate: 120deg }
+}
+
+@keyframes unspecified-to {
+    from { rotate: 360deg }
+}
+
+@keyframes base-value-to {
+    from { rotate: 80deg }
+}
+
+#explicit-from-and-to {
+    animation-name: explicit-from-and-to;
+}
+
+#unspecifed-from {
+    animation-name: unspecified-from;
+}
+
+#base-value-from {
+    rotate: 80deg;
+    animation-name: base-value-from;
+}
+
+#unspecifed-to {
+    animation-name: unspecified-to;
+}
+
+#base-value-to {
+    rotate: 120deg;
+    animation-name: base-value-to;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/css/css-transforms/animation/scale-explicit-and-implicit-keyframes-ref.html
+++ b/css/css-transforms/animation/scale-explicit-and-implicit-keyframes-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+}
+
+#explicit-from-and-to {
+    scale: 0.3;
+}
+
+#unspecifed-from {
+    scale: 0.8;
+}
+
+#base-value-from {
+    scale: 0.5;
+}
+
+#unspecifed-to {
+    scale: 0.4;
+}
+
+#base-value-to {
+    scale: 0.3;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/css/css-transforms/animation/scale-explicit-and-implicit-keyframes.html
+++ b/css/css-transforms/animation/scale-explicit-and-implicit-keyframes.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "scale" property with explicit and implicit keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="scale-explicit-and-implicit-keyframes-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    animation: none 100000s -25000s linear forwards;
+}
+
+@keyframes explicit-from-and-to {
+    from { scale: 0.1 }
+    to   { scale: 0.9 }
+}
+
+@keyframes implicit-from {
+    to { scale: 0.2 }
+}
+
+@keyframes implicit-to {
+    from { scale: 0.2 }
+}
+
+#explicit-from-and-to {
+    animation-name: explicit-from-and-to;
+}
+
+#unspecifed-from {
+    animation-name: implicit-from;
+}
+
+#base-value-from {
+    scale: 0.6;
+    animation-name: implicit-from;
+}
+
+#unspecifed-to {
+    animation-name: implicit-to;
+}
+
+#base-value-to {
+    scale: 0.6;
+    animation-name: implicit-to;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/css/css-transforms/animation/translate-explicit-and-implicit-keyframes-ref.html
+++ b/css/css-transforms/animation/translate-explicit-and-implicit-keyframes-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+}
+
+#explicit-from-and-to {
+    translate: 125px;
+}
+
+#unspecifed-from {
+    translate: 50px;
+}
+
+#base-value-from {
+    translate: 125px;
+}
+
+#unspecifed-to {
+    translate: 150px;
+}
+
+#base-value-to {
+    translate: 175px;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+</body>
+</html>

--- a/css/css-transforms/animation/translate-explicit-and-implicit-keyframes.html
+++ b/css/css-transforms/animation/translate-explicit-and-implicit-keyframes.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "translate" property with explicit and implicit keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="translate-explicit-and-implicit-keyframes-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    background-color: black;
+    animation: none 100000s -25000s linear forwards;
+}
+
+@keyframes explicit-from-and-to {
+    from { translate: 100px }
+    to   { translate: 200px }
+}
+
+@keyframes implicit-from {
+    to { translate: 200px }
+}
+
+@keyframes implicit-to {
+    from { translate: 200px }
+}
+
+#explicit-from-and-to {
+    animation-name: explicit-from-and-to;
+}
+
+#unspecifed-from {
+    animation-name: implicit-from;
+}
+
+#base-value-from {
+    translate: 100px;
+    animation-name: implicit-from;
+}
+
+#unspecifed-to {
+    animation-name: implicit-to;
+}
+
+#base-value-to {
+    translate: 100px;
+    animation-name: implicit-to;
+}
+
+</style>
+</head>
+<body>
+
+<div id="explicit-from-and-to"></div>
+<div id="unspecifed-from"></div>
+<div id="base-value-from"></div>
+<div id="unspecifed-to"></div>
+<div id="base-value-to"></div>
+
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[threaded-animations\] REGRESSION: animating to an implicit value for individual transform properties fails to animate](https://bugs.webkit.org/show_bug.cgi?id=310874)