### PR TITLE
File System: \ is not a path separator on non-Windows platforms

### DIFF
--- a/fs/resources/test-helpers.js
+++ b/fs/resources/test-helpers.js
@@ -28,11 +28,6 @@ function wfsModesAreContentious(mode1, mode2) {
   return primitiveModesAreContentious('exclusive', mode1, mode2);
 }
 
-// Array of separators used to separate components in hierarchical paths.
-// Consider both '/' and '\' as path separators to ensure file names are
-// platform-agnostic.
-let kPathSeparators = ['/', '\\'];
-
 async function getFileSize(handle) {
   const file = await handle.getFile();
   return file.size;

--- a/fs/script-tests/FileSystemDirectoryHandle-getDirectoryHandle.js
+++ b/fs/script-tests/FileSystemDirectoryHandle-getDirectoryHandle.js
@@ -89,26 +89,22 @@ directory_test(async (t, dir) => {
   const second_subdir =
       await createDirectory(second_subdir_name, /*parent=*/ first_subdir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator =
-        `${first_subdir_name}${kPathSeparators[i]}${second_subdir_name}`;
-    await promise_rejects_js(
-        t, TypeError, dir.getDirectoryHandle(path_with_separator),
-        `getDirectoryHandle() must reject names containing "${
-            kPathSeparators[i]}"`);
-  }
+  const path_with_separator =
+      `${first_subdir_name}/${second_subdir_name}`;
+  await promise_rejects_js(
+      t, TypeError, dir.getDirectoryHandle(path_with_separator),
+      `getDirectoryHandle() must reject names containing "/"`);
+
 }, 'getDirectoryHandle(create=false) with a path separator when the directory exists');
 
 directory_test(async (t, dir) => {
   const subdir_name = 'subdir-name';
   const subdir = await createDirectory(subdir_name, /*parent=*/ dir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator = `${subdir_name}${kPathSeparators[i]}file_name`;
-    await promise_rejects_js(
-        t, TypeError,
-        dir.getDirectoryHandle(path_with_separator, {create: true}),
-        `getDirectoryHandle(true) must reject names containing "${
-            kPathSeparators[i]}"`);
-  }
+  const path_with_separator = `${subdir_name}/file_name`;
+  await promise_rejects_js(
+      t, TypeError,
+      dir.getDirectoryHandle(path_with_separator, {create: true}),
+      `getDirectoryHandle(true) must reject names containing "/"`);
+
 }, 'getDirectoryHandle(create=true) with a path separator');

--- a/fs/script-tests/FileSystemDirectoryHandle-getFileHandle.js
+++ b/fs/script-tests/FileSystemDirectoryHandle-getFileHandle.js
@@ -19,15 +19,10 @@ directory_test(async (t, dir) => {
   // test the ascii characters -- start after the non-character ASCII values, exclude DEL
   for (let i = 32; i < 127; i++) {
     // Path separators are disallowed
-    let disallow = false;
-    for (let j = 0; j < kPathSeparators.length; ++j) {
-      if (String.fromCharCode(i) == kPathSeparators[j]) {
-        disallow = true;
-      }
+    if (String.fromCharCode(i) == '/' || String.fromCharCode(i) == '\\') {
+      continue;
     }
-    if (!disallow) {
-      name += String.fromCharCode(i);
-    }
+    name += String.fromCharCode(i);
   }
   // Add in CR, LF, FF, Tab, Vertical Tab
   for (let i = 9; i < 14; i++) {
@@ -117,24 +112,21 @@ directory_test(async (t, dir) => {
   const file_name = 'file-name';
   await createEmptyFile(file_name, /*parent=*/ subdir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator =
-        `${subdir_name}${kPathSeparators[i]}${file_name}`;
-    await promise_rejects_js(
-        t, TypeError, dir.getFileHandle(path_with_separator),
-        `getFileHandle() must reject names containing "${kPathSeparators[i]}"`);
-  }
+  const path_with_separator =
+      `${subdir_name}/${file_name}`;
+  await promise_rejects_js(
+      t, TypeError, dir.getFileHandle(path_with_separator),
+      `getFileHandle() must reject names containing "/"`);
+
 }, 'getFileHandle(create=false) with a path separator when the file exists.');
 
 directory_test(async (t, dir) => {
   const subdir_name = 'subdir-name';
   const subdir = await createDirectory(subdir_name, /*parent=*/ dir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator = `${subdir_name}${kPathSeparators[i]}file_name`;
-    await promise_rejects_js(
-        t, TypeError, dir.getFileHandle(path_with_separator, {create: true}),
-        `getFileHandle(create=true) must reject names containing "${
-            kPathSeparators[i]}"`);
-  }
+  const path_with_separator = `${subdir_name}/file_name`;
+  await promise_rejects_js(
+      t, TypeError, dir.getFileHandle(path_with_separator, {create: true}),
+      `getFileHandle(create=true) must reject names containing "/"`);
+
 }, 'getFileHandle(create=true) with a path separator');

--- a/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js
+++ b/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js
@@ -77,12 +77,11 @@ directory_test(async (t, root) => {
   const file_name = 'file-name';
   await createEmptyFile(file_name, dir);
 
-  for (let i = 0; i < kPathSeparators.length; ++i) {
-    const path_with_separator = `${dir_name}${kPathSeparators[i]}${file_name}`;
-    await promise_rejects_js(
-        t, TypeError, root.removeEntry(path_with_separator),
-        `removeEntry() must reject names containing "${kPathSeparators[i]}"`);
-  }
+  const path_with_separator = `${dir_name}/${file_name}`;
+  await promise_rejects_js(
+      t, TypeError, root.removeEntry(path_with_separator),
+      `removeEntry() must reject names containing "/"`);
+
 }, 'removeEntry() with a path separator should fail.');
 
 directory_test(async (t, root) => {


### PR DESCRIPTION
The specification is very clear on this:

    https://fs.spec.whatwg.org/#valid-file-name

In getFileHandle() we'll continue to skip \ in the create test as it's a known separator on at least one platform.