### PR TITLE
Fix #59047 - fix SVG fresh specs links

### DIFF
--- a/css/css-conditional/container-queries/container-units-svglength.html
+++ b/css/css-conditional/container-queries/container-units-svglength.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>CSS Container Queries Test: container-relative units in SVGLength</title>
 <link rel="help" href="https://drafts.csswg.org/css-conditional-5/#container-lengths">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGLength">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGLength">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/cq-testcommon.js"></script>

--- a/css/css-images/svg-images-are-ignored.html
+++ b/css/css-images/svg-images-are-ignored.html
@@ -5,7 +5,7 @@
     <title>CSS Image Test: SVG used as an image does not load images</title>
     <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
     <link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">
-    <link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#conform-referencing-modes">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#conform-referencing-modes">
     <link rel="match" href="svg-images-are-ignored-ref.html">
     <style>
       * {

--- a/css/css-images/svg-script-is-ignored.html
+++ b/css/css-images/svg-script-is-ignored.html
@@ -5,7 +5,7 @@
     <title>CSS Image Test: SVG used as an image does not execute any script</title>
     <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
     <link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">
-    <link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#conform-referencing-modes">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#conform-referencing-modes">
     <link rel="match" href="svg-script-is-ignored-ref.svg">
     <style>
       * {

--- a/css/css-transforms/transform-box/svgbox-stroke-box-002.html
+++ b/css/css-transforms/transform-box/svgbox-stroke-box-002.html
@@ -2,7 +2,7 @@
 <title>transform-box: stroke-box, stroke with dash array</title>
 <link rel="match" href="reference/svgbox-rect-dasharray-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-box">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#TermStrokeBoundingBox">
 <meta name="assert" content="A dash array does not contribute to the stroke bounding box"/>
 <style>
 #target {

--- a/css/css-transforms/transform-box/svgbox-stroke-box-003.html
+++ b/css/css-transforms/transform-box/svgbox-stroke-box-003.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Jonathan Watt" href="mailto:jwatt@jwatt.org">
 <link rel="match" href="reference/svgbox-rect-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-box">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffects">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9640">
 <meta name="assert" content="The used value of transform-box is fill-box on SVG with non-scaling-stroke"/>
 <style>

--- a/css/css-transforms/transform-box/svgbox-stroke-box-004.html
+++ b/css/css-transforms/transform-box/svgbox-stroke-box-004.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Jonathan Watt" href="mailto:jwatt@jwatt.org">
 <link rel="match" href="reference/svgbox-rect-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-box">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffects">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9640">
 <meta name="assert" content="The used value of transform-box is fill-box on SVG with non-scaling-stroke"/>
 <style>

--- a/css/css-transforms/transform-box/svgbox-stroke-box-005.html
+++ b/css/css-transforms/transform-box/svgbox-stroke-box-005.html
@@ -2,7 +2,7 @@
 <title>transform-box: border-box, stroke with vector-effect: non-scaling-stroke</title>
 <link rel="match" href="reference/svgbox-rect-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-box">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffects">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9640">
 <meta name="assert" content="The used value of transform-box is fill-box on SVG with non-scaling-stroke"/>
 <style>

--- a/css/filter-effects/svgfeblendelement-mode-001.html
+++ b/css/filter-effects/svgfeblendelement-mode-001.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <title>SVGFEBlendElement.prototype.mode</title>
 <link rel="help" href="https://drafts.fxtf.org/filter-effects/#InterfaceSVGFEBlendElement">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/css/motion/animation/offset-path-interpolation-002.html
+++ b/css/motion/animation/offset-path-interpolation-002.html
@@ -66,7 +66,7 @@
 
       // At progress 0.125/0.875, arc flags in path() should consider
       // non-zero interpolated values as one to match <path> behaviour.
-      // https://svgwg.org/specs/paths/#PathElement
+      // https://w3c.github.io/svgwg/specs/paths/#PathElement
       test_interpolation({
         property: 'offset-path',
         from: "path('M 100 400 A 10 20 30 1 0 140 450')",

--- a/css/motion/animation/offset-path-interpolation-004.html
+++ b/css/motion/animation/offset-path-interpolation-004.html
@@ -108,7 +108,7 @@
 
       // At progress 0.125/0.875, arc flags in path() should consider
       // non-zero interpolated values as one to match <path> behaviour.
-      // https://svgwg.org/specs/paths/#PathElement
+      // https://w3c.github.io/svgwg/specs/paths/#PathElement
       test_interpolation({
         property: 'offset-path',
         from: "path('m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50')",

--- a/css/motion/offset-path-url-002.html
+++ b/css/motion/offset-path-url-002.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Motion Path: offset-path:url() to rectangles</title>
     <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-url">
-    <link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#RectElement">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#RectElement">
     <link rel="match" href="offset-path-url-002-ref.html">
     <meta name="assert" content="This tests that url() referenced to a rect
       generates a rotation and translation.">

--- a/css/motion/offset-path-url-003.html
+++ b/css/motion/offset-path-url-003.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Motion Path: offset-path:url() to circles</title>
     <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-url">
-    <link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#CircleElement">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#CircleElement">
     <link rel="match" href="offset-path-url-003-ref.html">
     <meta name=fuzzy content="0-35;0-85">
     <meta name="assert" content="This tests that url() referenced to a circle

--- a/css/motion/offset-path-url-004.html
+++ b/css/motion/offset-path-url-004.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Motion Path: offset-path:url() to ellipses</title>
     <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-url">
-    <link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#EllipseElement">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement">
     <link rel="match" href="offset-path-url-004-ref.html">
     <meta name=fuzzy content="0-15;0-70">
     <meta name="assert" content="This tests that url() referenced to an ellipse

--- a/css/motion/offset-path-url-005.html
+++ b/css/motion/offset-path-url-005.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Motion Path: offset-path:url() to lines</title>
     <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-url">
-    <link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#LineElement">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#LineElement">
     <link rel="match" href="offset-path-url-001-ref.html">
     <meta name="assert" content="This tests that url() referenced to a line
       generates a rotation and translation.">

--- a/css/motion/offset-path-url-006.html
+++ b/css/motion/offset-path-url-006.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Motion Path: offset-path:url() to polylines</title>
     <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-url">
-    <link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#PolylineElement">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolylineElement">
     <link rel="match" href="offset-path-url-001-ref.html">
     <meta name="assert" content="This tests that url() referenced to a polyline
       generates a rotation and translation.">

--- a/css/motion/offset-path-url-007.html
+++ b/css/motion/offset-path-url-007.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Motion Path: offset-path:url() to polygons</title>
     <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-url">
-    <link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#PolygonElement">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolygonElement">
     <link rel="match" href="offset-path-url-002-ref.html">
     <meta name="assert" content="This tests that url() referenced to a polygon
       generates a rotation and translation.">

--- a/fetch/metadata/tools/fetch-metadata.conf.yml
+++ b/fetch/metadata/tools/fetch-metadata.conf.yml
@@ -635,7 +635,7 @@ cases:
         - expected: cors
       script-text-module-import-static.sub.html:
         - expected: cors
-      # https://svgwg.org/svg2-draft/linking.html#processingURL-fetch
+      # https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL-fetch
       svg-image.sub.html:
         - expected: no-cors
         - expected: cors

--- a/interfaces/svg-animations.idl
+++ b/interfaces/svg-animations.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into webref
 // (https://github.com/w3c/webref)
-// Source: SVG Animations (https://svgwg.org/specs/animations/)
+// Source: SVG Animations (https://w3c.github.io/svgwg/specs/animations/)
 
 [Exposed=Window]
 interface TimeEvent : Event {

--- a/interfaces/svg-paths.idl
+++ b/interfaces/svg-paths.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into webref
 // (https://github.com/w3c/webref)
-// Source: SVG Paths (https://svgwg.org/specs/paths/)
+// Source: SVG Paths (https://w3c.github.io/svgwg/specs/paths/)
 
 [LegacyNoInterfaceObject, Exposed=Window]
 interface SVGPathSegment {

--- a/svg/META.yml
+++ b/svg/META.yml
@@ -1,4 +1,4 @@
-spec: https://svgwg.org/svg2-draft/
+spec: https://w3c.github.io/svgwg/svg2-draft/
 suggested_reviewers:
   - nikosandronikos
   - boggydigital

--- a/svg/README.md
+++ b/svg/README.md
@@ -2,7 +2,7 @@ The `import` directory contains tests imported from the [SVG 1.1 Second
 Edition test suite](http://www.w3.org/Graphics/SVG/Test/20110816/),
 with tests renamed to contain `-manual` in their name.  These tests need
 review to verify that they are still correct for the latest version of
-SVG (which at the time of writing is [SVG 2](https://svgwg.org/svg2-draft/))
+SVG (which at the time of writing is [SVG 2](https://w3c.github.io/svgwg/svg2-draft/))
 and then need to be converted to reftests or testharness.js-based
 tests.
 

--- a/svg/animations/animate-fill-underlying-value-change.html
+++ b/svg/animations/animate-fill-underlying-value-change.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Invalidation test for fill color from underlying value</title>
-<link rel="help" href="https://svgwg.org/specs/animations/#AnimateElement">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AnimateElement">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <script src="/common/reftest-wait.js"></script>
 <p>Test passes if there is a filled green square.</p>

--- a/svg/animations/animate-path-by-animation-accumulate-mismatch.tentative.html
+++ b/svg/animations/animate-path-by-animation-accumulate-mismatch.tentative.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>SVG path 'd' attribute by animation with accumulate='sum' and mismatched commands</title>
 <link rel="help" href="https://www.w3.org/TR/SVG2/paths.html#TheDProperty"/>
-<link rel="help" href="https://svgwg.org/specs/animations/#AccumulateAttribute"/>
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AccumulateAttribute"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/animate-path-by-animation-accumulate.tentative.html
+++ b/svg/animations/animate-path-by-animation-accumulate.tentative.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>SVG path 'd' attribute by animation with accumulate='sum'</title>
 <link rel="help" href="https://www.w3.org/TR/SVG2/paths.html#TheDProperty"/>
-<link rel="help" href="https://svgwg.org/specs/animations/#AccumulateAttribute"/>
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AccumulateAttribute"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/animate-path-by-animation-additive-mismatch.tentative.html
+++ b/svg/animations/animate-path-by-animation-additive-mismatch.tentative.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>SVG path 'd' attribute by animation with additive='sum' and mismatched commands</title>
 <link rel="help" href="https://www.w3.org/TR/SVG2/paths.html#TheDProperty"/>
-<link rel="help" href="https://svgwg.org/specs/animations/#AdditionAttributes"/>
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AdditionAttributes"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/animate-path-by-animation-additive.tentative.html
+++ b/svg/animations/animate-path-by-animation-additive.tentative.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>SVG path 'd' attribute by animation with additive='sum'</title>
 <link rel="help" href="https://www.w3.org/TR/SVG2/paths.html#TheDProperty"/>
-<link rel="help" href="https://svgwg.org/specs/animations/#AdditionAttributes"/>
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AdditionAttributes"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/animate-path-from-to-animation-additive.tentative.html
+++ b/svg/animations/animate-path-from-to-animation-additive.tentative.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>SVG path 'd' attribute from-to animation with additive='sum'</title>
 <link rel="help" href="https://www.w3.org/TR/SVG2/paths.html#TheDProperty"/>
-<link rel="help" href="https://svgwg.org/specs/animations/#AdditionAttributes"/>
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AdditionAttributes"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/animate-reset-freeze.html
+++ b/svg/animations/animate-reset-freeze.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>SVG Animations: Rewinding fill='freeze' animations</title>
-<link rel="help" href="https://svgwg.org/specs/animations/">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/">
 <link rel="issue" href="https://bugs.webkit.org/show_bug.cgi?id=89846">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/animations/animateMotion-keyPoints-001.html
+++ b/svg/animations/animateMotion-keyPoints-001.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>'calcMode' paced and 'keyPoints' on &lt;animateMotion> with 'path'</title>
-<link rel="help" href="https://svgwg.org/specs/animations/#AnimateMotionElement">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AnimateMotionElement">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/animateMotion-keyPoints-002.html
+++ b/svg/animations/animateMotion-keyPoints-002.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>Setting keyPoints invalid and then valid should result in the animation running</title>
-<link rel="help" href="https://svgwg.org/specs/animations/#AnimateMotionElement">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AnimateMotionElement">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>

--- a/svg/animations/correct-events-for-short-animations-with-syncbases.html
+++ b/svg/animations/correct-events-for-short-animations-with-syncbases.html
@@ -5,7 +5,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Edvard Thörnros" href="mailto:edvardt@opera.com">
-<link rel="help" href="https://svgwg.org/specs/animations/#TimingAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#TimingAttributes">
 
 <svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
   <g id="a" opacity="0">

--- a/svg/animations/media-fragment-override-animation.html
+++ b/svg/animations/media-fragment-override-animation.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>animated background-image at a particular time</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#LinksIntoSVG">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#LinksIntoSVG">
 <link rel="match" href="../struct/reftests/reference/green-100x100.html">
 <style>
   .one {

--- a/svg/animations/repeatcount-numeric-limit.tentative.svg
+++ b/svg/animations/repeatcount-numeric-limit.tentative.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>A huge 'repeatCount' (1e+309) is treated as unspecified</title>
-  <h:link rel="help" href="https://svgwg.org/specs/animations/#TimingAttributes"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#TimingAttributes"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
 

--- a/svg/animations/scripted/animatetransform-type-missing-value-default.html
+++ b/svg/animations/scripted/animatetransform-type-missing-value-default.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>&lt;animateTransform> 'type' attribute missing/invalid value default</title>
-<link rel="help" href="https://svgwg.org/specs/animations/#AnimateTransformElementTypeAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#AnimateTransformElementTypeAttribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <svg height="10">

--- a/svg/animations/scripted/onhover-syncbases.html
+++ b/svg/animations/scripted/onhover-syncbases.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Check if onhover events reset correctly when triggered multiple times</title>
-    <link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#interact-EventAttributes">
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#interact-EventAttributes">
     <link rel="author" title="Edvard Thörnros" href="mailto:edvardt@opera.com">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/svg/animations/set-dynamic-attributeName-css-property-cleanup.html
+++ b/svg/animations/set-dynamic-attributeName-css-property-cleanup.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>Changing attributeName on set element clears old animated CSS property</title>
-<link rel="help" href="https://svgwg.org/specs/animations/">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <svg>

--- a/svg/animations/slider-switch.html
+++ b/svg/animations/slider-switch.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Check correct event bases for onclick</title>
 <meta charset="utf-8">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#interact-EventAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#interact-EventAttributes">
 <link rel="author" title="Edvard Thörnros" href="mailto:edvardt@opera.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/animations/spaces-at-end-of-path-data.html
+++ b/svg/animations/spaces-at-end-of-path-data.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/specs/animations/#ValuesAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/specs/animations/#ValuesAttribute">
 <link rel="author" title="Edvard Thörnros" href="mailto:edvardt@opera.com">
 
 <svg viewbox="0 0 100 100">

--- a/svg/coordinate-systems/outer-svg-intrinsic-size-003.html
+++ b/svg/coordinate-systems/outer-svg-intrinsic-size-003.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Outer SVG intrinsic size with degenerate ratio</title>
 <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#SizingSVGInCSS">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#SizingSVGInCSS">
 <link rel="help" href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6286">
 <link rel="match" href="../../css/reference/ref-filled-green-100px-square.xht">

--- a/svg/coordinate-systems/outer-svg-intrinsic-size-004.html
+++ b/svg/coordinate-systems/outer-svg-intrinsic-size-004.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Outer SVG intrinsic size with an negative size attribute</title>
 <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#SizingSVGInCSS">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#SizingSVGInCSS">
 <link rel="help" href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6286">
 <link rel="match" href="../../css/reference/ref-filled-green-100px-square.xht">

--- a/svg/coordinate-systems/outer-svg-intrinsic-size-005.html
+++ b/svg/coordinate-systems/outer-svg-intrinsic-size-005.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Outer SVG intrinsic size with negative size attributes</title>
 <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#SizingSVGInCSS">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#SizingSVGInCSS">
 <link rel="help" href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6286">
 <link rel="match" href="../../css/reference/ref-filled-green-100px-square.xht">

--- a/svg/coordinate-systems/svgtransformlist-replaceitem.html
+++ b/svg/coordinate-systems/svgtransformlist-replaceitem.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransformList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGTransformList">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>

--- a/svg/coordinate-systems/transform-translate-single-parameter.html
+++ b/svg/coordinate-systems/transform-translate-single-parameter.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGTransform">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>

--- a/svg/coordinate-systems/view-invalid-viewBox.html
+++ b/svg/coordinate-systems/view-invalid-viewBox.html
@@ -1,6 +1,6 @@
 <!doctype HTML>
 <title>view element with invalid viewBox should be ignored</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#ViewElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#ViewElement">
 <link rel="match" href="../struct/reftests/reference/green-100x100.html">
 <img src="support/views.svg#invalid">
 

--- a/svg/coordinate-systems/view-transform-viewBox.html
+++ b/svg/coordinate-systems/view-transform-viewBox.html
@@ -1,6 +1,6 @@
 <!doctype HTML>
 <title>view element with viewBox should be respected</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#ViewElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#ViewElement">
 <link rel="match" href="../struct/reftests/reference/green-100x100.html">
 <img src="support/views.svg#transform" style="transform-origin: 100% 100%; transform: scale(2)">
 

--- a/svg/embedded/image-embedding-svg-viewref-with-viewbox.svg
+++ b/svg/embedded/image-embedding-svg-viewref-with-viewbox.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>&#x3c;image&#x3e; referencing SVG image with &#x3c;view&#x3e; with 'viewBox'</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/embedded.html#ImageElement"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#LinksIntoSVG"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/embedded.html#ImageElement"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#LinksIntoSVG"/>
   <h:link rel="match" href="reference/green-rect-100x100.svg"/>
   <rect x="-355" y="-1110" width="455" height="1210" fill="red"/>
   <image preserveAspectRatio="none" x="-355" y="-1110" width="455" height="1210"

--- a/svg/embedded/image-fractional-width-vertical-fidelity.svg
+++ b/svg/embedded/image-fractional-width-vertical-fidelity.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Vertical fidelity of &#x3c;image&#x3e; element with fractional width</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/embedded.html#ImageElement"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/embedded.html#ImageElement"/>
   <h:link rel="match" href="reference/green-rect-100x100.svg"/>
   <rect x="95" width="5" height="100" fill="green"/>
   <rect width="95" height="100" fill="red"/>

--- a/svg/extensibility/foreignObject/composited-inside-object.html
+++ b/svg/extensibility/foreignObject/composited-inside-object.html
@@ -2,7 +2,7 @@
 <title>Compositing inside a non-stacking-context object works.</title>
 <link rel="author" title="Chris Harrelson" href="chrishtr@chromium.org">
 <link rel="match" href="composited-inside-object-ref.html">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 
 <object style="display: block; backface-visibility:hidden">
   <svg>

--- a/svg/extensibility/foreignObject/compositing-backface-visibility.html
+++ b/svg/extensibility/foreignObject/compositing-backface-visibility.html
@@ -2,7 +2,7 @@
 <title>Basic backface-visibility compositing works.</title>
 <link rel="author" title="Chris Harrelson" href="chrishtr@chromium.org">
 <link rel="match" href="compositing-backface-visibility-ref.html">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <style>
   * { backface-visibility: hidden }
 </style>

--- a/svg/extensibility/foreignObject/containing-block.html
+++ b/svg/extensibility/foreignObject/containing-block.html
@@ -1,5 +1,5 @@
 <!doctype HTML>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <style>
   * {
     margin: 5px;

--- a/svg/extensibility/foreignObject/filter-repaint.html
+++ b/svg/extensibility/foreignObject/filter-repaint.html
@@ -2,7 +2,7 @@
 <title>Test that re-painting a foreignObject element with a filter works.</title>
 <link rel="match" href="filter-repaint-ref.html">
 <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <svg>
   <foreignObject style="overflow: visible;"
         width="400" height="400" filter="url(#blur)">

--- a/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object.html
+++ b/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>An &lt;svg> wrapped in a &lt;foreignObject> in an &lt;object></title>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <link rel="match" href="../../struct/reftests/reference/green-100x100.html">
 <object data="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
   <foreignObject width='100' height='100'>

--- a/svg/extensibility/foreignObject/foreign-object-margin-collapsing.html
+++ b/svg/extensibility/foreignObject/foreign-object-margin-collapsing.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement">
 <link rel="help" href="https://www.w3.org/TR/CSS22/box.html#collapsing-margins">
 <link rel="match" href="foreign-object-size-ref.html">
 <svg>

--- a/svg/extensibility/foreignObject/foreign-object-paints-before-rect.html
+++ b/svg/extensibility/foreignObject/foreign-object-paints-before-rect.html
@@ -1,6 +1,6 @@
 <!doctype HTML>
 <link rel="match" href="foreign-object-paints-before-rect-ref.html">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <style>
 * {
   margin: 0

--- a/svg/extensibility/foreignObject/foreign-object-scale-scroll.html
+++ b/svg/extensibility/foreignObject/foreign-object-scale-scroll.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>foreignObject with scale transform and overflow:scroll</title>
 <meta name=fuzzy content="maxDifference=0-10;totalPixels=0-10">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <link rel="match" href="foreign-object-scale-scroll-ref.html">
 <svg width="400" height="400">
   <foreignObject x="100" y="100" transform="scale(2)" width="100" height="100" style="overflow: scroll">

--- a/svg/extensibility/foreignObject/foreign-object-size.html
+++ b/svg/extensibility/foreignObject/foreign-object-size.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Test: auto values for width and height properties on foreignObject compute to zero</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
 <link rel="match" href="foreign-object-size-ref.html">
 <style>
 div { width: 100px; height: 100px; }

--- a/svg/extensibility/foreignObject/foreign-object-with-position-under-clip-path.html
+++ b/svg/extensibility/foreignObject/foreign-object-with-position-under-clip-path.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Test: x & y on foreignObject don't transform a clipPath with clipPathUnits="objectBoundingBox"</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement">
 <link rel="match" href="foreign-object-size-ref.html">
 <svg>
   <defs>

--- a/svg/extensibility/foreignObject/getboundingclientrect.html
+++ b/svg/extensibility/foreignObject/getboundingclientrect.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>foreignObject: Element.prototype.getBoundingClientRect()</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/extensibility/foreignObject/isolation-with-html.html
+++ b/svg/extensibility/foreignObject/isolation-with-html.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>foreignObject should create an isolated group for html descendants</title>
 <meta name="assert" content="ForeignObject creates a stacking context which is an isolated group, so mix-blend-mode should not be affected by content outside the isolated group." />
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#render-EstablishingStackingContex" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#render-EstablishingStackingContex" />
 <link rel="help" href="https://drafts.fxtf.org/compositing-2/#csscompositingrules_CSS" />
 <link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org" />
 <link rel="match" href="isolation-with-html-ref.html" />

--- a/svg/extensibility/foreignObject/isolation-with-svg.html
+++ b/svg/extensibility/foreignObject/isolation-with-svg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>foreignObject should create an isolated group for svg descendants</title>
 <meta name="assert" content="ForeignObject creates a stacking context which is an isolated group, so mix-blend-mode should not be affected by content outside the isolated group." />
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#render-EstablishingStackingContex" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#render-EstablishingStackingContex" />
 <link rel="help" href="https://drafts.fxtf.org/compositing-2/#csscompositingrules_CSS" />
 <link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org" />
 <link rel="match" href="isolation-with-svg-ref.html" />

--- a/svg/extensibility/foreignObject/masked.html
+++ b/svg/extensibility/foreignObject/masked.html
@@ -2,7 +2,7 @@
 <title>Tests that an SVG mask applies to a foreignObject element</title>
 <link rel="match" href="masked-ref.html">
 <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <meta name="fuzzy" content="maxDifference=0-138; totalPixels=0-124">
 <svg style="display: block">
     <foreignObject x="0" y="0" width="32" height="32" mask="url(#circle)">

--- a/svg/extensibility/foreignObject/position-svg-root-in-foreign-object.html
+++ b/svg/extensibility/foreignObject/position-svg-root-in-foreign-object.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>SVG: svg root child of foreignObject should be positionable</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:futhark@chromium.org">
-<link rel="help" href="https://svgwg.org/svg2-draft/embedded.html#ForeignObjectElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/embedded.html#ForeignObjectElement">
 <link rel="match" href="position-svg-root-in-foreign-object-ref.html">
 <p>You should see the word PASS and no red below.</p>
 <svg>

--- a/svg/extensibility/foreignObject/properties.svg
+++ b/svg/extensibility/foreignObject/properties.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#styling-PresentationAttributes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#styling-PresentationAttributes"/>
     <h:meta name="assert" content="x y width height are presentation attributes of foreignObject"/>
   </metadata>
   <style>

--- a/svg/extensibility/foreignObject/scroll-transform-nested-stacked-children.html
+++ b/svg/extensibility/foreignObject/scroll-transform-nested-stacked-children.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>foreignObject under scroll and transform, with nested stacked children</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#render-EstablishingStackingContex">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#render-EstablishingStackingContex">
 <link rel="match" href="scroll-transform-nested-stacked-children-ref.html">
 <div style="height: 200px; overflow: scroll; background: white">
   <svg width="300" height="300">

--- a/svg/extensibility/foreignObject/stacking-context.html
+++ b/svg/extensibility/foreignObject/stacking-context.html
@@ -1,7 +1,7 @@
 <!doctype HTML>
 <title>Test that the foreignObject element is a stacking context</title>
 <link rel="match" href="stacking-context-ref.html">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <style>
   * {
     margin: 0;

--- a/svg/extensibility/foreignObject/will-change-in-foreign-object-paint-order.html
+++ b/svg/extensibility/foreignObject/will-change-in-foreign-object-paint-order.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>A foreignObject element containing will-change content is painted in correct order</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <link rel="author" title="Xianzhu Wang" href="mailto:wangxianzhu@chromium.org">
 <link rel="match" href="will-change-in-foreign-object-paint-order-ref.html">
 <svg style="width: 100px; height: 100px;">

--- a/svg/extensibility/interfaces/foreignObject-graphics.svg
+++ b/svg/extensibility/interfaces/foreignObject-graphics.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/embedded.html#InterfaceSVGForeignObjectElement"/>
-    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://svgwg.org/svg2-draft/changes.html#extend"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://w3c.github.io/svgwg/svg2-draft/changes.html#extend"/>
     <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="foreignObject is a graphics element"/>
   </metadata>
   <foreignObject id="target" />

--- a/svg/geometry/animations/cx-composition.html
+++ b/svg/geometry/animations/cx-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>cx composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CX">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/animations/cy-composition.html
+++ b/svg/geometry/animations/cy-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>cy composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CY">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/animations/r-composition.html
+++ b/svg/geometry/animations/r-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>r composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#R">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/animations/rx-composition.html
+++ b/svg/geometry/animations/rx-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>rx composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/animations/ry-composition.html
+++ b/svg/geometry/animations/ry-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>ry composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/animations/x-composition.html
+++ b/svg/geometry/animations/x-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>x composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#X">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/animations/y-composition.html
+++ b/svg/geometry/animations/y-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>y composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Y">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/geometry/inheritance.svg
+++ b/svg/geometry/inheritance.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>Inheritance of geometry properties</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
     <h:meta name="assert" content="None of the geometry properties inherit."/>
     <h:meta name="assert" content="Properties have initial values according to spec."/>
   </metadata>

--- a/svg/geometry/parsing/cx-computed.svg
+++ b/svg/geometry/parsing/cx-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().cx</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/cx-invalid.svg
+++ b/svg/geometry/parsing/cx-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing cx with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
     <h:meta name="assert" content="cx supports only the grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/cx-valid.svg
+++ b/svg/geometry/parsing/cx-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing cx with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
     <h:meta name="assert" content="cx supports the full grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/cy-computed.svg
+++ b/svg/geometry/parsing/cy-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().cy</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/cy-invalid.svg
+++ b/svg/geometry/parsing/cy-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing cy with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
     <h:meta name="assert" content="cy supports only the grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/cy-valid.svg
+++ b/svg/geometry/parsing/cy-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing cy with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
     <h:meta name="assert" content="cy supports the full grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/height-computed.svg
+++ b/svg/geometry/parsing/height-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Geometry Properties: getComputedStyle().height</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
     <h:link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>

--- a/svg/geometry/parsing/r-computed.svg
+++ b/svg/geometry/parsing/r-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().r</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/r-invalid.svg
+++ b/svg/geometry/parsing/r-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing r with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
     <h:meta name="assert" content="r supports only the grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/r-valid.svg
+++ b/svg/geometry/parsing/r-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing r with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
     <h:meta name="assert" content="r supports the full grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/rx-computed.svg
+++ b/svg/geometry/parsing/rx-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().rx</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/rx-invalid.svg
+++ b/svg/geometry/parsing/rx-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing rx with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
     <h:meta name="assert" content="rx supports only the grammar '&lt;length-percentage&gt; | auto'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/rx-valid.svg
+++ b/svg/geometry/parsing/rx-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing rx with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
     <h:meta name="assert" content="rx supports the full grammar '&lt;length-percentage&gt; | auto'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/ry-computed.svg
+++ b/svg/geometry/parsing/ry-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().ry</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/ry-invalid.svg
+++ b/svg/geometry/parsing/ry-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing ry with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
     <h:meta name="assert" content="ry supports only the grammar '&lt;length-percentage&gt; | auto'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/ry-valid.svg
+++ b/svg/geometry/parsing/ry-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing ry with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
     <h:meta name="assert" content="ry supports the full grammar '&lt;length-percentage&gt; | auto'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/sizing-properties-computed.svg
+++ b/svg/geometry/parsing/sizing-properties-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Geometry Properties: getComputedStyle().width</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
     <h:link rel="help" href="https://drafts.csswg.org/css-sizing-3/#preferred-size-properties"/>
     <h:link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values"/>
   </metadata>

--- a/svg/geometry/parsing/width-computed.svg
+++ b/svg/geometry/parsing/width-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Geometry Properties: getComputedStyle().width</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
     <h:link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>

--- a/svg/geometry/parsing/x-computed.svg
+++ b/svg/geometry/parsing/x-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().x</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/x-invalid.svg
+++ b/svg/geometry/parsing/x-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing x with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
     <h:meta name="assert" content="x supports only the grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/x-valid.svg
+++ b/svg/geometry/parsing/x-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing x with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
     <h:meta name="assert" content="x supports the full grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/y-computed.svg
+++ b/svg/geometry/parsing/y-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: getComputedStyle().y</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/geometry/parsing/y-invalid.svg
+++ b/svg/geometry/parsing/y-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing y with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
     <h:meta name="assert" content="y supports only the grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/parsing/y-valid.svg
+++ b/svg/geometry/parsing/y-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>SVG Geometry Properties: parsing y with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
     <h:meta name="assert" content="y supports the full grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/geometry/reftests/circle-001.svg
+++ b/svg/geometry/reftests/circle-001.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Circle coordinates and radius specified by properties</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match" href="circle-ref.svg" />
   <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8" />
   <style>

--- a/svg/geometry/reftests/circle-002.svg
+++ b/svg/geometry/reftests/circle-002.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Circle coordinates and radius specified in user units</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match" href="circle-ref.svg" />
   <html:meta name="fuzzy" content="maxDifference=0-53; totalPixels=0-370" />
   <style>

--- a/svg/geometry/reftests/circle-003.svg
+++ b/svg/geometry/reftests/circle-003.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Circle coordinates and radius specified by percentage</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match" href="circle-ref.svg" />
   <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2" />
   <style>

--- a/svg/geometry/reftests/circle-004.svg
+++ b/svg/geometry/reftests/circle-004.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Circle coordinates and radius specified using calc</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match" href="circle-ref.svg" />
   <html:meta name="fuzzy" content="maxDifference=0-35; totalPixels=0-434" />
   <style>

--- a/svg/geometry/reftests/circle-005.svg
+++ b/svg/geometry/reftests/circle-005.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Circle coordinates and radius specified by properties</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1683652"/>
   <html:link rel="match"  href="circle-ref.svg"/>
   <style>

--- a/svg/geometry/reftests/ellipse-001.svg
+++ b/svg/geometry/reftests/ellipse-001.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Ellipse coordinates and radii specified by properties</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="ellipse-ref.svg" />
   <style>
     ellipse {

--- a/svg/geometry/reftests/ellipse-002.svg
+++ b/svg/geometry/reftests/ellipse-002.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Ellipse coordinates and radii specified in user units</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match" href="ellipse-ref.svg" />
   <html:meta name="fuzzy" content="maxDifference=0-53; totalPixels=0-278" />
   <style>

--- a/svg/geometry/reftests/ellipse-003.svg
+++ b/svg/geometry/reftests/ellipse-003.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Ellipse coordinates and radii specified by percentage</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match" href="ellipse-ref.svg" />
   <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4" />
   <style>

--- a/svg/geometry/reftests/ellipse-004.svg
+++ b/svg/geometry/reftests/ellipse-004.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Ellipse coordinates and radii specified using calc</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="ellipse-ref.svg" />
   <style>
     ellipse {

--- a/svg/geometry/reftests/ellipse-005.svg
+++ b/svg/geometry/reftests/ellipse-005.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>A negative value for rx is invalid and must be ignored</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
   <html:link rel="match"  href="circle-ref.svg" />
   <ellipse cx="204" cy="56" rx="-65" ry="65" fill="blue"/>
 </svg>

--- a/svg/geometry/reftests/ellipse-006.svg
+++ b/svg/geometry/reftests/ellipse-006.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>A negative value for ry is invalid and must be ignored</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
   <html:link rel="match"  href="circle-ref.svg" />
   <ellipse cx="204" cy="56" rx="65" ry="-65" fill="blue"/>
 </svg>

--- a/svg/geometry/reftests/percentage-attribute.svg
+++ b/svg/geometry/reftests/percentage-attribute.svg
@@ -5,7 +5,7 @@
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Percentages in shapes</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="percentage-ref.svg" />
 
   <style>

--- a/svg/geometry/reftests/percentage.svg
+++ b/svg/geometry/reftests/percentage.svg
@@ -5,7 +5,7 @@
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Percentages in shapes</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="percentage-ref.svg" />
 
   <style>

--- a/svg/geometry/reftests/rect-001.svg
+++ b/svg/geometry/reftests/rect-001.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Rectangle coordinates and sizes specified by properties</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="rect-ref.svg" />
   <style>
     rect {

--- a/svg/geometry/reftests/rect-002.svg
+++ b/svg/geometry/reftests/rect-002.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Rectangle coordinates and sizes specified in user units</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="rect-ref.svg" />
   <style>
     rect {

--- a/svg/geometry/reftests/rect-003.svg
+++ b/svg/geometry/reftests/rect-003.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Rectangle coordinates and sizes specified by percentage</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="rect-ref.svg" />
   <style>
     rect {

--- a/svg/geometry/reftests/rect-004.svg
+++ b/svg/geometry/reftests/rect-004.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Rectangle coordinates and sizes specified using calc</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="rect-ref.svg" />
   <style>
     rect {

--- a/svg/geometry/svg-baseval-in-display-none.html
+++ b/svg/geometry/svg-baseval-in-display-none.html
@@ -2,8 +2,8 @@
 <title>baseVal in symbol and other display:none</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLength"/>
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedLength__baseVal"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedLength"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedLength__baseVal"/>
 <svg width="0" height="0">
   <svg width="600" height="400" font-size="5">
     <symbol width="40em" height="20em">

--- a/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto-dynamic-image-change.html
+++ b/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto-dynamic-image-change.html
@@ -2,8 +2,8 @@
 <title>Test <svg:image>'s sizing with css size as auto, with dynamic image change</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#geometry-Sizing"/>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-Placement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#geometry-Sizing"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-Placement"/>
 <svg height="0">
   <image width="128" height="128" xlink:href="/images/green-256x256.png" style="width:auto; height:auto"/>
 </svg>

--- a/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto.html
+++ b/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto.html
@@ -2,8 +2,8 @@
 <title>&lt;svg:image> 'auto' sizing</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#geometry-Sizing"/>
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-Placement"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#geometry-Sizing"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-Placement"/>
 <svg height="0">
   <image width="64" height="64" xlink:href="/images/green-256x256.png" />
   <image width="128" height="64" xlink:href="/images/green-256x256.png" style="width:auto"/>

--- a/svg/idlharness.window.js
+++ b/svg/idlharness.window.js
@@ -2,7 +2,7 @@
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 
-// https://svgwg.org/svg2-draft/
+// https://w3c.github.io/svgwg/svg2-draft/
 
 'use strict';
 

--- a/svg/interact/focus-inside-hidden-svg-containers-01.html
+++ b/svg/interact/focus-inside-hidden-svg-containers-01.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Tabbing through Non-Rendered SVG elements</title>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#interact-Focus">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#interact-Focus">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>

--- a/svg/interact/focus-inside-hidden-svg-containers-02.html
+++ b/svg/interact/focus-inside-hidden-svg-containers-02.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Tabbing through Non-Rendered SVG elements</title>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#interact-Focus">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#interact-Focus">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>

--- a/svg/interact/focus-inside-hidden-svg-containers-03.html
+++ b/svg/interact/focus-inside-hidden-svg-containers-03.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Tabbing through Non-Rendered SVG elements</title>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#interact-Focus">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#interact-Focus">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>

--- a/svg/interact/inheritance.svg
+++ b/svg/interact/inheritance.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>Inheritance of pointer-events</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty"/>
     <h:meta name="assert" content="pointer-events inherits according to the spec."/>
     <h:meta name="assert" content="pointer-events has initial value auto."/>
   </metadata>

--- a/svg/interact/manual/event-attribute-001-manual.svg
+++ b/svg/interact/manual/event-attribute-001-manual.svg
@@ -4,8 +4,8 @@
      width="100%" height="100%" viewBox="0 0 480 360">
   <title>Event attributes - onwheel</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#EventAttributes"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/attindex.html#RegularAttributes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#EventAttributes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/attindex.html#RegularAttributes"/>
     <h:meta name="assert" content="onwheel attribute runs script in response to wheel events"/>
   </metadata>
   <style>

--- a/svg/interact/parsing/pointer-events-computed.svg
+++ b/svg/interact/parsing/pointer-events-computed.svg
@@ -3,7 +3,7 @@
      width="800px" height="8000px">
   <title>SVG Scripting and Interactivity: getComputedStyle().pointerEvents</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty"/>
     <h:meta name="assert" content="pointer-events computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/interact/parsing/pointer-events-invalid.svg
+++ b/svg/interact/parsing/pointer-events-invalid.svg
@@ -3,7 +3,7 @@
      width="800px" height="8000px">
   <title>SVG Scripting and Interactivity: parsing pointer-events with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty"/>
     <h:meta name="assert" content="pointer-events supports only the grammar 'auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/interact/parsing/pointer-events-valid.svg
+++ b/svg/interact/parsing/pointer-events-valid.svg
@@ -3,7 +3,7 @@
      width="800px" height="8000px">
   <title>SVG Scripting and Interactivity: parsing pointer-events with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty"/>
     <h:meta name="assert" content="pointer-events supports the full grammar 'auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/interact/script-common.html
+++ b/svg/interact/script-common.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Test: </title>
-<link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement">
 <meta name="assert" content="The same scripts can work on both HTML and SVG elements.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/interact/script-content.svg
+++ b/svg/interact/script-content.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
   <h:meta name="assert" content="The script element is in the content model of all elements."/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/interact/scripted/async-01.svg
+++ b/svg/interact/scripted/async-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>async on script</title>
   <metadata>
-      <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+      <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
   </metadata>
   <h:meta name="timeout" content="long"/>
   <h:script src="/resources/testharness.js"/>

--- a/svg/interact/scripted/async-02.html
+++ b/svg/interact/scripted/async-02.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Inline async module script without external deps onload blocking</title>
-    <link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
     <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/svg/interact/scripted/async-03.html
+++ b/svg/interact/scripted/async-03.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Inline async script without external deps onload blocking</title>
-    <link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
     <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/svg/interact/scripted/async-04.html
+++ b/svg/interact/scripted/async-04.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Check async script state matches attribute</title>
-    <link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>

--- a/svg/interact/scripted/composed.window.svg
+++ b/svg/interact/scripted/composed.window.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
     <title>Focus events are composed</title>
     <metadata>
-        <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#Focus"/>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#Focus"/>
     </metadata>
     <a id="a1" href="#"></a>
     <h:script src="/resources/testharness.js"/>

--- a/svg/interact/scripted/defer-01.svg
+++ b/svg/interact/scripted/defer-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>defer on script</title>
   <metadata>
-      <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+      <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/interact/scripted/defer-02.html
+++ b/svg/interact/scripted/defer-02.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Inline defer module script without external deps onload blocking</title>
-    <link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
     <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/svg/interact/scripted/ellipse-hittest.html
+++ b/svg/interact/scripted/ellipse-hittest.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>elementFromPoint(...) on &lt;ellipse>s with continuous strokes</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/interact.html#hit-testing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#hit-testing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/svg/interact/scripted/focus-events.svg
+++ b/svg/interact/scripted/focus-events.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
     <title>Focus management</title>
     <metadata>
-        <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#Focus"/>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#Focus"/>
     </metadata>
     <a id="a1" href="#"></a>
     <a id="a2" href="#"></a>

--- a/svg/interact/scripted/focus-tabindex-default-value.svg
+++ b/svg/interact/scripted/focus-tabindex-default-value.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
     <title>SVG Test: focus - default value of tabindex</title>
     <metadata>
-        <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#Focus"/>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#Focus"/>
     </metadata>
     <a id="test1" href="#"></a>
     <rect id="test2"></rect>

--- a/svg/interact/scripted/module-01.svg
+++ b/svg/interact/scripted/module-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>script type="module"</title>
   <metadata>
-      <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+      <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/interact/scripted/module-02.html
+++ b/svg/interact/scripted/module-02.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Inline module script without external deps onload blocking</title>
-    <link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement"/>
     <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/svg/interact/scripted/rect-hittest-001.html
+++ b/svg/interact/scripted/rect-hittest-001.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>elementFromPoint(...) on &lt;rect>s</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/interact.html#hit-testing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#hit-testing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <svg id="svg" width="420" height="300">

--- a/svg/interact/scripted/rect-hittest-002.html
+++ b/svg/interact/scripted/rect-hittest-002.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>elementFromPoint(...) on &lt;rect>s with simple strokes</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/interact.html#hit-testing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#hit-testing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/svg/interact/scripted/svg-pointer-events-bbox.html
+++ b/svg/interact/scripted/svg-pointer-events-bbox.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>pointer-events: bounding-box</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/interact.html#PointerEventsProp">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProp">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/interact/scripted/svg-small-big-path.html
+++ b/svg/interact/scripted/svg-small-big-path.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Hit-test on a path whose x/y ranges have different magnitude</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/interact.html#hit-testing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#hit-testing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/svg/interact/scripted/tabindex-focus-flag.svg
+++ b/svg/interact/scripted/tabindex-focus-flag.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
     <metadata>
-        <h:link rel="help" href="https://svgwg.org/svg2-draft/interact.html#Focus"/>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#Focus"/>
     </metadata>
     <g id="default-samples">
         <!-- non-default focusable renderable element -->

--- a/svg/interact/use-instance-hover.html
+++ b/svg/interact/use-instance-hover.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: :hover effect on &lt;use&gt; element instance</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/svg/linking/reftests/media-fragment-override-multiple.html
+++ b/svg/linking/reftests/media-fragment-override-multiple.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>background-image with multiple layers using different views of the same image</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#LinksIntoSVG">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#LinksIntoSVG">
 <link rel="match" href="../../struct/reftests/reference/green-100x100.html">
 <style>
   .one {

--- a/svg/linking/reftests/svgview-viewbox-override-multiple.html
+++ b/svg/linking/reftests/svgview-viewbox-override-multiple.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>background-image with multiple layers using different views of the same image</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#LinksIntoSVG">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#LinksIntoSVG">
 <link rel="match" href="../../struct/reftests/reference/green-100x100.html">
 <style>
   .one {

--- a/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg
+++ b/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>URL processing: Fetching the document</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL-fetch"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingStrokePaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL-fetch"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
 
   <rect width="100" height="100" fill="url('http://{{hosts[][www]}}:{{ports[http][0]}}/svg/painting/reftests/support/resources.svg?pipe=header(Access-Control-Allow-Origin,*)#greenGradient') red"/>

--- a/svg/linking/reftests/url-processing-fetch-properties-002.sub.svg
+++ b/svg/linking/reftests/url-processing-fetch-properties-002.sub.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>URL processing: Fetching the document</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL-fetch"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingStrokePaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL-fetch"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
 
   <rect width="100" height="100" fill="url('http://{{hosts[][www]}}:{{ports[http][0]}}/svg/painting/reftests/support/resources.svg#redGradient') green"/>

--- a/svg/linking/reftests/url-processing-whitespace-001.svg
+++ b/svg/linking/reftests/url-processing-whitespace-001.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Leading and trailing whitespace is stripped from (local) URL references (&#x3c;paint&#x3e;)</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint"/>
   <html:link rel="match" href="reference/green-100x100.svg"/>
   <linearGradient id="green">
     <stop stop-color="green"/>

--- a/svg/linking/reftests/url-processing-whitespace-002.svg
+++ b/svg/linking/reftests/url-processing-whitespace-002.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Leading and trailing whitespace is stripped from (local) URL references (&#x3c;use&#x3e; href)</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <html:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <rect id="green" width="50" height="50" fill="green"/>

--- a/svg/linking/reftests/url-processing-whitespace-003.svg
+++ b/svg/linking/reftests/url-processing-whitespace-003.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Leading and trailing whitespace is stripped from (local) URL references (&#x3c;linearGradient&#x3e; href)</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#PaintServerTemplates"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#PaintServerTemplates"/>
   <html:link rel="match" href="reference/green-100x100.svg"/>
   <linearGradient id="green">
     <stop stop-color="green"/>

--- a/svg/linking/reftests/url-reference-local-textpath.svg
+++ b/svg/linking/reftests/url-reference-local-textpath.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Local URL reference on &#x3c;textPath&#x3e; with base URL different from document URL</title>
   <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#linkRefAttrs"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#linkRefAttrs"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <h:base href="http://www.example.com/"/>
 

--- a/svg/linking/reftests/use-descendant-combinator-001.html
+++ b/svg/linking/reftests/use-descendant-combinator-001.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>CSS Test: use element doesn't cross shadow tree boundaries in selector-matching</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <style>
 #test rect {

--- a/svg/linking/reftests/use-descendant-combinator-002.html
+++ b/svg/linking/reftests/use-descendant-combinator-002.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>CSS Test: use element doesn't cross shadow tree boundaries in selector-matching</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <style>
 #test rect {

--- a/svg/linking/reftests/use-descendant-combinator-003.html
+++ b/svg/linking/reftests/use-descendant-combinator-003.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>CSS Test: use element doesn't cross shadow tree boundaries in selector-matching, and is invalidated properly</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <style>
 #test rect {

--- a/svg/linking/reftests/use-hidden-attr-change.html
+++ b/svg/linking/reftests/use-hidden-attr-change.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>use element reacts to attribute changes when it's not rendered</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1502658">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <style>

--- a/svg/linking/reftests/use-nested-symbol-001.html
+++ b/svg/linking/reftests/use-nested-symbol-001.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>CSS Test: symbol doesn't improperly render in svg use shadow tree</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1547619">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <p>

--- a/svg/linking/reftests/use-symbol-rendered-001.html
+++ b/svg/linking/reftests/use-symbol-rendered-001.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>CSS Test: symbol referenced in a use shadow tree should actually be a symbol</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#SymbolNotes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#SymbolNotes">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1547619">
 <link rel="match" href="/svg/linking/reftests/use-descendant-combinator-ref.html">
 <p>

--- a/svg/linking/reftests/use-template.html
+++ b/svg/linking/reftests/use-template.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>CSS Test: Use element after cloning</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1866911">
 <link rel="match" href="/svg/linking/reftests/use-template-ref.html">
 <template>

--- a/svg/linking/reftests/view-viewbox-override.html
+++ b/svg/linking/reftests/view-viewbox-override.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>'viewBox' from referenced &lt;view> element</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#LinksIntoSVG">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#ViewElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#LinksIntoSVG">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#ViewElement">
 <link rel="match" href="../../struct/reftests/reference/green-100x100.html">
 <object style="height: 100px; background-color: red"
         data="data:image/svg+xml,

--- a/svg/linking/scripted/a-download-click.svg
+++ b/svg/linking/scripted/a-download-click.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Clicking on an &lt;a> element with a download attribute must not throw an exception</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/linking/scripted/a.hreflang-getter-01.svg
+++ b/svg/linking/scripted/a.hreflang-getter-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.hreflang getter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a" hreflang="en"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/a.hreflang-setter-01.svg
+++ b/svg/linking/scripted/a.hreflang-setter-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.hreflang setter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/a.rel-getter-01.svg
+++ b/svg/linking/scripted/a.rel-getter-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.rel getter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a" rel="noreferrer"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/a.rel-noreferrer-policy.html
+++ b/svg/linking/scripted/a.rel-noreferrer-policy.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement">
 <title> Rel attribute with noreferrer value </title>
 <svg>
   <a id="test" href="resources/a.rel-noreferrer-policy-target.html" rel="noreferrer"></a>

--- a/svg/linking/scripted/a.rel-setter-01.svg
+++ b/svg/linking/scripted/a.rel-setter-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.rel setter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/a.type-getter-01.svg
+++ b/svg/linking/scripted/a.type-getter-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.type getter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/a.type-getter-02.svg
+++ b/svg/linking/scripted/a.type-getter-02.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.type getter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a" type="text/plain"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/a.type-setter-01.svg
+++ b/svg/linking/scripted/a.type-setter-01.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGAElement.type setter</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <a id="test" href="a"></a>
   <h:script src="/resources/testharness.js"/>

--- a/svg/linking/scripted/rellist-feature-detection.svg
+++ b/svg/linking/scripted/rellist-feature-detection.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Test SVGAElement relList attribute</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/linking/scripted/resources/a.rel-noreferrer-policy-target.html
+++ b/svg/linking/scripted/resources/a.rel-noreferrer-policy-target.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement">
 <script>
   test(function () {
     assert_equals("", document.referrer);

--- a/svg/linking/scripted/xlink-href-compat.html
+++ b/svg/linking/scripted/xlink-href-compat.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>XLink 'href' backwards compatibility</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#XLinkRefAttrs">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#linkRefAttrs">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkRefAttrs">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#linkRefAttrs">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/svg/painting/animations/stroke-dasharray-composition.html
+++ b/svg/painting/animations/stroke-dasharray-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>stroke-dasharray composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/painting/animations/stroke-dashoffset-composition.html
+++ b/svg/painting/animations/stroke-dashoffset-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>stroke-dashoffset composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/painting/animations/stroke-width-composition.html
+++ b/svg/painting/animations/stroke-width-composition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <title>stroke-width composition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/painting/color-interpolation-001.svg
+++ b/svg/painting/color-interpolation-001.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>'color-interpolation: linearRGB' applies somewhat correctly</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolation"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolation"/>
   <h:link rel="match" href="../struct/reftests/reference/green-100x100.svg"/>
 
   <rect width="100" height="100" fill="green" color-interpolation="linearRGB"/>

--- a/svg/painting/inheritance.svg
+++ b/svg/painting/inheritance.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>Inheritance of SVG painting properties</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html"/>
     <h:meta name="assert" content="properties inherit according to the spec."/>
     <h:meta name="assert" content="properties have expected initial values."/>
   </metadata>

--- a/svg/painting/parsing/color-interpolation-computed.svg
+++ b/svg/painting/parsing/color-interpolation-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().colorInterpolation</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty"/>
     <h:meta name="assert" content="color-interpolation computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/color-interpolation-invalid.svg
+++ b/svg/painting/parsing/color-interpolation-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing color-interpolation with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty"/>
     <h:meta name="assert" content="color-interpolation supports only the grammar 'auto | sRGB | linearRGB'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/color-interpolation-valid.svg
+++ b/svg/painting/parsing/color-interpolation-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing color-interpolation with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty"/>
     <h:meta name="assert" content="color-interpolation supports the full grammar 'auto | sRGB | linearRGB'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-computed.svg
+++ b/svg/painting/parsing/fill-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().fill</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty"/>
     <h:meta name="assert" content="fill computed value is as specified, with url values absolute."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-invalid.svg
+++ b/svg/painting/parsing/fill-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing fill with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty"/>
     <h:meta name="assert" content="fill supports only the paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-opacity-computed.svg
+++ b/svg/painting/parsing/fill-opacity-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().fillOpacity</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillOpacity"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillOpacity"/>
     <h:meta name="assert" content="fill-opacity computed value is clamped to the range [0,1]."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-opacity-invalid.svg
+++ b/svg/painting/parsing/fill-opacity-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing fill-opacity with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillOpacityProperty"/>
     <h:meta name="assert" content="fill-opacity supports only the grammar 'alpha-value'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-opacity-valid.svg
+++ b/svg/painting/parsing/fill-opacity-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing fill-opacity with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillOpacityProperty"/>
     <h:meta name="assert" content="fill-opacity supports the full grammar 'alpha-value'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-rule-computed.svg
+++ b/svg/painting/parsing/fill-rule-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().fillRule</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillRuleProperty"/>
     <h:meta name="assert" content="fill-rule computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-rule-invalid.svg
+++ b/svg/painting/parsing/fill-rule-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing fill-rule with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillRuleProperty"/>
     <h:meta name="assert" content="fill-rule supports only the grammar 'nonzero | evenodd'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-rule-valid.svg
+++ b/svg/painting/parsing/fill-rule-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing fill-rule with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillRuleProperty"/>
     <h:meta name="assert" content="fill-rule supports the full grammar 'nonzero | evenodd'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/fill-valid.svg
+++ b/svg/painting/parsing/fill-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing fill with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty"/>
     <h:meta name="assert" content="fill supports the full paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/image-rendering-computed.svg
+++ b/svg/painting/parsing/image-rendering-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().imageRendering</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRenderingProperty"/>
     <h:meta name="assert" content="image-rendering computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/image-rendering-invalid.svg
+++ b/svg/painting/parsing/image-rendering-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing image-rendering with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRenderingProperty"/>
     <h:meta name="assert" content="image-rendering supports only the grammar 'auto | optimizeQuality | optimizeSpeed'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/image-rendering-valid.svg
+++ b/svg/painting/parsing/image-rendering-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing image-rendering with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRenderingProperty"/>
     <h:meta name="assert" content="image-rendering supports the full grammar 'auto | optimizeQuality | optimizeSpeed'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-computed.svg
+++ b/svg/painting/parsing/marker-computed.svg
@@ -3,7 +3,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().marker</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerProperty"/>
     <h:meta name="assert" content="marker computed value is as specified, with url values absolute."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-end-computed.svg
+++ b/svg/painting/parsing/marker-end-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().MarkerEnd</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerEndProperty"/>
     <h:meta name="assert" content="marker-end computed value is as specified, with url values absolute."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-end-invalid.svg
+++ b/svg/painting/parsing/marker-end-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker-end with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerEndProperty"/>
     <h:meta name="assert" content="marker-end supports only the paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-end-valid.svg
+++ b/svg/painting/parsing/marker-end-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker-end with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerEndProperty"/>
     <h:meta name="assert" content="marker-end supports the full paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-invalid.svg
+++ b/svg/painting/parsing/marker-invalid.svg
@@ -3,7 +3,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerProperty"/>
     <h:meta name="assert" content="marker supports only the paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-mid-computed.svg
+++ b/svg/painting/parsing/marker-mid-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().markerMid</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerMidProperty"/>
     <h:meta name="assert" content="marker-mid computed value is as specified, with url values absolute."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-mid-invalid.svg
+++ b/svg/painting/parsing/marker-mid-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker-mid with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerMidProperty"/>
     <h:meta name="assert" content="marker-mid supports only the paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-mid-valid.svg
+++ b/svg/painting/parsing/marker-mid-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker-mid with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerMidProperty"/>
     <h:meta name="assert" content="marker-mid supports the full paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-shorthand.svg
+++ b/svg/painting/parsing/marker-shorthand.svg
@@ -3,7 +3,7 @@
      width="800px" height="800px">
   <title>SVG Painting: marker sets longhands</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerProperty"/>
     <h:meta name="assert" content="marker supports the full paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-start-computed.svg
+++ b/svg/painting/parsing/marker-start-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().markerStart</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerStartProperty"/>
     <h:meta name="assert" content="marker-start computed value is as specified, with url values absolute."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-start-invalid.svg
+++ b/svg/painting/parsing/marker-start-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker-start with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerStartProperty"/>
     <h:meta name="assert" content="marker-start supports only the paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-start-valid.svg
+++ b/svg/painting/parsing/marker-start-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker-start with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerStartProperty"/>
     <h:meta name="assert" content="marker-start supports the full paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/marker-valid.svg
+++ b/svg/painting/parsing/marker-valid.svg
@@ -3,7 +3,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing marker with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerProperty"/>
     <h:meta name="assert" content="marker supports the full paint grammar 'none | marker-ref'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/paint-order-computed.svg
+++ b/svg/painting/parsing/paint-order-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().paintOrder</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty"/>
     <h:meta name="assert" content="paint-order computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/paint-order-invalid.svg
+++ b/svg/painting/parsing/paint-order-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing paint-order with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty"/>
     <h:meta name="assert" content="paint-order supports only the grammar 'normal | [ fill || stroke || markers ]'."/>
     <h:meta name="assert" content="paint-order uses the shortest serialization."/>
   </metadata>

--- a/svg/painting/parsing/paint-order-valid.svg
+++ b/svg/painting/parsing/paint-order-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing paint-order with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty"/>
     <h:meta name="assert" content="paint-order supports the full grammar 'normal | [ fill || stroke || markers ]'."/>
     <h:meta name="assert" content="paint-order uses the shortest serialization."/>
   </metadata>

--- a/svg/painting/parsing/shape-rendering-computed.svg
+++ b/svg/painting/parsing/shape-rendering-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().shapeRendering</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty"/>
     <h:meta name="assert" content="shape-rendering computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/shape-rendering-invalid.svg
+++ b/svg/painting/parsing/shape-rendering-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing shape-rendering with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty"/>
     <h:meta name="assert" content="shape-rendering supports only the grammar 'auto | optimizeSpeed | crispEdges | geometricPrecision'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/shape-rendering-valid.svg
+++ b/svg/painting/parsing/shape-rendering-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing shape-rendering with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty"/>
     <h:meta name="assert" content="shape-rendering supports the full grammar 'auto | optimizeSpeed | crispEdges | geometricPrecision'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-computed.svg
+++ b/svg/painting/parsing/stroke-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().stroke</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty"/>
     <h:meta name="assert" content="stroke computed value is as specified, with url values absolute."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-dasharray-computed.svg
+++ b/svg/painting/parsing/stroke-dasharray-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeDasharray</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDasharrayProperty"/>
     <h:meta name="assert" content="stroke-dasharray computed value uses absolute lengths."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-dasharray-invalid.svg
+++ b/svg/painting/parsing/stroke-dasharray-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-dasharray with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDasharrayProperty"/>
     <h:meta name="assert" content="stroke-dasharray supports only the grammar 'none | dasharray'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-dasharray-valid.svg
+++ b/svg/painting/parsing/stroke-dasharray-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-dasharray with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDasharrayProperty"/>
     <h:meta name="assert" content="stroke-dasharray supports the full grammar 'none | dasharray'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-dashoffset-computed.svg
+++ b/svg/painting/parsing/stroke-dashoffset-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeDashoffset</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
     <h:meta name="assert" content="stroke-dashoffset computed value is absolute length."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-dashoffset-invalid.svg
+++ b/svg/painting/parsing/stroke-dashoffset-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-dashoffset with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
     <h:meta name="assert" content="stroke-dashoffset supports only the grammar 'length-percentage'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-dashoffset-valid.svg
+++ b/svg/painting/parsing/stroke-dashoffset-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-dashoffset with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
     <h:meta name="assert" content="stroke-dashoffset supports the full grammar 'length-percentage'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-invalid.svg
+++ b/svg/painting/parsing/stroke-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty"/>
     <h:meta name="assert" content="stroke supports only the paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-linecap-computed.svg
+++ b/svg/painting/parsing/stroke-linecap-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeLinecap</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinecapProperty"/>
     <h:meta name="assert" content="stroke-linecap computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-linecap-invalid.svg
+++ b/svg/painting/parsing/stroke-linecap-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-linecap with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinecapProperty"/>
     <h:meta name="assert" content="stroke-linecap supports only the grammar 'butt | round | square'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-linecap-valid.svg
+++ b/svg/painting/parsing/stroke-linecap-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-linecap with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinecapProperty"/>
     <h:meta name="assert" content="stroke-linecap supports the full grammar 'butt | round | square'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-linejoin-computed.svg
+++ b/svg/painting/parsing/stroke-linejoin-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeLinejoin</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinejoinProperty"/>
     <h:meta name="assert" content="stroke-linejoin computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-linejoin-invalid.svg
+++ b/svg/painting/parsing/stroke-linejoin-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-linejoin with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinejoinProperty"/>
     <h:meta name="assert" content="stroke-linejoin supports only the grammar 'miter | miter-clip | round | bevel | arcs'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-linejoin-valid.svg
+++ b/svg/painting/parsing/stroke-linejoin-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-linejoin with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinejoinProperty"/>
     <h:meta name="assert" content="stroke-linejoin supports the full grammar 'miter | miter-clip | round | bevel | arcs'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-miterlimit-computed.svg
+++ b/svg/painting/parsing/stroke-miterlimit-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeMiterlimit</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
     <h:meta name="assert" content="stroke-miterlimit computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-miterlimit-invalid.svg
+++ b/svg/painting/parsing/stroke-miterlimit-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-miterlimit with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
     <h:meta name="assert" content="stroke-miterlimit supports only the grammar 'number'"/>
     <h:meta name="assert" content="A negative value for stroke-miterlimit must be treated as an illegal value."/>
   </metadata>

--- a/svg/painting/parsing/stroke-miterlimit-valid.svg
+++ b/svg/painting/parsing/stroke-miterlimit-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-miterlimit with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
     <h:meta name="assert" content="stroke-miterlimit supports the full grammar 'number'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-opacity-computed.svg
+++ b/svg/painting/parsing/stroke-opacity-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeOpacity</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeOpacityProperty"/>
     <h:meta name="assert" content="stroke-opacity computed value is clamped to the range [0,1]."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-opacity-invalid.svg
+++ b/svg/painting/parsing/stroke-opacity-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-opacity with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeOpacityProperty"/>
     <h:meta name="assert" content="stroke-opacity supports only the grammar 'alpha-value'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-opacity-valid.svg
+++ b/svg/painting/parsing/stroke-opacity-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke-opacity with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeOpacityProperty"/>
     <h:meta name="assert" content="stroke-opacity supports the full grammar 'alpha-value'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-valid.svg
+++ b/svg/painting/parsing/stroke-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing stroke with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty"/>
     <h:meta name="assert" content="stroke supports the full paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-width-computed.svg
+++ b/svg/painting/parsing/stroke-width-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().strokeWidth</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth"/>
     <h:meta name="assert" content="stroke-width computed value is absolute length."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-width-invalid.svg
+++ b/svg/painting/parsing/stroke-width-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="600px">
   <title>SVG Painting: parsing stroke-width with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth"/>
     <h:meta name="assert" content="stroke-width supports only the grammar '&lt;length-percentage&gt;'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/stroke-width-valid.svg
+++ b/svg/painting/parsing/stroke-width-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="600px">
   <title>SVG Painting: parsing stroke-width with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth"/>
     <h:meta name="assert" content="stroke-width supports the full grammar '&lt;length-percentage&gt;' and unitless."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/text-rendering-computed.svg
+++ b/svg/painting/parsing/text-rendering-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: getComputedStyle().textRendering</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty"/>
     <h:meta name="assert" content="text-rendering computed value is as specified."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/text-rendering-invalid.svg
+++ b/svg/painting/parsing/text-rendering-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing text-rendering with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty"/>
     <h:meta name="assert" content="text-rendering supports only the grammar 'auto | optimizeSpeed | optimizeLegibility | geometricPrecision'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/parsing/text-rendering-valid.svg
+++ b/svg/painting/parsing/text-rendering-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Painting: parsing text-rendering with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty"/>
     <h:meta name="assert" content="text-rendering supports the full grammar 'auto | optimizeSpeed | optimizeLegibility | geometricPrecision'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/painting/reftests/gradient-external-reference.svg
+++ b/svg/painting/reftests/gradient-external-reference.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>External file reference for gradient</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#Gradients"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingStrokePaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#Gradients"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#URLReference"/>
   <h:link rel="match" href="../../pservers/reftests/reference/green-100x100.svg"/>
 
   <rect width="100" height="100" fill="url(support/resources.svg#greenGradient) red"/>

--- a/svg/painting/reftests/marker-external-reference.svg
+++ b/svg/painting/reftests/marker-external-reference.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>External file reference for marker</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#VertexMarkerProperties"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#VertexMarkerProperties"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#URLReference"/>
   <h:link rel="match" href="../../pservers/reftests/reference/green-100x100.svg"/>
 
   <path d="M25,25h50v50h-50" fill="none" stroke="red" stroke-width="5"

--- a/svg/painting/reftests/marker-implicit-subpaths.html
+++ b/svg/painting/reftests/marker-implicit-subpaths.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Marker on implicit subpath</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#RenderingMarkers">
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataClosePathCommand">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#RenderingMarkers">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataClosePathCommand">
 <link rel="match" href="../../struct/reftests/reference/green-100x100.html">
 <svg width="400" viewBox="-200 0 400 150">
   <marker id="m" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">

--- a/svg/painting/reftests/marker-units-strokewidth-non-scaling-stroke.svg
+++ b/svg/painting/reftests/marker-units-strokewidth-non-scaling-stroke.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Markers: markerUnits=strokeWidth with vector-effect=non-scaling-stroke</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerUnitsAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerUnitsAttribute"/>
   <h:link rel="match" href="../../embedded/reference/green-rect-100x100.svg"/>
 
   <marker id="m" orient="0" refY="5" markerUnits="strokeWidth"

--- a/svg/painting/reftests/marker-units-userspaceonuse-non-scaling-stroke.svg
+++ b/svg/painting/reftests/marker-units-userspaceonuse-non-scaling-stroke.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Markers: markerUnits=userSpaceOnUse with vector-effect=non-scaling-stroke</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerUnitsAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerUnitsAttribute"/>
   <h:link rel="match" href="../../embedded/reference/green-rect-100x100.svg"/>
 
   <marker id="m" orient="0" refY="5" markerUnits="userSpaceOnUse"

--- a/svg/painting/reftests/markers-orient-002.svg
+++ b/svg/painting/reftests/markers-orient-002.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>orient='auto' with 180 degree turns</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#RenderingMarkers"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#RenderingMarkers"/>
   <h:link rel="match" href="../../pservers/reftests/reference/green-100x100.svg"/>
   <marker id="m" markerWidth="100" markerHeight="50" markerUnits="userSpaceOnUse"
           orient="auto" refX="50" refY="50">

--- a/svg/painting/reftests/non-scaling-stroke-001.html
+++ b/svg/painting/reftests/non-scaling-stroke-001.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <title>non-scaling-stroke with scaling</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects" />
 <link rel="match" href="green-100x100.svg" />
 <body>
   <style>

--- a/svg/painting/reftests/non-scaling-stroke-002.html
+++ b/svg/painting/reftests/non-scaling-stroke-002.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>non-scaling-stroke with scaling</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects" />
 <link rel="match" href="green-100x100.svg" />
 <script src="/common/reftest-wait.js"></script>
 <body>

--- a/svg/painting/reftests/non-scaling-stroke-003.html
+++ b/svg/painting/reftests/non-scaling-stroke-003.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <title>non-scaling-stroke with outer viewport transform</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects" />
 <link rel="match" href="green-100x100.svg" />
 <body>
   <style>

--- a/svg/painting/reftests/non-scaling-stroke-004.html
+++ b/svg/painting/reftests/non-scaling-stroke-004.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>non-scaling-stroke with scaling</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects" />
 <link rel="match" href="green-100x100.svg" />
 <body>
 <svg>

--- a/svg/painting/reftests/non-scaling-stroke-005.html
+++ b/svg/painting/reftests/non-scaling-stroke-005.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>non-scaling-stroke with scaling from viewBox</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects">
 <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
 <link rel="match" href="non-scaling-stroke-005-ref.html">
 <style>

--- a/svg/painting/reftests/non-scaling-stroke-006.html
+++ b/svg/painting/reftests/non-scaling-stroke-006.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>non-scaling-stroke with scaling from viewBox and preserveAspectRatio=none</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects">
 <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
 <link rel="match" href="non-scaling-stroke-006-ref.html">
 <style>

--- a/svg/painting/reftests/non-scaling-stroke-007.html
+++ b/svg/painting/reftests/non-scaling-stroke-007.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
 <link rel="author" title="Mozilla" href="https://mozilla.org">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1917604">
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects">
 <link rel="match" href="non-scaling-stroke-007-ref.html">
 <svg width="100" height="100">
   <svg width="100%" height="100%" viewBox="0 0 1 1" preserveAspectRatio="none">

--- a/svg/painting/reftests/non-scaling-stroke-precision-loss.html
+++ b/svg/painting/reftests/non-scaling-stroke-precision-loss.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
 <link rel="mismatch" href="about:blank">
 <link rel="help" href="https://issues.chromium.org/issues/40718465">
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects">
 <svg width="618" height="344" viewBox="2172660 0 90 0.375" preserveAspectRatio="none">
   <path stroke="black" fill="none" vector-effect="non-scaling-stroke"
         d="M 2172732 0.1

--- a/svg/painting/reftests/pattern-external-reference.svg
+++ b/svg/painting/reftests/pattern-external-reference.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>External file reference for pattern</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#Patterns"/>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingStrokePaint"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#Patterns"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#URLReference"/>
   <h:link rel="match" href="../../pservers/reftests/reference/green-100x100.svg"/>
 
   <rect width="100" height="100" fill="url(support/resources.svg#greenPattern) red"/>

--- a/svg/painting/reftests/percentage-attribute.svg
+++ b/svg/painting/reftests/percentage-attribute.svg
@@ -5,7 +5,7 @@
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Percentages in stroke dimensions</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="percentage-ref.svg" />
 
   <style>

--- a/svg/painting/reftests/percentage.svg
+++ b/svg/painting/reftests/percentage.svg
@@ -5,7 +5,7 @@
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Percentages in stroke dimensions</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html"/>
   <html:link rel="match"  href="percentage-ref.svg" />
 
   <style>

--- a/svg/painting/scripted/SVGMarkerElement-orientType-synchronization.html
+++ b/svg/painting/scripted/SVGMarkerElement-orientType-synchronization.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>SVGMarkerElement.orientType synchronization</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAngle">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#InterfaceSVGMarkerElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAngle">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/svg/path/animations/path-length-interpolation.tentative.html
+++ b/svg/path/animations/path-length-interpolation.tentative.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>path-length interpolation</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthProperty"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/interpolation-testcommon.js"></script>

--- a/svg/path/bearing/absolute.svg
+++ b/svg/path/bearing/absolute.svg
@@ -2,7 +2,7 @@
   <metadata>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/svg-paths/#PathDataBearingCommands"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/paths.html#PathDataBearingCommands"/>
-    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://svgwg.org/svg2-draft/changes.html#paths"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://w3c.github.io/svgwg/svg2-draft/changes.html#paths"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="absolute-ref.svg"/>
     <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="path element with B commands renders correctly."/>
   </metadata>

--- a/svg/path/bearing/relative.svg
+++ b/svg/path/bearing/relative.svg
@@ -2,7 +2,7 @@
   <metadata>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/svg-paths/#PathDataBearingCommands"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/paths.html#PathDataBearingCommands"/>
-    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://svgwg.org/svg2-draft/changes.html#paths"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://w3c.github.io/svgwg/svg2-draft/changes.html#paths"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="absolute-ref.svg"/>
     <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="path element with b commands renders correctly."/>
   </metadata>

--- a/svg/path/bearing/zero.svg
+++ b/svg/path/bearing/zero.svg
@@ -2,7 +2,7 @@
   <metadata>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/svg-paths/#PathDataBearingCommands"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/paths.html#PathDataBearingCommands"/>
-    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://svgwg.org/svg2-draft/changes.html#paths"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://w3c.github.io/svgwg/svg2-draft/changes.html#paths"/>
     <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="zero-ref.svg"/>
     <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="path element with bearing 0 renders correctly."/>
   </metadata>

--- a/svg/path/closepath/segment-completing.svg
+++ b/svg/path/closepath/segment-completing.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="300" height="200">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#paths-PathDataClosePathCommand"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#paths-PathDataClosePathCommand"/>
     <h:link rel="match" href="segment-completing-ref.svg"/>
     <h:meta name="assert" content="initial subpath point used to complete segment."/>
   </metadata>

--- a/svg/path/distance/path-length-css-overrides-presentation-attribute.tentative.svg
+++ b/svg/path/distance/path-length-css-overrides-presentation-attribute.tentative.svg
@@ -3,8 +3,8 @@
   <title>CSS path-length overrides presentation attribute</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes"/>
     <html:link rel="match" href="path-length-css-property-ref.tentative.svg"/>
   </metadata>
   <style>

--- a/svg/path/distance/path-length-css-property.tentative.svg
+++ b/svg/path/distance/path-length-css-property.tentative.svg
@@ -3,7 +3,7 @@
   <title>CSS path-length property</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
     <html:link rel="match" href="path-length-css-property-ref.tentative.svg"/>
   </metadata>
   <style>

--- a/svg/path/distance/path-length-css-zero.tentative.svg
+++ b/svg/path/distance/path-length-css-zero.tentative.svg
@@ -3,7 +3,7 @@
   <title>CSS path-length property set to zero</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
     <html:link rel="match" href="path-length-css-zero-ref.tentative.svg"/>
   </metadata>
   <style>

--- a/svg/path/distance/pathLength-positive-percentage.svg
+++ b/svg/path/distance/pathLength-positive-percentage.svg
@@ -4,7 +4,7 @@
      width="300" height="200" viewBox="0 0 300 200"
      font-family="sans-serif" font-size="28">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
     <h:link rel="match" href="pathLength-positive-ref.svg"/>
     <h:meta name="assert" content="pathLength scales distance along the path"/>
   </metadata>

--- a/svg/path/distance/pathLength-positive.svg
+++ b/svg/path/distance/pathLength-positive.svg
@@ -4,7 +4,7 @@
      width="300" height="200" viewBox="0 0 300 200">
 
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
     <h:link rel="match" href="pathLength-positive-ref.svg"/>
     <h:meta name="assert" content="pathLength scales distance along the path"/>
   </metadata>

--- a/svg/path/distance/pathLength-zero-percentage.svg
+++ b/svg/path/distance/pathLength-zero-percentage.svg
@@ -4,7 +4,7 @@
      width="300" height="200" viewBox="0 0 300 200"
      font-family="sans-serif" font-size="28">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
     <h:link rel="match" href="pathLength-zero-percentage-ref.svg"/>
     <h:meta name="assert" content="A value of zero is valid and must be treated as a scaling factor of infinity."/>
   </metadata>

--- a/svg/path/distance/pathLength-zero.svg
+++ b/svg/path/distance/pathLength-zero.svg
@@ -4,7 +4,7 @@
      width="300" height="200" viewBox="0 0 300 200">
 
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
     <h:link rel="match" href="pathLength-zero-ref.svg"/>
     <h:meta name="assert" content="A value of zero is valid and must be treated as a scaling factor of infinity."/>
   </metadata>

--- a/svg/path/distance/pathlength-circle-mutating.svg
+++ b/svg/path/distance/pathlength-circle-mutating.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" class="reftest-wait"
      width="100" height="100">
   <title>Mutating the 'pathLength' attribute ('circle' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="../../linking/reftests/reference/green-100x100.svg"/>
   <circle cx="100" cy="50" r="100" fill="red" pathLength="6400"
           stroke="green" stroke-width="200" stroke-dasharray="200"/>

--- a/svg/path/distance/pathlength-path-mutating.svg
+++ b/svg/path/distance/pathlength-path-mutating.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" class="reftest-wait">
   <title>Mutating the 'pathLength' attribute ('path' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="reference/pathlength-path-mutating-ref.svg"/>
   <path pathLength="800" d="M100,100h100v100h-100z" fill="none"
         stroke="blue" stroke-width="20" stroke-dasharray="25"/>

--- a/svg/path/distance/pathlength-path-negative.svg
+++ b/svg/path/distance/pathlength-path-negative.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>The 'pathLength' attribute set to a negative value ('path' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="reference/pathlength-path-negative-ref.svg"/>
   <path d="M10,10L110,10L110,110L10,110Z" pathLength="-4" stroke-dashoffset="1" stroke-dasharray="1 1"
         fill="none" stroke="black" stroke-width="10"></path>

--- a/svg/path/distance/pathlength-path-zero.svg
+++ b/svg/path/distance/pathlength-path-zero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>The 'pathLength' attribute set to zero ('path' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="reference/pathlength-path-zero-ref.svg"/>
   <path d="M10,10L110,10L110,110L10,110Z" pathLength="0" stroke-dashoffset="1" stroke-dasharray="1 1"
         fill="none" stroke="black" stroke-width="10"/>

--- a/svg/path/distance/pathlength-path.svg
+++ b/svg/path/distance/pathlength-path.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>The 'pathLength' attribute ('path' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="reference/pathlength-path-ref.svg"/>
   <path d="M10,10L110,10L110,110L10,110Z" pathLength="4"
         stroke-dashoffset="1" stroke-dasharray="1 1"

--- a/svg/path/distance/pathlength-rect-mutating.svg
+++ b/svg/path/distance/pathlength-rect-mutating.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" class="reftest-wait"
      width="100" height="100">
   <title>Mutating the 'pathLength' attribute ('rect' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="reference/pathlength-rect-mutating-ref.svg"/>
   <rect y="50" width="200" height="100" fill="red"
         stroke="green" stroke-width="100" stroke-dasharray="100"

--- a/svg/path/distance/pathlength-rect.svg
+++ b/svg/path/distance/pathlength-rect.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>The 'pathLength' attribute ('rect' element)</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
   <h:link rel="match" href="reference/pathlength-rect-ref.svg"/>
   <rect width="50" height="50" pathLength="4" fill="blue"
         stroke-dashoffset="1" stroke-dasharray="1 1" stroke="black" stroke-width="10"/>

--- a/svg/path/error-handling/bounding.svg
+++ b/svg/path/error-handling/bounding.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#paths-PathDataErrorHandling"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#paths-PathDataErrorHandling"/>
     <h:meta name="assert" content="render up to (but not including) the first error"/>
   </metadata>
   <g id="container">

--- a/svg/path/error-handling/render-until-error.svg
+++ b/svg/path/error-handling/render-until-error.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="100" height="100">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#paths-PathDataErrorHandling"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#paths-PathDataErrorHandling"/>
     <h:link rel="match" href="render-until-error-ref.svg"/>
     <h:meta name="assert" content="render up to (but not including) the first error"/>
   </metadata>

--- a/svg/path/interfaces/SVGAnimatedPathData-removed.svg
+++ b/svg/path/interfaces/SVGAnimatedPathData-removed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#changes-paths"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#changes-paths"/>
     <h:link rel="help" href="https://www.w3.org/TR/SVG11/paths.html#InterfaceSVGAnimatedPathData"/>
     <h:meta name="assert" content="SVGAnimatedPathData interface is not supported."/>
   </metadata>

--- a/svg/path/interfaces/SVGPathSegment.svg
+++ b/svg/path/interfaces/SVGPathSegment.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/specs/paths/#InterfaceSVGPathSegment"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/specs/paths/#InterfaceSVGPathSegment"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/path/parsing/arc-commands.html
+++ b/svg/path/parsing/arc-commands.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Elliptical arc (A/a)</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/curveto-commands.html
+++ b/svg/path/parsing/curveto-commands.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Curveto commands (C/c, S/s)</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/error-handling.html
+++ b/svg/path/parsing/error-handling.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Error handling - invalid commands and parameters</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/lineto-commands.html
+++ b/svg/path/parsing/lineto-commands.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Lineto commands (L/l, H/h, V/v)</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/moveto-absolute.html
+++ b/svg/path/parsing/moveto-absolute.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Moveto command - absolute (M)</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/moveto-relative.html
+++ b/svg/path/parsing/moveto-relative.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Moveto command - relative (m)</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/number-edge-case-consecutive.html
+++ b/svg/path/parsing/number-edge-case-consecutive.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Number parsing - consecutive numbers without separator</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/number-edge-case-decimal.html
+++ b/svg/path/parsing/number-edge-case-decimal.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Number parsing - decimal point consumption</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/number-error-trailing-decimal.html
+++ b/svg/path/parsing/number-error-trailing-decimal.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Error - trailing decimal point</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/number-exponent.html
+++ b/svg/path/parsing/number-exponent.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Number parsing - scientific notation with exponents</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/path-length-computed.tentative.svg
+++ b/svg/path/parsing/path-length-computed.tentative.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Path Properties: getComputedStyle().pathLength</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty"/>
   </metadata>
   <path id="target"/>
   <h:script src="/resources/testharness.js"/>

--- a/svg/path/parsing/path-length-invalid.tentative.svg
+++ b/svg/path/parsing/path-length-invalid.tentative.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Path Properties: parsing path-length with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty"/>
     <h:meta name="assert" content="path-length supports only the grammar 'none | &lt;number [0,∞]&gt;'."/>
   </metadata>
   <path id="target"/>

--- a/svg/path/parsing/path-length-valid.tentative.svg
+++ b/svg/path/parsing/path-length-valid.tentative.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Path Properties: parsing path-length with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty"/>
     <h:meta name="assert" content="path-length supports the full grammar 'none | &lt;number [0,∞]&gt;'."/>
   </metadata>
   <path id="target"/>

--- a/svg/path/parsing/quadratic-bezier-commands.html
+++ b/svg/path/parsing/quadratic-bezier-commands.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Quadratic Bezier curveto (Q/q, T/t)</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/parsing/whitespace-basic.html
+++ b/svg/path/parsing/whitespace-basic.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SVG Path Data: Whitespace handling</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/svg/path/property/d-interpolation-discrete.svg
+++ b/svg/path/property/d-interpolation-discrete.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:meta name="assert" content="d falls back to step interpolation when no interpolation is possible."/>
   </metadata>
 

--- a/svg/path/property/d-interpolation-relative-absolute.svg
+++ b/svg/path/property/d-interpolation-relative-absolute.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:meta name="assert" content="d can interpolate between absolute and relative paths."/>
   </metadata>
 
@@ -108,7 +108,7 @@
 
       // At progress 0.125/0.875, arc flags in path() should consider
       // non-zero interpolated values as one to match <path> behaviour.
-      // https://svgwg.org/specs/paths/#PathElement
+      // https://w3c.github.io/svgwg/specs/paths/#PathElement
       test_interpolation({
         property: 'd',
         from: 'path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")',

--- a/svg/path/property/d-interpolation-single.svg
+++ b/svg/path/property/d-interpolation-single.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:meta name="assert" content="Each path command interpolates."/>
   </metadata>
 
@@ -119,7 +119,7 @@
 
       // At progress 0.125/0.875, arc flags in path() should consider
       // non-zero interpolated values as one to match <path> behaviour.
-      // https://svgwg.org/specs/paths/#PathElement
+      // https://w3c.github.io/svgwg/specs/paths/#PathElement
       test_interpolation({
         property: 'd',
         from: 'path("M 100 400 A 10 20 30 1 0 140 450")',

--- a/svg/path/property/d-none.svg
+++ b/svg/path/property/d-none.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:link rel="match" href="d-none-ref.svg"/>
     <h:meta name="assert" content="Setting 'd: none' overrides the 'd' SVG attribute."/>
   </metadata>

--- a/svg/path/property/getComputedStyle.svg
+++ b/svg/path/property/getComputedStyle.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:meta name="assert" content="d is a property"/>
   </metadata>
   <style>

--- a/svg/path/property/inheritance.tentative.svg
+++ b/svg/path/property/inheritance.tentative.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Inheritance of path properties</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty"/>
     <h:meta name="assert" content="path-length does not inherit."/>
   </metadata>
   <g id="container">

--- a/svg/path/property/marker-path.svg
+++ b/svg/path/property/marker-path.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml" width="300" height="300">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:link rel="match" href="marker-path-ref.svg"/>
     <h:meta name="assert" content="d property is used for SVG markers."/>
   </metadata>

--- a/svg/path/property/mpath.svg
+++ b/svg/path/property/mpath.svg
@@ -3,7 +3,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="100">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:link rel="match" href="mpath-ref.svg"/>
     <h:meta name="assert" content="d property is used for SVG mpath ref path."/>
   </metadata>

--- a/svg/path/property/priority.svg
+++ b/svg/path/property/priority.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml" width="100" height="100">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:link rel="match" href="priority-ref.svg"/>
     <h:meta name="assert" content="Property overrides attribute."/>
   </metadata>

--- a/svg/path/property/serialization.svg
+++ b/svg/path/property/serialization.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
     <h:meta name="assert" content="computed d is serialized using absolute commands"/>
   </metadata>
   <path id="target"></path>

--- a/svg/pservers/inheritance.svg
+++ b/svg/pservers/inheritance.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>Inheritance of SVG paint server properties</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html"/>
     <h:meta name="assert" content="properties inherit according to the spec."/>
     <h:meta name="assert" content="properties have expected initial values."/>
   </metadata>

--- a/svg/pservers/parsing/stop-color-computed.svg
+++ b/svg/pservers/parsing/stop-color-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Paint Servers: getComputedStyle().stopColor</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty"/>
     <h:link rel="help" href="https://drafts.csswg.org/css-color/#resolve-color-values"/>
     <h:link rel="help" href="https://drafts.csswg.org/cssom/#serializing-css-values"/>
   </metadata>

--- a/svg/pservers/parsing/stop-color-invalid.svg
+++ b/svg/pservers/parsing/stop-color-invalid.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Paint Servers: parsing stop-color with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty"/>
   </metadata>
   <g id="target" style="color: blue"></g>
   <h:script src="/resources/testharness.js"/>

--- a/svg/pservers/parsing/stop-color-valid.svg
+++ b/svg/pservers/parsing/stop-color-valid.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Paint Servers: parsing stop-color with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty"/>
   </metadata>
   <g id="target" style="color: blue"></g>
   <h:script src="/resources/testharness.js"/>

--- a/svg/pservers/parsing/stop-opacity-computed.svg
+++ b/svg/pservers/parsing/stop-opacity-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Paint Servers: getComputedStyle().stopOpacity</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty"/>
     <h:meta name="assert" content="stop-opacity computed value is clamped to the range [0,1]."/>
   </metadata>
   <g id="target"></g>

--- a/svg/pservers/parsing/stop-opacity-invalid.svg
+++ b/svg/pservers/parsing/stop-opacity-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Paint Servers: parsing stop-opacity with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty"/>
     <h:meta name="assert" content="stop-opacity supports only the grammar 'alpha-value'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/pservers/parsing/stop-opacity-valid.svg
+++ b/svg/pservers/parsing/stop-opacity-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Paint Servers: parsing stop-opacity with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty"/>
     <h:meta name="assert" content="stop-opacity supports the full grammar 'alpha-value'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/pservers/radial-gradient-undefined-fx-fy.html
+++ b/svg/pservers/radial-gradient-undefined-fx-fy.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <title>SVG radialGradient fx and fy default to 50%</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFXAttribute">
-<link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFYAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementFXAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementFYAttribute">
 <link rel="author" title="Karl Dubost" href="https://otsukare.info/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/pservers/reftests/gradient-inheritance-not-in-rendertree-01.tentative.svg
+++ b/svg/pservers/reftests/gradient-inheritance-not-in-rendertree-01.tentative.svg
@@ -2,7 +2,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http:/www.w3.org/1999/xhtml">
   <title>&#x3c;linearGradient&#x3e; (without content) inheriting from a &#x3c;linearGradient&#x3e; in an invalid context</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopNotes"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopNotes"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <linearGradient id="linearGradient1" xlink:href="#linearGradient0"/>
   <rect width="100" height="100" fill="green"/>

--- a/svg/pservers/reftests/gradient-inheritance-not-in-rendertree-02.tentative.svg
+++ b/svg/pservers/reftests/gradient-inheritance-not-in-rendertree-02.tentative.svg
@@ -2,7 +2,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http:/www.w3.org/1999/xhtml">
   <title>&#x3c;linearGradient&#x3e; (with content) inheriting from a &#x3c;linearGradient&#x3e; in an invalid context</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopNotes"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopNotes"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <linearGradient id="linearGradient1" xlink:href="#linearGradient0">
     <stop stop-color="green"/>

--- a/svg/pservers/reftests/gradient-transform-01.svg
+++ b/svg/pservers/reftests/gradient-transform-01.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Gradients with non-invertible gradientTransforms, linearGradient</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#pservers-LinearGradientElementGradientTransformAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#pservers-LinearGradientElementGradientTransformAttribute"/>
   <h:link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-function-lists"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
 

--- a/svg/pservers/reftests/gradient-transform-02.svg
+++ b/svg/pservers/reftests/gradient-transform-02.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Gradients with non-invertible gradientTransforms, radialGradient</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#pservers-RadialGradientElementGradientTransformAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#pservers-RadialGradientElementGradientTransformAttribute"/>
   <h:link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-function-lists"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
 

--- a/svg/pservers/reftests/gradient-transform-03.svg
+++ b/svg/pservers/reftests/gradient-transform-03.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" class="reftest-wait">
   <title>Gradient with 'transform' property added dynamically</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#pservers-LinearGradientElementGradientTransformAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#pservers-LinearGradientElementGradientTransformAttribute"/>
   <h:link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-attribute-specificity"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <h:script src="/common/reftest-wait.js"/>

--- a/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg
+++ b/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml"
      class="reftest-wait">
   <title>SVG Pattern: Inherited pattern removed after style change</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <h:script src="/common/rendering-utils.js"/>
   <h:script src="/common/reftest-wait.js"/>

--- a/svg/pservers/reftests/pattern-transform-02.svg
+++ b/svg/pservers/reftests/pattern-transform-02.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Patterns with non-invertible patternTransforms</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#pservers-PatternElementPatternTransformAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#pservers-PatternElementPatternTransformAttribute"/>
   <h:link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-function-lists"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
 

--- a/svg/pservers/reftests/pattern-transform-03.svg
+++ b/svg/pservers/reftests/pattern-transform-03.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" class="reftest-wait">
   <title>Pattern with 'transform' property added dynamically</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#pservers-PatternElementPatternTransformAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#pservers-PatternElementPatternTransformAttribute"/>
   <h:link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-attribute-specificity"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <h:script src="/common/reftest-wait.js"/>

--- a/svg/pservers/reftests/radialgradient-fully-overlapping.svg
+++ b/svg/pservers/reftests/radialgradient-fully-overlapping.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Radial gradient with overlapping start and end circles</title>
   <metadata>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientNotes"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientNotes"/>
     <html:link rel="match" href="reference/green-100x100.svg"/>
     <html:meta name="assert" content="If the start circle fully overlaps with the end circle, the gradient should be drawn."/>
     <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500"/>

--- a/svg/pservers/reftests/stop-color-currentcolor-dynamic-001.svg
+++ b/svg/pservers/reftests/stop-color-currentcolor-dynamic-001.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
      style="color: red">
   <title>stop-color: Dynamically changing 'color' for a gradient with a stop with 'currentcolor'</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty"/>
   <html:link rel="match" href="reference/green-100x100.svg"/>
   <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2500"/>
   <linearGradient id="g">

--- a/svg/pservers/scripted/pattern-transform-clear.svg
+++ b/svg/pservers/scripted/pattern-transform-clear.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Paint Servers: Clear should cause patternTransform to be ignored.</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternTransformAttribute"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementPatternTransformAttribute"/>
     <h:link rel="match" href="../reftests/reference/green-100x100.svg"/>
   </metadata>
   <pattern id="p1" patternTransform="scale(2)"/>

--- a/svg/pservers/scripted/stop-color-inheritance-currentcolor.svg
+++ b/svg/pservers/scripted/stop-color-inheritance-currentcolor.svg
@@ -3,7 +3,7 @@
      color="red">
   <title>SVG Paint Servers: 'stop-color' inheritance of 'currentcolor'</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty"/>
     <h:link rel="help" href="https://drafts.csswg.org/css-color/#resolve-color-values"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>

--- a/svg/render/order/z-index.svg
+++ b/svg/render/order/z-index.svg
@@ -3,7 +3,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      width="300" height="200" viewBox="0 0 300 200">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/render.html#ZIndexProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/render.html#ZIndexProperty"/>
     <h:link rel="match" href="z-index-ref.svg"/>
     <h:meta name="assert" content="The z-index property allows an element to be assigned to a stack level."/>
   </metadata>

--- a/svg/scripted/text-attrs-dxdy-have-length.svg
+++ b/svg/scripted/text-attrs-dxdy-have-length.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#text-TSpanNotes"/>
     <h:meta name="assert" content="dx and dy attributes on text elements are lists that support length()"/>
 </metadata>
   <text id="text" font-family="Verdana" font-size="55" fill="blue"

--- a/svg/scripted/text-attrs-xyrotate-have-length.svg
+++ b/svg/scripted/text-attrs-xyrotate-have-length.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#text-TSpanNotes"/>
     <h:meta name="assert" content="x y and rotate attributes on text elements are lists that support length()"/>
 </metadata>
   <text id="text" font-family="Verdana" font-size="55" fill="blue"

--- a/svg/scripted/text-tspan-attrs-have-length.svg
+++ b/svg/scripted/text-tspan-attrs-have-length.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#text-TSpanNotes"/>
     <h:meta name="assert" content="x y dx dy and rotate attributes on text and tspan elements are lists that support length()"/>
 </metadata>
   <text id="text" font-family="Verdana" font-size="55" fill="blue"

--- a/svg/scripted/text-tspan-attrs-indexed-access.svg
+++ b/svg/scripted/text-tspan-attrs-indexed-access.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#text-TSpanNotes"/>
     <h:meta name="assert" content="x y dx dy and rotate attributes on text and tspan elements are lists that support length()"/>
 </metadata>
   <text id="text" font-family="Verdana" font-size="55" fill="blue"

--- a/svg/scripted/tspan-attrs-dxdy-have-length.svg
+++ b/svg/scripted/tspan-attrs-dxdy-have-length.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#text-TSpanNotes"/>
     <h:meta name="assert" content="dx, dy attrs on tspan support length()"/>
 </metadata>
   <text id="text" font-family="Verdana" font-size="55" fill="blue"

--- a/svg/scripted/tspan-attrs-xyrotate-have-length.svg
+++ b/svg/scripted/tspan-attrs-xyrotate-have-length.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#text-TSpanNotes"/>
     <h:meta name="assert" content="dx and dy attributes on text elements are lists that support length()"/>
 </metadata>
   <text id="text" font-family="Verdana" font-size="55" fill="blue"

--- a/svg/shapes/reftests/disabled-shapes-01.svg
+++ b/svg/shapes/reftests/disabled-shapes-01.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>Disabled shapes are not rendered</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#RectElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#CircleElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#EllipseElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#RectElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#CircleElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement"/>
     <h:link rel="match" href="reference/empty.svg"/>
   </metadata>
   <g stroke="red" stroke-width="100">

--- a/svg/shapes/scripted/disabled-shapes-not-hit.svg
+++ b/svg/shapes/scripted/disabled-shapes-not-hit.svg
@@ -3,9 +3,9 @@
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#RectElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#CircleElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#EllipseElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#RectElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#CircleElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement"/>
   </metadata>
   <g stroke="red" stroke-width="100">
     <g transform="translate(50, 50)">

--- a/svg/shapes/scripted/shapes-clip-path.svg
+++ b/svg/shapes/scripted/shapes-clip-path.svg
@@ -3,9 +3,9 @@
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#RectElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#CircleElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#EllipseElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#RectElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#CircleElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement"/>
   </metadata>
   <defs>
     <clipPath id="clip1">

--- a/svg/shapes/scripted/stroke-dashes-hit-at-high-scale.svg
+++ b/svg/shapes/scripted/stroke-dashes-hit-at-high-scale.svg
@@ -3,8 +3,8 @@
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/shapes.html#CircleElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperties"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#CircleElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperties"/>
   </metadata>
   <circle id="circle" cx="6" cy="10" r="5" stroke="blue" stroke-width="1" stroke-dasharray="10 21.4159" fill="none"/>
   <script>

--- a/svg/struct/reftests/nested-svg-through-display-contents.svg
+++ b/svg/struct/reftests/nested-svg-through-display-contents.svg
@@ -3,7 +3,7 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:h="http://www.w3.org/1999/xhtml">
  <h:link rel="match" href="reference/green-100x100.svg"/>
- <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#ForeignNamespaces"/>
+ <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#ForeignNamespaces"/>
  <rect x="0" y="0" width="100" height="100" fill="green"></rect>
  <h:div style="display: contents">
   <svg width="300" height="300">

--- a/svg/struct/reftests/requiredextensions-empty-string.svg
+++ b/svg/struct/reftests/requiredextensions-empty-string.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>requiredExtensions: present but empty attribute evaluates to false</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#RequiredExtensionsAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#RequiredExtensionsAttribute"/>
   <h:link rel="match" href="../scripted/support/blank.svg"/>
   <rect width="100" height="100" fill="red" requiredExtensions=""/>
 </svg>

--- a/svg/struct/reftests/use-cross-origin.svg
+++ b/svg/struct/reftests/use-cross-origin.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&#x3c;use&#x3e; with a cross-origin resource</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <rect width="100" height="100" fill="green"/>
   <script>

--- a/svg/struct/reftests/use-data-url-set-attributeName.tentative.svg
+++ b/svg/struct/reftests/use-data-url-set-attributeName.tentative.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&#x3c;use&#x3e; with a data: URL resource loaded by &#x3c;set attributeName&#x3e;</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <rect width="100" height="100" fill="green"/>
   <use>

--- a/svg/struct/reftests/use-data-url-setAttribute.tentative.html
+++ b/svg/struct/reftests/use-data-url-setAttribute.tentative.html
@@ -1,7 +1,7 @@
 <!doctype HTML>
 <meta charset="utf-8">
 <title>Testcase for changing a valid &#x3c;use&#x3e; to a data URL:</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute">
 <link rel="match" href="reference/green-100x100.html">
 <script>
   function go() {

--- a/svg/struct/reftests/use-data-url.tentative.svg
+++ b/svg/struct/reftests/use-data-url.tentative.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&#x3c;use&#x3e; with a data: URL resource</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <rect width="100" height="100" fill="green"/>
   <use href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxyZWN0IGlkPSJyZWQtcmVjdCIgd2lkdGg9IjEwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9InJlZCIvPgo8L3N2Zz4=#red-rect"/>

--- a/svg/struct/reftests/use-encoding.svg
+++ b/svg/struct/reftests/use-encoding.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&#x3c;use&#x3e; with an encoded href</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <rect id="a b" width="100" height="100" fill="green"/>

--- a/svg/struct/reftests/use-event-handler-no-loss-of-events.html
+++ b/svg/struct/reftests/use-event-handler-no-loss-of-events.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8">
 <title>No loss of events when use instances copies event handlers</title>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseEventHandling">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseEventHandling">
 <link rel="match" href="reference/green-100x100.html">
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>

--- a/svg/struct/reftests/use-external-html-resource-with-content-type-svg.html
+++ b/svg/struct/reftests/use-external-html-resource-with-content-type-svg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Reference to a &lt;symbol> in an SVG fragment in an html resource document with SVG content type</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL">
 <link rel="match" href="reference/green-100x100.html">
 <svg>
   <use href="support/html-resource-with-symbol-and-content-type-svg.html#green"/>

--- a/svg/struct/reftests/use-external-html-resource-with-doctype.html
+++ b/svg/struct/reftests/use-external-html-resource-with-doctype.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Reference to a &lt;symbol> in an SVG fragment in an html resource document with a doctype</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL">
 <link rel="match" href="reference/green-100x100.html">
 <svg>
   <use href="support/html-resource-with-doctype-and-symbol.html#green"/>

--- a/svg/struct/reftests/use-external-html-resource.html
+++ b/svg/struct/reftests/use-external-html-resource.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Reference to a &lt;symbol> in an SVG fragment in an html resource document</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL">
 <link rel="match" href="reference/green-100x100.html">
 <svg>
   <use href="support/html-resource-with-symbol.html#green"/>

--- a/svg/struct/reftests/use-external-resource-no-svg-root.html
+++ b/svg/struct/reftests/use-external-resource-no-svg-root.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Reference to a &lt;symbol> not in an SVG fragment in a resource document without an SVG root element</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL">
 <link rel="match" href="reference/green-100x100.html">
 <svg>
   <use href="support/non-svg-root-resource.xml#green"/>

--- a/svg/struct/reftests/use-external-resource-target-pseudo-001.html
+++ b/svg/struct/reftests/use-external-resource-target-pseudo-001.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>&lt;use> referencing an external document resource with :target pseudo class</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance">
 <link rel="help" href="https://drafts.csswg.org/selectors/#the-target-pseudo">
 <link rel="match" href="reference/green-100x100.html">
 <svg width="100" height="100">

--- a/svg/struct/reftests/use-external-resource-target-pseudo-002.html
+++ b/svg/struct/reftests/use-external-resource-target-pseudo-002.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>&lt;use> referencing an external document resource with :target pseudo class</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL">
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#processingURL">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance">
 <link rel="help" href="https://drafts.csswg.org/selectors/#the-target-pseudo">
 <link rel="match" href="reference/green-100x100.html">
 <svg width="100" height="100">

--- a/svg/struct/reftests/use-external-svg-resource-no-fragment-id.html
+++ b/svg/struct/reftests/use-external-svg-resource-no-fragment-id.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Allow use to reference an external document's root element by omitting the fragment.</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="reference/green-100x100.html">
 <svg>
   <use href="support/sprites-without-id.svg"/>

--- a/svg/struct/reftests/use-inheritance-001.svg
+++ b/svg/struct/reftests/use-inheritance-001.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Use property inheritance in SVG2</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance"/>
     <h:link rel="match" href="reference/green-100x100.svg"/>
     <h:link rel="author" title="Mike Bremford" href="http://bfo.com"/>
   </metadata>

--- a/svg/struct/reftests/use-inheritance-nth-child-of.svg
+++ b/svg/struct/reftests/use-inheritance-nth-child-of.svg
@@ -2,7 +2,7 @@
   <title>Use property inheritance with :nth-child(... of &lt;selector list&gt;) in SVG2</title>
   <metadata>
     <h:link rel="match" href="reference/green-100x100.svg"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance"/>
     <h:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1821258"/>
     <h:link rel="author" title="Zach Hoffman" href="mailto:zach@zrhoffman.net"/>
   </metadata>

--- a/svg/struct/reftests/use-inheritance-nth-last-child-of.svg
+++ b/svg/struct/reftests/use-inheritance-nth-last-child-of.svg
@@ -2,7 +2,7 @@
   <title>Use property inheritance with :nth-last-child(... of &lt;selector list&gt;) in SVG2</title>
   <metadata>
     <h:link rel="match" href="reference/green-100x100.svg"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseStyleInheritance"/>
     <h:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1821258"/>
     <h:link rel="author" title="Zach Hoffman" href="mailto:zach@zrhoffman.net"/>
   </metadata>

--- a/svg/struct/reftests/use-ref-inside-data-url.tentative.html
+++ b/svg/struct/reftests/use-ref-inside-data-url.tentative.html
@@ -1,7 +1,7 @@
 <!doctype HTML>
 <meta charset="utf-8">
 <title>Testcase for where SVG loaded via data: uses #ref</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute">
 <link rel="match" href="reference/green-100x100.html">
 <body>
 <!-- base64 SVG source:

--- a/svg/struct/reftests/use-referencing-non-svg-fragment-element.html
+++ b/svg/struct/reftests/use-referencing-non-svg-fragment-element.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>&lt;use> referencing an SVG element outside an SVG fragment</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="reference/green-100x100.html">
 <svg>
   <defs>

--- a/svg/struct/reftests/use-same-origin.svg
+++ b/svg/struct/reftests/use-same-origin.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&#x3c;use&#x3e; with a same-origin resource</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <use href="support/sprites.svg#green-rect"/>
 </svg>

--- a/svg/struct/reftests/use-svg-dimensions-override-001.svg
+++ b/svg/struct/reftests/use-svg-dimensions-override-001.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http://www.w3.org/1999/xhtml" width="800" height="600">
   <title>'width' and 'height' from &#x3c;use&#x3e; overrides values on referenced &#x3c;svg&#x3e;</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseLayout"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseLayout"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <svg id="s" width="10" height="10">

--- a/svg/struct/reftests/use-svg-dimensions-override-002.svg
+++ b/svg/struct/reftests/use-svg-dimensions-override-002.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http://www.w3.org/1999/xhtml" width="800" height="600">
   <title>'width' and 'height' from &#x3c;use&#x3e; overrides values on referenced &#x3c;svg&#x3e;</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseLayout"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseLayout"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <svg id="s">

--- a/svg/struct/reftests/use-svg-inline-css.svg
+++ b/svg/struct/reftests/use-svg-inline-css.svg
@@ -2,7 +2,7 @@
   <title>CSS width and height properties are ignored on use element referencing svg element</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/pull/1059"/>
     <html:link rel="match" href="reference/green-100x100.svg"/>
   </metadata>

--- a/svg/struct/reftests/use-symbol-dimensions-override-001.svg
+++ b/svg/struct/reftests/use-symbol-dimensions-override-001.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http://www.w3.org/1999/xhtml" width="800" height="600">
   <title>'width' and 'height' from &#x3c;use&#x3e; overrides values on referenced &#x3c;symbol&#x3e;</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseLayout"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseLayout"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <symbol id="s" width="10" height="10">

--- a/svg/struct/reftests/use-symbol-dimensions-override-002.svg
+++ b/svg/struct/reftests/use-symbol-dimensions-override-002.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:h="http://www.w3.org/1999/xhtml" width="800" height="600">
   <title>'width' and 'height' from &#x3c;use&#x3e; overrides values on referenced &#x3c;symbol&#x3e;</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseLayout"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseLayout"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <symbol id="s">

--- a/svg/struct/reftests/use-symbol-display-none.svg
+++ b/svg/struct/reftests/use-symbol-display-none.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&#x3c;use&#x3e; with a display="none" symbol</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute"/>
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <defs>
     <symbol id="a" display="none">

--- a/svg/struct/reftests/use-symbol-inline-css-001.svg
+++ b/svg/struct/reftests/use-symbol-inline-css-001.svg
@@ -2,8 +2,8 @@
   <title>CSS width and height properties are ignored on use element referencing symbol element</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#SymbolElement"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#SymbolElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/pull/1059"/>
     <html:link rel="match" href="reference/green-100x100.svg"/>
   </metadata>

--- a/svg/struct/reftests/use-symbol-inline-css-002.svg
+++ b/svg/struct/reftests/use-symbol-inline-css-002.svg
@@ -2,8 +2,8 @@
   <title>CSS width and height properties are ignored on use element when symbol has no dimensions</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#SymbolElement"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#SymbolElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/pull/1059"/>
     <html:link rel="match" href="reference/green-100x100.svg"/>
   </metadata>

--- a/svg/struct/scripted/autofocus-attribute.svg
+++ b/svg/struct/scripted/autofocus-attribute.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
     <title>Autofocus attribute</title>
     <metadata>
-        <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#autofocusattribute"/>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#autofocusattribute"/>
     </metadata>
     <h:script src="/resources/testharness.js"/>
     <h:script src="/resources/testharnessreport.js"/>

--- a/svg/struct/scripted/svg-checkIntersection-002.svg
+++ b/svg/struct/scripted/svg-checkIntersection-002.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>checkIntersection()</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__checkIntersection"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__checkIntersection"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
 

--- a/svg/struct/scripted/svg-getIntersectionList-001.svg
+++ b/svg/struct/scripted/svg-getIntersectionList-001.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:html="http://www.w3.org/1999/xhtml">
-<html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList"/>
+<html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList"/>
 <html:script src="/resources/testharness.js"/>
 <html:script src="/resources/testharnessreport.js"/>
 <html:link rel="stylesheet" href="/fonts/ahem.css"/>

--- a/svg/struct/scripted/svg-getIntersectionList-005.svg
+++ b/svg/struct/scripted/svg-getIntersectionList-005.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>getIntersectionList() on element with intersecting bounding box</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
 

--- a/svg/struct/scripted/svg-getIntersectionList-006.svg
+++ b/svg/struct/scripted/svg-getIntersectionList-006.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>getIntersectionList() with &lt;use></title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
 

--- a/svg/styling/css-selectors-case-sensitivity.html
+++ b/svg/styling/css-selectors-case-sensitivity.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>SVG CSS Selectors - Case-sensitivity</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/styling.html">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html">
 <link rel="help" href="https://drafts.csswg.org/selectors/#case-sensitive">
 <link rel="help" href="https://drafts.csswg.org/selectors/#attribute-case">
 <link rel="help" href="https://crbug.com/1246296">

--- a/svg/styling/image-sizing-min-content.tentative.svg
+++ b/svg/styling/image-sizing-min-content.tentative.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in auto) as presentation attributes on image</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match" href="image-sizing-min-content-expected.svg" />
   <image width="128" height="128" style="width:min-content;height:min-content" href="/images/green-256x256.png"/>
 </svg>

--- a/svg/styling/nested-svg-sizing-auto.tentative.svg
+++ b/svg/styling/nested-svg-sizing-auto.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in auto) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:auto;height:auto;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-calc-size.tentative.svg
+++ b/svg/styling/nested-svg-sizing-calc-size.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in calc-size) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:calc-size(fit-content, size);height:calc-size(fit-content, size);">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-calc.tentative.svg
+++ b/svg/styling/nested-svg-sizing-calc.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in calc) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-expected.svg" />
   <svg style="width:calc(100% - 50px);height:calc(100% - 50px);">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-ems.tentative.svg
+++ b/svg/styling/nested-svg-sizing-ems.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in Ems) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-expected.svg" />
   <svg font-size="2px" style="width:25em;height:25em;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-fit-content.tentative.svg
+++ b/svg/styling/nested-svg-sizing-fit-content.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in fit-content) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:fit-content;height:fit-content;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-inherit.tentative.svg
+++ b/svg/styling/nested-svg-sizing-inherit.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in inherit) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:inherit;height:inherit;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-initial.tentative.svg
+++ b/svg/styling/nested-svg-sizing-initial.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in initial) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:initial;height:initial;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-max-content.tentative.svg
+++ b/svg/styling/nested-svg-sizing-max-content.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in max-content) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:max-content;height:max-content;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-min-content.tentative.svg
+++ b/svg/styling/nested-svg-sizing-min-content.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in min-content) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:min-content;height:min-content;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-percent.tentative.svg
+++ b/svg/styling/nested-svg-sizing-percent.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in min-content) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-expected.svg" />
   <svg style="width:50%;height:50%;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-rems.tentative.svg
+++ b/svg/styling/nested-svg-sizing-rems.tentative.svg
@@ -1,6 +1,6 @@
 <svg font-size="2px" width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in Rems) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-expected.svg" />
   <svg style="width:25rem;height:25rem;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-stretch.tentative.svg
+++ b/svg/styling/nested-svg-sizing-stretch.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in stretch) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-full-circle-ref.svg" />
   <svg width="50" height="50" style="width:stretch;height:stretch;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-viewport-units-with-ICB.tentative.html
+++ b/svg/styling/nested-svg-sizing-viewport-units-with-ICB.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Width and Height (in viewport units) as presentation attributes on nested svg</title>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute">
 <link rel="match" href="nested-svg-sizing-viewport-units-with-ICB-expected.html">
 
 <svg width="50vw" height="100px" xmlns="http://www.w3.org/2000/svg">

--- a/svg/styling/nested-svg-sizing-viewport-units.tentative.svg
+++ b/svg/styling/nested-svg-sizing-viewport-units.tentative.svg
@@ -1,6 +1,6 @@
 <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in viewport units) as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-viewport-units-expected.svg" />
   <svg style="width:5vw;height:5vh;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/nested-svg-sizing-with-use.svg
+++ b/svg/styling/nested-svg-sizing-with-use.svg
@@ -1,6 +1,6 @@
 <svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-with-use-expected.svg" />
   <defs>
     <svg id="target" style="width:50px; height:50px;">

--- a/svg/styling/nested-svg-sizing.svg
+++ b/svg/styling/nested-svg-sizing.svg
@@ -1,6 +1,6 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height as presentation attributes on nested svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="nested-svg-sizing-expected.svg" />
   <svg style="width:50px;height:50px;">
     <circle cx="50" cy="50" r="40" fill="green" />

--- a/svg/styling/outermost-svg-sizing-viewport-units.svg
+++ b/svg/styling/outermost-svg-sizing-viewport-units.svg
@@ -1,6 +1,6 @@
 <svg style="width:10vw;height:10vh;" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in viewport units) as presentation attributes on outermost svg</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="outermost-svg-sizing-viewport-units-expected.svg" />
     <rect width="100%" height="100%" fill="green" />
 </svg>

--- a/svg/styling/presentation-attributes-irrelevant.html
+++ b/svg/styling/presentation-attributes-irrelevant.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVG presentation attributes - on irrelevant elements</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="presentation-attributes.js"></script>

--- a/svg/styling/presentation-attributes-relevant.html
+++ b/svg/styling/presentation-attributes-relevant.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVG presentation attributes - on relevant elements</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="presentation-attributes.js"></script>

--- a/svg/styling/presentation-attributes-special-cases.html
+++ b/svg/styling/presentation-attributes-special-cases.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVG presentation attributes - special cases</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="presentation-attributes.js"></script>

--- a/svg/styling/presentation-attributes-unknown.html
+++ b/svg/styling/presentation-attributes-unknown.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVG presentation attributes - on unknown SVG elements</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="presentation-attributes.js"></script>

--- a/svg/styling/rect-sizing-viewport-units.svg
+++ b/svg/styling/rect-sizing-viewport-units.svg
@@ -1,6 +1,6 @@
 <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Width and Height (in viewport units) as presentation attributes on rect</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#TermPresentationAttribute"/>
   <html:link rel="match"  href="rect-sizing-viewport-units-expected.svg" />
     <rect style="width:10vw;height:10vh;" fill="green" />
 </svg>

--- a/svg/styling/render/transform-box.svg
+++ b/svg/styling/render/transform-box.svg
@@ -3,7 +3,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      width="300" height="200" viewBox="0 0 300 200">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#RequiredProperties"/>
     <h:link rel="match" href="transform-box-ref.svg"/>
     <h:meta name="assert" content="The transform-box property impacts SVG rendering."/>
   </metadata>

--- a/svg/styling/render/transform-origin.svg
+++ b/svg/styling/render/transform-origin.svg
@@ -3,7 +3,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      width="300" height="200" viewBox="0 0 300 200">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#RequiredProperties"/>
     <h:link rel="match" href="transform-origin-ref.svg"/>
     <h:meta name="assert" content="The transform-origin property impacts SVG rendering."/>
   </metadata>

--- a/svg/styling/render/transform.svg
+++ b/svg/styling/render/transform.svg
@@ -3,7 +3,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      width="300" height="200" viewBox="0 0 300 200">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#RequiredProperties"/>
     <h:link rel="match" href="transform-ref.svg"/>
     <h:meta name="assert" content="The transform property impacts SVG rendering."/>
   </metadata>

--- a/svg/styling/required-properties.svg
+++ b/svg/styling/required-properties.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/propidx.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/propidx.html"/>
     <h:meta name="assert" content="All required properties are supported"/>
     <!-- Note: This test does not verify that the properties are actually applied to SVG rendering. -->
   </metadata>
@@ -12,7 +12,7 @@
   <h:script src="/resources/testharnessreport.js"/>
   <script><![CDATA[
   var properties = [
-    // Properties listed in https://svgwg.org/svg2-draft/propidx.html
+    // Properties listed in https://w3c.github.io/svgwg/svg2-draft/propidx.html
     "alignment-baseline",
     "baseline-shift",
     "clip",
@@ -73,7 +73,7 @@
     "white-space",
     "writing-mode",
 
-    // Properties listed in https://svgwg.org/svg2-draft/styling.html#RequiredProperties
+    // Properties listed in https://w3c.github.io/svgwg/svg2-draft/styling.html#RequiredProperties
     "display",
     "overflow",
     "visibility",

--- a/svg/styling/use-element-animations.html
+++ b/svg/styling/use-element-animations.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <title>SVG Test: Independent CSS animations on svg:use instantiation and corresponding element</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-transitions-ref.html">
 <style>
   use {

--- a/svg/styling/use-element-attr-selector-transition.tentative.html
+++ b/svg/styling/use-element-attr-selector-transition.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Attribute change in template starts transition in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://github.com/w3c/svgwg/issues/1002">
 <link rel="match" href="use-element-selector-ref.html">
 <style>

--- a/svg/styling/use-element-attr-selector.html
+++ b/svg/styling/use-element-attr-selector.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Attribute change in template affects attribute selector matching in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-selector-ref.html">
 <style>
   [attr] > #rect { fill: green; }

--- a/svg/styling/use-element-class-selector-transition.tentative.html
+++ b/svg/styling/use-element-class-selector-transition.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Class change in template starts transition in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://github.com/w3c/svgwg/issues/1002">
 <link rel="match" href="use-element-selector-ref.html">
 <style>

--- a/svg/styling/use-element-class-selector.html
+++ b/svg/styling/use-element-class-selector.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Class change in template affects class selector matching in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-selector-ref.html">
 <style>
   .class > #rect { fill: green; }

--- a/svg/styling/use-element-id-selector-transition.tentative.html
+++ b/svg/styling/use-element-id-selector-transition.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Id change in template starts transition in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://github.com/w3c/svgwg/issues/1002">
 <link rel="match" href="use-element-selector-ref.html">
 <style>

--- a/svg/styling/use-element-id-selector.html
+++ b/svg/styling/use-element-id-selector.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Id change in template affects id selector matching in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-selector-ref.html">
 <style>
   #id > #rect { fill: green; }

--- a/svg/styling/use-element-non-rendered-has-selector.html
+++ b/svg/styling/use-element-non-rendered-has-selector.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>SVG Test: CSS selector matching non-rendered descendant with :has() in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-selector-ref.html">
 <style>
   #rect:has(defs) { fill: green; }

--- a/svg/styling/use-element-non-rendered-sibling-selector.html
+++ b/svg/styling/use-element-non-rendered-sibling-selector.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>SVG Test: CSS selector matching non-rendered sibling in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-selector-ref.html">
 <style>
   defs + #rect { fill: green; }

--- a/svg/styling/use-element-transitions-dom-mutation.tentative.html
+++ b/svg/styling/use-element-transitions-dom-mutation.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: DOM mutations in template should not stop transition in &lt;use&gt; element tree</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://github.com/w3c/svgwg/issues/1002">
 <link rel="match" href="use-element-selector-ref.html">
 <style>

--- a/svg/styling/use-element-transitions.tentative.html
+++ b/svg/styling/use-element-transitions.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>SVG Test: Independent CSS transitions on svg:use instantiation and corresponding element</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="help" href="https://github.com/w3c/svgwg/issues/1002">
 <link rel="match" href="use-element-transitions-ref.html">
 <style>

--- a/svg/styling/use-element-web-animations.html
+++ b/svg/styling/use-element-web-animations.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <title>SVG Test: Independent Web animations on svg:use instantiation and corresponding element</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement">
 <link rel="match" href="use-element-transitions-ref.html">
 <style>
   use {

--- a/svg/text/inheritance.svg
+++ b/svg/text/inheritance.svg
@@ -4,7 +4,7 @@
      width="800px" height="8000px">
   <title>Inheritance of text properties</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html"/>
     <h:meta name="assert" content="text properties do not inherit."/>
     <h:meta name="assert" content="text properties have expected initial values."/>
   </metadata>

--- a/svg/text/parsing/inline-size-invalid.svg
+++ b/svg/text/parsing/inline-size-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing inline-size with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#InlineSizeProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSizeProperty"/>
     <h:link rel="help" href="https://drafts.csswg.org/css-logical/#dimension-properties"/>
     <h:meta name="assert" content="inline-size supports only the grammar 'auto | length-percentage'"/>
   </metadata>

--- a/svg/text/parsing/inline-size-valid.svg
+++ b/svg/text/parsing/inline-size-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing inline-size with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#InlineSizeProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSizeProperty"/>
     <h:link rel="help" href="https://drafts.csswg.org/css-logical/#dimension-properties"/>
     <h:meta name="assert" content="inline-size supports the full grammar 'auto | length-percentage'"/>
   </metadata>

--- a/svg/text/parsing/shape-inside-invalid.svg
+++ b/svg/text/parsing/shape-inside-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing shape-inside with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeInsideProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#ShapeInsideProperty"/>
     <h:meta name="assert" content="shape-inside supports only the grammar 'auto | [ basic-shape | uri ]+'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/shape-inside-valid.svg
+++ b/svg/text/parsing/shape-inside-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing shape-inside with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeInsideProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#ShapeInsideProperty"/>
     <h:meta name="assert" content="shape-inside supports the full grammar 'auto | [ basic-shape | uri ]+'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/shape-margin-invalid.svg
+++ b/svg/text/parsing/shape-margin-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing shape-margin with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeMarginProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#ShapeMarginProperty"/>
     <h:meta name="assert" content="shape-margin supports only the grammar 'length-percentage'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/shape-margin-valid.svg
+++ b/svg/text/parsing/shape-margin-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing shape-margin with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeMarginProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#ShapeMarginProperty"/>
     <h:meta name="assert" content="shape-margin supports the full grammar 'length-percentage'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/shape-subtract-invalid.svg
+++ b/svg/text/parsing/shape-subtract-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing shape-subtract with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextShapeSubtract"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeSubtract"/>
     <h:meta name="assert" content="shape-subtract supports only the grammar 'auto | [ basic-shape | uri ]+'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/shape-subtract-valid.svg
+++ b/svg/text/parsing/shape-subtract-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing shape-subtract with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextShapeSubtract"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeSubtract"/>
     <h:meta name="assert" content="shape-subtract supports the full grammar 'auto | [ basic-shape | uri ]+'"/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/text-anchor-computed.svg
+++ b/svg/text/parsing/text-anchor-computed.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: getComputedStyle().textAnchor</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty"/>
     <h:meta name="assert" content="text-anchor computed value is the specified keyword."/>
   </metadata>
   <text id="target"></text>

--- a/svg/text/parsing/text-anchor-invalid.svg
+++ b/svg/text/parsing/text-anchor-invalid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing text-anchor with invalid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty"/>
     <h:meta name="assert" content="text-anchor supports only the grammar 'start | middle | end'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/parsing/text-anchor-valid.svg
+++ b/svg/text/parsing/text-anchor-valid.svg
@@ -4,7 +4,7 @@
      width="800px" height="800px">
   <title>SVG Text: parsing text-anchor with valid values</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty"/>
     <h:meta name="assert" content="text-anchor supports the full grammar 'start | middle | end'."/>
   </metadata>
   <g id="target"></g>

--- a/svg/text/reftests/dominant-baseline-hanging-small-font-size.svg
+++ b/svg/text/reftests/dominant-baseline-hanging-small-font-size.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <title>'dominant-baseline: hanging' on &#x3c;text&#x3e; with small font-size</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchoringProperties"/>
     <h:link rel="match" href="../../embedded/reference/green-rect-100x100.svg"/>
     <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
   </metadata>

--- a/svg/text/reftests/dominant-baseline-text-after-edge.svg
+++ b/svg/text/reftests/dominant-baseline-text-after-edge.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <title>'dominant-baseline: text-after-edge'</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#DominantBaselineProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty"/>
     <h:link rel="match" href="../../embedded/reference/green-rect-100x100.svg"/>
     <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
   </metadata>

--- a/svg/text/reftests/dominant-baseline-text-before-edge.svg
+++ b/svg/text/reftests/dominant-baseline-text-before-edge.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <title>'dominant-baseline: text-before-edge'</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#DominantBaselineProperty"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty"/>
     <h:link rel="match" href="../../embedded/reference/green-rect-100x100.svg"/>
     <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
   </metadata>

--- a/svg/text/reftests/lang-attribute-dynamic.svg
+++ b/svg/text/reftests/lang-attribute-dynamic.svg
@@ -3,7 +3,7 @@
      class="reftest-wait">
   <metadata>
     <title>Update of lang attribute should recalculate style</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#LangSpaceAttrs"/>
     <h:link rel="match" href="lang-attribute-dynamic-ref.svg"/>
   </metadata>
   <style>

--- a/svg/text/reftests/lang-attribute.svg
+++ b/svg/text/reftests/lang-attribute.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <title>lang attribute should affect text rendering</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#LangSpaceAttrs"/>
     <h:link rel="mismatch" href="lang-attribute-ref.svg"/>
   </metadata>
   <text>

--- a/svg/text/reftests/no-background.svg
+++ b/svg/text/reftests/no-background.svg
@@ -2,8 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <g id="testmeta">
     <title>Background properties should not be supported in &lt;text></title>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextPropertiesAdaptions" />
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPropertiesAdaptions" />
     <html:link rel="match"  href="no-background-ref.svg" />
   </g>
 

--- a/svg/text/reftests/no-margin-border-padding.svg
+++ b/svg/text/reftests/no-margin-border-padding.svg
@@ -2,8 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <g id="testmeta">
     <title>Margin, border, and padding should not be supported in &lt;text></title>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextPropertiesAdaptions" />
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPropertiesAdaptions" />
     <html:link rel="match"  href="no-margin-border-padding-ref.svg" />
   </g>
 

--- a/svg/text/reftests/opacity.svg
+++ b/svg/text/reftests/opacity.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <h:title>Opacity on tspan, textPath, and a elements</h:title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html"/>
     <h:link rel="match" href="opacity-ref.svg"/>
     <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   </metadata>

--- a/svg/text/reftests/text-bidi-controls-anchors-1.svg
+++ b/svg/text/reftests/text-bidi-controls-anchors-1.svg
@@ -2,7 +2,7 @@
 <svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Text anchors and bidi control characters</title>
   <html:link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchoringProperties"/>
   <html:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1906978"/>
   <html:link rel="match" href="text-bidi-controls-anchors-1-ref.svg"/>
   <g transform="translate(200,20)" font-family="Arial, sans-serif" font-size="12px">

--- a/svg/text/reftests/text-bidi-controls-anchors-2.svg
+++ b/svg/text/reftests/text-bidi-controls-anchors-2.svg
@@ -2,7 +2,7 @@
 <svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Text anchors and bidi control characters</title>
   <html:link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchoringProperties"/>
   <html:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1906978"/>
   <html:link rel="match" href="text-bidi-controls-anchors-2-ref.svg"/>
   <g direction="rtl" transform="translate(200,20)" font-family="Arial, sans-serif" font-size="12px">

--- a/svg/text/reftests/text-complex-001-ref.svg
+++ b/svg/text/reftests/text-complex-001-ref.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>
   </g>

--- a/svg/text/reftests/text-complex-001.svg
+++ b/svg/text/reftests/text-complex-001.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <html:link rel="match"  href="text-complex-001-ref.svg" />
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>

--- a/svg/text/reftests/text-complex-002-ref.svg
+++ b/svg/text/reftests/text-complex-002-ref.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>
   </g>

--- a/svg/text/reftests/text-complex-002.svg
+++ b/svg/text/reftests/text-complex-002.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <html:link rel="match"  href="text-complex-002-ref.svg" />
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>

--- a/svg/text/reftests/text-inline-size-001.svg
+++ b/svg/text/reftests/text-inline-size-001.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-001-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-002.svg
+++ b/svg/text/reftests/text-inline-size-002.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-002-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-003.svg
+++ b/svg/text/reftests/text-inline-size-003.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-003-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-005.svg
+++ b/svg/text/reftests/text-inline-size-005.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-005-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-006.svg
+++ b/svg/text/reftests/text-inline-size-006.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-006-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-007.svg
+++ b/svg/text/reftests/text-inline-size-007.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-007-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-101.svg
+++ b/svg/text/reftests/text-inline-size-101.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-101-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-inline-size-201.svg
+++ b/svg/text/reftests/text-inline-size-201.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#InlineSize"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#InlineSize"/>
     <html:link rel="match"  href="text-inline-size-201-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-multiline-001.svg
+++ b/svg/text/reftests/text-multiline-001.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextLayoutPreMultiline"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextLayoutPreMultiline"/>
     <html:link rel="match"  href="text-multiline-001-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-multiline-002.svg
+++ b/svg/text/reftests/text-multiline-002.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextLayoutPreMultiline"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextLayoutPreMultiline"/>
     <html:link rel="match"  href="text-multiline-002-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-multiline-003.svg
+++ b/svg/text/reftests/text-multiline-003.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextLayoutPreMultiline"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextLayoutPreMultiline"/>
     <html:link rel="match"  href="text-multiline-003-ref.svg" />
   </g>
 

--- a/svg/text/reftests/text-shape-inside-001-ref.svg
+++ b/svg/text/reftests/text-shape-inside-001-ref.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>
   </g>

--- a/svg/text/reftests/text-shape-inside-001.svg
+++ b/svg/text/reftests/text-shape-inside-001.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <html:link rel="match"  href="text-shape-inside-001-ref.svg" />
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>

--- a/svg/text/reftests/text-shape-inside-002-ref.svg
+++ b/svg/text/reftests/text-shape-inside-002-ref.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>
   </g>

--- a/svg/text/reftests/text-shape-inside-002.svg
+++ b/svg/text/reftests/text-shape-inside-002.svg
@@ -13,8 +13,7 @@
           title="NAME_OF_REVIEWER"
           href="mailto:EMAIL OR http://CONTACT_PAGE" />
           <!-- YYYY-MM-DD -->
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextShapeInside"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextShapeInside"/>
     <html:link rel="match"  href="text-shape-inside-002-ref.svg" />
     <metadata class="flags">TOKENS</metadata>
     <desc class="assert">TEST ASSERTION</desc>

--- a/svg/text/reftests/text-xml-space-001.svg
+++ b/svg/text/reftests/text-xml-space-001.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVG Test: Behavior of xml:space="preserve"</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#UAStyleSheet"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#UAStyleSheet"/>
   <h:link rel="match" href="text-xml-space-001-ref.svg"/>
   <g xml:space="preserve">
     <text x="50" y="50" font-family="monospace">Some  Text</text>

--- a/svg/text/reftests/textpath-path-attr-empty-no-fallback.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-empty-no-fallback.tentative.svg
@@ -2,7 +2,7 @@
   <title>Empty `path` attribute takes precedence over `href` and does not render</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementPathAttribute"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/393"/>
     <html:link rel="match" href="textpath-path-attr-empty-ref.tentative.svg"/>
   </metadata>

--- a/svg/text/reftests/textpath-path-attr-invalid-no-fallback.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-invalid-no-fallback.tentative.svg
@@ -2,8 +2,8 @@
   <title>Invalid `path` attribute does not fallback to `href`</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementPathAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/393"/>
     <html:link rel="match" href="textpath-path-attr-empty-ref.tentative.svg"/>
   </metadata>

--- a/svg/text/reftests/textpath-path-attr-use-up-to-first-error.tentative.svg
+++ b/svg/text/reftests/textpath-path-attr-use-up-to-first-error.tentative.svg
@@ -2,8 +2,8 @@
   <title>textPath path data is used up to the first parse error</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementPathAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/393"/>
     <html:link rel="match" href="textpath-path-attr-ref.svg"/>
   </metadata>

--- a/svg/text/reftests/textpath-pathlength-css-display-none.tentative.svg
+++ b/svg/text/reftests/textpath-pathlength-css-display-none.tentative.svg
@@ -3,8 +3,8 @@
   <title>TextPath path-length with display:none path</title>
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElement"/>
     <html:link rel="match" href="textpath-pathlength-css-display-none-ref.tentative.svg"/>
   </metadata>
 

--- a/svg/text/reftests/textpath-shape-001.svg
+++ b/svg/text/reftests/textpath-shape-001.svg
@@ -9,8 +9,7 @@
     <html:link rel="author"
           title="Tavmjong Bah"
           href="mailto:tavmjong@free.fr"/>
-    <html:link rel="help"
-          href="https://svgwg.org/svg2-draft/text.html#TextPathAttributes"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathAttributes"/>
     <html:link rel="match"  href="textpath-shape-001-ref.svg" />
     <html:meta name="fuzzy" content="maxDifference=0-30;totalPixels=0-1150" />
   </g>

--- a/svg/text/reftests/textpath-side-001.svg
+++ b/svg/text/reftests/textpath-side-001.svg
@@ -5,7 +5,7 @@
   <metadata>
     <html:link rel="author" title="Tavmjong Bah" href="mailto:tavmjong@free.fr"/>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSideAttribute"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
     <html:link rel="match" href="textpath-side-001-ref.svg"/>
     <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100"/>

--- a/svg/text/reftests/textpath-side-002.svg
+++ b/svg/text/reftests/textpath-side-002.svg
@@ -4,7 +4,7 @@
   xmlns:html="http://www.w3.org/1999/xhtml">
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSideAttribute"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
     <html:link rel="match" href="textpath-side-002-ref.svg"/>
   </metadata>

--- a/svg/text/reftests/textpath-side-003.svg
+++ b/svg/text/reftests/textpath-side-003.svg
@@ -4,7 +4,7 @@
   xmlns:html="http://www.w3.org/1999/xhtml">
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSideAttribute"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
     <html:link rel="match" href="textpath-side-003-ref.svg"/>
     <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100"/>

--- a/svg/text/reftests/textpath-side-004.svg
+++ b/svg/text/reftests/textpath-side-004.svg
@@ -4,7 +4,7 @@
   xmlns:html="http://www.w3.org/1999/xhtml">
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSideAttribute"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
     <html:link rel="match" href="textpath-side-004-ref.svg"/>
   </metadata>

--- a/svg/text/reftests/textpath-side-005.svg
+++ b/svg/text/reftests/textpath-side-005.svg
@@ -4,7 +4,7 @@
   xmlns:html="http://www.w3.org/1999/xhtml">
   <metadata>
     <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSideAttribute"/>
     <html:link rel="help" href="https://github.com/w3c/svgwg/issues/1068"/>
     <html:link rel="match" href="textpath-side-005-ref.svg"/>
     <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-200"/>

--- a/svg/text/reftests/tspan-opacity-mixed-direction.svg
+++ b/svg/text/reftests/tspan-opacity-mixed-direction.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <h:title>Opacity on tspan containing mixed direction text interleaving with other text</h:title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html"/>
     <h:link rel="match" href="tspan-opacity-mixed-direction-ref.svg"/>
   </metadata>
   <text x="100" y="100" font-size="50">

--- a/svg/text/reftests/xml-lang-attribute-dynamic.svg
+++ b/svg/text/reftests/xml-lang-attribute-dynamic.svg
@@ -3,7 +3,7 @@
      class="reftest-wait">
   <metadata>
     <title>Update of lang attribute should recalculate style</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#LangSpaceAttrs"/>
     <h:link rel="match" href="lang-attribute-dynamic-ref.svg"/>
   </metadata>
   <style>

--- a/svg/text/reftests/xml-lang-attribute.svg
+++ b/svg/text/reftests/xml-lang-attribute.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
     <title>xml:lang attribute should affect text rendering</title>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#LangSpaceAttrs"/>
     <h:link rel="mismatch" href="lang-attribute-ref.svg"/>
   </metadata>
 

--- a/svg/text/scripted/getcharnumatposition-slr.tentative.html
+++ b/svg/text/scripted/getcharnumatposition-slr.tentative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVGTextContentElement.getCharNumAtPosition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getCharNumAtPosition">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getCharNumAtPosition">
 <link rel="help" href="https://github.com/w3c/svgwg/issues/955">
 <link rel="stylesheet" href="/fonts/ahem.css">
 <script src="/resources/testharness.js"></script>

--- a/svg/text/scripted/getcharnumatposition.html
+++ b/svg/text/scripted/getcharnumatposition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVGTextContentElement.getCharNumAtPosition</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getCharNumAtPosition">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getCharNumAtPosition">
 <link rel="stylesheet" href="/fonts/ahem.css">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/text/scripted/getextentofchar.html
+++ b/svg/text/scripted/getextentofchar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVGTextContentElement.getExtentOfChar</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getExtentOfChar">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getExtentOfChar">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/svg/text/scripted/getrotationofchar.html
+++ b/svg/text/scripted/getrotationofchar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>SVGTextContentElement.getRotationOfChar</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getRotationOfChar">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getRotationOfChar">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <svg id="container" width="800" height="300"></svg>

--- a/svg/text/scripted/getstartpositionofchar-dominant-baseline.html
+++ b/svg/text/scripted/getstartpositionofchar-dominant-baseline.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <title>SVGTextContentElement.getStartPositionOfChar and dominant-baseline</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/svg/text/scripted/getstartpositionofchar.html
+++ b/svg/text/scripted/getstartpositionofchar.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>SVGTextContentElement.getStartPositionOfChar and getEndPositionOfChar</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="stylesheet" href="/fonts/ahem.css">

--- a/svg/text/scripted/lengthadjust.html
+++ b/svg/text/scripted/lengthadjust.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>lengthAdjust content/IDL attribute</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextElementLengthAdjustAttribute">
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getComputedTextLength">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementLengthAdjustAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getComputedTextLength">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/svg/text/scripted/textpath-href-path-mutated.html
+++ b/svg/text/scripted/textpath-href-path-mutated.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>Mutation of 'd' on a 'display: none' &lt;path> referenced by &lt;textPath></title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElementHrefAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementHrefAttribute">
 <link rel="help" href="https://crbug.com/485900033">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/text/scripted/textpath-textlength-text-anchor-001.tentative.svg
+++ b/svg/text/scripted/textpath-textlength-text-anchor-001.tentative.svg
@@ -4,8 +4,8 @@
   <html:script src="/resources/testharness.js"/>
   <html:script src="/resources/testharnessreport.js"/>
   <html:link rel="stylesheet" href="/fonts/ahem.css"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextPathElement"/>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextElementTextLengthAttribute"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElement"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementTextLengthAttribute"/>
   <defs>
     <path id="p" d="M0,25h100"/>
   </defs>

--- a/svg/text/scripted/tspan-xml-space-preserve-position.html
+++ b/svg/text/scripted/tspan-xml-space-preserve-position.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>tspan positioning with xml:space="preserve" and whitespace between tspans</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/text.html#WhiteSpace">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#WhiteSpace">
 <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311185">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/svg/types/SVGElement.ownerSVGElement-01.html
+++ b/svg/types/SVGElement.ownerSVGElement-01.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>SVGElement.ownerSVGElement</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>

--- a/svg/types/SVGElement.ownerSVGElement-02.html
+++ b/svg/types/SVGElement.ownerSVGElement-02.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>SVGElement.ownerSVGElement</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>

--- a/svg/types/elements/SVGGeometryElement-rect.svg
+++ b/svg/types/elements/SVGGeometryElement-rect.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml">
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#types-InterfaceSVGGeometryElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#types-InterfaceSVGGeometryElement"/>
     <h:meta name="assert" content="SVGGeometryElement members work for rect elements."/>
   </metadata>
   <style>

--- a/svg/types/scripted/SVGElement.className-01.svg
+++ b/svg/types/scripted/SVGElement.className-01.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGElement.prototype.className: Reflects to .classList</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__className"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGElement__className"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <script>

--- a/svg/types/scripted/SVGGeometryElement.getPointAtLength-01.svg
+++ b/svg/types/scripted/SVGGeometryElement.getPointAtLength-01.svg
@@ -3,7 +3,7 @@
      xmlns:html="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.prototype.getPointAtLength clamps its argument to [0, length]</title>
   <metadata>
-    <html:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
     <html:meta name="assert" content="SVGGeometryElement.prototype.getPointAtLength clamps its argument."/>
   </metadata>
   <g stroke="blue">

--- a/svg/types/scripted/SVGGeometryElement.getPointAtLength-02.svg
+++ b/svg/types/scripted/SVGGeometryElement.getPointAtLength-02.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.prototype.getPointAtLength() query with 'pathLength'</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
   <path id='pathElement' d='M0,0L100,0L100,100' pathLength="1000"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/types/scripted/SVGGeometryElement.getPointAtLength-03.svg
+++ b/svg/types/scripted/SVGGeometryElement.getPointAtLength-03.svg
@@ -2,7 +2,7 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:html="http://www.w3.org/1999/xhtml">
   <title>When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception</title>
-  <html:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
+  <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
   <html:script src="/resources/testharness.js"/>
   <html:script src="/resources/testharnessreport.js"/>
   <script><![CDATA[

--- a/svg/types/scripted/SVGGeometryElement.getPointAtLength-04.svg
+++ b/svg/types/scripted/SVGGeometryElement.getPointAtLength-04.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.getPointAtLength: 'display' and a valid path</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <path id='pathElement1' d='M0,0L100,0L100,100' description='path with display: default'/>

--- a/svg/types/scripted/SVGGeometryElement.getPointAtLength-05.svg
+++ b/svg/types/scripted/SVGGeometryElement.getPointAtLength-05.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.getPointAtLength: 'display' and empty path</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <path id='pathElement1' description='path with display: default and an empty path'/>

--- a/svg/types/scripted/SVGGeometryElement.getTotalLength-01.svg
+++ b/svg/types/scripted/SVGGeometryElement.getTotalLength-01.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.prototype.getTotalLength()</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <script><![CDATA[

--- a/svg/types/scripted/SVGGeometryElement.getTotalLength-02.html
+++ b/svg/types/scripted/SVGGeometryElement.getTotalLength-02.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>SVGGeometryElement.getTotalLength: 'display:none'</title>
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength"/>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">

--- a/svg/types/scripted/SVGGeometryElement.isPointInFill-01.svg
+++ b/svg/types/scripted/SVGGeometryElement.isPointInFill-01.svg
@@ -2,8 +2,8 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.prototype.isPointInFill</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInFill"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInFill"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/types/scripted/SVGGeometryElement.isPointInStroke-01.svg
+++ b/svg/types/scripted/SVGGeometryElement.isPointInStroke-01.svg
@@ -2,8 +2,8 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGeometryElement.prototype.isPointInStroke</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/types/scripted/SVGGeometryElement.isPointInStroke-02.svg
+++ b/svg/types/scripted/SVGGeometryElement.isPointInStroke-02.svg
@@ -3,8 +3,8 @@
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke"/>
   </metadata>
   <circle id="circle" cx="6" cy="10" r="5" stroke="blue" stroke-width="1" stroke-dasharray="10 21.4159" fill="none"/>
   <script>

--- a/svg/types/scripted/SVGGraphicsElement-clone.svg
+++ b/svg/types/scripted/SVGGraphicsElement-clone.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>cloning a SVGGraphicsElement</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/types/scripted/SVGGraphicsElement-padding.svg
+++ b/svg/types/scripted/SVGGraphicsElement-padding.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGraphicsElement with padding</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/types/scripted/SVGGraphicsElement.getCTM-empty-viewBox.html
+++ b/svg/types/scripted/SVGGraphicsElement.getCTM-empty-viewBox.html
@@ -3,7 +3,7 @@
 <link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
 <link rel="author" href="https://mozilla.com" title="Mozilla">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1997351">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement" />
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGraphicsElement" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/svg/types/scripted/SVGGraphicsElement.getScreenCTM.html
+++ b/svg/types/scripted/SVGGraphicsElement.getScreenCTM.html
@@ -3,7 +3,7 @@
 <head>
   <title>SVGGraphicsElement.getScreenCTM</title>
   <metadata>
-    <link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
+    <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
   </metadata>
   <script src="../../linking/scripted/testcommon.js"></script>
   <script src="/resources/testharness.js"></script>

--- a/svg/types/scripted/SVGGraphicsElement.svg
+++ b/svg/types/scripted/SVGGraphicsElement.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
   <title>SVGGraphicsElement</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
   </metadata>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>

--- a/svg/types/scripted/SVGList-parse-invalid-clears-items.html
+++ b/svg/types/scripted/SVGList-parse-invalid-clears-items.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 <title>SVG list types clear items on invalid attribute parse</title>
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGLengthList">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGNumberList">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGPointList">
-<link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGTransformList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGLengthList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGNumberList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGPointList">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGTransformList">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/svg/types/scripted/event-handler-all-document-element-events.svg
+++ b/svg/types/scripted/event-handler-all-document-element-events.svg
@@ -3,7 +3,7 @@
      xmlns:h="http://www.w3.org/1999/xhtml">
     <title>oncopy / oncut / onpaste / oncontextmenu</title>
     <metadata>
-        <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement"/>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGElement"/>
     </metadata>
     <h:script src="/resources/testharness.js"/>
     <h:script src="/resources/testharnessreport.js"/>

--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -408,7 +408,7 @@ const gCSSProperties1 = {
     ]
   },
   'color-interpolation': {
-    // https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty
     types: [
       { type: 'discrete', options: [ [ 'linearrgb', 'auto' ] ] }
     ]
@@ -515,16 +515,16 @@ const gCSSProperties1 = {
     ]
   },
   'fill': {
-    // https://svgwg.org/svg2-draft/painting.html#FillProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty
     types: [
     ]
   },
   'fill-opacity': {
-    // https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#FillOpacityProperty
     types: [ 'opacity' ]
   },
   'fill-rule': {
-    // https://svgwg.org/svg2-draft/painting.html#FillRuleProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#FillRuleProperty
     types: [
       { type: 'discrete', options: [ [ 'evenodd', 'nonzero' ] ] }
     ]
@@ -962,7 +962,7 @@ const gCSSProperties2 = {
     ]
   },
   'marker-end': {
-    // https://svgwg.org/specs/markers/#MarkerEndProperty
+    // https://w3c.github.io/svgwg/specs/markers/#MarkerEndProperty
     types: [
       { type: 'discrete',
         options: [ [ 'url("http://localhost/test-1")',
@@ -970,7 +970,7 @@ const gCSSProperties2 = {
     ]
   },
   'marker-mid': {
-    // https://svgwg.org/specs/markers/#MarkerMidProperty
+    // https://w3c.github.io/svgwg/specs/markers/#MarkerMidProperty
     types: [
       { type: 'discrete',
         options: [ [ 'url("http://localhost/test-1")',
@@ -978,7 +978,7 @@ const gCSSProperties2 = {
     ]
   },
   'marker-start': {
-    // https://svgwg.org/specs/markers/#MarkerStartProperty
+    // https://w3c.github.io/svgwg/specs/markers/#MarkerStartProperty
     types: [
       { type: 'discrete',
         options: [ [ 'url("http://localhost/test-1")',
@@ -1258,13 +1258,13 @@ const gCSSProperties2 = {
     ]
   },
   'paint-order': {
-    // https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty
     types: [
       { type: 'discrete', options: [ [ 'fill', 'stroke' ] ] }
     ]
   },
   'path-length': {
-    // https://svgwg.org/svg2-draft/paths.html#PathLengthAttribute
+    // https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthAttribute
     types: [ 'positiveNumber' ],
     setup: t => {
       return createElement(t, 'path');
@@ -1297,7 +1297,7 @@ const gCSSProperties2 = {
     ]
   },
   'pointer-events': {
-    // https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty
+    // https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty
     types: [
       { type: 'discrete', options: [ [ 'fill', 'none' ] ] }
     ]
@@ -1413,21 +1413,21 @@ const gCSSProperties2 = {
     ]
   },
   'shape-rendering': {
-    // https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty
     types: [
       { type: 'discrete', options: [ [ 'optimizeSpeed', 'crispEdges' ] ] }
     ]
   },
   'stop-color': {
-    // https://svgwg.org/svg2-draft/pservers.html#StopColorProperty
+    // https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty
     types: [ 'color' ]
   },
   'stop-opacity': {
-    // https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty
+    // https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty
     types: [ 'opacity' ]
   },
   'stroke': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty
     types: [
     ]
   },
@@ -1436,25 +1436,25 @@ const gCSSProperties2 = {
     types: [ 'color' ]
   },
   'stroke-dasharray': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDasharrayProperty
     types: [
       'dasharray',
       { type: 'discrete', options: [ [ 'none', '10px, 20px' ] ] }
     ]
   },
   'stroke-dashoffset': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty
     types: [
     ]
   },
   'stroke-linecap': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinecapProperty
     types: [
       { type: 'discrete', options: [ [ 'round', 'square' ] ] }
     ]
   },
   'stroke-linejoin': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeLinejoinProperty
     types: [
       { type: 'discrete', options: [ [ 'round', 'miter' ] ] }
     ],
@@ -1463,15 +1463,15 @@ const gCSSProperties2 = {
     }
   },
   'stroke-miterlimit': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeMiterlimitProperty
     types: [ 'positiveNumber' ]
   },
   'stroke-opacity': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeOpacityProperty
     types: [ 'opacity' ]
   },
   'stroke-width': {
-    // https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidthProperty
     types: [
     ]
   },
@@ -1494,7 +1494,7 @@ const gCSSProperties2 = {
     ]
   },
   'text-anchor': {
-    // https://svgwg.org/svg2-draft/text.html#TextAnchorProperty
+    // https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty
     types: [
       { type: 'discrete', options: [ [ 'middle', 'end' ] ] }
     ]
@@ -1585,7 +1585,7 @@ const gCSSProperties2 = {
     ]
   },
   'text-rendering': {
-    // https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty
+    // https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty
     types: [
       { type: 'discrete', options: [ [ 'optimizeSpeed', 'optimizeLegibility' ] ] }
     ]
@@ -1669,7 +1669,7 @@ const gCSSProperties2 = {
     types: [ 'scaleList' ]
   },
   'vector-effect': {
-    // https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty
+    // https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffectProperty
     types: [
       { type: 'discrete', options: [ [ 'none', 'non-scaling-stroke' ] ] },
     ]


### PR DESCRIPTION
The domain name doesn't host anymore the fresh version of the SVG WG specifications.
This fixes the links to the current version of the spec and to avoid people double checking prose that would be eventually misleading with recent spec changes. 