### PR TITLE
layout: Use a consistent definition of "document white space"

### DIFF
--- a/css/css-flexbox/anonymous-flex-item-document-white-space-crash.html
+++ b/css/css-flexbox/anonymous-flex-item-document-white-space-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="assert" href="Flex containers that only contain document white space should not cause a crash">
+<link rel="help" href="https://github.com/servo/servo/issues/43550">
+
+<div style="display: flex">&#10;&#13;</div>
+<div style="display: flex">&#13;</div>
+<div style="display: flex">&#12;</div>


### PR DESCRIPTION
Because the definition of "document white space" differed in various
places in Servo layout, it was possible for the flexbox container
builder to expect to be able to build an inline formatting context from
text that was ultimately determined to be empty by the inline formatting
context builder. This led to a `BoxSlot` not being properly filled (a
thing that should never happen) and an assertion failing.

This change fixes that issue.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->43550.

Reviewed in servo/servo#44424