### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=312944

### DIFF
--- a/css/css-flexbox/percentage-size-quirks-004.html
+++ b/css/css-flexbox/percentage-size-quirks-004.html
@@ -1,0 +1,69 @@
+<title>CSS Flexbox: percentage height and relative position in column flex items in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#definite-sizes">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+    margin: 0;
+}
+</style>
+
+<!-- 1. Column flex (100px), flex:1 item, child height: 100% -->
+<div style="display: flex; flex-direction: column; height: 100px;">
+    <div style="height: 50px;"></div>
+    <div id="t1-item" style="flex: 1;">
+        <div id="t1" style="height: 100%; background: green;"></div>
+    </div>
+</div>
+
+<!-- 2. Column flex (auto height), flex:1 item, child height: 100% -->
+<div style="display: flex; flex-direction: column;">
+    <div style="height: 50px;"></div>
+    <div id="t2-item" style="flex: 1;">
+        <div id="t2" style="height: 100%; background: green;"></div>
+    </div>
+</div>
+
+<!-- 3. Column flex (100px), wrapper div, deep height: 100% -->
+<div style="display: flex; flex-direction: column; height: 100px;">
+    <div style="height: 50px;"></div>
+    <div id="t3-item" style="flex: 1;">
+        <div>
+            <div id="t3" style="height: 100%; background: green;"></div>
+        </div>
+    </div>
+</div>
+
+<!-- 4. Percentage height against auto parent resolves in quirks mode, top: 50% -->
+<div>
+    <div id="t4-cb" style="height: 50%;">
+        <div id="t4" style="width: 20px; height: 20px; background: green; position: relative; top: 50%;"></div>
+    </div>
+</div>
+
+<script>
+test(function() {
+    var item = document.getElementById('t1-item');
+    var child = document.getElementById('t1');
+    assert_equals(child.offsetHeight, item.offsetHeight);
+}, 'Quirks: column flex with definite height, height: 100% in flex item');
+
+test(function() {
+    var child = document.getElementById('t2');
+    assert_equals(child.offsetHeight, 0);
+}, 'Quirks: column flex with auto height, height: 100% in flex item');
+
+test(function() {
+    var item = document.getElementById('t3-item');
+    var child = document.getElementById('t3');
+    assert_equals(child.offsetHeight, item.offsetHeight);
+}, 'Quirks: column flex with definite height, deep height: 100% in flex item');
+
+test(function() {
+    var cb = document.getElementById('t4-cb');
+    var child = document.getElementById('t4');
+    var offset = child.getBoundingClientRect().top - cb.getBoundingClientRect().top;
+    assert_not_equals(offset, 0);
+}, 'Quirks: percentage height against auto parent resolves for top: 50%');
+</script>

--- a/css/css-flexbox/percentage-size-quirks-005.html
+++ b/css/css-flexbox/percentage-size-quirks-005.html
@@ -1,0 +1,27 @@
+<title>CSS Flexbox: stretch height is not affected by the percentage height quirk</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+    margin: 0;
+}
+</style>
+
+<!-- In quirks mode, percentage heights resolve freely against auto parents.
+     stretch should NOT get this treatment. -->
+<div>
+    <div id="t1-cb" style="height: stretch;">
+        <div id="t1" style="width: 20px; height: 20px; background: green; position: relative; top: 50%;"></div>
+    </div>
+</div>
+
+<script>
+test(function() {
+    var cb = document.getElementById('t1-cb');
+    var child = document.getElementById('t1');
+    var offset = child.getBoundingClientRect().top - cb.getBoundingClientRect().top;
+    assert_equals(offset, 0);
+}, 'Quirks: stretch height against auto parent does not resolve top: 50%');
+</script>

