### PR TITLE
Add customelementregistry global attribute test coverage

### DIFF
--- a/custom-elements/registries/scoped-custom-element-registry-initial-document-parse.html
+++ b/custom-elements/registries/scoped-custom-element-registry-initial-document-parse.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+<meta name="author" title="Jayson Chen" href="mailto:jaysonchen@microsoft.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#scoped-custom-element-registries">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<!-- Elements with customelementregistry attribute parsed during initial document load -->
+<div id="builtin-with-attr" customelementregistry></div>
+<custom-elem id="candidate-with-attr" customelementregistry></custom-elem>
+<div id="parent-with-attr" customelementregistry>
+  <div id="child-of-attr"></div>
+  <custom-elem id="candidate-child-of-attr"></custom-elem>
+  <div id="nested-parent">
+    <custom-elem id="deep-nested-candidate"></custom-elem>
+  </div>
+</div>
+
+<!-- Elements without customelementregistry attribute for comparison -->
+<div id="builtin-without-attr"></div>
+<custom-elem id="candidate-without-attr"></custom-elem>
+
+<!-- Elements for upgrade testing -->
+<upgrade-elem id="upgrade-with-attr" customelementregistry></upgrade-elem>
+<upgrade-elem id="upgrade-without-attr"></upgrade-elem>
+
+<script>
+// Tests for customelementregistry attribute on elements during initial document parse.
+
+test(() => {
+  const element = document.getElementById('builtin-with-attr');
+  assert_equals(element.customElementRegistry, null,
+    'Built-in element with customelementregistry attribute should have null registry');
+}, 'Initial parse: built-in element with customelementregistry has null registry');
+
+test(() => {
+  const element = document.getElementById('candidate-with-attr');
+  assert_equals(element.customElementRegistry, null,
+    'Custom element candidate with customelementregistry attribute should have null registry');
+}, 'Initial parse: custom element candidate with customelementregistry has null registry');
+
+test(() => {
+  const element = document.getElementById('builtin-without-attr');
+  assert_equals(element.customElementRegistry, window.customElements,
+    'Built-in element without customelementregistry should use the global registry');
+}, 'Initial parse: built-in element without customelementregistry uses global registry');
+
+test(() => {
+  const element = document.getElementById('candidate-without-attr');
+  assert_equals(element.customElementRegistry, window.customElements,
+    'Custom element candidate without customelementregistry should use the global registry');
+}, 'Initial parse: custom element candidate without customelementregistry uses global registry');
+
+// Tests for descendants inheriting null registry.
+
+test(() => {
+  const child = document.getElementById('child-of-attr');
+  assert_equals(child.customElementRegistry, null,
+    'Child of element with customelementregistry should have null registry');
+}, 'Initial parse: child of element with customelementregistry inherits null registry');
+
+test(() => {
+  const child = document.getElementById('candidate-child-of-attr');
+  assert_equals(child.customElementRegistry, null,
+    'Custom element candidate child of element with customelementregistry should have null registry');
+}, 'Initial parse: custom element candidate child inherits null registry from parent');
+
+test(() => {
+  const child = document.getElementById('deep-nested-candidate');
+  assert_equals(child.customElementRegistry, null,
+    'Deeply nested custom element candidate should have null registry');
+}, 'Initial parse: deeply nested descendant inherits null registry');
+
+// Test that custom element with a definition is NOT upgraded when customelementregistry is present.
+
+test(() => {
+  const withAttr = document.getElementById('upgrade-with-attr');
+  assert_equals(withAttr.constructor, HTMLElement,
+    'Custom element candidate with null registry should not be upgraded');
+  customElements.define('upgrade-elem', class extends HTMLElement {});
+  assert_equals(withAttr.constructor, HTMLElement,
+    'Custom element candidate with null registry should still not be upgraded after defining in global registry');
+
+  const withoutAttr = document.getElementById('upgrade-without-attr');
+  assert_true(withoutAttr instanceof customElements.get('upgrade-elem'),
+    'Custom element candidate without customelementregistry should be upgraded');
+}, 'Initial parse: global registry define only upgrades elements without customelementregistry');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adding WPT coverage on customelementregistry global attribute during document initial parse.