### PR TITLE
tools: Add test262 to test_types in test_wptrunner unit tests

### DIFF
--- a/tools/wptrunner/wptrunner/tests/test_wptrunner.py
+++ b/tools/wptrunner/wptrunner/tests/test_wptrunner.py
@@ -143,7 +143,7 @@ def get_loader_with_fakes(
         subsuites=None,
         tags=None,
         test_groups_file=None,
-        test_types={"crashtest", "print-reftest", "reftest", "testharness", "wdspec"},
+        test_types={"crashtest", "print-reftest", "reftest", "test262", "testharness", "wdspec"},
         this_chunk=1,
         total_chunks=1,
     )


### PR DESCRIPTION
This adds "test262" to the list of allowed test types in the get_loader_with_fakes helper in tools/wptrunner/wptrunner/tests/test_wptrunner.py. This keeps the hardcoded list of test types updated and consistent with the types supported by wptrunner, although they are not actively asserted against in these unit tests.

This change doesn't fix #59357 but I figured I would do it.