### PR TITLE
Add foundational tests for aria-description and aria-describedby.

### DIFF
--- a/wai-aria/description/description.tentative.html
+++ b/wai-aria/description/description.tentative.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/wai-aria/scripts/aria-utils.js"></script>
+
+<div data-testname="button with missing aria-description" role="button" data-expectedproperties='{ "description": "" }' class="ex-props"></div>
+<div data-testname="button with aria-description" role="button" aria-description="test aria-description" data-expectedproperties='{ "description": "test aria-description" }' class="ex-props"></div>
+<div id="simpleDescribedBy">simpleDescribedBy</div>
+<div data-testname="button with aria-describedby" role="button" aria-describedby="simpleDescribedBy" data-expectedproperties='{ "description": "simpleDescribedBy" }' class="ex-props"></div>
+
+<script>
+AriaUtils.verifyPropertiesBySelector(".ex-props");
+</script>


### PR DESCRIPTION
These just test the fundamentals: that aria-description and aria-describedby are correctly computed and exposed. Additional tests (e.g. HTML title attribute, more complex description computation) probably belong in html-aam and accname, though that's an open question because they will need to use aria-utils.js. I'm happy to add more tests in this first PR if people would prefer that, but I figured it was best to start small and grow if needed.