### PR TITLE
Show test result for content-visibility-svg's rect and path.

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-svg-path.html
+++ b/css/css-contain/content-visibility/content-visibility-svg-path.html
@@ -9,7 +9,7 @@ body {
   margin: 0;
   padding: 0;
 }
-div {
+#container {
   content-visibility:hidden;
 }
 path {
@@ -18,7 +18,7 @@ path {
 }
 </style>
 
-<div>
+<div id="container">
   <svg xmlns="http://www.w3.org/2000/svg">
     <path id="path" d="M5 5 L 10 5 L 10 10 L 5 10 Z"/>
   </svg>

--- a/css/css-contain/content-visibility/content-visibility-svg-rect.html
+++ b/css/css-contain/content-visibility/content-visibility-svg-rect.html
@@ -9,7 +9,7 @@ body {
   margin: 0;
   padding: 0;
 }
-div {
+#container {
   content-visibility:hidden;
 }
 rect {
@@ -18,7 +18,7 @@ rect {
 }
 </style>
 
-<div>
+<div id="container">
   <svg xmlns="http://www.w3.org/2000/svg">
     <rect id="rect" x="5" y="5" width="10" height="10"/>
   </svg>


### PR DESCRIPTION
The tests [content-visibility-svg-rect](https://wpt.live/css/css-contain/content-visibility/content-visibility-svg-rect.html) and [content-visibility-svg-path](https://wpt.live/css/css-contain/content-visibility/content-visibility-svg-path.html) are hiding all result block, because the test setup includes this style:
```css
div {
  content-visibility:hidden;
}
```

Instead of hiding any `<div>`, the test now only hides the `#container`.