--- a/css/css-flexbox/position-relative-percentage-top-004.html
+++ b/css/css-flexbox/position-relative-percentage-top-004.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<title>CSS Flexbox: percentage top/bottom on relatively positioned elements in flex items</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#definite-sizes">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#valdef-top-percentage">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.green {
+    width: 20px;
+    height: 20px;
+    background: green;
+    position: relative;
+}
+</style>
+
+<!-- 1. Row flex, stretched item, top: 50% -->
+<div style="display: flex; height: 200px;">
+    <div id="t1-item">
+        <div class="green" id="t1" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 2. Row flex, align-self: flex-start, top: 50% -->
+<div style="display: flex; height: 200px;">
+    <div id="t2-item" style="align-self: flex-start;">
+        <div class="green" id="t2" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 3. Column flex (200px), flex-grow item, top: 50% -->
+<div style="display: flex; flex-direction: column; height: 200px;">
+    <div style="height: 100px;"></div>
+    <div id="t3-item" style="flex-grow: 1;">
+        <div class="green" id="t3" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 4. Column flex (auto height), top: 50% -->
+<div style="display: flex; flex-direction: column;">
+    <div id="t4-item" style="flex-grow: 1;">
+        <div class="green" id="t4" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 5. Column flex, flex-basis: 100px, top: 50% -->
+<div style="display: flex; flex-direction: column; height: 200px;">
+    <div id="t5-item" style="flex: 0 0 100px;">
+        <div class="green" id="t5" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 6. Nested column flex (3 levels), innermost top: 50% -->
+<div style="display: flex; flex-direction: column; height: 200px;">
+    <div style="flex-grow: 1; display: flex; flex-direction: column;">
+        <div style="flex-grow: 1; display: flex; flex-direction: column;">
+            <div style="height: 100px;"></div>
+            <div id="t6-item" style="flex-grow: 1;">
+                <div class="green" id="t6" style="top: 50%;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 7. Row flex containing column flex, top: 50% -->
+<div style="display: flex; height: 200px;">
+    <div style="display: flex; flex-direction: column; width: 100px;">
+        <div style="height: 100px;"></div>
+        <div id="t7-item" style="flex-grow: 1;">
+            <div class="green" id="t7" style="top: 50%;"></div>
+        </div>
+    </div>
+</div>
+
+<!-- 8. Flex item with height: 50%, top: 50% -->
+<div style="display: flex; flex-direction: column; height: 200px;">
+    <div id="t8-item" style="height: 50%;">
+        <div class="green" id="t8" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 9. Percentage height child inside stretched flex item, top: 50% -->
+<div style="display: flex; height: 200px;">
+    <div>
+        <div id="t9-item" style="height: 50%;">
+            <div class="green" id="t9" style="top: 50%;"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+function offsetFromItem(greenId, itemId) {
+    var green = document.getElementById(greenId);
+    var item = document.getElementById(itemId);
+    return green.getBoundingClientRect().top - item.getBoundingClientRect().top;
+}
+
+test(function() {
+    assert_equals(offsetFromItem('t1', 't1-item'), 100);
+}, 'Row flex, stretched item, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t2', 't2-item'), 0);
+}, 'Row flex, align-self: flex-start, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t3', 't3-item'), 50);
+}, 'Column flex, flex-grow item, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t4', 't4-item'), 0);
+}, 'Column flex, auto height container, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t5', 't5-item'), 50);
+}, 'Column flex, definite flex-basis, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t6', 't6-item'), 50);
+}, 'Nested column flex, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t7', 't7-item'), 50);
+}, 'Row then column nesting, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t8', 't8-item'), 50);
+}, 'Flex item with percentage height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t9', 't9-item'), 50);
+}, 'Percentage height child inside stretched flex item, top: 50%');
+</script>

