### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=306387

### DIFF
--- a/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-ref.html
+++ b/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG fill and stroke references (reference)</title>
+<style>svg { display: block; }</style>
+<p>The rects below should be filled/stroked with gradients, not black.</p>
+<svg width="200" height="120" viewBox="0 0 200 120">
+  <defs>
+    <linearGradient id="foo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="green"/>
+    </linearGradient>
+    <linearGradient id="bar.baz" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Unencoded references (known to work) -->
+  <rect x="10" y="10" width="50" height="40" fill="url(#foo)"/>
+  <rect x="70" y="10" width="50" height="40" fill="url(#bar.baz)"/>
+  <rect x="130" y="10" width="50" height="40" fill="none"
+        stroke="url(#foo)" stroke-width="4"/>
+  <rect x="10" y="65" width="50" height="40" fill="url(#foo) red"/>
+  <rect x="70" y="65" width="50" height="40" fill="none"
+        stroke="url(#foo) red" stroke-width="4"/>
+</svg>

--- a/svg/pservers/reftests/percent-encoded-fragment-fill-stroke.html
+++ b/svg/pservers/reftests/percent-encoded-fragment-fill-stroke.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG fill and stroke references</title>
+<link rel="help" href="https://url.spec.whatwg.org/#fragment-percent-encode-set">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=306387">
+<link rel="match" href="percent-encoded-fragment-fill-stroke-ref.html">
+<meta name="assert" content="Percent-encoded characters in SVG fill/stroke URL fragment references should be decoded before element ID lookup, rendering the same as unencoded references.">
+<style>svg { display: block; }</style>
+<p>The rects below should be filled/stroked with gradients, not black.</p>
+<svg width="200" height="120" viewBox="0 0 200 120">
+  <defs>
+    <linearGradient id="foo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="green"/>
+    </linearGradient>
+    <linearGradient id="bar.baz" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+
+  <!-- fill with %66%6f%6f = "foo" -->
+  <rect x="10" y="10" width="50" height="40" fill="url(#%66%6f%6f)"/>
+
+  <!-- fill with %62%61%72%2e%62%61%7a = "bar.baz" -->
+  <rect x="70" y="10" width="50" height="40" fill="url(#%62%61%72%2e%62%61%7a)"/>
+
+  <!-- stroke with %66%6f%6f = "foo" -->
+  <rect x="130" y="10" width="50" height="40" fill="none"
+        stroke="url(#%66%6f%6f)" stroke-width="4"/>
+
+  <!-- fill with fallback: %66%6f%6f = "foo", fallback red (should NOT be red) -->
+  <rect x="10" y="65" width="50" height="40" fill="url(#%66%6f%6f) red"/>
+
+  <!-- stroke with fallback: %66%6f%6f = "foo", fallback red -->
+  <rect x="70" y="65" width="50" height="40" fill="none"
+        stroke="url(#%66%6f%6f) red" stroke-width="4"/>
+</svg>

--- a/svg/pservers/reftests/percent-encoded-fragment-refs.html
+++ b/svg/pservers/reftests/percent-encoded-fragment-refs.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG clip-path, filter, and mask references</title>
+<link rel="help" href="https://url.spec.whatwg.org/#fragment-percent-encode-set">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=306387">
+<meta name="assert" content="Percent-encoded characters in SVG URL fragment references should be decoded before element ID lookup. For clip-path, filter, and mask, the computed style falls back to 'none' when the reference fails, providing a reliable signal.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg width="200" height="60">
+  <defs>
+    <clipPath id="my clip">
+      <rect width="200" height="200"/>
+    </clipPath>
+    <filter id="f1">
+      <feFlood flood-color="green" result="green"/>
+      <feMerge><feMergeNode in="green"/></feMerge>
+    </filter>
+    <mask id="m1">
+      <rect width="200" height="200" fill="white"/>
+    </mask>
+  </defs>
+
+  <!-- clip-path: %6d%79%20%63%6c%69%70 = "my clip" -->
+  <rect id="r1" x="0" y="0" width="40" height="40" fill="green"
+        clip-path="url(#%6d%79%20%63%6c%69%70)"/>
+
+  <!-- filter: %66%31 = "f1" -->
+  <rect id="r2" x="50" y="0" width="40" height="40" filter="url(#%66%31)"/>
+
+  <!-- mask: %6d%31 = "m1" -->
+  <rect id="r3" x="100" y="0" width="40" height="40" fill="green"
+        mask="url(#%6d%31)"/>
+</svg>
+
+<script>
+test(() => {
+  const style = getComputedStyle(document.getElementById('r1'));
+  assert_not_equals(style.clipPath, 'none',
+    'clip-path should resolve percent-encoded fragment');
+  assert_true(style.clipPath.includes('url('),
+    'clip-path computed value should contain the URL reference');
+}, 'clip-path: url(#%6d%79%20%63%6c%69%70) resolves to clipPath id="my clip"');
+
+test(() => {
+  const style = getComputedStyle(document.getElementById('r2'));
+  assert_not_equals(style.filter, 'none',
+    'filter should resolve percent-encoded fragment');
+  assert_true(style.filter.includes('url('),
+    'filter computed value should contain the URL reference');
+}, 'filter: url(#%66%31) resolves to filter id="f1"');
+
+test(() => {
+  const style = getComputedStyle(document.getElementById('r3'));
+  assert_not_equals(style.mask, 'none',
+    'mask should resolve percent-encoded fragment');
+  assert_true(style.mask.includes('url('),
+    'mask computed value should contain the URL reference');
+}, 'mask: url(#%6d%31) resolves to mask id="m1"');
+</script>


### PR DESCRIPTION
WebKit export from bug: [Percent-decode fragments before using them for SVG references](https://bugs.webkit.org/show_bug.cgi?id=306387)