### PR TITLE
[text-autospace] Correct property value `none` to `no-autospace`

### DIFF
--- a/css/css-text/text-autospace/text-autospace-preformatted-001-ref.html
+++ b/css/css-text/text-autospace/text-autospace-preformatted-001-ref.html
@@ -3,7 +3,7 @@
 <style>
     .container {
         font: 40px sans-serif;
-        text-autospace: none;
+        text-autospace: no-autospace;
     }
     .mono {
         font-family: monospace;


### PR DESCRIPTION
`none` is not a valid `text-autospace` property value. It should be `no-autospace`.