--- a/css/css-flexbox/position-relative-stretch-height-001.html
+++ b/css/css-flexbox/position-relative-stretch-height-001.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<title>CSS Flexbox: relative position percentage top with height: stretch containing block</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#definite-sizes">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#valdef-top-percentage">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.green {
+    width: 20px;
+    height: 20px;
+    background: green;
+    position: relative;
+}
+</style>
+
+<!-- 1. height: stretch against definite parent -->
+<div style="height: 200px;">
+    <div id="t1-item" style="height: stretch;">
+        <div class="green" id="t1" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 2. height: stretch against auto parent (indefinite) -->
+<div>
+    <div id="t2-item" style="height: stretch;">
+        <div class="green" id="t2" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 3. height: stretch inside stretched flex item (definite per 9.8) -->
+<div style="display: flex; height: 200px;">
+    <div>
+        <div id="t3-item" style="height: stretch;">
+            <div class="green" id="t3" style="top: 50%;"></div>
+        </div>
+    </div>
+</div>
+
+<!-- 4. height: stretch inside auto-height column flex item (indefinite) -->
+<div style="display: flex; flex-direction: column;">
+    <div style="flex-grow: 1;">
+        <div id="t4-item" style="height: stretch;">
+            <div class="green" id="t4" style="top: 50%;"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+function offsetFromItem(greenId, itemId) {
+    var green = document.getElementById(greenId);
+    var item = document.getElementById(itemId);
+    return green.getBoundingClientRect().top - item.getBoundingClientRect().top;
+}
+
+test(function() {
+    assert_equals(offsetFromItem('t1', 't1-item'), 100);
+}, 'height: stretch against definite parent, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t2', 't2-item'), 0);
+}, 'height: stretch against auto parent, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t3', 't3-item'), 100);
+}, 'height: stretch inside stretched flex item, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromItem('t4', 't4-item'), 0);
+}, 'height: stretch inside auto-height column flex item, top: 50%');
+</script>

