### PR TITLE
script: Let `wheel`,  keyboard- and pointerevents be composed when fired by the user agent

### DIFF
--- a/dom/events/scrolling/wheel-event-composed.html
+++ b/dom/events/scrolling/wheel-event-composed.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+    <script>
+      promise_test(() => {
+        return new Promise(resolve => {
+          document.addEventListener("wheel", (event) => {
+            resolve(event);
+          });
+
+          new test_driver.Actions()
+            .addWheel("wheel1")
+            .scroll(0, 0, 0, 10)
+            .send();
+        }).then((event) => {
+          assert_true(event.composed);
+        });
+      }, `wheel event must be composed`);
+    </script>
+</body>
+
+</html>

--- a/uievents/keyboard/keyboardevent-composed.html
+++ b/uievents/keyboard/keyboardevent-composed.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>keydown and keypress and keyup events must be composed</title>
+<link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<div id="target" tabindex="0">Target</div>
+
+<script>
+  target.focus();
+
+  promise_test(() => {
+    return new Promise(resolve => {
+      target.addEventListener("keydown", (event) => {
+        resolve(event);
+      });
+
+      new test_driver.Actions()
+        .keyDown("a")
+        .keyUp("a")
+        .send();
+    }).then((event) => {
+      assert_true(event.composed);
+    });
+  }, `keydown event must be composed`);
+
+  promise_test(() => {
+    return new Promise(resolve => {
+      target.addEventListener("keypress", (event) => {
+        resolve(event);
+      });
+
+      new test_driver.Actions()
+        .keyDown("a")
+        .keyUp("a")
+        .send();
+    }).then((event) => {
+      assert_true(event.composed);
+    });
+  }, `keypress event must be composed`);
+
+  promise_test(() => {
+    return new Promise(resolve => {
+      target.addEventListener("keyup", (event) => {
+        resolve(event);
+      });
+
+      new test_driver.Actions()
+        .keyDown("a")
+        .keyUp("a")
+        .send();
+    }).then((event) => {
+      assert_true(event.composed);
+    });
+  }, `keyup event must be composed`);
+</script>


### PR DESCRIPTION
Addtionally, this updates lots of outdated spec links for mouse-related things that have moved from the uievents spec to the pointerevents spec.

Testing: This change adds new tests

Part of https://github.com/servo/servo/issues/35997
Fixes https://github.com/servo/servo/issues/37772

Reviewed in servo/servo#43799