### PR TITLE
script: Cancel animations for non-rendered nodes in script

### DIFF
--- a/css/css-animations/display-contents-animates.html
+++ b/css/css-animations/display-contents-animates.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:mrobinson@igalia.com">
+<link rel=help href="https://drafts.csswg.org/css-display-4/#display-animation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-animations/support/testcommon.js"></script>
+
+<div id="outer" style="visibility: hidden; display: contents">
+        <div id="inner">hello</div>
+</div>
+
+<style>
+@keyframes display1 {
+  /* Visibility, is discrete, animatable, and inherited. */
+  0% { visibility: visible; }
+  100% { visibility: hidden; }
+}
+.animate1 {
+  animation: display1 1s infinite;
+}
+</style>
+<script>
+promise_test(async (t) => {
+  t.add_cleanup(() => outer.classList.remove('animate1'));
+
+  let numAnimationstartFired = 0;
+  outer.addEventListener('animationstart', () => numAnimationstartFired++);
+
+  await waitForAnimationFrames(1);
+  outer.classList.add('animate1');
+  await waitForAnimationFrames(2);
+
+  assert_equals(getComputedStyle(inner).visibility, 'visible',
+    'The display should be inline during the animation.');
+  assert_equals(numAnimationstartFired, 1,
+    'Only one animation should start.');
+}, 'Animations inside of display:contents should work properly.');
+</script>


### PR DESCRIPTION
Instead of walking the entire fragment tree to find nodes for which
animations and image animations need to be cancelled, this change moves
that logic to `script`. Now, for each animating node the animation
managers will explicitly ask `layout` if the node is being rendered (or
delegating rendering in the case of CSS animations and transitions).

The main goal here is a performance improvement, elimating roughly 1% of
layout time from the profiler when running the
`flexbox-deeply-nested-column-flow.html` test case. This will almost
certainly be an even better improvement on more complex pages as we are
no longer doing things once per fragment tree entry, but once per
animating node.

There is also a subtle behavior improvement here. Before nodes with
`display: contents` had their animations canceled, but now they are not.
For instance, this test case now works properly:

```html
<!DOCTYPE html>
<style>
@keyframes anim {
  from { color: cyan }
  to { color: magenta }
}
div {
  display: contents;
  animation: anim 1s infinite alternate linear;
}
</style>
```

The new layout query will additionally be useful for other parts of
script that need to answer the same "being rendered" or "delegates
rendering to children" question.

Testing: This change adds a new test and gets one more subtest passing.

Reviewed in servo/servo#44299