### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=313278

### DIFF
--- a/css/css-images/gradient/gradient-analogous-missing-components-003.html
+++ b/css/css-images/gradient/gradient-analogous-missing-components-003.html
@@ -5,7 +5,7 @@
 <link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
 <meta name="assert" content="Tests that analogous missing components logic works.">
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-40000">
 <link rel="match" href="gradient-analogous-missing-components-003-ref.html">
 <style>
     .test {


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(311406@main): \[Tahoe\] imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html is a flaky IMAGE failure](https://bugs.webkit.org/show_bug.cgi?id=313278)