### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=74156

### DIFF
--- a/css/css-backgrounds/box-shadow/box-shadow-table-row-display-ref.html
+++ b/css/css-backgrounds/box-shadow/box-shadow-table-row-display-ref.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Box-shadow on display: table-row</title>
+<style>
+  body {
+    margin: 50px;
+    background: white;
+  }
+
+  .block {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px #000;
+  }
+
+  .block-red {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px red;
+  }
+
+  .block-green {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px green;
+  }
+
+  .block-blue {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px blue;
+  }
+
+  .group {
+    margin-bottom: 40px;
+  }
+</style>
+</head>
+<body>
+
+<div class="group">
+  <div class="block"></div>
+</div>
+
+<div class="group">
+  <div class="block"></div>
+  <div class="block"></div>
+</div>
+
+<div class="group">
+  <div class="block-red"></div>
+  <div class="block-green"></div>
+  <div class="block-blue"></div>
+</div>
+
+</body>
+</html>

--- a/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
+++ b/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Box-shadow on display: table-row</title>
+<link rel="match" href="table-row-box-shadow-ref.html">
+<meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-2890">
+<style>
+  body {
+    margin: 50px;
+    background: white;
+  }
+
+  .table {
+    display: table;
+    margin-bottom: 40px;
+  }
+
+  .row {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px #000;
+  }
+
+  .row-red {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px red;
+  }
+
+  .row-green {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px green;
+  }
+
+  .row-blue {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px blue;
+  }
+
+  .cell {
+    display: table-cell;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+</head>
+<body>
+
+<div class="table">
+  <div class="row">
+    <div class="cell"></div>
+  </div>
+</div>
+
+<div class="table">
+  <div class="row">
+    <div class="cell"></div>
+  </div>
+  <div class="row">
+    <div class="cell"></div>
+  </div>
+</div>
+
+<div class="table">
+  <div class="row-red">
+    <div class="cell"></div>
+  </div>
+  <div class="row-green">
+    <div class="cell"></div>
+  </div>
+  <div class="row-blue">
+    <div class="cell"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
+++ b/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>Box-shadow on display: table-row</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#box-shadow">
 <link rel="match" href="box-shadow-table-row-display-ref.html">
 <meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-2890">
 <style>

--- a/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
+++ b/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>Box-shadow on display: table-row</title>
-<link rel="match" href="table-row-box-shadow-ref.html">
+<link rel="match" href="box-shadow-table-row-display-ref.html">
 <meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-2890">
 <style>
   body {


### PR DESCRIPTION
WebKit export from bug: [WebKit does not support box-shadow on display:table-row element](https://bugs.webkit.org/show_bug.cgi?id=74156)