### PR TITLE
maps new scroll-related web features

### DIFF
--- a/css/css-overflow/parsing/WEB_FEATURES.yml
+++ b/css/css-overflow/parsing/WEB_FEATURES.yml
@@ -8,6 +8,9 @@ features:
 - name: scroll-buttons
   files:
   - scroll-button*
+- name: scroll-target-group
+  files:
+  - scroll-target-group*
 - name: scrollbar-gutter
   files:
   - scrollbar-gutter-*

--- a/css/css-overflow/scroll-markers/WEB_FEATURES.yaml
+++ b/css/css-overflow/scroll-markers/WEB_FEATURES.yaml
@@ -12,7 +12,14 @@ features:
   - targeted-scroll-marker*
   - chrome-421199213-crash.html
   - targeted-column-scroll-marker-selection-*
+  # scroll-marker-targets exclusions, keep synced
+  - "!scroll-marker-target-before-after.html"
+  - "!html-scroll-marker-target-before-after.html"
 - name: scroll-buttons
   files:
   - root-scroll-button*
   - scroll-button*
+- name: scroll-marker-targets
+  files:
+  - scroll-marker-target-before-after.html
+  - html-scroll-marker-target-before-after.html

--- a/css/css-overflow/scroll-markers/WEB_FEATURES.yaml
+++ b/css/css-overflow/scroll-markers/WEB_FEATURES.yaml
@@ -23,3 +23,6 @@ features:
   files:
   - scroll-marker-target-before-after.html
   - html-scroll-marker-target-before-after.html
+- name: scroll-target-group
+  files:
+  - scroll-target-group*

--- a/css/cssom-view/WEB_FEATURES.yml
+++ b/css/cssom-view/WEB_FEATURES.yml
@@ -42,6 +42,10 @@ features:
   files:
   - scrollIntoView-*
   - scrollintoview.html
+  - "!scrollIntoView-container.html"
+- name: scroll-into-view-container
+  files:
+  - scrollIntoView-container.html
 - name: scroll-behavior
   files:
   - scroll-behavior-*


### PR DESCRIPTION
Batch maps the following related web features:
* [scrollIntoView() container](https://github.com/web-platform-dx/web-features/blob/main/features/scroll-into-view-container.yml)
* [Scroll marker target pseudo-classes](https://github.com/web-platform-dx/web-features/blob/main/features/scroll-marker-targets.yml)
* [scroll-target-group](https://github.com/web-platform-dx/web-features/blob/main/features/scroll-target-group.yml)

cc @foolip @jcscottiii for review

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)