### PR TITLE
Adjust URL of Web NFC

### DIFF
--- a/web-nfc/META.yml
+++ b/web-nfc/META.yml
@@ -1,4 +1,4 @@
-spec: https://w3c.github.io/web-nfc/
+spec: https://w3c-cg.github.io/web-nfc/
 suggested_reviewers:
   - Honry
   - kenchris


### PR DESCRIPTION
Spec repository was moved on GitHub from `w3c/web-nfc` to `w3c-cg/web-nfc`. This adjusts the spec URL accordingly (FWIW, former URL redirects to the new one).