### PR TITLE
script: Add support for processing instructions to Sanitizer interface

### DIFF
--- a/sanitizer-api/sanitizer-config.tentative.html
+++ b/sanitizer-api/sanitizer-config.tentative.html
@@ -100,6 +100,14 @@ for (key of ["elements", "removeElements", "replaceWithChildrenElements"]) {
     {name: "bla", namespace: "http://fantasy.org/namespace"},
     {name: "bla", namespace: "http://fantasy.org/namespace", ...extra});
 }
+for (key of ["processingInstructions", "removeProcessingInstructions"]) {
+  test_normalization(key,
+    "target-1",
+    {target: "target-1"});
+  test_normalization(key,
+    {target: "target-1"},
+    {target: "target-1"});
+}
 for (key of ["attributes", "removeAttributes"]) {
   test_normalization(key,
     "href",
@@ -154,6 +162,34 @@ test(t => {
   assert_object_equals(s.get().replaceWithChildrenElements[0],
                        {name: "bla", namespace: "http://www.w3.org/1999/xhtml"});
 }, "Test elements replacewithchildren.");
+
+test(t => {
+  let s = new Sanitizer({processingInstructions: ["target-1", "target-2"]});
+  assert_equals(s.get().processingInstructions.length, 2);
+  s.allowProcessingInstruction("target-3");
+  assert_equals(s.get().processingInstructions.length, 3);
+  s.removeProcessingInstruction({target: "target-4"});
+  assert_equals(s.get().processingInstructions.length, 3);
+  s.removeProcessingInstruction({target: "target-1"});
+  assert_equals(s.get().processingInstructions.length, 2);
+  s.removeProcessingInstruction({target: "target-2"});
+  assert_equals(s.get().processingInstructions.length, 1);
+  assert_object_equals(s.get().processingInstructions[0],
+                       {target: "target-3"});
+}, "Test processingInstructions addition.");
+
+test(t => {
+  let s = new Sanitizer({removeProcessingInstructions: ["target-1", "target-2"]});
+  assert_equals(s.get().removeProcessingInstructions.length, 2);
+  s.removeProcessingInstruction("target-3");
+  assert_equals(s.get().removeProcessingInstructions.length, 3);
+  s.allowProcessingInstruction({target: "target-1"});
+  assert_equals(s.get().removeProcessingInstructions.length, 2);
+  s.allowProcessingInstruction({target: "target-2"});
+  assert_equals(s.get().removeProcessingInstructions.length, 1);
+  assert_object_equals(s.get().removeProcessingInstructions[0],
+                       {target: "target-3"});
+}, "Test processingInstructions removal.");
 
 test(t => {
   let s = new Sanitizer({attributes: ["href", "src"]});
@@ -228,6 +264,13 @@ test(() => {
   });
 }, "Both attributes and removeAttributes should not be allowed.");
 
+// The config has either a processingInstructions or a removeProcessingInstructions key, but not both.
+test(() => {
+  assert_throws_js(TypeError, () => {
+    new Sanitizer({ processingInstructions: [], removeProcessingInstructions: [] });
+  });
+}, "Both processingInstructions and removeProcessingInstructions should not be allowed.");
+
 // 3. Assert: All SanitizerElementNamespaceWithAttributes, SanitizerElementNamespace, and SanitizerAttributeNamespace items in config are canonical, meaning they have been run through canonicalize a sanitizer element or canonicalize a sanitizer attribute, as appropriate.
 // This is tested in the sanitizer-config test file.
 
@@ -291,6 +334,31 @@ test(() => {
     });
   }
 }, "config[removeAttributes] should not allow duplicates");
+
+// None of config[processingInstructions] or config[removeProcessingInstructions], if they exist, has duplicate targets.
+const DUPLICATE_TARGETS = [
+  ["", ""],
+  ["abc", "abc"],
+  ["data-xyz", "data-xyz"],
+  ["abc", {target: "abc"}],
+  [{target: "abc"}, {target: "abc"}]
+];
+
+test(() => {
+  for (let targets of DUPLICATE_TARGETS) {
+    assert_throws_js(TypeError, () => {
+      new Sanitizer({ processingInstructions: targets });
+    });
+  }
+}, "config[processingInstructions] should not allow duplicate targets");
+
+test(() => {
+  for (let targets of DUPLICATE_TARGETS) {
+    assert_throws_js(TypeError, () => {
+      new Sanitizer({ removeProcessingInstructions: targets });
+    });
+  }
+}, "config[removeProcessingInstructions] should not allow duplicate targets");
 
 // 11.1. For each element of config["replaceWithChildrenElements"]:
 // 11.1.1. If the built-in non-replaceable elements list contains element, then return false.

