### PR TITLE
Streams: Add ReadableStream.from() coverage for function iterators

### DIFF
--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -81,6 +81,19 @@ const iterableFactories = [
     return iterable;
   }],
 
+  ['a sync iterable with a function iterator', () => {
+    const chunks = ['a', 'b'];
+    function functionIterator() {}
+    functionIterator.next = () => ({
+      done: chunks.length === 0,
+      value: chunks.shift()
+    });
+    const iterable = {
+      [Symbol.iterator]: () => functionIterator
+    };
+    return iterable;
+  }],
+
   ['an async iterable', () => {
     const chunks = ['a', 'b'];
     const asyncIterator = {
@@ -93,6 +106,19 @@ const iterableFactories = [
     };
     const asyncIterable = {
       [Symbol.asyncIterator]: () => asyncIterator
+    };
+    return asyncIterable;
+  }],
+
+  ['an async iterable with a function iterator', () => {
+    const chunks = ['a', 'b'];
+    function functionAsyncIterator() {}
+    functionAsyncIterator.next = () => Promise.resolve({
+      done: chunks.length === 0,
+      value: chunks.shift()
+    });
+    const asyncIterable = {
+      [Symbol.asyncIterator]: () => functionAsyncIterator
     };
     return asyncIterable;
   }],


### PR DESCRIPTION
This adds coverage for `ReadableStream.from()` with callable iterator objects returned by `@@iterator` / `@@asyncIterator`.

The existing tests cover ordinary iterator objects and invalid non-object returns, but not callable iterator objects.