### PR TITLE
layout: Make border colour black instead of gray

### DIFF
--- a/html/rendering/non-replaced-elements/tables/td-default-border-color-ref.html
+++ b/html/rendering/non-replaced-elements/tables/td-default-border-color-ref.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>td default border color - ref</title>
+<meta name="assert" content="td border-color should default to black">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
 <style>
   body { background: #fff; color: black; }
   td {

--- a/html/rendering/non-replaced-elements/tables/td-default-border-color-ref.html
+++ b/html/rendering/non-replaced-elements/tables/td-default-border-color-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>td default border color - ref</title>
+<style>
+  body { background: #fff; color: black; }
+  td {
+    width: 100px;
+    border-style: solid;
+    border-width: 12px;
+    border-color: black;
+  }
+</style>
+<table>
+  <tr>
+    <td>Some data</td>
+  </tr>
+</table>

--- a/html/rendering/non-replaced-elements/tables/td-default-border-color.html
+++ b/html/rendering/non-replaced-elements/tables/td-default-border-color.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>td default border color</title>
+<style>
+  body { background: #fff; color: black; }
+  td {
+    width: 100px;
+    border-style: solid;
+    border-width: 12px;
+  }
+</style>
+<table>
+  <tr>
+    <td>Some data</td>
+  </tr>
+</table>

--- a/html/rendering/non-replaced-elements/tables/td-default-border-color.html
+++ b/html/rendering/non-replaced-elements/tables/td-default-border-color.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>td default border color</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="match" href="td-default-border-color-ref.html">
+<meta name="assert" content="td border-color should default to black">
 <style>
   body { background: #fff; color: black; }
   td {


### PR DESCRIPTION
Made border colour black instead of gray

Testing: `./mach test-wpt tests/wpt/tests/html/rendering/non-replaced-elements/tables` passed successfully
Fixes: #<!-- nolink -->44391
Reviewed in servo/servo#44444