### PR TITLE
Add pointer capture tests for "process pending pointer capture"

### DIFF
--- a/pointerevents/pointerevent_gotpointercapture_handler_redirects_capture.html
+++ b/pointerevents/pointerevent_gotpointercapture_handler_redirects_capture.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>gotpointercapture handler redirecting capture routes current event to new element immediately</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#setting-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+  });
+  // The gotpointercapture handler redirects capture from a to b.
+  // Per spec, step 3 re-reads pending and sees b, so override goes from
+  // not set directly to b - no a->b transition, no lostpointercapture@a
+  // or gotpointercapture@b.
+  a.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    b.setPointerCapture(event.pointerId);
+  });
+  b.addEventListener("gotpointercapture", logEvent);
+  for (const el of [a, b]) {
+    el.addEventListener("lostpointercapture", logEvent);
+    el.addEventListener("pointerover", logEvent);
+    el.addEventListener("pointerout", logEvent);
+    el.addEventListener("pointermove", logEvent);
+    el.addEventListener("pointerup", logEvent);
+  }
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: pending=a, handler redirects to b
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: steady state, override=b
+    .pointerMove(2, 2, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "gotpointercapture@a",
+    "pointerover@b",
+    "pointermove@b",
+    // Move 2
+    "pointermove@b",
+    "pointerup@b",
+    "lostpointercapture@b",
+    "pointerout@b",
+  ]);
+}, "Redirecting capture in gotpointercapture handler routes current event to new element immediately");
+</script>

--- a/pointerevents/pointerevent_gotpointercapture_handler_redirects_capture.tentative.html
+++ b/pointerevents/pointerevent_gotpointercapture_handler_redirects_capture.tentative.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>gotpointercapture handler redirecting capture defers gotpointercapture to next event</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#setting-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+  });
+  // The gotpointercapture handler redirects capture from a to b.
+  // Browsers read pending once at algorithm entry, so step 3 still sees
+  // pending=a and override becomes a. The a->b transfer is deferred to move 2.
+  a.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    b.setPointerCapture(event.pointerId);
+  });
+  b.addEventListener("gotpointercapture", logEvent);
+  for (const el of [a, b]) {
+    el.addEventListener("lostpointercapture", logEvent);
+    el.addEventListener("pointerover", logEvent);
+    el.addEventListener("pointerout", logEvent);
+    el.addEventListener("pointermove", logEvent);
+    el.addEventListener("pointerup", logEvent);
+  }
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: pending=a, handler redirects to b (ignored)
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: a->b transfer completes
+    .pointerMove(2, 2, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@a",
+    "gotpointercapture@a",
+    "pointermove@a",
+    // Move 2
+    "lostpointercapture@a",
+    "pointerout@a",
+    "pointerover@b",
+    "gotpointercapture@b",
+    "pointermove@b",
+    "pointerup@b",
+    "lostpointercapture@b",
+    "pointerout@b",
+  ]);
+}, "Redirecting capture in gotpointercapture handler defers lostpointercapture@a and gotpointercapture@b to the next event");
+</script>

--- a/pointerevents/pointerevent_gotpointercapture_release_routes_current_event.html
+++ b/pointerevents/pointerevent_gotpointercapture_release_routes_current_event.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Releasing capture in gotpointercapture routes current event to hit-test target</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#releasing-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="listener">listener</div>
+<div id="target">target</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const listener = document.getElementById("listener");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    listener.setPointerCapture(event.pointerId);
+  });
+  // Capture is released inside gotpointercapture. Per spec, step 3 re-reads
+  // pending and sees it cleared, so override stays not set and the main event
+  // routes to hit-test target.
+  //
+  // lostpointercapture@listener fires per the spec's MUST constraint, but its
+  // position relative to boundary events is unspecified.
+  listener.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    listener.releasePointerCapture(event.pointerId);
+  });
+  listener.addEventListener("lostpointercapture", logEvent);
+  listener.addEventListener("pointerover", logEvent);
+  listener.addEventListener("pointerout", logEvent);
+  listener.addEventListener("pointermove", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: pending=listener, handler releases
+    .pointerMove(1, 1, {origin: target})
+    .pointerUp()
+    .send();
+
+  // lostpointercapture@listener position relative to boundary events is
+  // unspecified; allow all valid orderings.
+  const valid_sequences = [
+    ["pointerdown@target", "gotpointercapture@listener", "lostpointercapture@listener", "pointerout@listener", "pointermove@target"],
+    ["pointerdown@target", "gotpointercapture@listener", "pointerout@listener", "lostpointercapture@listener", "pointermove@target"],
+    ["pointerdown@target", "gotpointercapture@listener", "pointerout@listener", "pointermove@target", "lostpointercapture@listener"],
+  ];
+
+  assert_in_array(event_log.join(","), valid_sequences.map(s => s.join(",")),
+    "event sequence must have gotpointercapture@listener, then pointerout@listener and pointermove@target (lostpointercapture@listener position unspecified)");
+}, "Releasing capture in gotpointercapture routes current event to hit-test target");
+</script>

