### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311630

### DIFF
--- a/interfaces/SVG.idl
+++ b/interfaces/SVG.idl
@@ -13,7 +13,6 @@ interface SVGElement : Element {
 };
 
 SVGElement includes GlobalEventHandlers;
-SVGElement includes SVGElementInstance;
 SVGElement includes HTMLOrSVGElement;
 
 dictionary SVGBoundingBoxOptions {
@@ -307,11 +306,6 @@ SVGUseElement includes SVGURIReference;
 
 [Exposed=Window]
 interface SVGUseElementShadowRoot : ShadowRoot {
-};
-
-interface mixin SVGElementInstance {
-  [SameObject] readonly attribute SVGElement? correspondingElement;
-  [SameObject] readonly attribute SVGUseElement? correspondingUseElement;
 };
 
 [Exposed=Window]


### PR DESCRIPTION
WebKit export from bug: [Remove correspondingElement/correspondingUseElement from WPT per SVGWG decision](https://bugs.webkit.org/show_bug.cgi?id=311630)