### PR TITLE
layout: Produce an empty display list when the `Document` element is removed

### DIFF
--- a/html/rendering/non-replaced-elements/the-page/Document-documentElement-remove-clears-content.html
+++ b/html/rendering/non-replaced-elements/the-page/Document-documentElement-remove-clears-content.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait" style="background-color: red;">
+<head>
+    <meta charset="utf-8">
+    <title>Content clearing on documentElement removal</title>
+    <link rel="match" href="/css/reference/blank.html">
+    <script src="/common/reftest-wait.js"></script>
+</head>
+<body>
+    <p>This is a content which should not be displayed</p>
+    <script>
+        addEventListener("load", () => {
+            document.documentElement.remove();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Previously, when the `Document` element was removed, no further display list updates would be sent to paint. This change makes it so that when the `Document` element is removed a single new empty display list is sent.

Testing: This change adds a new WPT test .
Fixes: #<!-- nolink -->44101


Reviewed in servo/servo#44133