### PR TITLE
layout: Handle `display: contents` in all `TraversalHandler`

### DIFF
--- a/css/css-display/display-contents-table-003.html
+++ b/css/css-display/display-contents-table-003.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in table layout</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="help" href="https://github.com/servo/servo/issues/42070">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div { color: red; font: 40px / 1 Ahem; }
+span { display: contents; color: green; }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="display: table"><span>XXXXX</span></div>
+<div style="display: table-caption"><span>XXXXX</span></div>
+<div style="display: table-row-group"><span>XXXXX</span></div>
+<div style="display: table-row"><span>XXXXX</span></div>
+<div style="display: table-cell"><span>XXXXX</span></div>
+
+<script src="/common/reftest-wait.js"></script>
+<script>
+document.fonts.ready.then(takeScreenshot);
+</script>
+</html>


### PR DESCRIPTION
The `TraversalHandler` trait defined the methods that handle elements with `display: contents` using a default implementation that was no-op. Therefore, it was easy for types implementing the trait to forget to handle `display: contents` correctly.

This patch removes the default implementation, and adds the missing implementations for `TableRowBuilder`, `TableRowGroupBuilder`, `TableColumnGroupBuilder` and `TableBuilderTraversal`.

Testing: 6 existing tests pass, and adding a new one. There is one new failure, because we lack `font-kerning: none`.
Fixes: #<!-- nolink -->42070

Reviewed in servo/servo#44551