### PR TITLE
Reject strings in `ReadableStream.from`

### DIFF
--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -18,11 +18,6 @@ const iterableFactories = [
     return ['a', 'b'][Symbol.iterator]();
   }],
 
-  ['a string', () => {
-    // This iterates over the code points of the string.
-    return 'ab';
-  }],
-
   ['a Set', () => {
     return new Set(['a', 'b']);
   }],
@@ -170,6 +165,7 @@ const badIterables = [
   ['Object.create(null)', Object.create(null)],
   ['a function', () => 42],
   ['a symbol', Symbol()],
+  ['a string', 'ab'],
   ['an object with a non-callable @@iterator method', {
     [Symbol.iterator]: 42
   }],


### PR DESCRIPTION
This aligns the tests with the expected behavior of `async_sequence` in Web IDL.

Accompanies https://github.com/whatwg/streams/pull/1372.