### PR TITLE
script: Achieve failure parity with other browsers for underline command

### DIFF
--- a/editing/data/underline.js
+++ b/editing/data/underline.js
@@ -657,7 +657,7 @@ var browserTests = [
     {"stylewithcss":[false,true,"",false,false,""],"underline":[false,true,"",false,false,""]}],
 ["foo<u>ba[r</u>]baz",
     [["stylewithcss","true"],["underline",""]],
-    "foo<span style=\"text-decoration:underline\">ba</span>[r]baz",
+    "foo<u>ba</u>rbaz",
     [true,true],
     {"stylewithcss":[false,false,"",false,true,""],"underline":[false,true,"",false,false,""]}],
 ["foo<u>ba[r</u>]baz",


### PR DESCRIPTION
With these changes, we now fail the minimum set of tests. That is to say: we don't fail any test that no other browser fails. All test failures therefore match at least 1 other browser.

The one exception is the updated test expectation. That's because all browsers fail this test in the exact same way, hence updating the expectation. We fail it, since I don't know how browsers reach to that point. I think it's related to traversal of the contained children and the order that they are traversed in. Unfortunately my attempts at fixing that have not been fruitful, so leaving that one for now.

Part of #<!-- nolink -->25005

Testing: WPT
Reviewed in servo/servo#44390