### PR TITLE
Call verifySelectedSnapTarget for single axis

### DIFF
--- a/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/resources/common.js
+++ b/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/resources/common.js
@@ -101,10 +101,10 @@ async function runScrollSnapSelectionVerificationTest(t, scroller,
     aligned_elements_y);
   t.step(() => {
     if (axis == "y" || axis == "both") {
-      verifySelectedSnapTarget(t, scroller, expected_target_y, axis);
+      verifySelectedSnapTarget(t, scroller, expected_target_y, "y");
     }
     if (axis == "x" || axis == "both") {
-      verifySelectedSnapTarget(t, scroller, expected_target_x, axis);
+      verifySelectedSnapTarget(t, scroller, expected_target_x, "x");
     }
   });
   // Restore initial scroll offsets.


### PR DESCRIPTION
`verifySelectedSnapTarget` only handles passing a single axis as the axis parameter to it gracefully.
`runScrollSnapSelectionVerificationTest` might call it with `axis=="both"` which could yield wrong results.

This changes calls `verifySelectedSnapTarget` twice (once for x, once for y) in case `axis=="both"`.