### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=289876

### DIFF
--- a/css/css-sizing/intrinsic-height-abspos-percentage-child-002.html
+++ b/css/css-sizing/intrinsic-height-abspos-percentage-child-002.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Abspos with intrinsic block size and height:100% child</title>
+<link rel="author" title="WebKit" href="https://webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="
+  An absolutely positioned element with height:max-content should not collapse
+  when a child has height:100%. The percentage is cyclic and should behave as auto.
+">
+
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: red;
+}
+.abspos {
+    position: absolute;
+    height: max-content;
+    width: 100px;
+    background: green;
+}
+.child {
+    height: 100%;
+}
+.content {
+    height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+    <div class="abspos">
+        <div class="child">
+            <div class="content"></div>
+        </div>
+    </div>
+</div>

--- a/css/css-sizing/intrinsic-height-abspos-percentage-child-003.html
+++ b/css/css-sizing/intrinsic-height-abspos-percentage-child-003.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Abspos with min-content height and percentage min-height child</title>
+<link rel="author" title="WebKit" href="https://webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="
+  An absolutely positioned element with height:min-content should not collapse
+  when a child has min-height:100%.
+">
+
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: red;
+}
+.abspos {
+    position: absolute;
+    height: min-content;
+    width: 100px;
+    background: green;
+}
+.child {
+    min-height: 100%;
+    height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+    <div class="abspos">
+        <div class="child"></div>
+    </div>
+</div>

--- a/css/css-sizing/intrinsic-height-abspos-percentage-child-004.html
+++ b/css/css-sizing/intrinsic-height-abspos-percentage-child-004.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Abspos with fit-content height and nested percentage children</title>
+<link rel="author" title="WebKit" href="https://webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="
+  An absolutely positioned element with height:fit-content should not collapse
+  when nested children use percentage heights. Cyclic percentages should
+  behave as auto.
+">
+
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: red;
+}
+.abspos {
+    position: absolute;
+    height: fit-content;
+    width: 100px;
+    background: green;
+}
+.middle {
+    height: 100%;
+}
+.inner {
+    max-height: 100%;
+    height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+    <div class="abspos">
+        <div class="middle">
+            <div class="inner"></div>
+        </div>
+    </div>
+</div>

--- a/css/css-sizing/intrinsic-height-abspos-percentage-child-ref.html
+++ b/css/css-sizing/intrinsic-height-abspos-percentage-child-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: three green 100px squares in a row</title>
+<style>
+.container {
+    position: relative;
+    width: 400px;
+    height: 100px;
+}
+.square {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: green;
+    top: 0;
+}
+</style>
+<p>Test passes if there are three filled green squares and <strong>no red</strong>.</p>
+
+<div class="container">
+    <div class="square" style="left: 0"></div>
+    <div class="square" style="left: 110px"></div>
+    <div class="square" style="left: 220px"></div>
+</div>

--- a/css/css-sizing/intrinsic-height-abspos-percentage-child.html
+++ b/css/css-sizing/intrinsic-height-abspos-percentage-child.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Abspos with intrinsic block size and percentage child height</title>
+<link rel="author" title="WebKit" href="https://webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="match" href="intrinsic-height-abspos-percentage-child-ref.html">
+<meta name="assert" content="
+  An absolutely positioned element with an intrinsic sizing keyword for height
+  (max-content, min-content, fit-content) should not collapse to zero when a
+  child uses max-height: 100%. The intrinsic height creates a circular dependency
+  with the percentage, so the percentage should behave as none.
+">
+
+<style>
+.container {
+    position: relative;
+    width: 400px;
+    height: 100px;
+}
+.abspos {
+    position: absolute;
+    background: green;
+    width: 100px;
+    top: 0;
+}
+.child {
+    max-height: 100%;
+    height: 100px;
+}
+.ref {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: red;
+    top: 0;
+}
+</style>
+<p>Test passes if there are three filled green squares and <strong>no red</strong>.</p>
+
+<div class="container">
+    <div class="ref" style="left: 0"></div>
+    <div class="abspos" style="height: max-content; left: 0">
+        <div class="child"></div>
+    </div>
+
+    <div class="ref" style="left: 110px"></div>
+    <div class="abspos" style="height: min-content; left: 110px">
+        <div class="child"></div>
+    </div>
+
+    <div class="ref" style="left: 220px"></div>
+    <div class="abspos" style="height: fit-content; left: 220px">
+        <div class="child"></div>
+    </div>
+</div>

--- a/css/css-sizing/intrinsic-height-abspos-stretch-percentage-child-ref.html
+++ b/css/css-sizing/intrinsic-height-abspos-stretch-percentage-child-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: tall green rectangle</title>
+<style>
+body { margin: 0; }
+</style>
+<p>Test passes if there is a tall green rectangle covering the left side of the viewport.</p>
+<div style="position: fixed; top: 0; left: 0; width: 200px; height: 100vh; background: green;"></div>

--- a/css/css-sizing/intrinsic-height-abspos-stretch-percentage-child.html
+++ b/css/css-sizing/intrinsic-height-abspos-stretch-percentage-child.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-auto-size">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-stretch">
+<link rel="match" href="intrinsic-height-abspos-stretch-percentage-child-ref.html">
+<meta name="assert" content="An out-of-flow positioned element with height: -webkit-fill-available should provide a definite height for percentage resolution of children, since -webkit-fill-available resolves to a definite value from the containing block.">
+<style>
+/*
+  Reproduces the Seesaw app blank screen bug.
+
+  The layout chain:
+    .modal    - position:fixed, height:-webkit-fill-available (resolves to viewport height)
+    .dialog   - height:100% (needs parent to have definite height)
+    .wrapper  - position:relative, height:100%
+    .content  - position:absolute, top:0, bottom:0 (fills wrapper)
+    .inner    - height:100%, the actual visible content
+
+  BUG: If -webkit-fill-available is treated as intrinsic (indefinite) for
+  percentage resolution, .dialog's height:100% cannot resolve. It collapses
+  to 0, .content gets 0px from its insets, and nothing is visible.
+
+  EXPECTED: -webkit-fill-available resolves to the viewport/containing block
+  size (a definite value), so height:100% should resolve through the chain
+  and the green box should be visible.
+*/
+body { margin: 0; }
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: -webkit-fill-available;
+    height: stretch;
+}
+
+.dialog {
+    height: 100%;
+    width: 200px;
+}
+
+.wrapper {
+    position: relative;
+    height: 100%;
+    width: 200px;
+}
+
+.content {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 200px;
+}
+
+.inner {
+    height: 100%;
+    width: 200px;
+    background: green;
+}
+</style>
+
+<p>Test passes if there is a tall green rectangle covering the left side of the viewport.</p>
+<div class="modal">
+    <div class="dialog">
+        <div class="wrapper">
+            <div class="content">
+                <div class="inner"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/css/css-sizing/intrinsic-height-fixedpos-percentage-child.html
+++ b/css/css-sizing/intrinsic-height-fixedpos-percentage-child.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fixed position with intrinsic block size and percentage child</title>
+<link rel="author" title="WebKit" href="https://webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="
+  A fixed position element with height:max-content should not collapse
+  when a child has max-height:100%.
+">
+
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: red;
+}
+.fixed {
+    position: fixed;
+    height: max-content;
+    width: 100px;
+    background: green;
+}
+.child {
+    max-height: 100%;
+    height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+    <div class="fixed">
+        <div class="child"></div>
+    </div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [`position: absolute` with inner `max-height: 100%` makes `height: max-content` resolve to 0](https://bugs.webkit.org/show_bug.cgi?id=289876)