--- a/css/css-position/position-relative-015.html
+++ b/css/css-position/position-relative-015.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<title>CSS Position: percentage top on relatively positioned elements with various containing block heights</title>
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#valdef-top-percentage">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#percentage-sizing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.green {
+    width: 20px;
+    height: 20px;
+    background: green;
+    position: relative;
+}
+</style>
+
+<!-- 1. Fixed height containing block, top: 50% -->
+<div id="t1-cb" style="height: 200px;">
+    <div class="green" id="t1" style="top: 50%;"></div>
+</div>
+
+<!-- 2. Auto height containing block, top: 50% -->
+<div id="t2-cb">
+    <div class="green" id="t2" style="top: 50%;"></div>
+</div>
+
+<!-- 3. Percentage height containing block (parent has fixed height), top: 50% -->
+<div style="height: 200px;">
+    <div id="t3-cb" style="height: 50%;">
+        <div class="green" id="t3" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 4. OOF with both insets (implicit height), top: 50% -->
+<div style="position: relative; height: 200px;">
+    <div id="t4-cb" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+        <div class="green" id="t4" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 5. Grid item stretched, top: 50% -->
+<div style="display: grid; height: 200px;">
+    <div id="t5-cb">
+        <div class="green" id="t5" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 6. Grid item with 0px track, top: 50% -->
+<div style="display: grid; grid-template-rows: 0px; height: 200px;">
+    <div id="t6-cb">
+        <div class="green" id="t6" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 7. Grid item with auto track, top: 50% -->
+<div style="display: grid; height: 200px;">
+    <div id="t7-cb" style="height: auto;">
+        <div class="green" id="t7" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 8. Grid item with fixed track, top: 50% -->
+<div style="display: grid; grid-template-rows: 100px; height: 200px;">
+    <div id="t8-cb">
+        <div class="green" id="t8" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 9. Grid item with percentage track, top: 50% -->
+<div style="display: grid; grid-template-rows: 50%; height: 200px;">
+    <div id="t9-cb">
+        <div class="green" id="t9" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 10. Percentage height against auto-height body, top: 50% -->
+<div id="t10-cb" style="height: 100%;">
+    <div class="green" id="t10" style="top: 50%;"></div>
+</div>
+
+<!-- 11. Percentage height against auto parent (unresolvable), top: 50% -->
+<div>
+    <div id="t11-cb" style="height: 50%; min-height: 200px;">
+        <div class="green" id="t11" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 12. fit-content height, top: 50% -->
+<div id="t12-cb" style="height: fit-content; min-height: 200px;">
+    <div class="green" id="t12" style="top: 50%;"></div>
+</div>
+
+<!-- 13. max-content height, top: 50% -->
+<div id="t13-cb" style="height: max-content; min-height: 200px;">
+    <div class="green" id="t13" style="top: 50%;"></div>
+</div>
+
+<!-- 14. min-content height, top: 50% -->
+<div id="t14-cb" style="height: min-content; min-height: 200px;">
+    <div class="green" id="t14" style="top: 50%;"></div>
+</div>
+
+<!-- 15. Nested unresolvable percentages, top: 50% -->
+<div>
+    <div style="height: 50%;">
+        <div id="t15-cb" style="height: 50%; min-height: 200px;">
+            <div class="green" id="t15" style="top: 50%;"></div>
+        </div>
+    </div>
+</div>
+
+<!-- 16. calc() fixed height, top: 50% -->
+<div id="t16-cb" style="height: calc(100px + 100px);">
+    <div class="green" id="t16" style="top: 50%;"></div>
+</div>
+
+<!-- 17. calc() with resolvable percentage, top: 50% -->
+<div style="height: 200px;">
+    <div id="t17-cb" style="height: calc(50% + 0px);">
+        <div class="green" id="t17" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 18. calc() with unresolvable percentage, top: 50% -->
+<div>
+    <div id="t18-cb" style="height: calc(50% + 0px); min-height: 200px;">
+        <div class="green" id="t18" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 19. stretch height, top: 50% -->
+<div style="height: 200px;">
+    <div id="t19-cb" style="height: stretch;">
+        <div class="green" id="t19" style="top: 50%;"></div>
+    </div>
+</div>
+
+<!-- 20. Chain of percentages resolving to fixed height, top: 50% -->
+<div style="height: 200px;">
+    <div style="height: 50%;">
+        <div id="t20-cb" style="height: 50%;">
+            <div class="green" id="t20" style="top: 50%;"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+function offsetFromParent(greenId, parentId) {
+    var green = document.getElementById(greenId);
+    var parent = document.getElementById(parentId);
+    return green.getBoundingClientRect().top - parent.getBoundingClientRect().top;
+}
+
+test(function() {
+    assert_equals(offsetFromParent('t1', 't1-cb'), 100);
+}, 'Fixed height containing block, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t2', 't2-cb'), 0);
+}, 'Auto height containing block, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t3', 't3-cb'), 50);
+}, 'Percentage height containing block, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t4', 't4-cb'), 100);
+}, 'OOF with implicit height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t5', 't5-cb'), 100);
+}, 'Grid item stretched, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t6', 't6-cb'), 0);
+}, 'Grid item with 0px track, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t7', 't7-cb'), 100);
+}, 'Grid item with auto track (stretched to 200px), top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t8', 't8-cb'), 50);
+}, 'Grid item with fixed 100px track, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t9', 't9-cb'), 50);
+}, 'Grid item with 50% track, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t10', 't10-cb'), 0);
+}, 'Unresolvable percentage height (100% of auto body), top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t11', 't11-cb'), 0);
+}, 'Unresolvable percentage height with min-height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t12', 't12-cb'), 0);
+}, 'fit-content height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t13', 't13-cb'), 0);
+}, 'max-content height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t14', 't14-cb'), 0);
+}, 'min-content height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t15', 't15-cb'), 0);
+}, 'Nested unresolvable percentage heights, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t16', 't16-cb'), 100);
+}, 'calc() fixed height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t17', 't17-cb'), 50);
+}, 'calc() with resolvable percentage, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t18', 't18-cb'), 0);
+}, 'calc() with unresolvable percentage, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t19', 't19-cb'), 100);
+}, 'stretch height, top: 50%');
+
+test(function() {
+    assert_equals(offsetFromParent('t20', 't20-cb'), 25);
+}, 'Chain of resolvable percentages, top: 50%');
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[Flex\] Avoid expensive percentage height walk when resolving relative position offsets](https://bugs.webkit.org/show_bug.cgi?id=312944)