### PR TITLE
Speculation Rules prerender tests should check for support

### DIFF
--- a/speculation-rules/prerender-until-script/prerender-until-script.https.html
+++ b/speculation-rules/prerender-until-script/prerender-until-script.https.html
@@ -8,7 +8,7 @@
 <script src="../resources/utils.js"></script>
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   /*

--- a/speculation-rules/prerender/about-blank-iframes.https.html
+++ b/speculation-rules/prerender/about-blank-iframes.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/accept-client-hint-cache.https.html
+++ b/speculation-rules/prerender/accept-client-hint-cache.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(
   async t => {

--- a/speculation-rules/prerender/activation-by-form-submission.https.html
+++ b/speculation-rules/prerender/activation-by-form-submission.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/activation-start.https.html
+++ b/speculation-rules/prerender/activation-start.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const ACTIVATION_DELAY = 10;

--- a/speculation-rules/prerender/blob_object_url.https.html
+++ b/speculation-rules/prerender/blob_object_url.https.html
@@ -11,7 +11,7 @@ objects</title>
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const {exec} = await create_prerendered_page(t);

--- a/speculation-rules/prerender/cache-storage.https.html
+++ b/speculation-rules/prerender/cache-storage.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const cacheName = token();

--- a/speculation-rules/prerender/cancel-prerendering-after-clear-site-data-cache-different-origins.https.html
+++ b/speculation-rules/prerender/cancel-prerendering-after-clear-site-data-cache-different-origins.https.html
@@ -10,7 +10,7 @@
 <script src="../resources/utils.js"></script>
 <script src="resources/utils.js"></script>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
 

--- a/speculation-rules/prerender/cancel-prerendering-after-clear-site-data-cache-same-origin.https.html
+++ b/speculation-rules/prerender/cancel-prerendering-after-clear-site-data-cache-same-origin.https.html
@@ -10,7 +10,7 @@
 <script src="../resources/utils.js"></script>
 <script src="resources/utils.js"></script>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
 

--- a/speculation-rules/prerender/clients-matchall.https.html
+++ b/speculation-rules/prerender/clients-matchall.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/cookies.https.html
+++ b/speculation-rules/prerender/cookies.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 cookie_test(async t => {
   const {exec} = await create_prerendered_page(t);

--- a/speculation-rules/prerender/credentialed-prerender-not-opt-in.https.html
+++ b/speculation-rules/prerender/credentialed-prerender-not-opt-in.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/credentialed-prerender-opt-in.https.html
+++ b/speculation-rules/prerender/credentialed-prerender-opt-in.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/cross-origin-iframe-prerender.https.html
+++ b/speculation-rules/prerender/cross-origin-iframe-prerender.https.html
@@ -15,7 +15,7 @@ Tests for cross-origin iframes `document.prerendering` state with
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/cross-origin-iframe.https.html
+++ b/speculation-rules/prerender/cross-origin-iframe.https.html
@@ -19,7 +19,7 @@ This file cannot be upstreamed to WPT until:
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/cross-origin-isolated.https.html
+++ b/speculation-rules/prerender/cross-origin-isolated.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/csp-script-src-elem-inline-speculation-rules.https.html
+++ b/speculation-rules/prerender/csp-script-src-elem-inline-speculation-rules.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   // The key used for storing a test result in the server.

--- a/speculation-rules/prerender/csp-script-src-inline-speculation-rules.https.html
+++ b/speculation-rules/prerender/csp-script-src-inline-speculation-rules.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   // The key used for storing a test result in the server.

--- a/speculation-rules/prerender/csp-script-src-self.https.html
+++ b/speculation-rules/prerender/csp-script-src-self.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   // The key used for storing a test result in the server.

--- a/speculation-rules/prerender/csp-script-src-strict-dynamic.https.html
+++ b/speculation-rules/prerender/csp-script-src-strict-dynamic.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   // The key used for storing a test result in the server.

--- a/speculation-rules/prerender/csp-script-src-unsafe-inline.https.html
+++ b/speculation-rules/prerender/csp-script-src-unsafe-inline.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   // The key used for storing a test result in the server.

--- a/speculation-rules/prerender/fetch-blob.https.html
+++ b/speculation-rules/prerender/fetch-blob.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rule_extras = {'target_hint': getTargetHint()};

--- a/speculation-rules/prerender/fetch-intercepted-by-service-worker.https.html
+++ b/speculation-rules/prerender/fetch-intercepted-by-service-worker.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/headers.https.html
+++ b/speculation-rules/prerender/headers.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async () => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/iframe-added-post-activation.https.html
+++ b/speculation-rules/prerender/iframe-added-post-activation.https.html
@@ -13,7 +13,7 @@ document.prerendering false.
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/indexeddb.https.html
+++ b/speculation-rules/prerender/indexeddb.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const db = await openIndexedDatabase(t);

--- a/speculation-rules/prerender/local-storage.https.html
+++ b/speculation-rules/prerender/local-storage.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid1 = token();

--- a/speculation-rules/prerender/main-frame-navigation.https.html
+++ b/speculation-rules/prerender/main-frame-navigation.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/media-autoplay.https.html
+++ b/speculation-rules/prerender/media-autoplay.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const {exec, activate} = await create_prerendered_page(t);

--- a/speculation-rules/prerender/navigation-api-location-replace.https.html
+++ b/speculation-rules/prerender/navigation-api-location-replace.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/navigation-api-multiple-entries.https.html
+++ b/speculation-rules/prerender/navigation-api-multiple-entries.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/navigation-api-redirect.https.html
+++ b/speculation-rules/prerender/navigation-api-redirect.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/navigation-api.https.html
+++ b/speculation-rules/prerender/navigation-api.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/navigation-intercepted-by-service-worker.https.html
+++ b/speculation-rules/prerender/navigation-intercepted-by-service-worker.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/navigator-plugins.https.html
+++ b/speculation-rules/prerender/navigator-plugins.https.html
@@ -10,7 +10,7 @@
 <body>
 <script>
 setup(() => {
-  assertSpeculationRulesIsSupported();
+  assertSpeculationRulesIsSupported('prerender');
   assert_implements_optional(
       'plugins' in navigator, 'navigator.plugins is not provided.'
     );

--- a/speculation-rules/prerender/no-vary-search-hint-target-blank.https.html
+++ b/speculation-rules/prerender/no-vary-search-hint-target-blank.https.html
@@ -43,7 +43,7 @@
 
 <body></body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function prerender_no_vary_search_test(description, noVarySearch, noVarySearchHint, prefetchQuery, navigateQuery, shouldUse) {
   promise_test(async t => {

--- a/speculation-rules/prerender/no-vary-search-hint.https.html
+++ b/speculation-rules/prerender/no-vary-search-hint.https.html
@@ -43,7 +43,7 @@
 
 <body></body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function prerender_no_vary_search_test(description, noVarySearch, noVarySearchHint, prefetchQuery, navigateQuery, shouldUse) {
   promise_test(async t => {

--- a/speculation-rules/prerender/no-vary-search-target-blank.https.html
+++ b/speculation-rules/prerender/no-vary-search-target-blank.https.html
@@ -45,7 +45,7 @@
 
 <body></body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function prerender_no_vary_search_test(description, noVarySearch, prefetchQuery, navigateQuery, shouldUse) {
   promise_test(async t => {

--- a/speculation-rules/prerender/no-vary-search.https.html
+++ b/speculation-rules/prerender/no-vary-search.https.html
@@ -45,7 +45,7 @@
 
 <body></body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function prerender_no_vary_search_test(description, noVarySearch, prefetchQuery, navigateQuery, shouldUse) {
   promise_test(async t => {

--- a/speculation-rules/prerender/prefetch.https.html
+++ b/speculation-rules/prerender/prefetch.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const {tryToActivate, getNetworkRequestCount} =

--- a/speculation-rules/prerender/prerender-while-prerender.https.html
+++ b/speculation-rules/prerender/prerender-while-prerender.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // We attempted to write this test using `RemoteContextHelper`. See
 // https://github.com/web-platform-tests/wpt/blob/23ed0c7015082f21dd29dd09a545e2979dc3e08c/speculation-rules/prerender/prerender-while-prerender.html.

--- a/speculation-rules/prerender/protocol-handler-register.https.html
+++ b/speculation-rules/prerender/protocol-handler-register.https.html
@@ -22,7 +22,7 @@ function getNextWindowMessageFromFrame(frame) {
 }
 
 promise_setup(async () => {
-  assertSpeculationRulesIsSupported()
+  assertSpeculationRulesIsSupported('prerender')
   await test_driver.set_rph_registration_mode('autoAccept');
   await test_driver.bless('handler registration');
 });

--- a/speculation-rules/prerender/protocol-handler-unregister.https.html
+++ b/speculation-rules/prerender/protocol-handler-unregister.https.html
@@ -31,7 +31,7 @@ function getNextMessageFromServiceWorker(serviceWorker) {
 }
 
 promise_setup(async () => {
-  assertSpeculationRulesIsSupported()
+  assertSpeculationRulesIsSupported('prerender')
   await test_driver.set_rph_registration_mode('autoAccept');
   await test_driver.bless('handler registration');
 });

--- a/speculation-rules/prerender/protocol-handler-validation.https.html
+++ b/speculation-rules/prerender/protocol-handler-validation.https.html
@@ -29,7 +29,7 @@ async function registerProtocolHandlerTestHelper(
   assert_equals(result, expected_result);
 }
 
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   await registerProtocolHandlerTestHelper(

--- a/speculation-rules/prerender/referrer-policy-from-rules.https.html
+++ b/speculation-rules/prerender/referrer-policy-from-rules.https.html
@@ -17,7 +17,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 subsetTest(promise_test, async t => {
   const {exec, tryToActivate} = await create_prerendered_page(

--- a/speculation-rules/prerender/referrer-policy-mismatch.https.html
+++ b/speculation-rules/prerender/referrer-policy-mismatch.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/referrer-policy-no-referrer.https.html
+++ b/speculation-rules/prerender/referrer-policy-no-referrer.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // Tests that the referrer on the prerendering navigation request is not sent
 // when the triggering page's referrer policy is set to no-referrer.

--- a/speculation-rules/prerender/referrer-policy-origin.https.html
+++ b/speculation-rules/prerender/referrer-policy-origin.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // Tests that the referrer on the prerendering navigation request is the
 // triggering page's origin when the referrer policy is set to origin.

--- a/speculation-rules/prerender/referrer-policy-strict-origin.https.html
+++ b/speculation-rules/prerender/referrer-policy-strict-origin.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // Tests that the referrer on the prerendering navigation request is the
 // triggering page's origin when the referrer policy is set to strict-origin.

--- a/speculation-rules/prerender/referrer.https.html
+++ b/speculation-rules/prerender/referrer.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // Tests that the referrer on the prerendering navigation request is the
 // triggering page's URL by default.

--- a/speculation-rules/prerender/register-service-worker.https.html
+++ b/speculation-rules/prerender/register-service-worker.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // To make sure the service worker registered by the prerendered page starts up,
 // this test sends messages as the following sequence:

--- a/speculation-rules/prerender/remove-script-element.https.html
+++ b/speculation-rules/prerender/remove-script-element.https.html
@@ -8,7 +8,7 @@
 <body>
 <iframe id="iframe"></iframe>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 async_test(t => {
   const doc = iframe.contentDocument;

--- a/speculation-rules/prerender/response-code-non-successful.https.html
+++ b/speculation-rules/prerender/response-code-non-successful.https.html
@@ -16,7 +16,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const params = new URLSearchParams(window.location.search);
 

--- a/speculation-rules/prerender/response-code-successful.https.html
+++ b/speculation-rules/prerender/response-code-successful.https.html
@@ -15,7 +15,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const params = new URLSearchParams(window.location.search);
 

--- a/speculation-rules/prerender/restriction-audio-setSinkId-with-invalid-sinkId.https.tentative.https.html
+++ b/speculation-rules/prerender/restriction-audio-setSinkId-with-invalid-sinkId.https.tentative.https.html
@@ -13,7 +13,7 @@ Access to the setSinkId of the Audio API with an invalid value is deferred
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-audio-setSinkId.https.tentative.https.html
+++ b/speculation-rules/prerender/restriction-audio-setSinkId.https.tentative.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-background-fetch.https.html
+++ b/speculation-rules/prerender/restriction-background-fetch.https.html
@@ -14,7 +14,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-background-sync.https.html
+++ b/speculation-rules/prerender/restriction-background-sync.https.html
@@ -14,7 +14,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-battery-status.https.html
+++ b/speculation-rules/prerender/restriction-battery-status.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-bluetooth.tentative.https.html
+++ b/speculation-rules/prerender/restriction-bluetooth.tentative.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-broadcast-channel.https.html
+++ b/speculation-rules/prerender/restriction-broadcast-channel.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-dedicated-worker.https.html
+++ b/speculation-rules/prerender/restriction-dedicated-worker.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-encrypted-media-unsupported-config.https.html
+++ b/speculation-rules/prerender/restriction-encrypted-media-unsupported-config.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-encrypted-media.https.html
+++ b/speculation-rules/prerender/restriction-encrypted-media.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-focus.https.html
+++ b/speculation-rules/prerender/restriction-focus.https.html
@@ -11,7 +11,7 @@
 <body>
 <input type="text" id = "prerenderTextField">
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   document.getElementById('prerenderTextField').focus();

--- a/speculation-rules/prerender/restriction-idle-detection.https.html
+++ b/speculation-rules/prerender/restriction-idle-detection.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-local-file-system-access.https.html
+++ b/speculation-rules/prerender/restriction-local-file-system-access.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-media-auto-play-attribute.https.html
+++ b/speculation-rules/prerender/restriction-media-auto-play-attribute.https.html
@@ -16,7 +16,7 @@ spec will allow loading and only disallow playback.
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function RunTest(type, description) {
   promise_test(async t => {

--- a/speculation-rules/prerender/restriction-media-camera.https.html
+++ b/speculation-rules/prerender/restriction-media-camera.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-media-capabilities-decoding-info.https.html
+++ b/speculation-rules/prerender/restriction-media-capabilities-decoding-info.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-media-capabilities-encoding-info.https.html
+++ b/speculation-rules/prerender/restriction-media-capabilities-encoding-info.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-media-device-info.https.html
+++ b/speculation-rules/prerender/restriction-media-device-info.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-media-microphone.https.html
+++ b/speculation-rules/prerender/restriction-media-microphone.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-media-play.https.html
+++ b/speculation-rules/prerender/restriction-media-play.https.html
@@ -16,7 +16,7 @@ spec will allow loading and only disallow playback.
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function RunTest(type, description) {
   promise_test(async t => {

--- a/speculation-rules/prerender/restriction-message-boxes.https.html
+++ b/speculation-rules/prerender/restriction-message-boxes.https.html
@@ -8,7 +8,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function runTest(test_file, expectation, description) {
   promise_test(async t => {

--- a/speculation-rules/prerender/restriction-midi-sysex.https.html
+++ b/speculation-rules/prerender/restriction-midi-sysex.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-midi.https.html
+++ b/speculation-rules/prerender/restriction-midi.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-notification.https.html
+++ b/speculation-rules/prerender/restriction-notification.https.html
@@ -17,7 +17,7 @@ TODO(https://crbug.com/1198110): Add the following tests:
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-presentation-request.https.html
+++ b/speculation-rules/prerender/restriction-presentation-request.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-prompt-by-before-unload.https.html
+++ b/speculation-rules/prerender/restriction-prompt-by-before-unload.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-push.https.html
+++ b/speculation-rules/prerender/restriction-push.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-request-picture-in-picture.https.html
+++ b/speculation-rules/prerender/restriction-request-picture-in-picture.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-screen-capture.https.html
+++ b/speculation-rules/prerender/restriction-screen-capture.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-screen-orientation-lock.https.html
+++ b/speculation-rules/prerender/restriction-screen-orientation-lock.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-sensor-accelerometer.https.html
+++ b/speculation-rules/prerender/restriction-sensor-accelerometer.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-sensor-ambient-light-sensor.https.html
+++ b/speculation-rules/prerender/restriction-sensor-ambient-light-sensor.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-sensor-gyroscope.https.html
+++ b/speculation-rules/prerender/restriction-sensor-gyroscope.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-sensor-magnetometer.https.html
+++ b/speculation-rules/prerender/restriction-sensor-magnetometer.https.html
@@ -13,7 +13,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-service-worker-postmessage.https.html
+++ b/speculation-rules/prerender/restriction-service-worker-postmessage.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/restriction-service-worker-unregister.https.html
+++ b/speculation-rules/prerender/restriction-service-worker-unregister.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/restriction-service-worker-update.https.html
+++ b/speculation-rules/prerender/restriction-service-worker-update.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/restriction-speech-synthesis.https.html
+++ b/speculation-rules/prerender/restriction-speech-synthesis.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function RunTest(method, description) {
   promise_test(async t => {

--- a/speculation-rules/prerender/restriction-storage-persist.https.html
+++ b/speculation-rules/prerender/restriction-storage-persist.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 promise_test(async t => {
   const uid = token();
   const bc = new PrerenderChannel('test-channel', uid);

--- a/speculation-rules/prerender/restriction-wake-lock.https.html
+++ b/speculation-rules/prerender/restriction-wake-lock.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-hid.https.html
+++ b/speculation-rules/prerender/restriction-web-hid.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-locks.https.html
+++ b/speculation-rules/prerender/restriction-web-locks.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function RunTest(method, description) {
   promise_test(async t => {

--- a/speculation-rules/prerender/restriction-web-nfc.https.html
+++ b/speculation-rules/prerender/restriction-web-nfc.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-serial.tentative.https.html
+++ b/speculation-rules/prerender/restriction-web-serial.tentative.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-share.https.html
+++ b/speculation-rules/prerender/restriction-web-share.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-usb.https.html
+++ b/speculation-rules/prerender/restriction-web-usb.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-xr-immersive-vr-session.https.html
+++ b/speculation-rules/prerender/restriction-web-xr-immersive-vr-session.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-web-xr-inline-session.https.html
+++ b/speculation-rules/prerender/restriction-web-xr-inline-session.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restriction-window-move.https.html
+++ b/speculation-rules/prerender/restriction-window-move.https.html
@@ -8,7 +8,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // moveTo and moveBy operations should be ignored.
 // See https://github.com/jeremyroman/alternate-loading-modes/issues/73.

--- a/speculation-rules/prerender/restriction-window-open.https.html
+++ b/speculation-rules/prerender/restriction-window-open.https.html
@@ -8,7 +8,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function runTest(test_file, expectation, description) {
   promise_test(async t => {

--- a/speculation-rules/prerender/restriction-window-resize.https.html
+++ b/speculation-rules/prerender/restriction-window-resize.https.html
@@ -8,7 +8,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // ResizeTo and ResizeBy operations should be ignored.
 // See https://github.com/jeremyroman/alternate-loading-modes/issues/73.

--- a/speculation-rules/prerender/restrictions.https.html
+++ b/speculation-rules/prerender/restrictions.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 test_prerender_restricted(
   () => navigator.clipboard.writeText(location.href),

--- a/speculation-rules/prerender/restrictions_shared_storage.https.html
+++ b/speculation-rules/prerender/restrictions_shared_storage.https.html
@@ -9,7 +9,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/restrictions_shared_storage_worklet.https.html
+++ b/speculation-rules/prerender/restrictions_shared_storage_worklet.https.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 promise_test(async t => {
     const uid = token();
     const bc = new PrerenderChannel('test-channel', uid);

--- a/speculation-rules/prerender/sandbox-iframe.https.html
+++ b/speculation-rules/prerender/sandbox-iframe.https.html
@@ -17,7 +17,7 @@ This file cannot be upstreamed to WPT until:
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/scroll-into-view-cross-origin-iframe.https.html
+++ b/speculation-rules/prerender/scroll-into-view-cross-origin-iframe.https.html
@@ -17,7 +17,7 @@ same origin in process behavior.
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 function runTest(originKey, label) {
   promise_test(async t => {

--- a/speculation-rules/prerender/send-beacon.https.html
+++ b/speculation-rules/prerender/send-beacon.https.html
@@ -10,7 +10,7 @@
 <script src="../resources/utils.js"></script>
 <script src="resources/utils.js"></script>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const STORE_URL = '/speculation-rules/prerender/resources/key-value-store.py';

--- a/speculation-rules/prerender/service-workers.https.html
+++ b/speculation-rules/prerender/service-workers.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // This delay is to prevent a race condition which can cause false passes -
 // a service worker might take some time to install, and if activation is too quick it might

--- a/speculation-rules/prerender/session-history-activation.https.html
+++ b/speculation-rules/prerender/session-history-activation.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/session-history-location.https.html
+++ b/speculation-rules/prerender/session-history-location.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/session-history-navigation.https.html
+++ b/speculation-rules/prerender/session-history-navigation.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/session-history-pushstate.https.html
+++ b/speculation-rules/prerender/session-history-pushstate.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/session-history-subframe-navigation.https.html
+++ b/speculation-rules/prerender/session-history-subframe-navigation.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/session-history-subframe-reload.https.html
+++ b/speculation-rules/prerender/session-history-subframe-reload.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/session-storage.tentative.https.html
+++ b/speculation-rules/prerender/session-storage.tentative.https.html
@@ -9,10 +9,13 @@ This file is marked as "tentative" until:
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/utils.js"></script>
+<script src="../resources/utils.js"></script>
 <script src="resources/utils.js"></script>
 <script src="resources/session-storage-utils.js"></script>
 <body>
 <script>
+setup(() => assertSpeculationRulesIsSupported('prerender'));
+
 const uid = token();
 
 session_storage_test(

--- a/speculation-rules/prerender/state-and-event.https.html
+++ b/speculation-rules/prerender/state-and-event.https.html
@@ -8,7 +8,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   // The key used for storing a test result in the server.

--- a/speculation-rules/prerender/visibility-state.https.html
+++ b/speculation-rules/prerender/visibility-state.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const rcHelper = new PrerenderingRemoteContextHelper();

--- a/speculation-rules/prerender/windowclient-navigate-to-cross-origin-url-on-iframe.https.html
+++ b/speculation-rules/prerender/windowclient-navigate-to-cross-origin-url-on-iframe.https.html
@@ -16,7 +16,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const PAGE_URL = 'resources/windowclient-navigate-on-iframe.html';
 const WORKER_URL = 'resources/windowclient-navigate-worker.js';

--- a/speculation-rules/prerender/windowclient-navigate-to-same-origin-url-on-iframe.https.html
+++ b/speculation-rules/prerender/windowclient-navigate-to-same-origin-url-on-iframe.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const PAGE_URL = 'resources/windowclient-navigate-on-iframe.html';
 const WORKER_URL = 'resources/windowclient-navigate-worker.js';

--- a/speculation-rules/prerender/windowclient-navigate.https.html
+++ b/speculation-rules/prerender/windowclient-navigate.https.html
@@ -11,7 +11,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 const uid = token();
 

--- a/speculation-rules/prerender/workers-in-cross-origin-iframe.https.html
+++ b/speculation-rules/prerender/workers-in-cross-origin-iframe.https.html
@@ -12,7 +12,7 @@
 <!-- This is a regression test for https://crbug.com/1424250 -->
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const uid = token();

--- a/speculation-rules/prerender/workers.https.html
+++ b/speculation-rules/prerender/workers.https.html
@@ -10,7 +10,7 @@
 
 <body>
 <script>
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 promise_test(async t => {
   const {exec, activate} = await create_prerendered_page(t);

--- a/speculation-rules/resources/utils.js
+++ b/speculation-rules/resources/utils.js
@@ -1,10 +1,17 @@
-globalThis.assertSpeculationRulesIsSupported = () => {
+globalThis.assertSpeculationRulesIsSupported = (...types) => {
   assert_implements(
       'supports' in HTMLScriptElement,
       'HTMLScriptElement.supports must be supported');
   assert_implements(
       HTMLScriptElement.supports('speculationrules'),
       '<script type="speculationrules"> must be supported');
+  for (const type of types) {
+    if (type === 'prerender') {
+      assert_implements(
+          'prerendering' in document,
+          'Prerendering must be supported (document.prerendering)');
+    }
+  }
 };
 
 // If you want access to these, be sure to include

--- a/speculation-rules/speculation-tags/no-tags.https.html
+++ b/speculation-rules/speculation-tags/no-tags.https.html
@@ -30,6 +30,7 @@ promise_test(async t => {
 }, "Sec-Speculation-Tags: no tags (prefetch)");
 
 promise_test(async t => {
+  assertSpeculationRulesIsSupported('prerender');
   const rcHelper = new PrerenderingRemoteContextHelper();
   const referrerRC = await rcHelper.addWindow(undefined, { features: 'noopener' });
 

--- a/speculation-rules/speculation-tags/prerender-target-hint.https.html
+++ b/speculation-rules/speculation-tags/prerender-target-hint.https.html
@@ -11,7 +11,7 @@
 <script>
 "use strict";
 
-setup(() => assertSpeculationRulesIsSupported());
+setup(() => assertSpeculationRulesIsSupported('prerender'));
 
 // Test that tags are sent for prerendering with target_hint.
 promise_test(async t => {

--- a/speculation-rules/speculation-tags/resources/speculation-tags-utils.js
+++ b/speculation-rules/speculation-tags/resources/speculation-tags-utils.js
@@ -49,6 +49,7 @@
 
         const extraConfig = {};
         const preloadingType = getPreloadingType();
+        assertSpeculationRulesIsSupported(preloadingType);
         const preloadedRC = await referrerRC.helper.createContext({
             executorCreator(url) {
               return referrerRC.executeScript((preloadingType, tag, url, expectedTag) => {
@@ -91,6 +92,7 @@
 
         const extraConfig = {};
         const preloadingType = getPreloadingType();
+        assertSpeculationRulesIsSupported(preloadingType);
         const preloadedRC = await referrerRC.helper.createContext({
             executorCreator(url) {
               return referrerRC.executeScript((preloadingType, tag, url) => {


### PR DESCRIPTION
We're seeing timeouts on the STP bots, because spending over an hour timing out on speculation rules tests just eats into the timeout.

This should fix https://github.com/web-platform-tests/wpt/issues/59251.
