### PR TITLE
Add test262 support for Ladybird

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/ladybird.py
+++ b/tools/wptrunner/wptrunner/browsers/ladybird.py
@@ -22,7 +22,8 @@ __wptrunner__ = {
         "testharness": "WebDriverTestharnessExecutor",
         "reftest": "WebDriverRefTestExecutor",
         "wdspec": "WdspecExecutor",
-        "crashtest": "WebDriverCrashtestExecutor"
+        "crashtest": "WebDriverCrashtestExecutor",
+        "test262": "WebDriverTestharnessExecutor"
     }
 }
 


### PR DESCRIPTION
Adds support for the new `test262` test type to the Ladybird test runner.