--- a/sanitizer-api/sanitizer-default-config.tentative.html
+++ b/sanitizer-api/sanitizer-default-config.tentative.html
@@ -1125,6 +1125,7 @@ test(() => {
         ]
       }
     ],
+    "processingInstructions": [],
     "attributes": [
       {
         "name": "alignment-baseline",

--- a/sanitizer-api/sanitizer-get.tentative.html
+++ b/sanitizer-api/sanitizer-get.tentative.html
@@ -61,6 +61,38 @@ for (const key of ["attributes", "removeAttributes"]) {
   }, `Sorting of element's ${key}`);
 }
 
+const PI_TEST_CASES = [
+  [
+    ["b", "a"],
+    ["a", "b"]
+  ],
+  [
+    ["c", "b", "a"],
+    ["a", "b", "c"]
+  ],
+  [
+    [{target: "b"}, {target: "a"}],
+    [{target: "a"}, {target: "b"}]
+  ],
+  [
+    [{target: "c"}, {target: "b"}, {target: "a"}],
+    [{target: "a"}, {target: "b"}, {target: "c"}]
+  ]
+];
+
+for (const key of ["processingInstructions", "removeProcessingInstructions"]) {
+  test(() => {
+    for (const [input, expected] of PI_TEST_CASES) {
+      let s = new Sanitizer({
+        [key]: input
+      });
+      assert_config(s.get(), {
+        [key]: expected
+      });
+    }
+  }, `Sorting of ${key}`);
+}
+
 </script>
 </body>
 </html>

--- a/sanitizer-api/sanitizer-processing-instructions.tentative.html
+++ b/sanitizer-api/sanitizer-processing-instructions.tentative.html
@@ -30,13 +30,6 @@
 #data
 <?target data?>
 #config
-{ "processingInstructions": ["target"], "removeProcessingInstructions": ["target"] }
-#document
-| <?target data>
-
-#data
-<?target data?>
-#config
 { "processingInstructions": ["Target"] }
 #document
 

--- a/sanitizer-api/support/util.js
+++ b/sanitizer-api/support/util.js
@@ -12,6 +12,10 @@ function is_same_sanitizer_name(a, b) {
   return a.name === b.name && a.namespace === b.namespace;
 }
 
+function is_same_sanitizer_target(a, b) {
+  return a.target === b.target;
+}
+
 function is_data_attribute(attribute) {
   return attribute.name.startsWith("data-") && attribute.namespace === null;
 }
