### PR TITLE
[WebKit export] Bug 311942 - Add metadata to subgrid paint containment crash test

### DIFF
--- a/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
+++ b/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
@@ -18,4 +18,3 @@
   document.getElementById("change").style.contain = 'paint';
 </script>
 </html>
-


### PR DESCRIPTION
Exported from WebKit commit 2cc90f478c7e.

Adds `<link rel="help">` metadata to `css/css-grid/subgrid/subgrid-paint-containment-change-crash.html` referencing [WebKit Bug 311942](https://bugs.webkit.org/show_bug.cgi?id=311942).