### PR TITLE
script: Fix "RefCell already borrowed" for DOMString in DataTransfer.getData

### DIFF
--- a/html/editing/dnd/crashtests/DataTransfer-getData-RefCell-already-borrowed.html
+++ b/html/editing/dnd/crashtests/DataTransfer-getData-RefCell-already-borrowed.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/44599">
+<script>(new DataTransfer()).getData("");</script>


### PR DESCRIPTION
`match_domstring_ascii!` presumably borrows that RefCell, and `.clone()` borrows it again.

Testing: adding a new crashtest
Fixes: https://github.com/servo/servo/issues/44599

Reviewed in servo/servo#44607