### PR TITLE
Pass through force argument to Browser.stop()

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -972,7 +972,7 @@ class TestRunnerManager(threading.Thread):
             # TODO(web-platform-tests/wpt#48030): Consider removing the
             # `stop(force=...)` argument.
             if self.browser:
-                self.browser.stop(force)
+                self.browser.stop(force=force)
         except (OSError, PermissionError):
             self.logger.error("Failed to stop either the runner or the browser process",
                               exc_info=True)

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -972,7 +972,7 @@ class TestRunnerManager(threading.Thread):
             # TODO(web-platform-tests/wpt#48030): Consider removing the
             # `stop(force=...)` argument.
             if self.browser:
-                self.browser.stop(force=True)
+                self.browser.stop(force)
         except (OSError, PermissionError):
             self.logger.error("Failed to stop either the runner or the browser process",
                               exc_info=True)


### PR DESCRIPTION
If we unconditionally force stop then Firefox at least doesn't have the chance to do a clean shutdown, which breaks some testing (e.g. leak checks)