### PR TITLE
Avoid re-installing Safari Technology Preview for each run

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -89,8 +89,7 @@ jobs:
         run: |-
           set -eux -o pipefail
           export SYSTEM_VERSION_COMPAT=0
-          ./wpt install --channel preview --download-only -d . --rename STP safari browser
-          sudo installer -pkg STP.pkg -target LocalSystem
+          ./wpt install --channel preview safari browser
           sudo /Applications/Safari\ Technology\ Preview.app/Contents/MacOS/safaridriver --enable
       - name: Update hosts
         run: |-

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1,14 +1,17 @@
 # mypy: allow-untyped-defs
 import configparser
+import glob
 import json
 import os
 import platform
+import plistlib
 import re
 import shutil
 import stat
 import subprocess
 import sys
 import tempfile
+import xml.etree.ElementTree as etree  # noqa: N813
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta, timezone
 from shutil import which
@@ -18,6 +21,7 @@ from urllib.parse import urlsplit, quote
 import html5lib
 import requests
 from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 from .utils import (
     call,
@@ -2312,18 +2316,149 @@ class Safari(Browser):
             image_path = self._download_image(stp_downloads, tmpdir, system_version)
             return self._download_extract(image_path, dest, rename)
 
+    def _installed_version(self, channel=None):
+        binary = self.find_binary(channel=channel)
+        if binary is None:
+            return None
+        plist_path = os.path.join(binary, "Contents", "Info.plist")
+        try:
+            with open(plist_path, "rb") as f:
+                return plistlib.load(f).get("CFBundleVersion")
+        except (OSError, plistlib.InvalidFileException) as e:
+            self.logger.debug(f"Failed to read plist at {plist_path}: {e}")
+            return None
+
+    @staticmethod
+    def _stp_version_from_expanded_pkg(expanded):
+        package_infos = glob.glob(os.path.join(expanded, "*.pkg", "PackageInfo"))
+        if not package_infos:
+            return None
+
+        for pi_path in package_infos:
+            try:
+                root = etree.parse(pi_path).getroot()
+            except etree.ParseError:
+                continue
+            bundle = root.find(".//bundle[@id='com.apple.SafariTechnologyPreview']")
+            if bundle is not None:
+                return bundle.get("CFBundleVersion")
+
+        return None
+
+    def _pkg_version(self, pkg_path):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            expanded = os.path.join(tmpdir, "pkg")
+            try:
+                subprocess.run(
+                    ["pkgutil", "--expand", pkg_path, expanded],
+                    capture_output=True,
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                self.logger.warning(f"Failed to expand {pkg_path}")
+                return None
+
+            version = self._stp_version_from_expanded_pkg(expanded)
+            if version is None:
+                self.logger.warning(f"STP bundle version not found in {pkg_path}")
+
+            return version
+
+    def _install_package(self, pkg_path):
+        pkg_version = self._pkg_version(pkg_path)
+        if pkg_version is None:
+            self.logger.warning(f"Failed to determine version of downloaded package {pkg_path}")
+        installed_version = self._installed_version()
+
+        if pkg_version is not None and installed_version is not None:
+            try:
+                if Version(installed_version) >= Version(pkg_version):
+                    self.logger.info(f"STP {installed_version} already installed, pkg has {pkg_version}")
+                    return self.find_binary(channel="preview")
+            except InvalidVersion:
+                self.logger.warning(
+                    f"Failed to compare versions: installed {installed_version}, pkg {pkg_version}; "
+                    "proceeding with install"
+                )
+
+        self.logger.info(f"Installing STP: pkg {pkg_version}, installed {installed_version}")
+        subprocess.run(
+            ["sudo", "-p", "Password (installing Safari Technology Preview): ",
+             "installer", "-pkg", pkg_path, "-target", "LocalSystem"],
+            check=True,
+        )
+        app_path = self.find_binary(channel="preview")
+        if app_path is None or not os.path.isdir(app_path):
+            raise RuntimeError(f"STP installation failed: app not found at {app_path}")
+        return app_path
+
     def install(self, dest=None, channel=None, url=None):
-        # We can't do this because stable/beta releases are system components and STP
-        # requires admin permissions to install.
-        raise NotImplementedError
+        if channel != "preview":
+            raise ValueError(f"can only install 'preview', not '{channel}'")
+
+        if dest is not None:
+            self.logger.warning("Safari.install() ignores dest; STP is always installed to /Applications/")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_path = self.download(tmpdir, channel)
+            return self._install_package(pkg_path)
+
+    def find_binary(self, venv_path=None, channel=None):
+        if channel is None or channel == "preview":
+            bundle_id = "com.apple.SafariTechnologyPreview"
+            default = "/Applications/Safari Technology Preview.app"
+        elif channel in ("stable", "beta"):
+            bundle_id = "com.apple.Safari"
+            default = "/Applications/Safari.app"
+        else:
+            return None
+
+        try:
+            result = subprocess.run(
+                ["mdfind", "-0", f"kMDItemCFBundleIdentifier == '{bundle_id}'"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            paths = result.stdout.split("\x00")
+            if default in paths and os.path.isdir(default):
+                return default
+            for path in paths:
+                if os.path.isdir(path):
+                    return path
+        except subprocess.CalledProcessError:
+            self.logger.debug(f"mdfind failed; assuming default path: {default}")
+
+        if not os.path.isdir(default):
+            self.logger.error(
+                f"Unable to find {bundle_id}. Spotlight could not locate it and "
+                f"it does not exist at the default path: {default}"
+            )
+            return None
+
+        return default
 
     def find_webdriver(self, venv_path=None, channel=None):
         path = None
-        if channel == "preview":
-            path = "/Applications/Safari Technology Preview.app/Contents/MacOS"
+        if channel not in ("stable", "beta"):
+            binary = self.find_binary(channel=channel)
+            if binary is None:
+                return None
+            path = os.path.join(binary, "Contents", "MacOS")
         return which("safaridriver", path=path)
 
     def version(self, binary=None, webdriver_binary=None):
+        if binary is not None:
+            plist_path = os.path.join(binary, "Contents", "Info.plist")
+            try:
+                with open(plist_path, "rb") as f:
+                    info = plistlib.load(f)
+            except (OSError, plistlib.InvalidFileException) as e:
+                self.logger.debug(f"Failed to read plist at {plist_path}: {e}")
+                return None
+            if info.get("CFBundleIdentifier") != "com.apple.SafariTechnologyPreview":
+                return info.get("CFBundleShortVersionString")
+
         if webdriver_binary is None:
             self.logger.warning("Cannot find Safari version without safaridriver")
             return None

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -725,9 +725,6 @@ class Safari(BrowserSetup):
     name = "safari"
     browser_cls = browser.Safari
 
-    def install(self, channel=None, url=None):
-        raise NotImplementedError
-
     def setup_kwargs(self, kwargs):
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = self.browser.find_webdriver(channel=kwargs["browser_channel"])

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -500,3 +500,50 @@ def test_wpewebkit_minibrowser_find_binary(mocked_os_path_isfile, mocked_os_list
     mocked_os_listdir.side_effect = lambda contents: sorted(['wpewebkit-6.0', 'webkit2gtk-4.0', 'wpe-webkit-2.0', 'wpe-webkit-1.0'])
     mocked_which.side_effect = lambda found: None
     assert wpewebkit_minibrowser.find_binary() == '/usr/libexec/wpe-webkit-2.0/MiniBrowser'
+
+
+@pytest.mark.parametrize("pkg_version,installed_version,expect_install", [
+    pytest.param("210", "211", False, id="installed-newer"),
+    pytest.param("210", "210", False, id="installed-equal"),
+    pytest.param("211", "210", True, id="pkg-newer"),
+    pytest.param(None, "210", True, id="pkg-version-unknown"),
+    pytest.param("211", None, True, id="installed-version-unknown"),
+    pytest.param(None, None, True, id="both-unknown"),
+    pytest.param("not-a-version", "also-not-a-version", True, id="invalid-versions"),
+])
+@mock.patch('subprocess.run')
+@mock.patch('os.path.isdir', return_value=True)
+def test_safari_install(mocked_isdir, mocked_run, pkg_version, installed_version, expect_install):
+    safari = browser.Safari(logger)
+    safari.download = mock.MagicMock(return_value="/tmp/STP.pkg")
+    safari._pkg_version = mock.MagicMock(return_value=pkg_version)
+    safari._installed_version = mock.MagicMock(return_value=installed_version)
+    safari.find_binary = mock.MagicMock(return_value="/Applications/Safari Technology Preview.app")
+
+    result = safari.install(channel="preview")
+
+    assert result == "/Applications/Safari Technology Preview.app"
+    if expect_install:
+        mocked_run.assert_called_once()
+        assert "installer" in mocked_run.call_args[0][0]
+    else:
+        mocked_run.assert_not_called()
+
+
+@mock.patch('subprocess.run')
+def test_safari_install_raises_when_app_not_found_after_install(mocked_run):
+    safari = browser.Safari(logger)
+    safari.download = mock.MagicMock(return_value="/tmp/STP.pkg")
+    safari._pkg_version = mock.MagicMock(return_value="211")
+    safari._installed_version = mock.MagicMock(return_value="210")
+    safari.find_binary = mock.MagicMock(return_value=None)
+
+    with pytest.raises(RuntimeError):
+        safari.install(channel="preview")
+
+
+def test_safari_install_rejects_non_preview_channel():
+    safari = browser.Safari(logger)
+
+    with pytest.raises(ValueError):
+        safari.install(channel="stable")


### PR DESCRIPTION
This avoids some of the occasional issues we've seen with STP failing to launch.