### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311190

### DIFF
--- a/css/css-values/attr-namespace-wildcard.html
+++ b/css/css-values/attr-namespace-wildcard.html
@@ -3,7 +3,7 @@
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="Wildcard not supported in attr() function">
 <style>
-.a {
+.outer {
    background: green;
    height: 100px;
    width: 100px;
@@ -11,7 +11,9 @@
 
 .attr {
   background: attr(*|bar type(*));
+  height: 100%;
+  width: 100%;
 }
 </style>
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
-<div class="a attr" bar="red"></div>
+<div class="outer"><div class="attr" bar="red"></div></div>


### PR DESCRIPTION
WebKit export from bug: [\[css-values-5 attr()\] Implement namespace parsing](https://bugs.webkit.org/show_bug.cgi?id=311190)