### PR TITLE
Refactor file path resolution in echo-preload-header.py

### DIFF
--- a/preload/resources/echo-preload-header.py
+++ b/preload/resources/echo-preload-header.py
@@ -10,15 +10,23 @@ def main(request, response):
         response.headers.set(b"Link", link)
 
     if b"file" in request.GET:
-        base_dir = os.path.abspath(os.path.dirname(isomorphic_encode(__file__)))
+        base_dir = os.path.realpath(os.path.dirname(isomorphic_encode(__file__)))
         target_file = request.GET.first(b"file")
-        path = os.path.abspath(os.path.join(base_dir, target_file))
-        if os.path.commonpath([base_dir, path]) != base_dir:
+        path = os.path.realpath(os.path.join(base_dir, target_file))
+
+        try:
+            if os.path.commonpath([base_dir, path]) != base_dir:
+                raise ValueError("Path traversal attempt detected.")
+        except ValueError:
+            # A ValueError is expected in two scenarios:
+            # 1) os.path.commonpath raises it if paths are on different drives
+            #    (e.g., on Windows).
+            # 2) We explicitly raise it when a path traversal attempt is detected.
             response.status = 403
             return b"Forbidden"
 
         try:
-            response.content = open(path, mode=u'rb').read()
+            response.content = open(path, mode='rb').read()
         except IOError:
             response.status = 404
             return b"Not found"

--- a/preload/resources/echo-preload-header.py
+++ b/preload/resources/echo-preload-header.py
@@ -10,7 +10,17 @@ def main(request, response):
         response.headers.set(b"Link", link)
 
     if b"file" in request.GET:
-        path = os.path.join(os.path.dirname(isomorphic_encode(__file__)), request.GET.first(b"file"));
-        response.content = open(path, mode=u'rb').read();
+        base_dir = os.path.abspath(os.path.dirname(isomorphic_encode(__file__)))
+        target_file = request.GET.first(b"file")
+        path = os.path.abspath(os.path.join(base_dir, target_file))
+        if not path.startswith(base_dir):
+            response.status = 403
+            return b"Forbidden"
+
+        try:
+            response.content = open(path, mode=u'rb').read()
+        except IOError:
+            response.status = 404
+            return b"Not found"
     else:
         return request.GET.first(b"content")

--- a/preload/resources/echo-preload-header.py
+++ b/preload/resources/echo-preload-header.py
@@ -13,7 +13,7 @@ def main(request, response):
         base_dir = os.path.abspath(os.path.dirname(isomorphic_encode(__file__)))
         target_file = request.GET.first(b"file")
         path = os.path.abspath(os.path.join(base_dir, target_file))
-        if not path.startswith(base_dir):
+        if os.path.commonpath([base_dir, path]) != base_dir:
             response.status = 403
             return b"Forbidden"
 


### PR DESCRIPTION
This commit standardizes the file reading logic to use absolute paths and enforces subdirectory bounds checking. This aligns the script with better I/O practices, ensuring that file reads are properly scoped to the intended resources directory and preventing accidental out-of-bounds path traversal.