### PR TITLE
Increase Azure parallel tasks to 15 for Edge

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -262,7 +262,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_stable'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_stable']))
   strategy:
-    parallel: 10 # chosen to make runtime ~2h
+    parallel: 15 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'windows-latest'
@@ -298,7 +298,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_dev'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_dev']))
   strategy:
-    parallel: 10 # chosen to make runtime ~2h
+    parallel: 15 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'windows-latest'
@@ -335,7 +335,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_canary'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_canary']))
   strategy:
-    parallel: 10 # chosen to make runtime ~2h
+    parallel: 15 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'windows-latest'


### PR DESCRIPTION
These jobs have been timing out since we added test262 support. Try running more jobs in line with the approach for taskcluster