### PR TITLE
layout: Scope table row-group children with TableRowGroupBuilder

### DIFF
--- a/css/css-tables/table-row-group-color-inheritance-001.html
+++ b/css/css-tables/table-row-group-color-inheritance-001.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Row-group color wins over table color</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#fixup-algorithm">
+<link rel="help" href="https://github.com/servo/servo/issues/43660">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: table; color: red">
+  <div style="display: table-row-group; color: green; font: 200px/1 Ahem">X</div>
+</div>

--- a/css/css-tables/table-row-group-nested-anonymous-001-ref.html
+++ b/css/css-tables/table-row-group-nested-anonymous-001-ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  .t { display: table; }
+  .r { display: table-row; }
+  .c { display: table-cell; border: 1px solid gray; padding: 4px; font: 16px serif; }
+</style>
+
+<div class="t">
+  <div class="r">
+    <div class="c">a</div>
+    <div class="c">b</div>
+    <div class="c">cccc</div>
+    <div class="c">dddd</div>
+  </div>
+</div>

--- a/css/css-tables/table-row-group-nested-anonymous-001.html
+++ b/css/css-tables/table-row-group-nested-anonymous-001.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Nested table-row-group anonymous table fixup</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#fixup-algorithm">
+<link rel="help" href="https://github.com/servo/servo/issues/43660">
+<link rel="match" href="table-row-group-nested-anonymous-001-ref.html">
+<style>
+  .cell { display: table-cell; border: 1px solid gray; padding: 4px; font: 16px serif; }
+</style>
+
+<div style="display: table-row-group">
+  <div style="display: table-row-group">
+    <div class="cell">a</div>
+    <div class="cell">b</div>
+  </div>
+  <div class="cell">cccc</div>
+  <div class="cell">dddd</div>
+</div>


### PR DESCRIPTION
This pr adds the following changes:
- Introduces `TableRowGroupBuilder` to handle row-group-scoped traversal more cleanly and explicitly.  
- Adds logic to save and restore `current_row_group_index`, ensuring correct behavior when processing nested row groups.  
- Prevents direct traversal of row-group children from the main table traversal flow to avoid incorrect context handling.  
- Ensures that anonymous rows created within a row group correctly inherit the row-group context.  
- Keeps existing row handling logic unchanged by continuing to delegate row-specific behavior to `TableRowBuilder`.

Fixes: #<!-- nolink -->43660

Testing: One existing test improves, and adding 2 new tests
Reviewed in servo/servo#43674