### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308225

### DIFF
--- a/css/css-overflow/parsing/overflow-clip-margin.html
+++ b/css/css-overflow/parsing/overflow-clip-margin.html
@@ -27,6 +27,17 @@ test_valid_value("overflow-clip-margin", 'border-box 0px', 'border-box');
 test_valid_value("overflow-clip-margin", 'border-box 10px', 'border-box 10px');
 test_valid_value("overflow-clip-margin", '10px border-box', 'border-box 10px');
 
+test_valid_value("overflow-clip-margin", "calc(100px - 50px)", "calc(50px)");
+test_valid_value("overflow-clip-margin", "calc(100px - 100px)", "calc(0px)");
+test_valid_value("overflow-clip-margin", "calc(0.5em - 100px)");
+test_invalid_value("overflow-clip-margin", "calc(100% - 0.5em)");
+test_invalid_value("overflow-clip-margin", "calc(100% - 50px)");
+
+test_valid_value("overflow-clip-margin", 'padding-box calc(0.5em - 100px)', 'calc(0.5em - 100px)');
+test_valid_value("overflow-clip-margin", 'padding-box calc(100px - 100px)', 'calc(0px)');
+test_valid_value("overflow-clip-margin", 'border-box calc(0.5em - 100px)', 'border-box calc(0.5em - 100px)');
+test_invalid_value("overflow-clip-margin", 'border-box calc(0.5em - 100%)');
+
 test_invalid_value("overflow-clip-margin", 'margin-box');
 test_invalid_value("overflow-clip-margin", 'inset(10px)');
 test_invalid_value("overflow-clip-margin", '50px 50px');

--- a/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin.html
@@ -13,14 +13,20 @@
 <script>
 'use strict';
 
+runPropertyTests('overflow-clip-margin', [
+  { syntax: 'border-box' },
+  { syntax: 'content-box' },
+  { syntax: 'padding-box' },
+  // FIXME: Add support for testing non-negative lengths
+  {
+    syntax: '<length>',
+    specified: assert_is_equal_with_range_handling,
+  }, 
+]);
+
 runUnsupportedPropertyTests('overflow-clip-margin', [
-  'border-box',
-  'content-box',
-  'padding-box',
-  'padding-box 10px',
+  'border-box 10px',
   '10px content-box',
-  '0px',
-  '10px',
 ]);
 
 </script>

--- a/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin.html
@@ -21,7 +21,7 @@ runPropertyTests('overflow-clip-margin', [
   {
     syntax: '<length>',
     specified: assert_is_equal_with_range_handling,
-  }, 
+  },
 ]);
 
 runUnsupportedPropertyTests('overflow-clip-margin', [


### PR DESCRIPTION
WebKit export from bug: [Implement overflow-clip-margin parsing](https://bugs.webkit.org/show_bug.cgi?id=308225)