### PR TITLE
add dialog to html-aam/roles.html

### DIFF
--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -52,6 +52,7 @@
 <del data-testname="el-del" data-expectedrole="deletion" class="ex">x</del>
 <details data-testname="el-details" data-expectedrole="group" class="ex"><summary>x</summary>x</details>
 <dfn data-testname="el-dfn" data-expectedrole="term" class="ex">x</dfn>
+<dialog open data-testname="el-dialog" data-expectedrole="dialog" class="ex">x</dialog>
 <!-- dir -> ./dir-role.tentative.html -->
 <!-- div -> ./roles-generic.html -->
 <!-- todo: dl -->

--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -52,7 +52,8 @@
 <del data-testname="el-del" data-expectedrole="deletion" class="ex">x</del>
 <details data-testname="el-details" data-expectedrole="group" class="ex"><summary>x</summary>x</details>
 <dfn data-testname="el-dfn" data-expectedrole="term" class="ex">x</dfn>
-<dialog open data-testname="el-dialog" data-expectedrole="dialog" class="ex">x</dialog>
+<!-- todo: dialog(modal) -> needs to be tested in a separate file so background inertness won't break the other tests  -->
+<dialog open data-testname="el-dialog-non-modal" data-expectedrole="dialog" class="ex">x</dialog>
 <!-- dir -> ./dir-role.tentative.html -->
 <!-- div -> ./roles-generic.html -->
 <!-- todo: dl -->


### PR DESCRIPTION
close https://github.com/web-platform-tests/interop-accessibility/issues/223

Using `open` attribute, we don't have to divide file because dialog isn't modal and doesn't make inert status.
If we want to use `showModal` instead of `open` attribute, I'll fix it.