--- a/pointerevents/pointerevent_gotpointercapture_release_routes_current_event.tentative.html
+++ b/pointerevents/pointerevent_gotpointercapture_release_routes_current_event.tentative.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Releasing capture in gotpointercapture routes current event to capture element</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#releasing-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="listener">listener</div>
+<div id="target">target</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const listener = document.getElementById("listener");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    listener.setPointerCapture(event.pointerId);
+  });
+  // Capture is released inside gotpointercapture. Browsers read pending once
+  // at algorithm entry, so step 3 still sees pending=listener and sets
+  // override=listener. The main event routes to listener, not hit-test target.
+  listener.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    listener.releasePointerCapture(event.pointerId);
+  });
+  listener.addEventListener("lostpointercapture", logEvent);
+  listener.addEventListener("pointerover", logEvent);
+  listener.addEventListener("pointerout", logEvent);
+  listener.addEventListener("pointermove", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: pending=listener, handler releases (ignored)
+    .pointerMove(1, 1, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@listener",
+    "gotpointercapture@listener",
+    "pointermove@listener",
+    "lostpointercapture@listener",
+    "pointerout@listener",
+  ]);
+}, "Releasing capture in gotpointercapture handler routes current pointermove to the capture element");
+</script>

--- a/pointerevents/pointerevent_lostpointercapture_fires_at_old_target_during_transfer.html
+++ b/pointerevents/pointerevent_lostpointercapture_fires_at_old_target_during_transfer.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>lostpointercapture fires at old capture target during transfer, gotpointercapture at new</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#setting-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#releasing-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  // Basic a-to-b transfer with no handler mutations. The result is identical
+  // regardless of whether steps read live state or snapshot at algorithm entry.
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+  });
+  a.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    a.addEventListener("pointermove", event => {
+      logEvent(event);
+      a.releasePointerCapture(event.pointerId);
+      b.setPointerCapture(event.pointerId);
+    }, {once: true});
+  }, {once: true});
+
+  a.addEventListener("lostpointercapture", logEvent);
+  a.addEventListener("pointerover", logEvent);
+  a.addEventListener("pointerout", logEvent);
+  a.addEventListener("pointerup", logEvent);
+
+  b.addEventListener("gotpointercapture", logEvent);
+  b.addEventListener("lostpointercapture", logEvent);
+  b.addEventListener("pointerover", logEvent);
+  b.addEventListener("pointerout", logEvent);
+  b.addEventListener("pointermove", logEvent);
+  b.addEventListener("pointerup", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: a gets capture; pointermove handler initiates transfer
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: process pending pointer capture; override=a, pending=b
+    .pointerMove(2, 2, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@a",
+    "gotpointercapture@a",
+    "pointermove@a",
+    // Move 2
+    "lostpointercapture@a",
+    "pointerout@a",
+    "pointerover@b",
+    "gotpointercapture@b",
+    "pointermove@b",
+    "pointerup@b",
+    "lostpointercapture@b",
+    "pointerout@b",
+  ]);
+}, "lostpointercapture fires at old capture element A and gotpointercapture fires at new element B during transfer");
+</script>

