### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311471

### DIFF
--- a/scroll-animations/css/view-timeline-inset-parsing.html
+++ b/scroll-animations/css/view-timeline-inset-parsing.html
@@ -20,6 +20,9 @@ test_valid_value('view-timeline-inset', '1px auto, auto 4px');
 test_valid_value('view-timeline-inset', '1px, 2px, 3px');
 test_valid_value('view-timeline-inset', '1px 1px, 2px 3px', '1px, 2px 3px');
 test_valid_value('view-timeline-inset', 'auto auto, auto auto', 'auto, auto');
+test_valid_value('view-timeline-inset', '1.5px 1.5px', '1.5px');
+test_valid_value('view-timeline-inset', '300px 300px', '300px');
+test_valid_value('view-timeline-inset', '1em 1em', '1em');
 
 test_invalid_value('view-timeline-inset', 'none');
 test_invalid_value('view-timeline-inset', 'foo bar');


### PR DESCRIPTION
WebKit export from bug: [view-timeline-inset serialization fails to coalesce identical non-pooled values](https://bugs.webkit.org/show_bug.cgi?id=311471)