### PR TITLE
Add moveBefore tests to ensure internal id and name maps are correctly updated

### DIFF
--- a/dom/nodes/moveBefore/moveBefore-id-map.html
+++ b/dom/nodes/moveBefore/moveBefore-id-map.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <div id="container"></div>
+  <div id="target" data-target></div>
+</body>
+
+<script>
+  test(() => {
+      let shadowRoot = container.attachShadow({mode: "open"});
+      let div = document.createElement("div");
+      shadowRoot.appendChild(div);
+      let target = document.querySelector('[data-target]');
+
+      assert_equals(document.getElementById("target"), target);
+      assert_equals(shadowRoot.getElementById("target"), null);
+
+      div.moveBefore(target, null);
+
+      assert_equals(document.getElementById("target"), document.querySelector('[data-span]'));
+      assert_equals(shadowRoot.getElementById("target"), target);
+  }, 'moveBefore() correctly updates id map');
+</script>

--- a/dom/nodes/moveBefore/moveBefore-id-map.html
+++ b/dom/nodes/moveBefore/moveBefore-id-map.html
@@ -5,6 +5,7 @@
 <body>
   <div id="container"></div>
   <div id="target" data-target></div>
+  <span id="target" data-span></span>
 </body>
 
 <script>

--- a/dom/nodes/moveBefore/moveBefore-name-map.html
+++ b/dom/nodes/moveBefore/moveBefore-name-map.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <div id="container"></div>
+  <img name="target" data-target>
+</body>
+
+<script>
+  test(() => {
+      let shadowRoot = container.attachShadow({mode: "open"});
+      let div = document.createElement("div");
+      shadowRoot.appendChild(div);
+
+      let target = document.querySelector('[data-target]');
+
+      assert_equals(window.target, target);
+      let nameMap = document.getElementsByName("target");
+      assert_equals(nameMap.length, 1);
+      assert_equals(nameMap[0], target);
+
+      div.moveBefore(target, null);
+
+      assert_equals(window.target, undefined);
+      nameMap = document.getElementsByName("target");
+      assert_equals(nameMap.length, 0);
+  }, 'moveBefore() correctly updates name map');
+</script>


### PR DESCRIPTION
This was something found in Servo, so upstreaming some tests in case it happens elsewhere.