### PR TITLE
Payment Handler: Add test for OperationError propagation

### DIFF
--- a/web-based-payment-handler/app-reject-errors.js
+++ b/web-based-payment-handler/app-reject-errors.js
@@ -1,0 +1,34 @@
+/**
+ * A payment handler that opens a window and allows the user to trigger
+ * different types of promise rejections for testing error propagation.
+ */
+self.addEventListener('canmakepayment', event => {
+  event.respondWith(true);
+});
+
+self.addEventListener('paymentrequest', event => {
+  const methodName = event.methodData[0].supportedMethods;
+  event.respondWith(new Promise((resolve, reject) => {
+    const handler = (msgEvent) => {
+      if (msgEvent.data === 'success') {
+        resolve({
+          methodName: methodName,
+          details: {status: 'success'},
+        });
+      } else if (msgEvent.data === 'reject-operation-error') {
+        reject(new DOMException('Reject with OperationError', 'OperationError'));
+      } else if (msgEvent.data === 'reject-syntax-error') {
+        reject(new DOMException('Reject with SyntaxError', 'SyntaxError'));
+      } else {
+        return; // Message not for us.
+      }
+      self.removeEventListener('message', handler);
+    };
+    self.addEventListener('message', handler);
+
+    event.openWindow('payment-app/reject-errors.html').catch(err => {
+      self.removeEventListener('message', handler);
+      reject(err);
+    });
+  }));
+});