--- a/pointerevents/pointerevent_lostpointercapture_handler_cancels_transfer.html
+++ b/pointerevents/pointerevent_lostpointercapture_handler_cancels_transfer.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>lostpointercapture handler can successfully cancel a transfer</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#releasing-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+  });
+  a.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    a.addEventListener("pointermove", event => {
+      logEvent(event);
+      // Initiate transfer a->b.
+      a.releasePointerCapture(event.pointerId);
+      b.setPointerCapture(event.pointerId);
+    }, {once: true});
+  }, {once: true});
+
+  // The lostpointercapture@a handler cancels the a->b transfer by releasing b.
+  // Per spec, step 2 re-reads pending and sees it cleared, so no
+  // gotpointercapture@b fires and the main event routes to hit-test target.
+  a.addEventListener("lostpointercapture", event => {
+    logEvent(event);
+    b.releasePointerCapture(event.pointerId);
+  });
+
+  for (const el of [a, b]) {
+    el.addEventListener("pointerover", logEvent);
+    el.addEventListener("pointerout", logEvent);
+    el.addEventListener("pointerup", logEvent);
+  }
+  b.addEventListener("gotpointercapture", logEvent);
+  b.addEventListener("lostpointercapture", logEvent);
+  b.addEventListener("pointermove", logEvent);
+  target.addEventListener("pointermove", logEvent);
+  target.addEventListener("pointerup", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: a gets capture; pointermove handler initiates transfer
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: override=a, pending=b; handler cancels the transfer
+    .pointerMove(2, 2, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@a",
+    "gotpointercapture@a",
+    "pointermove@a",
+    // Move 2
+    "lostpointercapture@a",
+    "pointerout@a",
+    "pointermove@target",
+    "pointerup@target",
+  ]);
+}, "lostpointercapture handler can successfully cancel a transfer by releasing the pending capture element");
+</script>

--- a/pointerevents/pointerevent_lostpointercapture_handler_cancels_transfer.tentative.html
+++ b/pointerevents/pointerevent_lostpointercapture_handler_cancels_transfer.tentative.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>lostpointercapture handler cancellation attempt fails; gotpointercapture fires</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#releasing-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+  });
+  a.addEventListener("gotpointercapture", event => {
+    logEvent(event);
+    a.addEventListener("pointermove", event => {
+      logEvent(event);
+      // Initiate transfer a->b.
+      a.releasePointerCapture(event.pointerId);
+      b.setPointerCapture(event.pointerId);
+    }, {once: true});
+  }, {once: true});
+
+  // The lostpointercapture@a handler attempts to cancel the a->b transfer by
+  // releasing b. Browsers read pending once at algorithm entry, so step 2
+  // still sees pending=b and fires gotpointercapture@b despite the release.
+  a.addEventListener("lostpointercapture", event => {
+    logEvent(event);
+    b.releasePointerCapture(event.pointerId);
+  });
+
+  for (const el of [a, b]) {
+    el.addEventListener("pointerover", logEvent);
+    el.addEventListener("pointerout", logEvent);
+    el.addEventListener("pointerup", logEvent);
+  }
+  b.addEventListener("gotpointercapture", logEvent);
+  b.addEventListener("lostpointercapture", logEvent);
+  b.addEventListener("pointermove", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: a gets capture; pointermove handler initiates transfer
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: override=a, pending=b; handler release ignored
+    .pointerMove(2, 2, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@a",
+    "gotpointercapture@a",
+    "pointermove@a",
+    // Move 2
+    "lostpointercapture@a",
+    "pointerout@a",
+    "pointerover@b",
+    "gotpointercapture@b",
+    "pointermove@b",
+    "lostpointercapture@b",
+    "pointerout@b",
+  ]);
+}, "gotpointercapture@b fires even when lostpointercapture@a handler cancels the transfer");
+</script>

--- a/pointerevents/pointerevent_lostpointercapture_handler_sets_capture.html
+++ b/pointerevents/pointerevent_lostpointercapture_handler_sets_capture.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Setting capture in lostpointercapture handler fires gotpointercapture in the same event</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#setting-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  // Add pointermove listener on target only after pointerdown, so the initial
+  // positioning move is not captured in the event log.
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+    target.addEventListener("pointermove", logEvent);
+  }, {once: true});
+
+  a.addEventListener("gotpointercapture", logEvent);
+
+  a.addEventListener("pointermove", event => {
+    logEvent(event);
+    a.releasePointerCapture(event.pointerId);
+    a.addEventListener("pointermove", logEvent);
+  }, {once: true});
+
+  // The lostpointercapture@a handler sets capture on b. Per spec, step 2
+  // re-reads pending and sees b, so gotpointercapture@b fires in the same
+  // "process pending pointer capture" invocation.
+  a.addEventListener("lostpointercapture", event => {
+    logEvent(event);
+    b.setPointerCapture(event.pointerId);
+  });
+
+  for (const el of [a, b]) {
+    el.addEventListener("pointerover", logEvent);
+    el.addEventListener("pointerout", logEvent);
+    el.addEventListener("pointerup", logEvent);
+  }
+  b.addEventListener("pointermove", logEvent);
+  b.addEventListener("gotpointercapture", logEvent);
+  b.addEventListener("lostpointercapture", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: a gets capture; pointermove handler releases
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: lostpointercapture@a fires; handler sets capture on b
+    .pointerMove(2, 2, {origin: target})
+    // Move 3: override=b, pending=b, no changes
+    .pointerMove(3, 3, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@a",
+    "gotpointercapture@a",
+    "pointermove@a",
+    // Move 2
+    "lostpointercapture@a",
+    "pointerout@a",
+    "pointerover@b",
+    "gotpointercapture@b",
+    "pointermove@b",
+    // Move 3
+    "pointermove@b",
+    "pointerup@b",
+    "lostpointercapture@b",
+    "pointerout@b",
+  ]);
+}, "Setting capture in lostpointercapture handler fires gotpointercapture in the same event");
+</script>

