### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311942

### DIFF
--- a/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
+++ b/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
@@ -1,4 +1,7 @@
 <html>
+<head>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311942">
+</head>
 <body>
 <div style="display: grid">
   <div id="change" style="display: grid; grid-template-rows: subgrid [a] [b] [c];">

--- a/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
+++ b/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+<div style="display: grid">
+  <div id="change" style="display: grid; grid-template-rows: subgrid [a] [b] [c];">
+    <div>one</div>
+    <foo style="display: grid; grid-template-rows: subgrid [a] [b] [c];">
+      <bar id="x">two</bar>
+    </foo>
+  </div>
+</div>
+</body>
+<script>
+  document.body.offsetHeight;
+  x.style.border = "1px solid red";
+  document.getElementById("change").style.contain = 'paint';
+</script>
+</html>
+


### PR DESCRIPTION
WebKit export from bug: [\[Grid\] Crash under GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid when paint containment changes on subgrid](https://bugs.webkit.org/show_bug.cgi?id=311942)