### PR TITLE
Don't mess with sys.path in environment.py

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -21,9 +21,6 @@ from .wptlogging import LogLevelRewriter, QueueHandler, LogQueueThread
 here = os.path.dirname(__file__)
 repo_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir, os.pardir))
 
-sys.path.insert(0, repo_root)
-from tools import localpaths  # noqa: F401
-
 serve = None
 
 


### PR DESCRIPTION
This file isn't being imported directly, so it's unclear why we need to do that