### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=306258

### DIFF
--- a/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001.html
+++ b/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#grid-item-sizing">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<style>
+.flex {
+    display: flex;
+    flex-direction: column;
+    height: 200px;
+    width: 100px;
+}
+.grid {
+    height: 100%;
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+}
+img {
+    height: 100%;
+}
+</style>
+<div class="flex">
+    <div class="grid">
+        <img src="grid-items/support/100x100-green.png">
+    </div>
+</div>

--- a/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002.html
+++ b/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#grid-item-sizing">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<style>
+.flex {
+    display: flex;
+    flex-direction: column;
+    height: 400px;
+    width: 100px;
+}
+.grid {
+    height: 100%;
+    display: grid;
+    grid-template-rows: 1fr 3fr;
+}
+img {
+    height: 100%;
+}
+</style>
+<div class="flex">
+    <div class="grid">
+        <img src="grid-items/support/100x100-green.png">
+    </div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [`height: 100%` has wrong calculation for img as grid cell nested inside flexbox](https://bugs.webkit.org/show_bug.cgi?id=306258)