### PR TITLE
AttachShadow should use document's registry instead of tree scope's registry by default

### DIFF
--- a/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -25,6 +25,25 @@ test(() => {
 
 test(() => {
     const registry = new CustomElementRegistry;
+    const host = document.createElement('div', {customElementRegistry: registry});
+    assert_equals(host.customElementRegistry, registry);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    assert_equals(shadowRoot.customElementRegistry, window.customElements);
+}, 'A newly attached ShadowRoot should use the global registry by default even if the host uses a custom registry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    const outerHost = document.body.appendChild(document.createElement('div'));
+    const outerShadow = outerHost.attachShadow({mode: 'closed', customElementRegistry: registry});
+    outerShadow.innerHTML = '<div></div>';
+    assert_equals(outerShadow.querySelector('div').customElementRegistry, registry);
+    const host = outerShadow.querySelector('div');
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    assert_equals(shadowRoot.customElementRegistry, window.customElements);
+}, 'A newly attached ShadowRoot should use the global registry by default even if the host is within another shadow tree that uses a custom registry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
     const shadowRoot = document.createElement('div').attachShadow({mode: 'closed', customElementRegistry: registry});
     assert_equals(shadowRoot.customElementRegistry, registry);
 }, 'A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow');

--- a/custom-elements/registries/ShadowRoot-init-declarative.html
+++ b/custom-elements/registries/ShadowRoot-init-declarative.html
@@ -15,8 +15,8 @@ test(() => {
   customElement.attachShadow({
     mode: "open"
   });
-  assert_equals(customElement.shadowRoot.customElementRegistry, null);
-}, "Custom element inside 'shadowrootcustomelementregistry' declarative shadow root");
+  assert_equals(customElement.shadowRoot.customElementRegistry, window.customElements);
+}, "Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry");
 
 test(() => {
   const divElement = host.shadowRoot.lastElementChild;
@@ -24,6 +24,6 @@ test(() => {
   divElement.attachShadow({
     mode: "open"
   });
-  assert_equals(divElement.shadowRoot.customElementRegistry, null);
-}, "Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root");
+  assert_equals(divElement.shadowRoot.customElementRegistry, window.customElements);
+}, "Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry");
 </script>

--- a/custom-elements/registries/ShadowRoot-init-declarative.html
+++ b/custom-elements/registries/ShadowRoot-init-declarative.html
@@ -15,6 +15,7 @@ test(() => {
   customElement.attachShadow({
     mode: "open"
   });
+  assert_equals(customElement.customElementRegistry, null);
   assert_equals(customElement.shadowRoot.customElementRegistry, window.customElements);
 }, "Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry");
 
@@ -24,6 +25,7 @@ test(() => {
   divElement.attachShadow({
     mode: "open"
   });
+  assert_equals(divElement.customElementRegistry, null);
   assert_equals(divElement.shadowRoot.customElementRegistry, window.customElements);
 }, "Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry");
 </script>


### PR DESCRIPTION
According to spec, AttachShadow should use the document's
registry instead of tree scope's registry by default.