### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=284973

### DIFF
--- a/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html
+++ b/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>prefers-color-scheme in cross-origin frame inherits color-scheme from embedding element</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<link rel="match" href="color-scheme-iframe-preferred-ref.html">
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<iframe style="color-scheme: dark" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>
+<iframe style="color-scheme: light" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>

--- a/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html
+++ b/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>prefers-color-scheme in cross-origin frame inherits color-scheme from embedding element - page supports dark</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<link rel="match" href="color-scheme-iframe-preferred-page-dark-ref.html">
+<meta name="color-scheme" content="dark">
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<iframe style="color-scheme: normal" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>

--- a/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub.html
+++ b/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>prefers-color-scheme in cross-origin frame inherits color-scheme from embedding element - page supports light</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<link rel="match" href="color-scheme-iframe-preferred-page-light-ref.html">
+<meta name="color-scheme" content="light">
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<iframe style="color-scheme: normal" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>


### PR DESCRIPTION
WebKit export from bug: [@media (prefers-color-scheme: dark) inside iframe not matching when the iframe itself has style.colorScheme = 'dark'](https://bugs.webkit.org/show_bug.cgi?id=284973)