### PR TITLE
script: Reduce `ShadowRoot::bind_to_tree` complexity from O(2^N) to O(N)

### DIFF
--- a/shadow-dom/build-deep-detached-shadow-then-append-text.html
+++ b/shadow-dom/build-deep-detached-shadow-then-append-text.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Build detached deeply nested shadow tree, attach to document, then append text node</title>
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<link rel="help" href="https://github.com/servo/servo/issues/43998">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="X"></div>
+
+<script>
+test(() => {
+  const detachedRoot = document.createElement('div');
+  let currentContainer = detachedRoot;
+  const depth = 999;
+
+  for (let i = 0; i < depth; i++) {
+    const childHost = document.createElement('div');
+    const childShadow = childHost.attachShadow({ mode: 'open' });
+    currentContainer.appendChild(childHost);
+    currentContainer = childShadow;
+  }
+
+  document.getElementById('X').appendChild(detachedRoot);
+  currentContainer.appendChild(document.createTextNode('Hello!'));
+
+  assert_equals(currentContainer.textContent, 'Hello!');
+}, "Build detached deeply nested shadow tree, attaching to the document, then appending a text node should not hang or crash");
+</script>


### PR DESCRIPTION
During traversal, exclude shadow roots.

Analysis:
Each shadow root is processed twice:
- via host: Element::bind_to_tree()
-  Via iterator

In total, this would be
```math
\sum_{i=0}^{N-1} 2^i = 2^N - 1
```

Testing: Added a test.
Fixes: https://github.com/servo/servo/issues/43998
Reviewed in servo/servo#44016