### PR TITLE
Fix css/selectors/selectors-4/lang-020.html so it can run properly on…

### DIFF
--- a/css/selectors/selectors-4/lang-020-ref.html
+++ b/css/selectors/selectors-4/lang-020-ref.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <meta charset="utf-8">
-<title>CSS Selectors 4 - :lang matching</title>
+<title>CSS Selectors 4 - :lang matching reference</title>
 <link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com">
-<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-lang-pseudo">
-<link rel="match" href="lang-020-ref.html">
 
 <style>
-div.test { color: red; }
-:lang("iw") { color: green; }
+div.test { color: green; }
 </style>
 
 <div class="test"><span lang="iw-ase-jpan-basiceng">This should be green</span></div>


### PR DESCRIPTION
… WebKit/macOS

The test checks that `:lang("iw")` matches `lang="iw-ase-jpan-basiceng"` by verifying the text renders green. The expected file had the text directly in a `<div>`, while the test wraps it in a `<span>` with the `lang` attribute. On macOS, the Hebrew language tag causes different font selection, making the pixel comparison fail even though the color was correct. Fix by adding the same `<span lang>` wrapper to the expected file so font metrics match.

This is upstreaming from WebKit https://commits.webkit.org/310436@main.