### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=210474

### DIFF
--- a/css/css-flexbox/getcomputedstyle/first-line-computed-style.html
+++ b/css/css-flexbox/getcomputedstyle/first-line-computed-style.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta name="assert" content="::first-line style cannot be applied to a flexbox since it does not contribute a first formatted line. Checks via getComputedStyle">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-containers">
+<style>
+  div { display: flex; }
+  div::first-line { vertical-align: top; }
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div>Triceratops</div>
+
+<script>
+  test(function() {
+    let verticalAlign = getComputedStyle(document.querySelector('div'), '::first-line').verticalAlign;
+    assert_not_equals(verticalAlign, "top");
+  });
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[Interop 2021\]\[css-flexbox\] Incorrect computed style for first-letter pseudo-element](https://bugs.webkit.org/show_bug.cgi?id=210474)