### PR TITLE
script: Clear style data from detached subtrees when attaching a shadow DOM

### DIFF
--- a/shadow-dom/restyle-on-disconnected-child-after-attach-crash.html
+++ b/shadow-dom/restyle-on-disconnected-child-after-attach-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/40731">
+<div id="container">
+  <span id="outer"><slot id="slot"><span id="inner">before</span></slot></span>
+</div>
+<script>
+  container.scrollHeight;
+  container.hidden = true;
+  outer.attachShadow({mode: "open"});
+  document.createElement("canvas").toBlob(_ => inner.innerText = "hello");
+</script>


### PR DESCRIPTION
Instead of just clearing layout data, also clear style data from
descendants that are now no longer part of the flat tree when attaching
shadow DOM. This ensures that Stylo does not try to process them during
restyling. This matches what Gecko does.

Testing: This change adds a crash test and also causes a few subtests
to start passing.
Fixes: #<!-- nolink -->40731.

Reviewed in servo/servo#44259