### PR TITLE
Add tests for SVG foreignObjects being cloned by reference with use

### DIFF
--- a/svg/struct/reftests/use-foreignObject-with-canvas.html
+++ b/svg/struct/reftests/use-foreignObject-with-canvas.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test: foreignObject containing a canvas is duplicated with use</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement:~:text=Previous%20versions%20of%20SVG,subtree%20to%20be%20cloned.">
+<link rel="match" href="reference/green-100x100.html">
+<svg>
+  <rect width="100" height="100" fill="blue" />
+  <foreignObject id="box" width="50" height="50">
+    <canvas id="foreignCanvas" width="50" height="50" style="background-color: red"></canvas>
+  </foreignObject>
+  <use href="#box" x="50" y="0" />
+  <use href="#box" x="0" y="50" />
+  <use href="#box" x="50" y="50" />
+</svg>
+<script type="text/javascript">
+    const canvas = document.getElementById('foreignCanvas')
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "green"
+    ctx.fillRect(0,0, 50, 50)
+</script>

--- a/svg/struct/reftests/use-foreignObject-with-restyle.html
+++ b/svg/struct/reftests/use-foreignObject-with-restyle.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test: modifying style of div inside foreignObject that is duplicated with use</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement:~:text=Previous%20versions%20of%20SVG,subtree%20to%20be%20cloned.">
+<link rel="match" href="reference/green-100x100.html">
+<style>
+div { width: 50px; height: 50px; }
+</style>
+<svg>
+  <rect width="100" height="100" fill="blue" />
+  <foreignObject id="box" width="50" height="50">
+    <div id="testdiv" style="background-color: red;"></div>
+  </foreignObject>
+  <use href="#box" x="50" y="0" />
+  <use href="#box" x="0" y="50" />
+  <use href="#box" x="50" y="50" />
+</svg>
+<script type="text/javascript">
+    document.getElementById("testdiv").style.backgroundColor = 'green';
+</script>


### PR DESCRIPTION
This is an extension of #55576 by @Psychpsyo, which added a test to allow `foreignObject` inside `use` elements.

This PR adds two more test for `foreignObject` and `use` behavior:
* `use-foreignObject-with-restyle.html` tests if changing the background color of a `div` inside a `foreignObject`, that is duplicated with `use`, changes the background color for all clones. 
   * This test passes in Firefox, but fails in Chrome (blue), because there `foreignObject` is not yet supported for `use` at all.
* `use-foreignObject-with-canvas.html` tests if a canvas inside a `foreignObject`, that is duplicated with `use`, is rendered multiple times.
   * This test fails in Firefox (red) and Chrome (blue).

I tried to write the tests in a way, that it fails with blue color, when `foreginObject` inside `use` is not supported at all and only fail with red, when the restyle isn't applied or the canvas content isn't rendered. I hope that is the intended usage of the different colors.

The behavior of the restyle test in Firefox is also kind of an indication to me, that the canvas test should also pass, because it means, that the `foreignObject` clones are not independent copies, but are linked.
I don't think the spec is actually clear on what is supposed to happen, but I'd argue the expected behavior is the only one that is useful.

(Sadly I was not able to run the tests locally, because a Windows update broke my WSL 🙄😞.)