### PR TITLE
script: Rewrite NodeList::ChildrenList with a cached Vec of nodes

### DIFF
--- a/dom/nodes/crashtests/childNodes-last_visited-unwrap-crash.html
+++ b/dom/nodes/crashtests/childNodes-last_visited-unwrap-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/36764">
+<script>
+  let div1 = document.createElement("div");
+  let div2 = document.createElement("div");
+  div1.appendChild(div2);
+  div1.childNodes;
+  div1.insertBefore(div2, div2);
+  div2.after("");
+  div2.remove();
+</script>


### PR DESCRIPTION
In DOM APIs, `Node.childNodes` is a `NodeList` that has an `.item(index)` method that allows random access, but DOM nodes only store pointers to their first/last child and next/previous sibling. The previous implementation involved keeping a "last accessed" pointer, and a significant amount of logic to find the requested index by walking next/previous sibling pointers from whichever of last accessed, first child, or last child is nearest. This logic sometimes incorrectly assumed the (nullable) last accessed pointer to be present, causing a panic in `Option::unwrap`.
    
Rather than try to fix that logic, this replaces entirely with the approach suggested in #<!-- nolink -->25206 and used [by Firefox](https://searchfox.org/firefox-main/source/dom/base/nsChildContentList.h): keep a cached `Vec` of pointers to all child nodes, created lazily when needed, and invalidated whenever any part of it changes.
    
Testing: the first commit adds a failing WPT crashtest, the second commit fixes it
Fixes: https://github.com/servo/servo/issues/25206
Fixes: https://github.com/servo/servo/issues/36764
Reviewed in servo/servo#44435