### PR TITLE
script: Prevent panic on multiple calls to MessagePort::close

### DIFF
--- a/webmessaging/message-channels/close.any.js
+++ b/webmessaging/message-channels/close.any.js
@@ -60,3 +60,19 @@ test(() => {
   assert_throws_dom("DataCloneError", () => c2.port1.postMessage(null, [c1.port1]));
   c2.port1.postMessage(null, [c1.port2]);
 }, "close() detaches a MessagePort (but not the one its entangled with)");
+
+test(() => {
+    const channel = new MessageChannel();
+    channel.port1.close();
+    // Calling close() again in the same task must not throw/panic.
+    channel.port1.close();
+}, "close is idempotent within a task");
+
+async_test(t => {
+    const channel = new MessageChannel();
+    channel.port1.close();
+    // Queue a timer and call close() again from the next task.
+    setTimeout(t.step_func_done(() => {
+        channel.port1.close(); // must not panic or throw
+    }), 0);
+}, "close is idempotent across tasks");


### PR DESCRIPTION
Converted ```ManagedMessagePort``` from a struct to an enum with ```Enabled``` and ```Disabled``` variants.

Testing: ran ```./mach test-wpt tests/wpt/tests/webmessaging/message-channels/close.any.js``` result: ```web-platform-test
~~~~~~~~~~~~~~~~~
Ran 18 checks (16 subtests, 2 tests)
Expected results: 18
Unexpected results: 0
OK
```

Fixes #<!-- nolink -->36765

Reviewed in servo/servo#43553