### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=312092

### DIFF
--- a/domxpath/resolver-callback-interface-cross-realm.tentative.html
+++ b/domxpath/resolver-callback-interface-cross-realm.tentative.html
@@ -79,7 +79,7 @@ function assert_reports_exception(fn) {
   resolverGlobalObject.removeEventListener("error", onErrorHandler);
 
   assert_equals(typeof error, "object");
-  assert_equals(error.constructor, evaluateGlobalObject.TypeError);
+  assert_equals(error.constructor, resolverGlobalObject.TypeError);
 }
 
 function bind_evaluate(resolver) {


### PR DESCRIPTION
WebKit export from bug: [Use callback object's associated Realm in JSCallbackData::invokeCallback per WebIDL spec](https://bugs.webkit.org/show_bug.cgi?id=312092)