### PR TITLE
[wasm][js-api] WebAssembly.Exception.length should be 2

### DIFF
--- a/wasm/jsapi/exception/constructor.tentative.any.js
+++ b/wasm/jsapi/exception/constructor.tentative.any.js
@@ -10,7 +10,7 @@ test(() => {
 }, "name");
 
 test(() => {
-  assert_function_length(WebAssembly.Exception, 1, "WebAssembly.Exception");
+  assert_function_length(WebAssembly.Exception, 2, "WebAssembly.Exception");
 }, "length");
 
 test(() => {


### PR DESCRIPTION
This is a copy of https://github.com/WebAssembly/spec/pull/2123.

@Ms2ger / @eqrion: I'll just manually update this as there isn't an automated process for synchronizing it?

How does the bot work that creates PRs like https://github.com/web-platform-tests/wpt/pull/58842? Could it also copy over the non-wast plain JavaScript js-api test cases?