### PR TITLE
layout: Disregard 'content' property for <input> elements

### DIFF
--- a/css/css-ui/crashtests/input-range-content-url.html
+++ b/css/css-ui/crashtests/input-range-content-url.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/44540">
+<input style="content: url()" type="range">


### PR DESCRIPTION
On elements (as opposed to pseudo-elements), CSS `content: url(something)` turns the element into a replaced element like `<img>` and ignores the DOM child nodes

Some elements like `<input>` are "widgets" that can have native appearance: https://drafts.csswg.org/css-ui/#widget

When both apply to the same element like in the added test case, the native appearance should take priority and the `content` property should be disregarded: https://drafts.csswg.org/css-ui/#disregard

Previously Servo would do something half-way, generating boxes for the native appearance (including an absolutely-positioned pseudo-element for the slider of `<input type=range>`) but not generate fragments and later expect to find fragments, causing a panic.

Testing: adding the issue reproduction as a WPT crashtest
Fixes: https://github.com/servo/servo/issues/44540
Reviewed in servo/servo#44762