### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311536

### DIFF
--- a/css/css-flexbox/flex-order-last-baseline-multiple-ref.html
+++ b/css/css-flexbox/flex-order-last-baseline-multiple-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test Reference: flex last baseline with multiple order values</title>
+  <style>
+    .outer {
+        display: flex;
+        align-items: last baseline;
+        height: 100px;
+        border: 1px solid black;
+    }
+    .flex {
+        display: flex;
+        flex-wrap: wrap;
+        width: 60px;
+    }
+    .flex > div {
+        width: 60px;
+    }
+    .a { font-size: 10px; background: lightblue; }
+    .b { font-size: 20px; background: lightyellow; }
+    .c { font-size: 30px; background: lightgreen; }
+  </style>
+</head>
+<body>
+  <p>Test passes if "Ref" is aligned to the baseline of "C" (the large green text).</p>
+  <div class="outer">
+      <div class="flex">
+          <div class="a">A</div>
+          <div class="b">B</div>
+          <div class="c">C</div>
+      </div>
+      <div>Ref</div>
+  </div>
+</body>
+</html>

--- a/css/css-flexbox/flex-order-last-baseline-multiple.html
+++ b/css/css-flexbox/flex-order-last-baseline-multiple.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test: flex last baseline with multiple order values</title>
+  <link rel="author" title="WebKit" href="https://webkit.org">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#order-property">
+  <link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+  <link rel="match" href="flex-order-last-baseline-multiple-ref.html">
+  <meta name="assert" content="The last baseline of a flex container with multiple order values should come from the item with the highest order value.">
+  <style>
+    .outer {
+        display: flex;
+        align-items: last baseline;
+        height: 100px;
+        border: 1px solid black;
+    }
+    .flex {
+        display: flex;
+        flex-wrap: wrap;
+        width: 60px;
+    }
+    .flex > div {
+        width: 60px;
+        align-self: baseline;
+    }
+    .a { order: 1; font-size: 10px; background: lightblue; }
+    .b { order: 2; font-size: 20px; background: lightyellow; }
+    .c { order: 3; font-size: 30px; background: lightgreen; }
+  </style>
+</head>
+<body>
+  <p>Test passes if "Ref" is aligned to the baseline of "C" (the large green text).</p>
+  <div class="outer">
+      <div class="flex">
+          <div class="a">A</div>
+          <div class="b">B</div>
+          <div class="c">C</div>
+      </div>
+      <div>Ref</div>
+  </div>
+</body>
+</html>

--- a/css/css-flexbox/flex-order-last-baseline-ref.html
+++ b/css/css-flexbox/flex-order-last-baseline-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test Reference: flex last baseline with order property</title>
+  <style>
+    .outer {
+        display: flex;
+        align-items: last baseline;
+        height: 100px;
+        border: 1px solid black;
+    }
+    .flex {
+        display: flex;
+        flex-wrap: wrap;
+        width: 60px;
+    }
+    .flex > div {
+        width: 60px;
+    }
+    /* Reference: items in DOM order matching visual order, no order property needed. */
+    .a { font-size: 10px; background: lightblue; }
+    .b { font-size: 30px; background: lightgreen; }
+  </style>
+</head>
+<body>
+  <p>Test passes if "Ref" is aligned to the baseline of "B" (the large green text).</p>
+  <div class="outer">
+      <div class="flex">
+          <div class="a">A</div>
+          <div class="b">B</div>
+      </div>
+      <div>Ref</div>
+  </div>
+</body>
+</html>

--- a/css/css-flexbox/flex-order-last-baseline.html
+++ b/css/css-flexbox/flex-order-last-baseline.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test: flex last baseline with order property</title>
+  <link rel="author" title="WebKit" href="https://webkit.org">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#order-property">
+  <link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+  <link rel="match" href="flex-order-last-baseline-ref.html">
+  <meta name="assert" content="The last baseline of a flex container should come from the last item in order, not the first.">
+  <style>
+    .outer {
+        display: flex;
+        align-items: last baseline;
+        height: 100px;
+        border: 1px solid black;
+    }
+    .flex {
+        display: flex;
+        flex-wrap: wrap;
+        width: 60px;
+    }
+    .flex > div {
+        width: 60px;
+        align-self: baseline;
+    }
+    .a { order: 1; font-size: 10px; background: lightblue; }
+    .b { order: 2; font-size: 30px; background: lightgreen; }
+  </style>
+</head>
+<body>
+  <p>Test passes if "Ref" is aligned to the baseline of "B" (the large green text).</p>
+  <div class="outer">
+      <div class="flex">
+          <div class="a">A</div>
+          <div class="b">B</div>
+      </div>
+      <div>Ref</div>
+  </div>
+</body>
+</html>

--- a/css/css-flexbox/flex-order-wrap-reverse-baseline-ref.html
+++ b/css/css-flexbox/flex-order-wrap-reverse-baseline-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test Reference: flex first baseline with wrap-reverse and order property</title>
+  <style>
+    .outer {
+        display: flex;
+        align-items: baseline;
+        height: 150px;
+        border: 1px solid black;
+    }
+    .flex {
+        display: flex;
+        flex-wrap: wrap-reverse;
+        width: 60px;
+    }
+    .flex > div {
+        width: 60px;
+    }
+    .a { font-size: 10px; background: lightblue; }
+    .b { font-size: 30px; background: lightgreen; }
+  </style>
+</head>
+<body>
+  <p>Test passes if "Ref" is aligned to the baseline of "B" (the large green text).</p>
+  <div class="outer">
+      <div class="flex">
+          <div class="a">A</div>
+          <div class="b">B</div>
+      </div>
+      <div>Ref</div>
+  </div>
+</body>
+</html>

--- a/css/css-flexbox/flex-order-wrap-reverse-baseline.html
+++ b/css/css-flexbox/flex-order-wrap-reverse-baseline.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test: flex first baseline with wrap-reverse and order property</title>
+  <link rel="author" title="WebKit" href="https://webkit.org">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#order-property">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
+  <link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+  <link rel="match" href="flex-order-wrap-reverse-baseline-ref.html">
+  <meta name="assert" content="With wrap-reverse, the first baseline should come from the visually first line (logically last), iterating order values in reverse.">
+  <style>
+    .outer {
+        display: flex;
+        align-items: baseline;
+        height: 150px;
+        border: 1px solid black;
+    }
+    .flex {
+        display: flex;
+        flex-wrap: wrap-reverse;
+        width: 60px;
+    }
+    .flex > div {
+        width: 60px;
+        align-self: baseline;
+    }
+    .a { order: 1; font-size: 10px; background: lightblue; }
+    .b { order: 2; font-size: 30px; background: lightgreen; }
+  </style>
+</head>
+<body>
+  <p>Test passes if "Ref" is aligned to the baseline of "B" (the large green text).</p>
+  <div class="outer">
+      <div class="flex">
+          <div class="a">A</div>
+          <div class="b">B</div>
+      </div>
+      <div>Ref</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Flex items with different order values cause wrong baseline alignment](https://bugs.webkit.org/show_bug.cgi?id=311536)