### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=310398

### DIFF
--- a/css/css-anchor-position/anchor-function-chain-pseudo-elements.html
+++ b/css/css-anchor-position/anchor-function-chain-pseudo-elements.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of pseudo-elements that anchor to each other using anchor() works</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-pos">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/pseudo-element-chain-ref.html">
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-after::after, .box-before::before {
+    position: absolute;
+    left: calc(anchor(--box right) + 10px);
+    anchor-name: --box;
+
+    width: 50px;
+    height: 50px;
+    content: "";
+  }
+
+  /* Give both ::before and ::after background colors,
+     so we can switch boxes between ::before and ::after. */
+  #box1::before, #box1::after { background-color: #cce7cc; }
+  #box2::before, #box2::after { background-color: #99cf99; }
+  #box3::before, #box3::after { background-color: #66b866; }
+  #box4::before, #box4::after { background-color: #33a033; }
+  #box5::before, #box5::after { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-after" id="box5"></div>
+</div>

--- a/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-ref.html
+++ b/css/css-anchor-position/anchor-size-function-chain-pseudo-elements-ref.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-before::before, .box-after::after {
+    position: absolute;
+    background-color: green;
+    content: "";
+  }
+
+  #box1::before, #box1::after {
+    width: 50px;
+    height: 60px;
+  }
+
+  #box2::before, #box2::after {
+    left: 60px;
+    width: 60px;
+    height: 80px;
+  }
+
+  #box3::before, #box3::after {
+    left: 130px;
+    width: 70px;
+    height: 100px;
+  }
+
+  #box4::before, #box4::after {
+    left: 210px;
+    width: 80px;
+    height: 120px;
+  }
+
+  #box5::before, #box5::after {
+    left: 300px;
+    width: 90px;
+    height: 140px;
+  }
+</style>
+
+<p>You should see a row of five rectangles growing in size.</p>
+
+<div class="containing-block">
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-before" id="box5"></div>
+</div>

--- a/css/css-anchor-position/anchor-size-function-chain-pseudo-elements.html
+++ b/css/css-anchor-position/anchor-size-function-chain-pseudo-elements.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of elements that anchor to each other using anchor-size() works.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="anchor-size-function-chain-pseudo-elements-ref.html">
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-before::before, .box-after::after {
+    /* Can only use anchor-size() with position: absolute */
+    position: absolute;
+    anchor-name: --box;
+    width: calc(anchor-size(--box width) + 10px);
+    height: calc(anchor-size(--box height) + 20px);
+
+    background-color: green;
+    content: "";
+  }
+
+  #box1::before, #box1::after {
+    width: 50px;
+    height: 60px;
+  }
+
+  #box2::before, #box2::after { left: 60px; }
+  #box3::before, #box3::after { left: 130px; }
+  #box4::before, #box4::after { left: 210px; }
+  #box5::before, #box5::after { left: 300px; }
+</style>
+
+<p>You should see a row of five rectangles growing in size.</p>
+
+<div class="containing-block">
+  <!--
+    The increasing size is to check that the boxes are anchoring to each other
+    in the correct order i.e box2 chains to box1, box3 chains to box2, ...
+  -->
+  <div class="box-after" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-before" id="box3"></div>
+  <div class="box-after" id="box4"></div>
+  <div class="box-before" id="box5"></div>
+</div>

--- a/css/css-anchor-position/position-area-chain-pseudo-elements.html
+++ b/css/css-anchor-position/position-area-chain-pseudo-elements.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of pseudo-elements that anchor to each other using position-area works</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-area">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="reference/pseudo-element-chain-ref.html">
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box-after::after, .box-before::before {
+    position: absolute;
+    anchor-name: --box;
+    position-area: center right;
+    position-anchor: --box;
+
+    width: 50px;
+    height: 50px;
+    content: "";
+    border-right: 10px white solid;
+  }
+
+  /* Give both ::before and ::after background colors,
+     so we can switch boxes between ::before and ::after. */
+  #box1::before, #box1::after { background-color: #cce7cc; }
+  #box2::before, #box2::after { background-color: #99cf99; }
+  #box3::before, #box3::after { background-color: #66b866; }
+  #box4::before, #box4::after { background-color: #33a033; }
+  #box5::before, #box5::after { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box-before" id="box1"></div>
+  <div class="box-before" id="box2"></div>
+  <div class="box-after" id="box3"></div>
+  <div class="box-before" id="box4"></div>
+  <div class="box-after" id="box5"></div>
+</div>

