### PR TITLE
[WebCryptoAPI] Fix en/decapsulate key supports tests

### DIFF
--- a/WebCryptoAPI/supports-modern.tentative.https.any.js
+++ b/WebCryptoAPI/supports-modern.tentative.https.any.js
@@ -17,7 +17,7 @@ const modernAlgorithms = {
   'ML-KEM-512': {
     operations: [
       'generateKey', 'importKey', 'encapsulateKey', 'encapsulateBits',
-      'decapuslateKey', 'decapsulateBits'
+      'decapsulateKey', 'decapsulateBits'
     ],
   },
   'ML-KEM-768': {
@@ -72,7 +72,7 @@ for (const [algorithmName, algorithmInfo] of Object.entries(modernAlgorithms)) {
 
       // Use appropriate algorithm parameters for each operation
       let algorithm;
-      let length;
+      let lengthOrAdditionalAlgorithm;
       switch (operation) {
         case 'generateKey':
           algorithm = algorithmInfo.keyGenParams || algorithmName;
@@ -94,7 +94,7 @@ for (const [algorithmName, algorithmInfo] of Object.entries(modernAlgorithms)) {
             algorithm.public = (await algorithm.public).publicKey;
           }
           if (algorithmName === 'PBKDF2' || algorithmName === 'HKDF') {
-            length = 256;
+            lengthOrAdditionalAlgorithm = 256;
           }
           break;
         case 'digest':
@@ -105,12 +105,15 @@ for (const [algorithmName, algorithmInfo] of Object.entries(modernAlgorithms)) {
         case 'decapsulateKey':
         case 'decapsulateBits':
           algorithm = algorithmName;
+          if (operation === 'encapsulateKey' || operation === 'decapsulateKey') {
+            lengthOrAdditionalAlgorithm = { name: 'AES-GCM', length: 256 };
+          }
           break;
         default:
           algorithm = algorithmName;
       }
 
-      const result = SubtleCrypto.supports(operation, algorithm, length);
+      const result = SubtleCrypto.supports(operation, algorithm, lengthOrAdditionalAlgorithm);
 
       if (isSupported) {
         assert_true(result, `${algorithmName} should support ${operation}`);


### PR DESCRIPTION
Some of the SubtleCrypto.supports() tests introduced in 1f26f6b64332958fdb81cb26e2986cf287b0ade5 are incorrect.

1) there's a typo in one of the methods
2) encapsulateKey and decapsulateKey tests lack the additionalAlgorithm parameter