### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=210791

### DIFF
--- a/css/css-flexbox/percentage-size-quirks-003.html
+++ b/css/css-flexbox/percentage-size-quirks-003.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#definite-sizes">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk" title="Number 4">
+</head>
+<body>
+<p style="margin-top: 1em">Test passes if there is a filled green square.</p>
+<div style="display: flex; width: 100px; height: 100px; flex-direction: column;">
+  <div style="flex-grow: 1; height: 0;">
+    <div style="display: flex; flex-direction: column; height: 100%;">
+      <div style="width: 100px; height: 50px; background-color: green;"></div>
+      <div style="flex: 1;">
+          <div style="height: 100%; background-color: green;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-flexbox\] The percentage height resolution quirk shouldn't be applied to flexboxes](https://bugs.webkit.org/show_bug.cgi?id=210791)