### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=220724

### DIFF
--- a/content-security-policy/plugin-types/plugin-types-does-not-block-pdf-embed.html
+++ b/content-security-policy/plugin-types/plugin-types-does-not-block-pdf-embed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <!--
+    Regression test: the deprecated 'plugin-types' CSP directive must not block
+    <embed> elements that load application/pdf content via a src URL.
+    See https://github.com/w3c/webappsec-csp/issues/424
+  -->
+  <embed src="resources/blank.pdf.py" type="application/pdf">
+  <script async defer src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+
+</html>

--- a/content-security-policy/plugin-types/plugin-types-does-not-block-pdf-embed.html.sub.headers
+++ b/content-security-policy/plugin-types/plugin-types-does-not-block-pdf-embed.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: plugin-types-does-not-block-pdf-embed={{$id:uuid()}}; Path=/content-security-policy/plugin-types/
+Content-Security-Policy: plugin-types application/x-shockwave-flash; report-uri ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/plugin-types/resources/blank.pdf.py
+++ b/content-security-policy/plugin-types/resources/blank.pdf.py
@@ -1,0 +1,2 @@
+def main(request, response):
+    return [(b"Content-Type", b"application/pdf")], b"%PDF-1.0\n%%EOF\n"


### PR DESCRIPTION
New test to guard against misuse of the deprecated `plugin-types` CSP directive. A bug here prevented PDFs from being displayed on sites that had not been updated since the spec change.