### PR TITLE
Update wptrunner for compatibility with a change in Python 3.13.

### DIFF
--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -115,7 +115,7 @@ def get_all_products() -> Mapping[str, EntryPoint]:
     # same name.
     return {
         ep.name: ep
-        for ep in itertools.chain(_BUILTIN_ENTRY_POINTS, reversed(eps))
+        for ep in itertools.chain(_BUILTIN_ENTRY_POINTS, reversed(list(eps)))
     }
 
 


### PR DESCRIPTION
This addresses #58984.

In Python 3.13, they upgraded to version 7.0.0 of importlib_metadata; as part of that upgrade, the EntryPoints class changed to something that no longer supported indexed access (it became more of a dict-like thing than a list- or tuple-like thing)
changed so that the EntryPoint class no longer supported __getitem__.
(See https://importlib-metadata.readthedocs.io/en/latest/history.html#v7-0-0).

As a result, if you were using a custom entry point to register an external test runner, tools/wptrunner/wptrunner.products.py would crash in a call to `reverse()`.

This fixes the issue by converting the "tuple" of EntryPoints into a list of values, which can then be accessed by index (and hence `reverse()` would work.