### PR TITLE
Remove requestIdleCallback from a dialog test

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
@@ -58,7 +58,7 @@ promise_test(async (t) => {
   // the `focusin` event.
   dialog.close();
   await new Promise(resolve => {
-    document.defaultView.requestIdleCallback(() => {
+    requestAnimationFrame(() => {
       dialog.close();
       resolve();
     });


### PR DESCRIPTION
As far as I can tell, it just wants to make sure we've had time to process the close before then calling it again: we don't need to wait for as long as requestIdleCallback would.

(Mostly a drive-by, having noticed this when looking at https://github.com/web-platform-tests/wpt/pull/58862.)