--- a/pointerevents/pointerevent_lostpointercapture_handler_sets_capture.tentative.html
+++ b/pointerevents/pointerevent_lostpointercapture_handler_sets_capture.tentative.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Setting capture in lostpointercapture handler defers gotpointercapture to next event</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#process-pending-pointer-capture">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">
+<link rel="help" href="https://w3c.github.io/pointerevents/#setting-pointer-capture">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target">target</div>
+<div id="a">a</div>
+<div id="b">b</div>
+<script>
+"use strict";
+
+promise_test(async () => {
+  const target = document.getElementById("target");
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const event_log = [];
+
+  function logEvent(event) {
+    event_log.push(event.type + "@" + event.target.id);
+  }
+
+  // Add pointermove listener on target only after pointerdown, so the initial
+  // positioning move is not captured in the event log.
+  target.addEventListener("pointerdown", event => {
+    logEvent(event);
+    a.setPointerCapture(event.pointerId);
+    target.addEventListener("pointermove", logEvent);
+  }, {once: true});
+
+  a.addEventListener("gotpointercapture", logEvent);
+
+  a.addEventListener("pointermove", event => {
+    logEvent(event);
+    a.releasePointerCapture(event.pointerId);
+    a.addEventListener("pointermove", logEvent);
+  }, {once: true});
+
+  // The lostpointercapture@a handler sets capture on b. Browsers read pending
+  // once at algorithm entry, so step 2 still sees pending not set and
+  // gotpointercapture@b is deferred to move 3.
+  a.addEventListener("lostpointercapture", event => {
+    logEvent(event);
+    b.setPointerCapture(event.pointerId);
+  });
+
+  for (const el of [a, b]) {
+    el.addEventListener("pointerover", logEvent);
+    el.addEventListener("pointerout", logEvent);
+    el.addEventListener("pointerup", logEvent);
+  }
+  b.addEventListener("pointermove", logEvent);
+  b.addEventListener("gotpointercapture", logEvent);
+  b.addEventListener("lostpointercapture", logEvent);
+
+  await new test_driver.Actions()
+    .pointerMove(0, 0, {origin: target})
+    .pointerDown()
+    // Move 1: a gets capture; pointermove handler releases
+    .pointerMove(1, 1, {origin: target})
+    // Move 2: lostpointercapture@a fires; handler sets pending=b (ignored)
+    .pointerMove(2, 2, {origin: target})
+    // Move 3: deferred gotpointercapture@b fires
+    .pointerMove(3, 3, {origin: target})
+    .pointerUp()
+    .send();
+
+  assert_array_equals(event_log, [
+    "pointerdown@target",
+    // Move 1
+    "pointerover@a",
+    "gotpointercapture@a",
+    "pointermove@a",
+    // Move 2
+    "lostpointercapture@a",
+    "pointerout@a",
+    "pointermove@target",
+    // Move 3
+    "pointerover@b",
+    "gotpointercapture@b",
+    "pointermove@b",
+    "pointerup@b",
+    "lostpointercapture@b",
+    "pointerout@b",
+  ]);
+}, "Setting capture in lostpointercapture handler defers gotpointercapture to the next event");
+</script>


### PR DESCRIPTION
This introduces four tests, each of which have both a non-tentative
and a tentative variant, to provide coverage of how spec and current
browser behaviour differs:

Non-tentative tests match the current spec, requiring each step to
read the current state, allowing handler mutations between steps to be
observable.

Tentative tests match current browsers, which read override and
pending once at algorithm entry.

Additionally, we add one test
(pointerevents/pointerevent_lostpointercapture_fires_at_old_target_during_transfer.html)
which verifies basic transfering capture from a to b transfer with no
handler mutations. There is no tentative version as the semantics are
the same either way.
