### PR TITLE
script: Fix assertion failure when stringifying cross-origin location object

### DIFF
--- a/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
+++ b/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<title>Stringifying cross-origin location should not crash</title>
+<meta name="assert" content="console.log of a cross-origin location object should not crash.">
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+  var iframe = document.createElement("iframe");
+  iframe.src = get_host_info().HTTP_REMOTE_ORIGIN + "/common/blank.html";
+  iframe.onload = function() {
+    console.log(iframe.contentWindow.location);
+    document.documentElement.classList.remove("test-wait");
+  };
+  document.body.appendChild(iframe);
+</script>
+</html>

--- a/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
+++ b/html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
@@ -4,6 +4,7 @@
 <title>Stringifying cross-origin location should not crash</title>
 <meta name="assert" content="console.log of a cross-origin location object should not crash.">
 <script src="/common/get-host-info.sub.js"></script>
+<body>
 <script>
   var iframe = document.createElement("iframe");
   iframe.src = get_host_info().HTTP_REMOTE_ORIGIN + "/common/blank.html";
@@ -13,4 +14,5 @@
   };
   document.body.appendChild(iframe);
 </script>
+</body>
 </html>

--- a/lint.ignore
+++ b/lint.ignore
@@ -132,6 +132,7 @@ CONSOLE: webaudio/resources/audit.js:41
 # Intentional use of console.*
 CONSOLE: infrastructure/testdriver/bidi/subscription.html
 CONSOLE: infrastructure/testdriver/bidi/subscription.window.js
+CONSOLE: html/browsers/history/the-location-interface/cross-origin-location-stringify-crash.sub.html
 CONSOLE: html/editing/dnd/events/ua-shadow-contents-manual.html
 
 # use of console in a public library - annotation-model ensures


### PR DESCRIPTION
This fixes the assertion failure (`!JS_IsExceptionPending(*cx)`) that happens when `console.log()` is called on a cross-origin location object (e.g. `console.log(frame.contentWindow.location)`).

The problem was that `maybe_stringify_dom_object` calls `ToString` on cross-origin objects, which throws a JS exception via the `DissimilarOriginLocation` stringifier. That exception was never cleared, so subsequent JS API calls would hit the assertion.

The fix refactors `console_argument_from_handle_value` using an inner/outer function pattern based on @jdm's suggestion:
- The inner function returns `Result<ConsoleArgument, ()>` and returns `Err(())` when `console_object_from_handle_value` returns `None` for an object, instead of falling through to `stringify_handle_value` which could trigger the same crash
- The outer function catches the `Err`, reports any pending JS exception via `report_pending_exception`, and returns a fallback `ConsoleArgument`

Fixes #<!-- nolink -->43530

Reviewed in servo/servo#43844