### PR TITLE
Speculation Rules: scope cookies

### DIFF
--- a/speculation-rules/prefetch/resources/cookies.py
+++ b/speculation-rules/prefetch/resources/cookies.py
@@ -15,9 +15,11 @@ def main(request, response):
   cookie_count = int(
       request.cookies[b"count"].value) if b"count" in request.cookies else 0
   response.set_cookie("count", f"{cookie_count+1}",
+                      path="/speculation-rules/",
                       secure=True, samesite="None")
   response.set_cookie(
-      "type", "prefetch" if sec_purpose.startswith("prefetch") else "navigate")
+      "type", "prefetch" if sec_purpose.startswith("prefetch") else "navigate",
+      path="/speculation-rules/")
 
   headers = [(b"Content-Type", b"text/html"), (b"Cache-Control", b"no-store")]
 


### PR DESCRIPTION
As far as I can tell the lack of scoping here is responsible for Safari failing an xhr/ test: https://wpt.fyi/results/xhr/anonymous-mode-unsupported.htm