### PR TITLE
Test Authorization header behaviour for CORs preflight cache

### DIFF
--- a/fetch/api/cors/cors-preflight-cache.any.js
+++ b/fetch/api/cors/cors-preflight-cache.any.js
@@ -43,4 +43,46 @@ promise_test((test) => {
       assert_equals(resp.headers.get("x-did-preflight"), "0", "Preflight request has not been made");
       return fetch(cors_url + "?token=" + uuid_token + "&clear-stash");
     });
-});
+}, "CORS preflight cache reuses explicit header entries");
+
+// Ref:
+//  - https://github.com/whatwg/fetch/issues/1919
+//  - https://github.com/whatwg/fetch/issues/1278
+promise_test((test) => {
+  var uuid_token = token();
+  var request_url =
+      cors_url + "?token=" + uuid_token + "&max_age=12000&allow_methods=POST" +
+      "&allow_headers=*";
+  return fetch(cors_url + "?token=" + uuid_token + "&clear-stash")
+    .then(() => {
+      return fetch(
+        new Request(request_url,
+                    {
+                      mode: "cors",
+                      method: "POST",
+                      headers: [["x-test-header", "test1"]]
+                    }));
+    })
+    .then((resp) => {
+      assert_equals(resp.status, 200, "Response's status is 200");
+      assert_equals(resp.headers.get("x-did-preflight"), "1", "Preflight request has been made");
+      return fetch(cors_url + "?token=" + uuid_token + "&clear-stash");
+    })
+    .then((res) => res.text())
+    .then((txt) => {
+      assert_equals(txt, "1", "Server stash must be cleared.");
+      return promise_rejects_js(test, TypeError,
+        fetch(
+          new Request(request_url,
+                      {
+                        mode: "cors",
+                        method: "POST",
+                        headers: [["authorization", "test2"]]
+                      })));
+    })
+    .then(() => fetch(cors_url + "?token=" + uuid_token + "&clear-stash"))
+    .then((res) => res.text())
+    .then((txt) => {
+      assert_equals(txt, "1", "Authorization request made a new preflight");
+    });
+}, "CORS preflight cache does not reuse wildcard header entries for Authorization");


### PR DESCRIPTION
Specifically the requirement specified under:

https://fetch.spec.whatwg.org/#concept-cache-match-header

Unfortunately no browser currently implements this behaviour, but this adds a test matching the specification.

Ref:
- https://github.com/whatwg/fetch/issues/1919
- https://github.com/whatwg/fetch/issues/1278