### PR TITLE
script: Fix effectively contained including ancestors of text nodes

### DIFF
--- a/selection/crashtests/selection-modify-line-boundary-around-empty-details.html
+++ b/selection/crashtests/selection-modify-line-boundary-around-empty-details.html
@@ -9,7 +9,19 @@ addEventListener("load", () => {
   let i = 0;
   const details = document.querySelector("details");
   const id = setInterval(() => {
-    getSelection().modify("move", "forward", "lineboundary");
+    const selection = getSelection();
+    if (!selection) {
+      clearInterval(id);
+      throw new Error("Should always have a selection");
+    }
+    // This means that the browser doesn't support modify.
+    // Rather than endless looping and crashing the browser,
+    // exit early.
+    if (!selection.modify) {
+      clearInterval(id);
+      return;
+    }
+    selection.modify("move", "forward", "lineboundary");
     if (details.isConnected) {
       details.outerHTML = undefined;
     }


### PR DESCRIPTION
There is a tricky bit of text nodes that also consider their ancestors
effectively contained. To make that properly work, when computing all
nodes that are effectively contained, we now traverse from the
editing host, rather than the common ancestor container.

However, that then would fail numerous tests. That's because when
text nodes are moved, their positions would be updated to be the
new parent, instead of the original text node. The spec states that
this is implicit, but turns out it is not. It might be that this is
related to the implementation of ranges in Servo, but for now let's
make it explicit it when moving. I also think this is nicer anyways,
since we should retain the original selection and that should be
the text node.

Overall, this makes more tests pass, while also fail others. I will
continue investigating why, but unfortunately that's the nature of
this suite of WPT tests.

Lastly, during debugging I needed to know the exact text contents of
these text nodes. Therefore, update the way to format nodes to also
consider characterdata, for nicer debugging experience.

Part of #<!-- nolink -->25005

Testing: WPT
Reviewed in servo/servo#44735