### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=312074

### DIFF
--- a/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html
+++ b/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSSOM - StyleSheetList does not include adopted style sheets in shadow roots even after style recalc</title>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#css-style-sheet-collections">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({mode: 'open'});
+
+        const style = document.createElement('style');
+        style.textContent = ':host { color: red }';
+        shadow.appendChild(style);
+
+        const sheet = new CSSStyleSheet();
+        shadow.adoptedStyleSheets = [sheet];
+
+        host.offsetTop;
+
+        var styleSheets = shadow.styleSheets;
+        assert_equals(styleSheets.length, 1);
+        assert_equals(styleSheets[0], style.sheet);
+      }, 'shadowRoot.styleSheets does not include adopted style sheets');
+    </script>
+  </body>
+</html>

--- a/css/cssom/StyleSheetList-constructable-shadow.html
+++ b/css/cssom/StyleSheetList-constructable-shadow.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSSOM - StyleSheetList does not include adopted style sheets in shadow roots</title>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#css-style-sheet-collections">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({mode: 'open'});
+
+        const style = document.createElement('style');
+        style.textContent = ':host { color: red }';
+        shadow.appendChild(style);
+
+        const sheet = new CSSStyleSheet();
+        shadow.adoptedStyleSheets = [sheet];
+
+        var styleSheets = shadow.styleSheets;
+        assert_equals(styleSheets.length, 1);
+        assert_equals(styleSheets[0], style.sheet);
+      }, 'shadowRoot.styleSheets does not include adopted style sheets');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [document.styleSheets and shadowRoot.styleSheets incorrectly include adopted style sheets](https://bugs.webkit.org/show_bug.cgi?id=312074)