### PR TITLE
Service Workers: correct nested_load_worker.js

### DIFF
--- a/service-workers/service-worker/resources/nested_load_worker.js
+++ b/service-workers/service-worker/resources/nested_load_worker.js
@@ -2,7 +2,7 @@
 self.onmessage = evt => {
   try {
     const worker = new Worker('load_worker.js');
-    worker.onmessage = evt => self.postMessage(evt.data);
+    worker.onmessage = msg => self.postMessage(msg.data);
     worker.postMessage(evt.data);
   } catch (err) {
     self.postMessage('Unexpected error! ' + err.message);
@@ -14,8 +14,8 @@ self.onconnect = evt => {
   evt.ports[0].onmessage = e => {
     try {
       const worker = new Worker('load_worker.js');
-      worker.onmessage = e => evt.ports[0].postMessage(e.data);
-      worker.postMessage(evt.data);
+      worker.onmessage = msg => evt.ports[0].postMessage(msg.data);
+      worker.postMessage(e.data);
     } catch (err) {
       evt.ports[0].postMessage('Unexpected error! ' + err.message);
     }


### PR DESCRIPTION
It contained a typo which meant it posted event.data from the connect event (always the empty string) instead of from the message event. Renamed some other variables to make the scoping clearer.