### PR TITLE
layout: Do not assume layout data structures exist during queries

### DIFF
--- a/dom/nodes/crashtests/documentElement-remove-descendant-query.html
+++ b/dom/nodes/crashtests/documentElement-remove-descendant-query.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/44536">
+<span id="span"></span>
+<script>
+  var span = document.getElementById("span");
+  document.documentElement.remove();
+  span.offsetHeight;
+</script>
+
+


### PR DESCRIPTION
Data structures, such as the fragment tree and and stacking context
tree, might not exist even after a layout if there is no root element.
This change makes it so that the code stops assuming they exist. This
does expose us to cases where logic errors may mean we try to run a
script query without running the appropriate phase of layout first, but
that is better than panicking.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->44536.

Reviewed in servo/servo#44560