### PR TITLE
script: Claim blob before loading `<video>` poster frame

### DIFF
--- a/html/semantics/embedded-content/the-video-element/video-poster-from-revoked-blob.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-from-revoked-blob.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <title>Verifies that video poster is shown even if video element has 'preload="auto"' attribute</title>
+        <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+        <link rel="match" href="video-poster-shown-preload-auto-ref.html">
+    </head>
+    <body>
+        <video id="target" src="/media/video.webm" width="100" height="100"></video>
+        <script>
+            const video = document.querySelector("video");
+            fetch("/media/poster.png")
+              .then(response => {
+                  response.blob().then((blob) => {
+                    let url = URL.createObjectURL(blob);
+                    video.poster = url;
+                    URL.revokeObjectURL(url);
+
+                    video.oncanplaythrough = () => document.documentElement.classList.remove("reftest-wait");
+                  })
+              });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Refer to https://github.com/servo/servo/pull/43746 for a description of the problem. This change ensures that video posters can be loaded from blob URLs, even if the URL is revoked right after.

Testing: This change adds a test
Reviewed in servo/servo#44035