### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=306831

### DIFF
--- a/css/css-anchor-position/anchor-parse-valid.html
+++ b/css/css-anchor-position/anchor-parse-valid.html
@@ -83,4 +83,8 @@ test_valid_value('top', 'calc((anchor(--foo top) + anchor(--bar bottom)) / 2)', 
 test_valid_value('top', 'calc(0.5 * (anchor(--foo top) + anchor(--bar bottom)))');
 test_valid_value('top', 'anchor(--foo top, calc(0.5 * anchor(--bar bottom)))');
 test_valid_value('top', 'min(100px, 10%, anchor(--foo top), anchor(--bar bottom))');
+
+// Should accept unitless zero
+test_valid_value('top', "anchor(--foo left, 0)", "anchor(--foo left, 0px)");
+test_valid_value('top', "calc(anchor(--foo left, 0))", "anchor(--foo left, 0px)");
 </script>

--- a/css/css-anchor-position/anchor-size-parse-valid.html
+++ b/css/css-anchor-position/anchor-size-parse-valid.html
@@ -105,4 +105,8 @@ for (const prop of ['width', 'max-width', 'margin-left']) {
   test_valid_value(prop, 'anchor-size(--foo width, calc(0.5 * anchor-size(--bar height)))');
   test_valid_value(prop, 'min(100px, 10%, anchor-size(--foo width), anchor-size(--bar height))');
 }
+
+// Should accept unitless zero
+test_valid_value('width', "anchor-size(--foo width, 0)", "anchor-size(--foo width, 0px)");
+test_valid_value('width', "calc(anchor-size(--foo width, 0))", "anchor-size(--foo width, 0px)");
 </script>


### PR DESCRIPTION
WebKit export from bug: [anchor() fallback value should support unitless zero](https://bugs.webkit.org/show_bug.cgi?id=306831)