### PR TITLE
tools: Add test262 to test_types in testfiles.py

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -238,7 +238,7 @@ def affected_testfiles(files_changed: Iterable[Text],
     nontests_changed = set(files_changed)
     wpt_manifest = load_manifest(manifest_path, manifest_update)
 
-    test_types = ["crashtest", "print-reftest", "reftest", "testharness", "wdspec"]
+    test_types = ["crashtest", "print-reftest", "reftest", "testharness", "wdspec", "test262"]
     support_files = {os.path.join(wpt_root, path)
                      for _, path, _ in wpt_manifest.itertypes("support")}
     wdspec_test_files = {os.path.join(wpt_root, path)

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -238,7 +238,7 @@ def affected_testfiles(files_changed: Iterable[Text],
     nontests_changed = set(files_changed)
     wpt_manifest = load_manifest(manifest_path, manifest_update)
 
-    test_types = ["crashtest", "print-reftest", "reftest", "testharness", "wdspec", "test262"]
+    test_types = ["crashtest", "print-reftest", "reftest", "test262", "testharness", "wdspec"]
     support_files = {os.path.join(wpt_root, path)
                      for _, path, _ in wpt_manifest.itertypes("support")}
     wdspec_test_files = {os.path.join(wpt_root, path)


### PR DESCRIPTION
This adds "test262" to the list of test types in tools/wpt/testfiles.py. This ensures that test262 tests are considered when determining affected tests based on file changes in Pull Requests. This fixes the issue of missing Test262 results on wpt.fyi for optimized runs.

Fixes #59357