@@ -24,6 +28,22 @@ function has_duplicates(list) {
   for (let i = 0; i < list.length; i++) {
     for (let j = i + 1; j < list.length; j++) {
       if (is_same_sanitizer_name(list[i], list[j])) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function has_duplicate_targets(list) {
+  if (!list) {
+    return false;
+  }
+
+  for (let i = 0; i < list.length; i++) {
+    for (let j = i + 1; j < list.length; j++) {
+      if (is_same_sanitizer_target(list[i], list[j])) {
         return true;
       }
     }
@@ -76,57 +96,79 @@ function assert_config_is_valid(config) {
     'If config["elements"] exists and config["removeElements"] exists, then return false.',
   );
 
-  // 3. Assert: Either config["attributes"] exists or config["removeAttributes"] exists.
+  // 3. Assert: Either config["processingInstructions"] exists or config["removeProcessingInstructions"] exists.
+  assert_true(
+    "processingInstructions" in config || "removeProcessingInstructions" in config,
+    'Assert: Either config["processingInstructions"] exists or config["removeProcessingInstructions"] exists.',
+  );
+
+  // 4. If config["processingInstructions"] exists and config["removeProcessingInstructions"] exists, then return false.
+  assert_false(
+    "processingInstructions" in config && "removeProcessingInstructions" in config,
+    'If config["processingInstructions"] exists and config["removeProcessingInstructions"] exists, then return false.',
+  );
+
+  // 5. Assert: Either config["attributes"] exists or config["removeAttributes"] exists.
   assert_true(
     "attributes" in config || "removeAttributes" in config,
     'Assert: Either config["attributes"] exists or config["removeAttributes"] exists.',
   );
 
-  // 4. If config["attributes"] exists and config["removeAttributes"] exists, then return false.
+  // 6. If config["attributes"] exists and config["removeAttributes"] exists, then return false.
   assert_false(
     "attributes" in config && "removeAttributes" in config,
     'If config["attributes"] exists and config["removeAttributes"] exists, then return false.',
   );
 
-  // 5. Assert: All SanitizerElementNamespaceWithAttributes, SanitizerElementNamespace, and SanitizerAttributeNamespace items in config are canonical, meaning they have been run through canonicalize a sanitizer element or canonicalize a sanitizer attribute, as appropriate.
+  // 7. Assert: All SanitizerElementNamespaceWithAttributes, SanitizerElementNamespace, SanitizerProcessingInstruction, and SanitizerAttributeNamespace items in config are canonical, meaning they have been run through canonicalize a sanitizer element, canonicalize a sanitizer processing instruction, or canonicalize a sanitizer attribute, as appropriate.
 
-  // 6. If config["elements"] exists:
+  // 8. If config["elements"] exists:
   if ("elements" in config) {
-    // 6.1. If config["elements"] has duplicates, then return false.
+    // 8.1. If config["elements"] has duplicates, then return false.
     assert_false(has_duplicates(config.elements), 'If config["elements"] has duplicates, then return false.');
   } else {
-    // 7. Otherwise:
-    // 7.1. If config["removeElements"] has duplicates, then return false.
+    // 9. Otherwise:
+    // 9.1. If config["removeElements"] has duplicates, then return false.
     assert_false(has_duplicates(config.removeElements), 'If config["removeElements"] has duplicates, then return false.');
   }
 
-  // 8. If config["replaceWithChildrenElements"] exists and has duplicates, then return false.
+  // 10. If config["replaceWithChildrenElements"] exists and has duplicates, then return false.
   if (config.replaceWithChildrenElements) {
     assert_false(has_duplicates(config.replaceWithChildrenElements), 'If config["replaceWithChildrenElements"] exists and has duplicates, then return false.');
   }
 
-  // 9. If config["attributes"] exists:
+  // 11. If config["processingInstructions"] exists:
+  if ("processingInstructions" in config) {
+    // 11.1. If config["processingInstructions"] has duplicate targets, then return false.
+    assert_false(has_duplicate_targets(config.processingInstructions), 'If config["processingInstructions"] has duplicate targets, then return false.')
+  } else {
+    // 12. Otherwise:
+    // 12.1. If config["removeProcessingInstructions"] has duplicate targets, then return false.
+    assert_false(has_duplicate_targets(config.removeProcessingInstructions), 'If config["removeProcessingInstructions"] has duplicate targets, then return false.')
+  }
+
+  // 13. If config["attributes"] exists:
   if ("attributes" in config) {
-    // 9.1. If config["attributes"] has duplicates, then return false.
+    // 13.1. If config["attributes"] has duplicates, then return false.
     assert_false(has_duplicates(config.attributes), 'If config["attributes"] has duplicates, then return false.');
   } else {
-    // 10. Otherwise:
-    // 10.1. If config["removeAttributes"] has duplicates, then return false.
+    // 14. Otherwise:
+    // 14.1. If config["removeAttributes"] has duplicates, then return false.
     assert_false(has_duplicates(config.removeAttributes), 'If config["removeAttributes"] has duplicates, then return false.');
   }
 
-  // 11. If config["replaceWithChildrenElements"] exists:
+  // 15. If config["replaceWithChildrenElements"] exists:
   if (config.replaceWithChildrenElements) {
-    // 11.1. If config["elements"] exists:
+    // 15.1. If config["elements"] exists:
     if (config.elements) {
-      // 11.1.1. If the intersection of config["elements"] and config["replaceWithChildrenElements"] is not empty, then return false.
+      // 15.1.1. If the intersection of config["elements"] and config["replaceWithChildrenElements"] is not empty, then return false.
       assert_false(
         has_intersection(config.elements, config.replaceWithChildrenElements),
         'If the intersection of config["elements"] and config["replaceWithChildrenElements"] is not empty, then return false.',
       );
     } else {
-      // 11.2. Otherwise:
-      // 11.2.1. If the intersection of config["removeElements"] and config["replaceWithChildrenElements"] is not empty, then return false.
+      // 15.2. Otherwise:
+      // 15.2.1. If the intersection of config["removeElements"] and config["replaceWithChildrenElements"] is not empty, then return false.
       assert_false(
         has_intersection(config.removeElements, config.replaceWithChildrenElements),
         'If the intersection of config["removeElements"] and config["replaceWithChildrenElements"] is not empty, then return false.',
@@ -134,36 +176,36 @@ function assert_config_is_valid(config) {
     }
   }
 
-  // 12. If config["attributes"] exists:
+  // 16. If config["attributes"] exists:
   if (config.attributes) {
-    // 12.1. Assert: config["dataAttributes"] exists.
+    // 16.1. Assert: config["dataAttributes"] exists.
     assert_true("dataAttributes" in config, 'Assert: config["dataAttributes"] exists.');
 
-    // 12.2. If config["elements"] exists:
+    // 16.2. If config["elements"] exists:
     if (config.elements) {
-      // 12.2.1. For each element of config["elements"]:
+      // 16.2.1. For each element of config["elements"]:
       for (let element of config.elements) {
-        // 12.2.1.1. If element["attributes"] exists and element["attributes"] has duplicates, then return false.
+        // 16.2.1.1. If element["attributes"] exists and element["attributes"] has duplicates, then return false.
         if (element.attributes) {
           assert_false(has_duplicates(element.attributes),
                       `If element["attributes"] exists and element["attributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 12.2.1.2. If element["removeAttributes"] exists and element["removeAttributes"] has duplicates, then return false.
+        // 16.2.1.2. If element["removeAttributes"] exists and element["removeAttributes"] has duplicates, then return false.
         if (element.removeAttributes) {
           assert_false(has_duplicates(element.removeAttributes),
                       `If element["removeAttributes"] exists and element["removeAttributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 12.2.1.3. If the intersection of config["attributes"] and element["attributes"] with default « » is not empty, then return false.
+        // 16.2.1.3. If the intersection of config["attributes"] and element["attributes"] with default « » is not empty, then return false.
         assert_false(has_intersection(config.attributes, element.attributes),
                     `If the intersection of config["attributes"] and element["attributes"] with default « » is not empty, then return false. (element: ${element.name})`);
 
-        // 12.2.1.4. If element["removeAttributes"] with default « » is not a subset of config["attributes"], then return false.
+        // 16.2.1.4. If element["removeAttributes"] with default « » is not a subset of config["attributes"], then return false.
         assert_true(is_subset(element.removeAttributes, config.attributes),
                     `If element["removeAttributes"] with default « » is not a subset of config["attributes"], then return false. (element: ${element.name})`);
 
-        // 12.2.1.5. If config["dataAttributes"] is true and element["attributes"] contains a custom data attribute, then return false.
+        // 16.2.1.5. If config["dataAttributes"] is true and element["attributes"] contains a custom data attribute, then return false.
         if (config.dataAttributes && element.attributes) {
           for (let attr of element.attributes) {
             assert_false(is_data_attribute(attr),
@@ -173,7 +215,7 @@ function assert_config_is_valid(config) {
       }
     }
 
-    // 12.3. If config["dataAttributes"] is true and config["attributes"] contains a custom data attribute, then return false.
+    // 16.3. If config["dataAttributes"] is true and config["attributes"] contains a custom data attribute, then return false.
     if (config.dataAttributes) {
       for (let attr of config.attributes) {
         assert_false(is_data_attribute(attr),
@@ -181,34 +223,34 @@ function assert_config_is_valid(config) {
       }
     }
   } else {
-    // 13. Otherwise:
-    // 13.1. If config["elements"] exists:
+    // 17. Otherwise:
+    // 17.1. If config["elements"] exists:
     if (config.elements) {
-      // 13.1.1. For each element of config["elements"]:
+      // 17.1.1. For each element of config["elements"]:
       for (let element of config.elements) {
-        // 13.1.1.1. If element["attributes"] exists and element["removeAttributes"] exists, then return false.
+        // 17.1.1.1. If element["attributes"] exists and element["removeAttributes"] exists, then return false.
         assert_false("attributes" in element && "removeAttributes" in element,
                      `If element["attributes"] exists and element["removeAttributes"] exists, then return false. (element: ${element.name})`);
 
-        // 13.1.1.2. If element["attributes"] exist and element["attributes"] has duplicates, then return false.
+        // 17.1.1.2. If element["attributes"] exist and element["attributes"] has duplicates, then return false.
         if (element.attributes) {
           assert_false(has_duplicates(element.attributes),
                       `If element["attributes"] exist and element["attributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 13.1.1.3. If element["removeAttributes"] exist and element["removeAttributes"] has duplicates, then return false.
+        // 17.1.1.3. If element["removeAttributes"] exist and element["removeAttributes"] has duplicates, then return false.
         if (element.removeAttributes) {
           assert_false(has_duplicates(element.removeAttributes),
                       `If element["removeAttributes"] exist and element["removeAttributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 13.1.1.4. If the intersection of config["removeAttributes"] and element["attributes"] with default « » is not empty, then return false.
+        // 17.1.1.4. If the intersection of config["removeAttributes"] and element["attributes"] with default « » is not empty, then return false.
         if (element.attributes) {
           assert_false(has_intersection(config.removeAttributes, element.attributes),
                       `If the intersection of config["removeAttributes"] and element["attributes"] with default « » is not empty, then return false. (element: ${element.name})`);
         }
 
-        // 13.1.1.5. If the intersection of config["removeAttributes"] and element["removeAttributes"] with default « » is not empty, then return false.
+        // 17.1.1.5. If the intersection of config["removeAttributes"] and element["removeAttributes"] with default « » is not empty, then return false.
         if (element.removeAttributes) {
           assert_false(has_intersection(config.removeAttributes, element.removeAttributes),
                       `If the intersection of config["removeAttributes"] and element["removeAttributes"] with default « » is not empty, then return false. (element: ${element.name})`);
@@ -216,17 +258,19 @@ function assert_config_is_valid(config) {
       }
     }
 
-    // 13.2. If config["dataAttributes"] exists, then return false.
+    // 17.2. If config["dataAttributes"] exists, then return false.
     assert_false("dataAttributes" in config, 'If config["dataAttributes"] exists, then return false.');
   }
 
-  // 14. Return true.
+  // 18. Return true.
 }
 
 function assert_config(config, expected) {
   const PROPERTIES = [
     "attributes",
     "removeAttributes",
+    "processingInstructions",
+    "removeProcessingInstructions",
     "elements",
     "removeElements",
     "replaceWithChildrenElements",
@@ -277,6 +321,39 @@ function assert_config(config, expected) {
 
   assert_attrs("attributes", config, expected);
   assert_attrs("removeAttributes", config, expected);
+
+  function assert_pis(key, config, expected, prefix = "config") {
+    if (!(key in expected)) {
+      return;
+    }
+
+    if (expected[key] === undefined) {
+      assert_false(key in config, `Unexpected '${key}' in ${prefix}`);
+      return;
+    }
+
+    assert_true(key in config, `Missing '${key}' from ${prefix}`);
+    assert_equals(config[key]?.length, expected[key].length, `${prefix}.${key}.length`);
+    for (let i = 0; i < expected[key].length; i++) {
+      let processingInstructions = expected[key][i];
+      if (typeof processingInstructions === "string") {
+        assert_object_equals(
+          config[key][i],
+          { target: processingInstructions },
+          `${prefix}.${key}[${i}] should match`,
+        );
+      } else {
+        assert_object_equals(
+          config[key][i],
+          processingInstructions,
+          `${prefix}.${key}[${i}] should match`,
+        );
+      }
+    }
+  }
+
+  assert_pis("processingInstructions", config, expected);
+  assert_pis("removeProcessingInstructions", config, expected);
 
   function assert_elems(key) {
     if (!(key in expected)) {


### PR DESCRIPTION
Implement support for processing instructions in our Sanitizer API implementation.

This patch implements the `Sanitizer.allowProcessingInstructions()` and `Sanitizer.removeProcessingInstructions()` methods, along with some supporting algorithms and missing steps related to processing instructions.

Specification:
- https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowprocessinginstruction
- https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeprocessinginstruction
- https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-processing-instruction
- https://wicg.github.io/sanitizer-api/#sanitizerconfig-contains-a-target
- https://wicg.github.io/sanitizer-api/#sanitizerconfig-has-duplicate-targets

Testing:
- Add new WPT tests to:
  - `sanitizer-api/sanitizer-config.tentative.html` and
  - `sanitizer-api/sanitizer-get.tentative.html`
- Update tests in:
  - `sanitizer-api/sanitizer-default-config.tentative.html`
- Remove a test case from:
  - `sanitizer-api/sanitizer-processing-instructions.tentative.html` (According to Step 4 of https://wicg.github.io/sanitizer-api/#sanitizerconfig-valid, the configuration of that test case is invalid since both "processingInstructions" and "removeProcessingInstructions" keys exist.)
- Update supporting file:
  - `sanitizer-api/support/util.js`

Fixes: Part of #<!-- nolink -->43948
Reviewed in servo/servo#44734