### PR TITLE
maps "supports-at-rule" web feature

### DIFF
--- a/css/css-conditional/js/WEB_FEATURES.yml
+++ b/css/css-conditional/js/WEB_FEATURES.yml
@@ -3,6 +3,10 @@ features:
   files:
   - "supports-*.html"
   - 001.html
+  - "!supports-at-rule.html"
 - name: css-supports
   files:
   - CSS-supports-*
+- name: supports-at-rule
+  files:
+  - supports-at-rule.html


### PR DESCRIPTION
web feature docs: https://github.com/web-platform-dx/web-features/blob/main/features/supports-at-rule.yml

cc @jugglinmike for review

---
As of 2025-12-05, [the wpt-pr-bot is requesting reviews from code owners for changes to WEB_FEATURES.yml files](https://github.com/web-platform-tests/wpt-pr-bot/pull/268). To learn more about the purpose of these files, check out this presentation from TPAC 2025, [Annotating WPT to Surface the Status of the Platform](https://bocoup.github.io/presentation-tpac-web-features/)