### PR TITLE
wptserve: detect TLS ClientHello on non-TLS HTTP server

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -849,6 +849,14 @@ class Http1WebTestRequestHandler(BaseWebTestRequestHandler):
             return False
         if not self.raw_requestline:
             self.close_connection = True
+            return True
+        if (len(self.raw_requestline) >= 6 and
+                self.raw_requestline[0] == 0x16 and   # TLS record: content type "handshake"
+                self.raw_requestline[1] == 0x03 and   # TLS record: major version 3 (all of TLS 1.0–1.3)
+                self.raw_requestline[5] == 0x01):      # TLS handshake type: ClientHello
+            self.log_message("TLS ClientHello received on plain HTTP server; "
+                             "client may have sent an HTTPS request to an HTTP port")
+            self.close_connection = True
         return True
 
 class WebTestHttpd:


### PR DESCRIPTION
When a browser, e.g. one that does HTTPS-by-default, sends a TLS
ClientHello to our (non-TLS) HTTP port, the binary data falls through
into parse_request() which emits confusing "Bad HTTP/0.9 request type"
and "Bad request version" warnings with garbled binary characters, and
then loops reading further into the TLS record body.

Instead, we detect the ClientHello and log one info-level message
before closing the connection.

Fixes: https://github.com/web-platform-tests/wpt/issues/51342