--- a/css/css-anchor-position/pseudo-element-anchor-tree-order.html
+++ b/css/css-anchor-position/pseudo-element-anchor-tree-order.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+
+<title>Tests the ordering of pseudo-element anchors by tree order</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#target">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  main {
+    border: 1px solid black;
+
+    position: relative;
+    width: 500px;
+    height: 200px;
+  }
+
+  .box, .box-before::before, .box-after::after {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    content: "";
+  }
+
+  .box-anchor, .box-before-anchor::before, .box-after-anchor::after { anchor-name: --box; }
+  .box-red, .box-before-red::before, .box-after-red::after { background-color: red; }
+  .box-green, .box-before-green::before, .box-after-green::after { background-color: green; }
+
+  .target {
+    position: absolute;
+    position-anchor: --box;
+    top: calc(anchor(bottom) + 10px);
+    left: anchor(left);
+    width: 50px;
+    height: 50px;
+    background-color: blue;
+  }
+</style>
+
+<script>
+  function inflate(t, template_element) {
+    t.add_cleanup(() => main.replaceChildren());
+    main.append(template_element.content.cloneNode(true));
+  }
+</script>
+
+<main id="main">
+</main>
+
+<template id="one_element_two_pseudo_elements">
+  <style>
+    #anchor1 { inset: 0 }
+    #anchor23::before { top: 0; left: 60px; }
+    #anchor23::after { top: 0; left: 120px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box box-anchor box-red" id="anchor1"></div>
+    <div class="box-before box-before-anchor box-before-red box-after box-after-anchor box-after-green" id="anchor23"></div>
+    <!-- Anchor used is #anchor23::after -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, one_element_two_pseudo_elements);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "120px");
+  }, "One element anchor, two pseudo-element anchors (::before, ::after)");
+</script>
+
+<template id="one_pseudo_in_one_host_two_pseudos_in_another_host">
+  <style>
+    #anchor1 { inset: 0 }
+    #anchor23::before { top: 0; left: 60px; }
+    #anchor23::after { top: 0; left: 120px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-before box-before-anchor box-before-red" id="anchor1"></div>
+    <div class="box-before box-before-anchor box-before-red box-after box-after-anchor box-after-green" id="anchor23"></div>
+    <!-- Anchor used is #anchor23::after -->
+    <div class="target" id="target" data-offset-x="120" data-offset-y="50"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, one_pseudo_in_one_host_two_pseudos_in_another_host);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "120px");
+  }, "One pseudo-element anchor in one host element, two pseudo-element anchors (::before, ::after) in another host element");
+</script>
+
+<template id="two_pseudos_in_same_host">
+  <style>
+    #anchor12::before { inset: 0; }
+    #anchor12::after { top: 0; left: 60px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-before box-before-anchor box-before-red box-after box-after-anchor box-after-green" id="anchor12"></div>
+    <!-- Anchor used is #anchor12::after -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, two_pseudos_in_same_host);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "60px");
+  }, "Two pseudo-element anchors in the same host");
+</script>
+
+<template id="before_and_element_sibling">
+  <style>
+    #anchor1::before { inset: 0 }
+    #anchor2 { top: 0; left: 60px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-before box-before-anchor box-before-green" id="anchor1">
+      <div class="box box-anchor box-red" id="anchor2"></div>
+    </div>
+    <!-- Anchor used is #anchor2 -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, before_and_element_sibling);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "60px");
+  }, "Two sibling anchors, ::before and an element");
+</script>
+
+<template id="element_and_after_sibling">
+  <style>
+    #anchor1 { inset: 0 }
+    #anchor2::after { top: 0; left: 60px; }
+  </style>
+
+  <div class="containing-block">
+    <div class="box-after box-after-anchor box-after-green" id="anchor2">
+      <div class="box box-anchor box-red" id="anchor1"></div>
+    </div>
+    <!-- Anchor used is #anchor2::after -->
+    <div class="target" id="target"></div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    inflate(t, element_and_after_sibling);
+
+    const targetComputedStyle = getComputedStyle(main.querySelector("#target"));
+    assert_equals(targetComputedStyle.top, "60px");
+    assert_equals(targetComputedStyle.left, "60px");
+  }, "Two sibling anchors, an element and ::after");
+</script>

--- a/css/css-anchor-position/reference/pseudo-element-chain-ref.html
+++ b/css/css-anchor-position/reference/pseudo-element-chain-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    width: 500px;
+    height: 200px;
+
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+  }
+
+  #box1 { background-color: #cce7cc; }
+  #box2 { background-color: #99cf99; }
+  #box3 { background-color: #66b866; }
+  #box4 { background-color: #33a033; }
+  #box5 { background-color: #008000; }
+</style>
+
+<p>You should see a row of five boxes in increasing gradient.</p>
+
+<div class="containing-block">
+  <div class="box" id="box1"></div>
+  <div class="box" id="box2"></div>
+  <div class="box" id="box3"></div>
+  <div class="box" id="box4"></div>
+  <div class="box" id="box5"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[css-anchor-position-1\] Accommodate pseudo-elements when sorting anchor elements by tree order](https://bugs.webkit.org/show_bug.cgi?id=310398)