### PR TITLE
Fix relative URL in `Cache.add` test

### DIFF
--- a/service-workers/cache-storage/cache-add.https.any.js
+++ b/service-workers/cache-storage/cache-add.https.any.js
@@ -276,7 +276,7 @@ cache_test(function(cache, test) {
   }, 'Cache.addAll with a mix of succeeding and failing requests');
 
 cache_test(function(cache, test) {
-    var request = new Request('../resources/simple.txt');
+    var request = new Request('./resources/simple.txt');
     return promise_rejects_dom(
       test,
       'InvalidStateError',


### PR DESCRIPTION
The resources subdirectory is in the same directory as the tests. This matches all other tests in this file.