### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311238

### DIFF
--- a/html/semantics/embedded-content/the-img-element/sizes/support/sizes-iframed.sub.html
+++ b/html/semantics/embedded-content/the-img-element/sizes/support/sizes-iframed.sub.html
@@ -184,3 +184,6 @@
 <img srcset='/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w' sizes='-1e0px'>
 <img srcset='/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w' sizes='1e1.5px'>
 <img srcset='/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w' style='--foo: 1px' sizes='var(--foo)'>
+<img srcset='/images/green-1x1.png?f50 50w, /images/green-16x16.png?f50 51w' sizes='calc(1px / 0)'>
+<img srcset='/images/green-1x1.png?f51 50w, /images/green-16x16.png?f51 51w' sizes='calc(0px / 0)'>
+<img srcset='/images/green-1x1.png?f52 50w, /images/green-16x16.png?f52 51w' sizes='calc(-1px / 0)'>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(305392@main): Image with srcset and sizes containing calc(number / 0) is not displayed](https://bugs.webkit.org/show_bug.cgi?id=311238)