--- a/web-based-payment-handler/app-reject-errors.js
+++ b/web-based-payment-handler/app-reject-errors.js
@@ -12,18 +12,26 @@ self.addEventListener('canmakepayment', event => {
 });
 
 self.addEventListener('message', msgEvent => {
-  if (!resolver || !rejecter) return;
+  console.log(`[ServiceWorker] Received message from payment app: ${msgEvent.data}`);
+  if (!resolver || !rejecter) {
+    console.error('[ServiceWorker] Received message, but no active payment request found.');
+    return;
+  }
 
   if (msgEvent.data === 'success') {
+    console.log('[ServiceWorker] Resolving payment request with success');
     resolver({
       methodName: activeMethodName,
       details: {status: 'success'},
     });
   } else if (msgEvent.data === 'reject-operation-error') {
+    console.log('[ServiceWorker] Rejecting payment request with OperationError');
     rejecter(new DOMException('Reject with OperationError', 'OperationError'));
   } else if (msgEvent.data === 'reject-syntax-error') {
+    console.log('[ServiceWorker] Rejecting payment request with SyntaxError');
     rejecter(new DOMException('Reject with SyntaxError', 'SyntaxError'));
   } else {
+    console.log(`[ServiceWorker] Unrecognized message data: ${msgEvent.data}`);
     return; // Message not for us.
   }
 
@@ -33,12 +41,17 @@ self.addEventListener('message', msgEvent => {
 });
 
 self.addEventListener('paymentrequest', event => {
+  console.log('[ServiceWorker] Received paymentrequest event');
   activeMethodName = event.methodData[0].supportedMethods;
   event.respondWith(new Promise((resolve, reject) => {
     resolver = resolve;
     rejecter = reject;
 
-    event.openWindow('payment-app/reject-errors.html').catch(err => {
+    console.log('[ServiceWorker] Opening payment app window...');
+    event.openWindow('payment-app/reject-errors.html').then(() => {
+      console.log('[ServiceWorker] Payment app window opened successfully');
+    }).catch(err => {
+      console.error(`[ServiceWorker] Failed to open payment app window: ${err}`);
       resolver = null;
       rejecter = null;
       activeMethodName = null;

--- a/web-based-payment-handler/app-reject-errors.js
+++ b/web-based-payment-handler/app-reject-errors.js
@@ -2,32 +2,46 @@
  * A payment handler that opens a window and allows the user to trigger
  * different types of promise rejections for testing error propagation.
  */
+
+let resolver = null;
+let rejecter = null;
+let activeMethodName = null;
+
 self.addEventListener('canmakepayment', event => {
   event.respondWith(true);
 });
 
+self.addEventListener('message', msgEvent => {
+  if (!resolver || !rejecter) return;
+
+  if (msgEvent.data === 'success') {
+    resolver({
+      methodName: activeMethodName,
+      details: {status: 'success'},
+    });
+  } else if (msgEvent.data === 'reject-operation-error') {
+    rejecter(new DOMException('Reject with OperationError', 'OperationError'));
+  } else if (msgEvent.data === 'reject-syntax-error') {
+    rejecter(new DOMException('Reject with SyntaxError', 'SyntaxError'));
+  } else {
+    return; // Message not for us.
+  }
+
+  resolver = null;
+  rejecter = null;
+  activeMethodName = null;
+});
+
 self.addEventListener('paymentrequest', event => {
-  const methodName = event.methodData[0].supportedMethods;
+  activeMethodName = event.methodData[0].supportedMethods;
   event.respondWith(new Promise((resolve, reject) => {
-    const handler = (msgEvent) => {
-      if (msgEvent.data === 'success') {
-        resolve({
-          methodName: methodName,
-          details: {status: 'success'},
-        });
-      } else if (msgEvent.data === 'reject-operation-error') {
-        reject(new DOMException('Reject with OperationError', 'OperationError'));
-      } else if (msgEvent.data === 'reject-syntax-error') {
-        reject(new DOMException('Reject with SyntaxError', 'SyntaxError'));
-      } else {
-        return; // Message not for us.
-      }
-      self.removeEventListener('message', handler);
-    };
-    self.addEventListener('message', handler);
+    resolver = resolve;
+    rejecter = reject;
 
     event.openWindow('payment-app/reject-errors.html').catch(err => {
-      self.removeEventListener('message', handler);
+      resolver = null;
+      rejecter = null;
+      activeMethodName = null;
       reject(err);
     });
   }));

--- a/web-based-payment-handler/app-reject-errors.js
+++ b/web-based-payment-handler/app-reject-errors.js
@@ -12,26 +12,18 @@ self.addEventListener('canmakepayment', event => {
 });
 
 self.addEventListener('message', msgEvent => {
-  console.log(`[ServiceWorker] Received message from payment app: ${msgEvent.data}`);
-  if (!resolver || !rejecter) {
-    console.error('[ServiceWorker] Received message, but no active payment request found.');
-    return;
-  }
+  if (!resolver || !rejecter) return;
 
   if (msgEvent.data === 'success') {
-    console.log('[ServiceWorker] Resolving payment request with success');
     resolver({
       methodName: activeMethodName,
       details: {status: 'success'},
     });
   } else if (msgEvent.data === 'reject-operation-error') {
-    console.log('[ServiceWorker] Rejecting payment request with OperationError');
     rejecter(new DOMException('Reject with OperationError', 'OperationError'));
   } else if (msgEvent.data === 'reject-syntax-error') {
-    console.log('[ServiceWorker] Rejecting payment request with SyntaxError');
     rejecter(new DOMException('Reject with SyntaxError', 'SyntaxError'));
   } else {
-    console.log(`[ServiceWorker] Unrecognized message data: ${msgEvent.data}`);
     return; // Message not for us.
   }
 
@@ -41,17 +33,12 @@ self.addEventListener('message', msgEvent => {
 });
 
 self.addEventListener('paymentrequest', event => {
-  console.log('[ServiceWorker] Received paymentrequest event');
   activeMethodName = event.methodData[0].supportedMethods;
   event.respondWith(new Promise((resolve, reject) => {
     resolver = resolve;
     rejecter = reject;
 
-    console.log('[ServiceWorker] Opening payment app window...');
-    event.openWindow('payment-app/reject-errors.html').then(() => {
-      console.log('[ServiceWorker] Payment app window opened successfully');
-    }).catch(err => {
-      console.error(`[ServiceWorker] Failed to open payment app window: ${err}`);
+    event.openWindow('payment-app/reject-errors.html').catch(err => {
       resolver = null;
       rejecter = null;
       activeMethodName = null;

--- a/web-based-payment-handler/payment-app/reject-errors.html
+++ b/web-based-payment-handler/payment-app/reject-errors.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Reject Error Payment App</title>
+<p>Please click one of the buttons below to complete or reject the payment.</p>
+<button id="success">Authorize (Success)</button>
+<button id="reject-operation-error">Reject with OperationError</button>
+<button id="reject-syntax-error">Reject with SyntaxError</button>
+
+<script>
+  for (const id of ['success', 'reject-operation-error', 'reject-syntax-error']) {
+    document.getElementById(id).onclick = () => {
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage(id);
+      }
+      window.close();
+    };
+  }
+</script>

--- a/web-based-payment-handler/payment-app/reject-errors.html
+++ b/web-based-payment-handler/payment-app/reject-errors.html
@@ -9,14 +9,9 @@
 <script>
   for (const id of ['success', 'reject-operation-error', 'reject-syntax-error']) {
     document.getElementById(id).onclick = () => {
-      console.log(`[PaymentApp] Button clicked: ${id}`);
       if (navigator.serviceWorker.controller) {
-        console.log(`[PaymentApp] Posting message to service worker: ${id}`);
         navigator.serviceWorker.controller.postMessage(id);
-      } else {
-        console.error('[PaymentApp] No service worker controller found!');
       }
-      console.log('[PaymentApp] Closing window');
       window.close();
     };
   }

--- a/web-based-payment-handler/payment-app/reject-errors.html
+++ b/web-based-payment-handler/payment-app/reject-errors.html
@@ -9,9 +9,14 @@
 <script>
   for (const id of ['success', 'reject-operation-error', 'reject-syntax-error']) {
     document.getElementById(id).onclick = () => {
+      console.log(`[PaymentApp] Button clicked: ${id}`);
       if (navigator.serviceWorker.controller) {
+        console.log(`[PaymentApp] Posting message to service worker: ${id}`);
         navigator.serviceWorker.controller.postMessage(id);
+      } else {
+        console.error('[PaymentApp] No service worker controller found!');
       }
+      console.log('[PaymentApp] Closing window');
       window.close();
     };
   }

--- a/web-based-payment-handler/payment-request-reject-errors-manifest.json
+++ b/web-based-payment-handler/payment-request-reject-errors-manifest.json
@@ -10,6 +10,6 @@
   ],
   "serviceworker": {
     "src": "app-reject-errors.js",
-    "scope": "payment-request-reject-errors-payment-app/"
+    "scope": "./"
   }
 }

--- a/web-based-payment-handler/payment-request-reject-errors-manifest.json
+++ b/web-based-payment-handler/payment-request-reject-errors-manifest.json
@@ -1,0 +1,15 @@
+{
+  "default_applications": ["payment-request-reject-errors-manifest.json"],
+  "name": "Reject Errors Payment Handler",
+  "icons": [
+    {
+      "src": "/images/rgrg-256x256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    }
+  ],
+  "serviceworker": {
+    "src": "app-reject-errors.js",
+    "scope": "payment-request-reject-errors-payment-app/"
+  }
+}

--- a/web-based-payment-handler/payment-request-reject-errors-manifest.json.headers
+++ b/web-based-payment-handler/payment-request-reject-errors-manifest.json.headers
@@ -1,0 +1,1 @@
+Link: </web-based-payment-handler/payment-request-reject-errors-manifest.json>; rel="payment-method-manifest"

--- a/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
+++ b/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
@@ -18,20 +18,36 @@
       + 'payment-request-reject-errors-manifest.json';
 
   promise_test(async t => {
+    console.log('[Test] Starting OperationError test case');
     await test_driver.bless('invoking a payment app for OperationError');
     const request = new PaymentRequest([{supportedMethods: methodName}], {
       total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
     });
+    console.log('[Test] Calling show() for OperationError');
     // show() should reject with the SAME error if it's OperationError.
-    await promise_rejects_dom(t, 'OperationError', request.show());
+    try {
+      await promise_rejects_dom(t, 'OperationError', request.show());
+      console.log('[Test] show() rejected correctly with OperationError');
+    } catch (err) {
+      console.error(`[Test] show() failed to reject as expected: ${err}`);
+      throw err;
+    }
   }, 'If a payment app rejects with OperationError, show() rejects with OperationError');
 
   promise_test(async t => {
+    console.log('[Test] Starting SyntaxError test case');
     await test_driver.bless('invoking a payment app for SyntaxError');
     const request = new PaymentRequest([{supportedMethods: methodName}], {
       total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
     });
+    console.log('[Test] Calling show() for SyntaxError');
     // show() should reject with AbortError for other error types.
-    await promise_rejects_dom(t, 'AbortError', request.show());
+    try {
+      await promise_rejects_dom(t, 'AbortError', request.show());
+      console.log('[Test] show() rejected correctly with AbortError');
+    } catch (err) {
+      console.error(`[Test] show() failed to reject as expected: ${err}`);
+      throw err;
+    }
   }, 'If a payment app rejects with SyntaxError, show() rejects with AbortError');
 </script>

--- a/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
+++ b/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
@@ -18,36 +18,20 @@
       + 'payment-request-reject-errors-manifest.json';
 
   promise_test(async t => {
-    console.log('[Test] Starting OperationError test case');
     await test_driver.bless('invoking a payment app for OperationError');
     const request = new PaymentRequest([{supportedMethods: methodName}], {
       total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
     });
-    console.log('[Test] Calling show() for OperationError');
     // show() should reject with the SAME error if it's OperationError.
-    try {
-      await promise_rejects_dom(t, 'OperationError', request.show());
-      console.log('[Test] show() rejected correctly with OperationError');
-    } catch (err) {
-      console.error(`[Test] show() failed to reject as expected: ${err}`);
-      throw err;
-    }
+    await promise_rejects_dom(t, 'OperationError', request.show());
   }, 'If a payment app rejects with OperationError, show() rejects with OperationError');
 
   promise_test(async t => {
-    console.log('[Test] Starting SyntaxError test case');
     await test_driver.bless('invoking a payment app for SyntaxError');
     const request = new PaymentRequest([{supportedMethods: methodName}], {
       total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
     });
-    console.log('[Test] Calling show() for SyntaxError');
     // show() should reject with AbortError for other error types.
-    try {
-      await promise_rejects_dom(t, 'AbortError', request.show());
-      console.log('[Test] show() rejected correctly with AbortError');
-    } catch (err) {
-      console.error(`[Test] show() failed to reject as expected: ${err}`);
-      throw err;
-    }
+    await promise_rejects_dom(t, 'AbortError', request.show());
   }, 'If a payment app rejects with SyntaxError, show() rejects with AbortError');
 </script>

--- a/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
+++ b/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Manual Tests for rejecting respondWith with errors</title>
+<link rel="help" href="https://w3c.github.io/web-based-payment-handler/#the-paymentrequestevent">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<p>This test verifies that if a payment app rejects the promise passed to <code>respondWith</code> with an <code>OperationError</code>, the original <code>PaymentRequest.show()</code> call also rejects with an <code>OperationError</code>. For other error types, it should still reject with an <code>AbortError</code>.</p>
+<p>Please follow these instructions:</p>
+<ol>
+  <li>For the first test (<b>OperationError</b>), select "Reject Errors Payment Handler" in the payment sheet. When the app window opens, click "Reject with OperationError".</li>
+  <li>For the second test (<b>SyntaxError</b>), select "Reject Errors Payment Handler" in the payment sheet. When the app window opens, click "Reject with SyntaxError".</li>
+</ol>
+
+<script>
+  const methodName = window.location.origin + '/web-based-payment-handler/'
+      + 'payment-request-reject-errors-manifest.json';
+
+  promise_test(async t => {
+    await test_driver.bless('invoking a payment app for OperationError');
+    const request = new PaymentRequest([{supportedMethods: methodName}], {
+      total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
+    });
+    // show() should reject with the SAME error if it's OperationError.
+    await promise_rejects_dom(t, 'OperationError', request.show());
+  }, 'If a payment app rejects with OperationError, show() rejects with OperationError');
+
+  promise_test(async t => {
+    await test_driver.bless('invoking a payment app for SyntaxError');
+    const request = new PaymentRequest([{supportedMethods: methodName}], {
+      total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
+    });
+    // show() should reject with AbortError for other error types.
+    await promise_rejects_dom(t, 'AbortError', request.show());
+  }, 'If a payment app rejects with SyntaxError, show() rejects with AbortError');
+</script>

--- a/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
+++ b/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
@@ -9,8 +9,8 @@
 <p>This test verifies that if a payment app rejects the promise passed to <code>respondWith</code> with an <code>OperationError</code>, the original <code>PaymentRequest.show()</code> call also rejects with an <code>OperationError</code>. For other error types, it should still reject with an <code>AbortError</code>.</p>
 <p>Please follow these instructions:</p>
 <ol>
-  <li>For the first test (<b>OperationError</b>), select "Reject Errors Payment Handler" in the payment sheet. When the app window opens, click "Reject with OperationError".</li>
-  <li>For the second test (<b>SyntaxError</b>), select "Reject Errors Payment Handler" in the payment sheet. When the app window opens, click "Reject with SyntaxError".</li>
+  <li>For the first test (<b>OperationError</b>), click "Reject with OperationError".</li>
+  <li>For the second test (<b>SyntaxError</b>), click "Reject with SyntaxError".</li>
 </ol>
 
 <script>

--- a/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
+++ b/web-based-payment-handler/payment-request-reject-operation-error-manual.https.html
@@ -4,8 +4,6 @@
 <link rel="help" href="https://w3c.github.io/web-based-payment-handler/#the-paymentrequestevent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <p>This test verifies that if a payment app rejects the promise passed to <code>respondWith</code> with an <code>OperationError</code>, the original <code>PaymentRequest.show()</code> call also rejects with an <code>OperationError</code>. For other error types, it should still reject with an <code>AbortError</code>.</p>
 <p>Please follow these instructions:</p>
 <ol>
@@ -18,7 +16,6 @@
       + 'payment-request-reject-errors-manifest.json';
 
   promise_test(async t => {
-    await test_driver.bless('invoking a payment app for OperationError');
     const request = new PaymentRequest([{supportedMethods: methodName}], {
       total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
     });
@@ -27,7 +24,6 @@
   }, 'If a payment app rejects with OperationError, show() rejects with OperationError');
 
   promise_test(async t => {
-    await test_driver.bless('invoking a payment app for SyntaxError');
     const request = new PaymentRequest([{supportedMethods: methodName}], {
       total: {label: 'Total', amount: {currency: 'USD', value: '0.01'}},
     });


### PR DESCRIPTION
This change adds a new manual test to verify that if a web-based payment handler rejects the promise passed to respondWith with an OperationError, the original PaymentRequest.show() call also rejects with an OperationError.

For other error types (like SyntaxError), show() should still reject with an AbortError.

Spec: https://github.com/w3c/web-based-payment-handler/issues/428