### PR TITLE
Update web-feature mappings for recent rename

### DIFF
--- a/css/css-text/parsing/WEB_FEATURES.yml
+++ b/css/css-text/parsing/WEB_FEATURES.yml
@@ -18,21 +18,13 @@ features:
 - name: text-wrap-pretty
   files:
   - text-wrap-pretty.html
-- name: text-wrap-style
-  files:
-  - text-wrap-style-*
 - name: white-space-collapse
   files:
   - white-space-collapse-*
 - name: text-wrap
   files:
-  # No wildcard here to avoid capturing text-wrap-mode-*.
-  - text-wrap-computed.html
-  - text-wrap-invalid.html
-  - text-wrap-valid.html
-- name: text-wrap-mode
-  files:
-  - text-wrap-mode-*
+  - text-wrap-*
+  - "!text-wrap-pretty.html"
 - name: word-spacing
   files:
   - word-spacing-*

--- a/css/css-text/white-space/WEB_FEATURES.yml
+++ b/css/css-text/white-space/WEB_FEATURES.yml
@@ -2,7 +2,7 @@ features:
 - name: text-wrap-balance
   files:
   - text-wrap-balance-*
-- name: text-wrap-nowrap
+- name: text-wrap
   files:
   - text-wrap-nowrap-*
 - name: white-space


### PR DESCRIPTION
Ref: https://github.com/web-platform-dx/web-features/pull/2900

---

Today, three tests are mapped to the recently-remove `text-wrap-style` web-feature. In this patch, I've remapped them all to `text-wrap` despite the fact that [the web-feature itself was split into three](https://github.com/web-platform-dx/web-features/pull/2900) because they can't be segmented so cleanly. Please let me know if it would be better to omit them from classification.