### PR TITLE
adds linter rule to catch "yaml" extension

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -757,7 +757,10 @@ def check_meta_file(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Err
 
 
 def check_web_features_file_path(repo_root: Text, path: Text) -> List[rules.Error]:
-    if os.path.basename(path) != WEB_FEATURES_YML_FILENAME:
+    basename = os.path.basename(path)
+    if basename == "WEB_FEATURES.yaml":
+        return [rules.InvalidWebFeaturesFile.error(path, ("Use 'WEB_FEATURES.yml' instead of 'WEB_FEATURES.yaml'",))]
+    if basename != WEB_FEATURES_YML_FILENAME:
         return []
     source_file = SourceFile(repo_root, path, "/")
     if source_file.in_non_test_dir():

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -186,3 +186,23 @@ def test_web_features_file_in_non_test_directory(path):
 def test_web_features_file_in_non_test_directory_negative(path):
     errors = check_path("/foo/", path)
     assert not any(e[0] == "WEB-FEATURES-FILE-IN-NON-TEST-DIRECTORY" for e in errors)
+
+
+@pytest.mark.parametrize("path", [
+    os.path.join("css", "css-images", "WEB_FEATURES.yaml"),
+    os.path.join("html", "semantics", "WEB_FEATURES.yaml"),
+])
+def test_wrong_web_features_file_extension(path):
+    errors = check_path("/foo/", path)
+    assert len(errors) == 1
+    assert errors[0][0] == "INVALID-WEB-FEATURES-FILE"
+
+
+@pytest.mark.parametrize("path", [
+    os.path.join("css", "css-images", "WEB_FEATURES.yml"),
+    os.path.join("html", "semantics", "WEB_FEATURES.yml"),
+    os.path.join("css", "css-images", "other_file.yaml"),
+])
+def test_wrong_web_features_file_extension_negative(path):
+    errors = check_path("/foo/", path)
+    assert not any(e[0] == "INVALID-WEB-FEATURES-FILE" for e in errors)


### PR DESCRIPTION
Following https://github.com/web-platform-tests/wpt/pull/58927, this enforces use of the `.yml` extension (over `.yaml`) for `WEB_FEATURES` files. 

cc @jcscottiii @jugglinmike for review