### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=312477

### DIFF
--- a/css/css-flexbox/flex-grow-009.html
+++ b/css/css-flexbox/flex-grow-009.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="https://webkit.org">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+  .container {
+    background-color: red;
+    display: flex;
+    height: 100px;
+    width: 100px;
+  }
+  .infinite-grow {
+    flex: calc(infinity) 0 0px;
+    background: green;
+  }
+  .normal-grow {
+    flex: 1 0 0px;
+    background: red;
+  }
+</style>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="container">
+    <div class="infinite-grow"></div>
+    <div class="normal-grow"></div>
+  </div>
+</body>


### PR DESCRIPTION
WebKit export from bug: [Flexbox: calc(infinity) flex-grow factor fails to stretch item to 100% width.](https://bugs.webkit.org/show_bug.cgi?id=312477)