### PR TITLE
script: Fix panic when deleting after range.deleteContents

### DIFF
--- a/editing/crashtests/delete-after-removing-first-child.html
+++ b/editing/crashtests/delete-after-removing-first-child.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html id="a">
+<script id="b">
+window.onload = () => {
+  document.getSelection().collapse(span1);
+  const range = document.createRange();
+  range.setEndBefore(span2);
+  // This deletes the document element, but leaves behind span 2. The document
+  // now contains the div with 1 child, which is span 2.
+  range.deleteContents();
+  document.execCommand("delete", false, null);
+}
+</script>
+<div contenteditable><span id="span1"></span><span id="span2"></span></div>

--- a/editing/other/delete-editing-host.html
+++ b/editing/other/delete-editing-host.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Deletion of full editing host</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div contenteditable id="empty"></div>
+<div contenteditable id="with-child"><span>Here is a child</span></div>
+<script>
+const emptyDiv = document.getElementById("empty");
+const withChildDiv = document.getElementById("with-child");
+
+test(function() {
+  document.getSelection().collapse(emptyDiv);
+
+  assert_true(document.execCommand("delete", false, null));
+
+  assert_true(emptyDiv.isConnected);
+  assert_equals(emptyDiv.innerHTML, "");
+}, "Should not do anything when deleting full editing host");
+
+test(function() {
+  document.getSelection().collapse(withChildDiv);
+
+  assert_true(document.execCommand("delete", false, null));
+
+  assert_true(withChildDiv.isConnected);
+  assert_equals(withChildDiv.innerHTML, "<span>Here is a child</span>");
+}, "Should retain all children when deleting full editing host");
+</script>


### PR DESCRIPTION
The state of the document after `range.deleteContents` leads to the delete command to traverse to the root element and then crash. Instead, we should simply stop the loop and continue the algorithm and delete backwards.

Also added an additional test I created when trying to figure out what other browsers are doing
and added spec comments to `deleteContents`. Lastly, also incorporate the spec fix of https://github.com/whatwg/dom/pull/1452

Fixes #<!-- nolink -->44742

Testing: WPT
Reviewed in servo/servo#44748