### PR TITLE
fix faulty shadowrootslotassignment test

### DIFF
--- a/shadow-dom/declarative/declarative-shadow-dom-slot-assignment-serialization.tentative.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-slot-assignment-serialization.tentative.html
@@ -8,17 +8,18 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<div id="host"></div>
+<div id="wrapper"></div>
 
 <script>
   // Attribute serialization order follows the ShadowRoot IDL attribute order:
   // mode, delegatesFocus, slotAssignment, clonable, serializable
 
   test((t) => {
-    t.add_cleanup(() => host.replaceChildren());
-    host.setHTMLUnsafe(
-      `<template shadowrootmode="open" shadowrootserializable shadowrootslotassignment="manual"></template>`,
+    t.add_cleanup(() => wrapper.replaceChildren());
+    wrapper.setHTMLUnsafe(
+      `<div id="host"><template shadowrootmode="open" shadowrootserializable shadowrootslotassignment="manual"></template></div>`,
     );
+    const host = wrapper.querySelector("#host");
     assert_equals(host.shadowRoot.slotAssignment, "manual");
     assert_equals(
       host.getHTML({ serializableShadowRoots: true }),
@@ -27,10 +28,11 @@
   }, "shadowrootslotassignment=manual is serialized and appears before shadowrootclonable and shadowrootserializable");
 
   test((t) => {
-    t.add_cleanup(() => host.replaceChildren());
-    host.setHTMLUnsafe(
-      `<template shadowrootmode="open" shadowrootserializable shadowrootslotassignment="named"></template>`,
+    t.add_cleanup(() => wrapper.replaceChildren());
+    wrapper.setHTMLUnsafe(
+      `<div id="host"><template shadowrootmode="open" shadowrootserializable shadowrootslotassignment="named"></template></div>`,
     );
+    const host = wrapper.querySelector("#host");
     assert_equals(host.shadowRoot.slotAssignment, "named");
     assert_equals(
       host.getHTML({ serializableShadowRoots: true }),
@@ -39,10 +41,11 @@
   }, "shadowrootslotassignment=named is not serialized as it's the default");
 
   test((t) => {
-    t.add_cleanup(() => host.replaceChildren());
-    host.setHTMLUnsafe(
-      `<template shadowrootmode="open" shadowrootdelegatesfocus shadowrootserializable shadowrootclonable shadowrootslotassignment="manual"></template>`,
+    t.add_cleanup(() => wrapper.replaceChildren());
+    wrapper.setHTMLUnsafe(
+      `<div id="host"><template shadowrootmode="open" shadowrootdelegatesfocus shadowrootserializable shadowrootclonable shadowrootslotassignment="manual"></template></div>`,
     );
+    const host = wrapper.querySelector("#host");
     assert_equals(host.shadowRoot.slotAssignment, "manual");
     assert_equals(
       host.getHTML({ serializableShadowRoots: true }),


### PR DESCRIPTION
This test called `setHTMLUnsafe` on the host which caused errors due to the shadow root only being set once. This updates it to create a new host element each time.