### PR TITLE
Exclude DNS from the server startup check

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -336,7 +336,7 @@ class TestEnvironment:
                     pending.append((host, port))
 
             for scheme, servers in self.servers.items():
-                if scheme == "webtransport-h3":
+                if scheme in ("dns", "webtransport-h3"):
                     continue
                 for port, server in servers:
                     s = socket.socket()


### PR DESCRIPTION
Similar to the H3 server, DNS uses UDP and thus our TCP connection
test is wrong.
