### PR TITLE
[WebCryptoAPI] dont assert the return prototype in encap/decap

### DIFF
--- a/WebCryptoAPI/encap_decap/encap_decap_bits.tentative.https.any.js
+++ b/WebCryptoAPI/encap_decap/encap_decap_bits.tentative.https.any.js
@@ -21,11 +21,6 @@ function define_bits_tests() {
         { name: algorithmName },
         keyPair.publicKey
       );
-
-      assert_true(
-        encapsulatedBits instanceof Object,
-        'encapsulateBits should return an object'
-      );
       assert_true(
         encapsulatedBits.hasOwnProperty('sharedKey'),
         'Result should have sharedKey property'

--- a/WebCryptoAPI/encap_decap/encap_decap_keys.tentative.https.any.js
+++ b/WebCryptoAPI/encap_decap/encap_decap_keys.tentative.https.any.js
@@ -55,11 +55,6 @@ function define_key_tests() {
             extractable,
             config.usages
           );
-
-          assert_true(
-            encapsulatedKey instanceof Object,
-            'encapsulateKey should return an object'
-          );
           assert_true(
             encapsulatedKey.hasOwnProperty('sharedKey'),
             'Result should have sharedKey property'


### PR DESCRIPTION
I don't believe a particular object's prototype is prescribed.