### PR TITLE
Digital Credentials: update spec URL from WICG to w3c-fedid

### DIFF
--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Digital Credential API tests for create.</title>
-<link rel="help" href="https://wicg.github.io/digital-credentials/" />
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/digital-credentials/digital-credentials-static-methods.tentative.https.html
+++ b/digital-credentials/digital-credentials-static-methods.tentative.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Digital Credential static methods.</title>
-<link rel="help" href="https://wicg.github.io/digital-credentials/" />
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/digital-credentials/get.https.html
+++ b/digital-credentials/get.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Digital Credential tests.</title>
-<link rel="help" href="https://wicg.github.io/digital-credentials/" />
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
The Digital Credentials spec moved from `wicg.github.io/digital-credentials` to `w3c-fedid.github.io/digital-credentials` when the work transferred to the Federated Identity Working Group. Updates the `<link rel="help">` URLs in 3 test files.