### PR TITLE
Unflake new-scroll-event-dispatched-at-next-updating-rendering-time.html in Safari

### DIFF
--- a/html/webappapis/scripting/event-loops/new-scroll-event-dispatched-at-next-updating-rendering-time.html
+++ b/html/webappapis/scripting/event-loops/new-scroll-event-dispatched-at-next-updating-rendering-time.html
@@ -86,7 +86,7 @@ promise_test(async function() {
 
   // Now it's time to receive the MQL change event.
   await mqlChangeEvent;
-  assert_less_than(timeOnScrollEvent, timeOnMQLChange,
+  assert_less_than_equal(timeOnScrollEvent, timeOnMQLChange,
     "The MQL change event should have been dispatched after the first scroll event");
   assert_equals(timeOnScrollEventOnAnotherScroller, null,
     "The new scroll event should not yet have been dispatched");


### PR DESCRIPTION
The assertion related to the main bug measuring the timeOnTransitionRun relative to the timeOnScrollEvent is always passing in Safari.

The MQ listener happens occasionally too quickly and performance.now() ends up equal for both the scroll event and the MQ listener. This causes a flaky test failure in Safari. Make the test more flexible by allowing the timestamps to be equal.