### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311469

### DIFF
--- a/svg/types/scripted/SVGList-parse-invalid-clears-items.html
+++ b/svg/types/scripted/SVGList-parse-invalid-clears-items.html
@@ -38,7 +38,7 @@ test(function() {
 
     assert_equals(polygon.points.numberOfItems, 4, "initial valid parse gives 4 items");
 
-    // Setting a partially invalid value: valid point pairs followed by a invalid one.
+    // Setting a partially invalid value: valid point pairs followed by an invalid one.
     polygon.setAttribute("points", "0,0 100,0 INVALID");
     assert_equals(polygon.points.numberOfItems, 0,
         "SVGPointList: partially invalid attribute value should result in 0 items");


### PR DESCRIPTION
WebKit export from bug: <a href="https://bugs.webkit.org/show_bug.cgi?id=311469">SVGPointList should keep valid coordinate pairs when trailing y value is missing</a>