### PR TITLE
WebVTT: update regions-lines test

### DIFF
--- a/webvtt/parsing/file-parsing/support/regions-lines.test
+++ b/webvtt/parsing/file-parsing/support/regions-lines.test
@@ -1,7 +1,7 @@
 regions, lines
 <link rel="help" href="https://w3c.github.io/webvtt/#collect-webvtt-region-settings">
 
-assert_equals(cues.length, 13);
+assert_equals(cues.length, 11);
 
 var regions = Array.from(cues).map(function(cue) {
     return cue.region;
@@ -13,9 +13,7 @@ var valid_lines = [
     100,
     101,
     65536,
-    4294967296,
-    18446744073709552000,
-    10000000000000000000000000000000000,
+    4294967295,
     2,
 ];
 valid_lines.forEach(function(valid, index) {
@@ -55,37 +53,29 @@ lines:65536
 
 REGION
 id:6
-lines:4294967296
+lines:4294967295
 
 REGION
 id:7
-lines:18446744073709552000
-
-REGION
-id:8
-lines:10000000000000000000000000000000000
-
-REGION
-id:9
 lines:1 lines:3
 lines:2
 
 NOTE invalid
 
 REGION
-id:10
+id:8
 lines:-0
 
 REGION
-id:11
+id:9
 lines:1.5
 
 REGION
-id:12
+id:10
 lines:-1
 
 REGION
-id:13
+id:11
 lines: 1
 lines :1
 
@@ -120,10 +110,4 @@ text
 text
 
 00:00:00.000 --> 00:00:01.000 region:11
-text
-
-00:00:00.000 --> 00:00:01.000 region:12
-text
-
-00:00:00.000 --> 00:00:01.000 region:13
 text

--- a/webvtt/parsing/file-parsing/tests/comment-in-cue-text.html
+++ b/webvtt/parsing/file-parsing/tests/comment-in-cue-text.html
@@ -3,7 +3,7 @@
 <!-- See /webvtt/parsing/file-parsing/README.md -->
 <meta charset=utf-8>
 <title>WebVTT parser test: comment-in-cue-text</title>
-<link rel="help" href="https://www.w3.org/TR/webvtt1/#webvtt-comment-block">
+<link rel="help" href="https://www.w3.org/TR/webvtt1/#introduction-comments">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/webvtt/parsing/file-parsing/tests/regions-lines.html
+++ b/webvtt/parsing/file-parsing/tests/regions-lines.html
@@ -27,7 +27,7 @@ function trackLoaded(event) {
     var video = track.parentNode;
     var cues = video.textTracks[0].cues;
     {
-assert_equals(cues.length, 13);
+assert_equals(cues.length, 11);
 
 var regions = Array.from(cues).map(function(cue) {
     return cue.region;
@@ -39,9 +39,7 @@ var valid_lines = [
     100,
     101,
     65536,
-    4294967296,
-    18446744073709552000,
-    10000000000000000000000000000000000,
+    4294967295,
     2,
 ];
 valid_lines.forEach(function(valid, index) {

--- a/webvtt/parsing/file-parsing/tests/support/regions-lines.vtt
+++ b/webvtt/parsing/file-parsing/tests/support/regions-lines.vtt
@@ -24,37 +24,29 @@ lines:65536
 
 REGION
 id:6
-lines:4294967296
+lines:4294967295
 
 REGION
 id:7
-lines:18446744073709552000
-
-REGION
-id:8
-lines:10000000000000000000000000000000000
-
-REGION
-id:9
 lines:1 lines:3
 lines:2
 
 NOTE invalid
 
 REGION
-id:10
+id:8
 lines:-0
 
 REGION
-id:11
+id:9
 lines:1.5
 
 REGION
-id:12
+id:10
 lines:-1
 
 REGION
-id:13
+id:11
 lines: 1
 lines :1
 
@@ -89,10 +81,4 @@ text
 text
 
 00:00:00.000 --> 00:00:01.000 region:11
-text
-
-00:00:00.000 --> 00:00:01.000 region:12
-text
-
-00:00:00.000 --> 00:00:01.000 region:13
 text

--- a/webvtt/parsing/file-parsing/tools/build.py
+++ b/webvtt/parsing/file-parsing/tools/build.py
@@ -108,8 +108,14 @@ def main():
 
     tests_pattern = path.join(file_parsing_path, TEST_FILE_PATTERN)
 
-    # Clean test directory
-    shutil.rmtree(test_output_path)
+    # Clean generated files
+    for file in glob.glob(tests_pattern):
+        test_basefilename = path.splitext(path.basename(file))[0]
+        html_file = path.join(test_output_path, test_basefilename + '.html')
+        vtt_file = path.join(test_output_path, 'support', test_basefilename + '.vtt')
+        for f in [html_file, vtt_file]:
+            if path.exists(f):
+                os.remove(f)
 
     # Generate tests
     for file in glob.glob(tests_pattern):


### PR DESCRIPTION
VTTRegion uses unsigned long for its lines member, not double. Adjust the test accordingly.

Also make sure running build.py doesn't delete the entire tests/ directory.