### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308522

### DIFF
--- a/css/css-overflow/parsing/overflow-clip-margin-computed.html
+++ b/css/css-overflow/parsing/overflow-clip-margin-computed.html
@@ -28,6 +28,14 @@ test_computed_value("overflow-clip-margin", "border-box");
 test_computed_value("overflow-clip-margin", "border-box 0px", "border-box");
 test_computed_value("overflow-clip-margin", "border-box 10px");
 test_computed_value("overflow-clip-margin", "10px border-box", "border-box 10px");
+
+test_computed_value("overflow-clip-margin", "calc(100px - 50px)", "50px");
+test_computed_value("overflow-clip-margin", "calc(100px - 100px)", "0px");
+test_computed_value("overflow-clip-margin", "calc(0.5em + 100px)", "108px");
+
+test_computed_value("overflow-clip-margin", "padding-box calc(0.5em + 100px)", "108px");
+test_computed_value("overflow-clip-margin", "padding-box calc(100px - 100px)", "0px");
+test_computed_value("overflow-clip-margin", "border-box calc(0.5em + 100px)", "border-box 108px");
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [Implement overflow-clip-margin computed style](https://bugs.webkit.org/show_bug.cgi?id=308522)