### PR TITLE
Improve the WebTransport H3 Server

### DIFF
--- a/tools/requirements_tests.txt
+++ b/tools/requirements_tests.txt
@@ -1,3 +1,4 @@
+-r webtransport/requirements.txt
 httpx[http2]==0.27.2
 json-e==4.7.0
 jsonschema==4.25.1; python_version >= '3.9'

--- a/tools/webtransport/h3/docroot/echo.py
+++ b/tools/webtransport/h3/docroot/echo.py
@@ -1,0 +1,2 @@
+def stream_data_received(session, stream_id, data, stream_ended):
+    session.send_stream_data(stream_id, data, end_stream=stream_ended)

--- a/tools/webtransport/h3/test_webtransport_h3_server.py
+++ b/tools/webtransport/h3/test_webtransport_h3_server.py
@@ -1,0 +1,173 @@
+# type: ignore
+
+import asyncio
+import importlib.util
+import os
+import socket
+import ssl
+
+import pytest
+
+if importlib.util.find_spec("aioquic"):
+    has_aioquic = True
+    from aioquic.asyncio import QuicConnectionProtocol
+    from aioquic.asyncio.client import connect
+    from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection
+    from aioquic.h3.events import HeadersReceived, WebTransportStreamDataReceived
+    from aioquic.quic.configuration import QuicConfiguration
+    from aioquic.quic.events import QuicEvent, ProtocolNegotiated
+
+    from .webtransport_h3_server import WebTransportH3Server
+else:
+    has_aioquic = False
+
+
+here = os.path.dirname(__file__)
+
+
+SERVER_HOST = "127.0.0.1"
+
+
+def get_free_udp_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((SERVER_HOST, 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+if has_aioquic:
+
+    class WebTransportClientProtocol(QuicConnectionProtocol):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._http = None
+            self._session_id = None
+            self._session_ready = None
+            self._stream_data_received = None
+
+        def quic_event_received(self, event: QuicEvent) -> None:
+            if isinstance(event, ProtocolNegotiated):
+                self._http = H3Connection(self._quic, enable_webtransport=True)
+
+            if self._http is not None:
+                for h3_event in self._http.handle_event(event):
+                    self._h3_event_received(h3_event)
+
+        def _h3_event_received(self, event):
+            if isinstance(event, HeadersReceived):
+                headers = dict(event.headers)
+                if self._session_ready and not self._session_ready.done():
+                    status = int(headers.get(b":status", b"0"))
+                    self._session_ready.set_result(status)
+            elif isinstance(event, WebTransportStreamDataReceived):
+                if self._stream_data_received and not self._stream_data_received.done():
+                    self._stream_data_received.set_result(
+                        (event.data, event.stream_ended)
+                    )
+
+        async def connect_session(self, authority, path):
+            assert self._http is not None
+            loop = asyncio.get_event_loop()
+            self._session_ready = loop.create_future()
+
+            stream_id = self._quic.get_next_available_stream_id()
+            self._session_id = stream_id
+            self._http.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"CONNECT"),
+                    (b":scheme", b"https"),
+                    (b":authority", authority.encode()),
+                    (b":path", path.encode()),
+                    (b":protocol", b"webtransport"),
+                    (b"origin", b"https://localhost"),
+                ],
+            )
+            self.transmit()
+
+            return await asyncio.wait_for(self._session_ready, timeout=5.0)
+
+        async def send_bidi_stream(self, data):
+            assert self._http is not None
+            assert self._session_id is not None
+            loop = asyncio.get_event_loop()
+            self._stream_data_received = loop.create_future()
+
+            stream_id = self._http.create_webtransport_stream(
+                self._session_id, is_unidirectional=False
+            )
+            # Workaround: aioquic doesn't register the stream for receiving
+            # data after create_webtransport_stream (same issue as server
+            # side in webtransport_h3_server.py create_bidirectional_stream).
+            stream = self._http._get_or_create_stream(stream_id)
+            stream.frame_type = FrameType.WEBTRANSPORT_STREAM
+            stream.session_id = self._session_id
+            self._quic.send_stream_data(stream_id, data, end_stream=True)
+            self.transmit()
+
+            return await asyncio.wait_for(self._stream_data_received, timeout=5.0)
+
+
+@pytest.mark.skipif(not has_aioquic, reason="aioquic not installed")
+class TestWebTransportH3Server:
+    def setup_method(self):
+        from tools import localpaths
+
+        repo_root = localpaths.repo_root
+        self.port = get_free_udp_port()
+        self.server = WebTransportH3Server(
+            host=SERVER_HOST,
+            port=self.port,
+            doc_root=os.path.join(here, "docroot"),
+            cert_path=os.path.join(
+                repo_root, "tools", "certs", "web-platform.test.pem"
+            ),
+            key_path=os.path.join(repo_root, "tools", "certs", "web-platform.test.key"),
+            logger=None,
+        )
+        self.server.start()
+
+    def teardown_method(self):
+        self.server.stop()
+
+    def test_session_establishment(self):
+        async def run():
+            configuration = QuicConfiguration(
+                alpn_protocols=H3_ALPN,
+                is_client=True,
+                verify_mode=ssl.CERT_NONE,
+            )
+            async with connect(
+                SERVER_HOST,
+                self.port,
+                configuration=configuration,
+                create_protocol=WebTransportClientProtocol,
+            ) as protocol:
+                authority = f"{SERVER_HOST}:{self.port}"
+                status = await protocol.connect_session(authority, "/echo.py")
+                assert status == 200
+
+        asyncio.run(run())
+
+    def test_bidi_stream_echo(self):
+        async def run():
+            configuration = QuicConfiguration(
+                alpn_protocols=H3_ALPN,
+                is_client=True,
+                verify_mode=ssl.CERT_NONE,
+            )
+            async with connect(
+                SERVER_HOST,
+                self.port,
+                configuration=configuration,
+                create_protocol=WebTransportClientProtocol,
+            ) as protocol:
+                authority = f"{SERVER_HOST}:{self.port}"
+                status = await protocol.connect_session(authority, "/echo.py")
+                assert status == 200
+                data, stream_ended = await protocol.send_bidi_stream(b"hello")
+                assert data == b"hello"
+                assert stream_ended is True
+
+        asyncio.run(run())

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -567,7 +567,7 @@ class WebTransportH3Server:
         ticket_store = SessionTicketStore()
 
         self.server_thread = threading.Thread(
-            target=self._start_on_server_thread,
+            target=self._run,
             args=(configuration, ticket_store),
             daemon=True,
         )
@@ -577,7 +577,7 @@ class WebTransportH3Server:
             raise self._thread_exception
         self.started = True
 
-    def _start_on_server_thread(
+    def _run(
         self, configuration: QuicConfiguration, ticket_store: SessionTicketStore
     ) -> None:
         try:
@@ -592,21 +592,9 @@ class WebTransportH3Server:
             self._stop_event = asyncio.Event()
 
             try:
-                try:
-                    self.loop.run_until_complete(
-                        serve(
-                            self.host,
-                            self.port,
-                            configuration=configuration,
-                            create_protocol=WebTransportH3Protocol,
-                            session_ticket_fetcher=ticket_store.pop,
-                            session_ticket_handler=ticket_store.add,
-                        )
-                    )
-                finally:
-                    self._loop_ready.set()
-
-                self.loop.run_until_complete(self._stop_event.wait())
+                self.loop.run_until_complete(
+                    self._serve_forever(configuration, ticket_store)
+                )
             finally:
                 self.loop.run_until_complete(self.loop.shutdown_asyncgens())
                 self.loop.run_until_complete(self.loop.shutdown_default_executor())
@@ -615,6 +603,20 @@ class WebTransportH3Server:
             _logger.error("_start_on_server_thread: %s", e)
             self._thread_exception = e
             self._loop_ready.set()
+
+    async def _serve_forever(
+        self, configuration: QuicConfiguration, ticket_store: SessionTicketStore
+    ) -> None:
+        await serve(
+            self.host,
+            self.port,
+            configuration=configuration,
+            create_protocol=WebTransportH3Protocol,
+            session_ticket_fetcher=ticket_store.pop,
+            session_ticket_handler=ticket_store.add,
+        )
+        self._loop_ready.set()
+        await self._stop_event.wait()
 
     def stop(self) -> None:
         """Stop the server."""

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -579,8 +579,9 @@ class WebTransportH3Server:
         # doesn't seem to work when aioquic detects a connection loss.
         # Use SelectorEventLoop to work around the problem.
         if sys.platform == "win32":
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        self.loop = asyncio.new_event_loop()
+            self.loop = asyncio.SelectorEventLoop()
+        else:
+            self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
 
         self.loop.run_until_complete(

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -527,6 +527,7 @@ class WebTransportH3Server:
         self.key_path = key_path
         self.started = False
         self.loop = None
+        self._loop_ready = threading.Event()
         global _doc_root
         _doc_root = self.doc_root
         global _logger
@@ -571,6 +572,9 @@ class WebTransportH3Server:
             daemon=True,
         )
         self.server_thread.start()
+        self._loop_ready.wait()
+        if not self.server_thread.is_alive():
+            raise self._thread_exception
         self.started = True
 
     def _start_on_server_thread(
@@ -586,20 +590,24 @@ class WebTransportH3Server:
                 self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
 
-            self.loop.run_until_complete(
-                serve(
-                    self.host,
-                    self.port,
-                    configuration=configuration,
-                    create_protocol=WebTransportH3Protocol,
-                    session_ticket_fetcher=ticket_store.pop,
-                    session_ticket_handler=ticket_store.add,
+            try:
+                self.loop.run_until_complete(
+                    serve(
+                        self.host,
+                        self.port,
+                        configuration=configuration,
+                        create_protocol=WebTransportH3Protocol,
+                        session_ticket_fetcher=ticket_store.pop,
+                        session_ticket_handler=ticket_store.add,
+                    )
                 )
-            )
+            finally:
+                self._loop_ready.set()
             self.loop.run_forever()
         except Exception as e:
             _logger.error("_start_on_server_thread: %s", e)
             self._thread_exception = e
+            self._loop_ready.set()
 
     def stop(self) -> None:
         """Stop the server."""

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -511,8 +511,15 @@ class WebTransportH3Server:
     :param logger: a Logger object for this server.
     """
 
-    def __init__(self, host: str, port: int, doc_root: str, cert_path: str,
-                 key_path: str, logger: Optional[logging.Logger]) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        doc_root: str,
+        cert_path: str,
+        key_path: str,
+        logger: Optional[logging.Logger],
+    ) -> None:
         self.host = host
         self.port = port
         self.doc_root = doc_root
@@ -528,7 +535,8 @@ class WebTransportH3Server:
     def start(self) -> None:
         """Start the server."""
         self.server_thread = threading.Thread(
-            target=self._start_on_server_thread, daemon=True)
+            target=self._start_on_server_thread, daemon=True
+        )
         self.server_thread.start()
         self.started = True
 
@@ -555,8 +563,9 @@ class WebTransportH3Server:
                 max_datagram_frame_size=65536,
             )
 
-        _logger.info("Starting WebTransport over HTTP/3 server on %s:%s",
-                     self.host, self.port)
+        _logger.info(
+            "Starting WebTransport over HTTP/3 server on %s:%s", self.host, self.port
+        )
 
         configuration.load_cert_chain(Path(self.cert_path), Path(self.key_path))
 
@@ -566,8 +575,7 @@ class WebTransportH3Server:
         # doesn't seem to work when aioquic detects a connection loss.
         # Use SelectorEventLoop to work around the problem.
         if sys.platform == "win32":
-            asyncio.set_event_loop_policy(
-                asyncio.WindowsSelectorEventLoopPolicy())
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
 
@@ -579,17 +587,18 @@ class WebTransportH3Server:
                 create_protocol=WebTransportH3Protocol,
                 session_ticket_fetcher=ticket_store.pop,
                 session_ticket_handler=ticket_store.add,
-            ))
+            )
+        )
         self.loop.run_forever()
 
     def stop(self) -> None:
         """Stop the server."""
         if self.started:
-            asyncio.run_coroutine_threadsafe(self._stop_on_server_thread(),
-                                             self.loop)
+            asyncio.run_coroutine_threadsafe(self._stop_on_server_thread(), self.loop)
             self.server_thread.join()
-            _logger.info("Stopped WebTransport over HTTP/3 server on %s:%s",
-                         self.host, self.port)
+            _logger.info(
+                "Stopped WebTransport over HTTP/3 server on %s:%s", self.host, self.port
+            )
         self.started = False
 
     async def _stop_on_server_thread(self) -> None:
@@ -617,7 +626,9 @@ async def _connect_server_with_timeout(host: str, port: int, timeout: float) -> 
     return True
 
 
-def _close_unusable_writer(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+def _close_unusable_writer(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
     # Starting in python3.11, `StreamWriter.__del__` implicitly `close()`s
     # itself [0], if it has not done so already. Because aioquic sometimes
     # models a unidirectional stream with a bidirectional transport [1], the
@@ -631,7 +642,9 @@ def _close_unusable_writer(reader: asyncio.StreamReader, writer: asyncio.StreamW
     # [0]: https://github.com/python/cpython/blob/3.11/Lib/asyncio/streams.py#L413
     # [1]: https://github.com/aiortc/aioquic/blob/1.2.0/src/aioquic/asyncio/protocol.py#L241
     stream_id = cast(QuicStreamAdapter, writer.transport).stream_id
-    if stream_is_unidirectional(stream_id) and not stream_is_client_initiated(stream_id):
+    if stream_is_unidirectional(stream_id) and not stream_is_client_initiated(
+        stream_id
+    ):
         with contextlib.suppress(ValueError):
             writer.close()
 
@@ -643,6 +656,7 @@ async def _connect_to_server(host: str, port: int) -> None:
         verify_mode=ssl.CERT_NONE,
     )
 
-    async with connect(host, port, configuration=configuration,
-                       stream_handler=_close_unusable_writer) as protocol:
+    async with connect(
+        host, port, configuration=configuration, stream_handler=_close_unusable_writer
+    ) as protocol:
         await protocol.ping()

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -589,21 +589,28 @@ class WebTransportH3Server:
             else:
                 self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
+            self._stop_event = asyncio.Event()
 
             try:
-                self.loop.run_until_complete(
-                    serve(
-                        self.host,
-                        self.port,
-                        configuration=configuration,
-                        create_protocol=WebTransportH3Protocol,
-                        session_ticket_fetcher=ticket_store.pop,
-                        session_ticket_handler=ticket_store.add,
+                try:
+                    self.loop.run_until_complete(
+                        serve(
+                            self.host,
+                            self.port,
+                            configuration=configuration,
+                            create_protocol=WebTransportH3Protocol,
+                            session_ticket_fetcher=ticket_store.pop,
+                            session_ticket_handler=ticket_store.add,
+                        )
                     )
-                )
+                finally:
+                    self._loop_ready.set()
+
+                self.loop.run_until_complete(self._stop_event.wait())
             finally:
-                self._loop_ready.set()
-            self.loop.run_forever()
+                self.loop.run_until_complete(self.loop.shutdown_asyncgens())
+                self.loop.run_until_complete(self.loop.shutdown_default_executor())
+                self.loop.close()
         except Exception as e:
             _logger.error("_start_on_server_thread: %s", e)
             self._thread_exception = e
@@ -614,7 +621,7 @@ class WebTransportH3Server:
         if self.started:
             if not self.server_thread.is_alive():
                 raise self._thread_exception
-            asyncio.run_coroutine_threadsafe(self._stop_on_server_thread(), self.loop)
+            self.loop.call_soon_threadsafe(self._stop_event.set)
             self.server_thread.join()
             _logger.info(
                 "Stopped WebTransport over HTTP/3 server on %s:%s", self.host, self.port

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -534,13 +534,6 @@ class WebTransportH3Server:
 
     def start(self) -> None:
         """Start the server."""
-        self.server_thread = threading.Thread(
-            target=self._start_on_server_thread, daemon=True
-        )
-        self.server_thread.start()
-        self.started = True
-
-    def _start_on_server_thread(self) -> None:
         secrets_log_file = None
         if "SSLKEYLOGFILE" in os.environ:
             try:
@@ -571,6 +564,17 @@ class WebTransportH3Server:
 
         ticket_store = SessionTicketStore()
 
+        self.server_thread = threading.Thread(
+            target=self._start_on_server_thread,
+            args=(configuration, ticket_store),
+            daemon=True,
+        )
+        self.server_thread.start()
+        self.started = True
+
+    def _start_on_server_thread(
+        self, configuration: QuicConfiguration, ticket_store: SessionTicketStore
+    ) -> None:
         # On Windows, the default event loop is ProactorEventLoop but it
         # doesn't seem to work when aioquic detects a connection loss.
         # Use SelectorEventLoop to work around the problem.

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -526,6 +526,7 @@ class WebTransportH3Server:
         self.cert_path = cert_path
         self.key_path = key_path
         self.started = False
+        self.loop = None
         global _doc_root
         _doc_root = self.doc_root
         global _logger
@@ -575,30 +576,36 @@ class WebTransportH3Server:
     def _start_on_server_thread(
         self, configuration: QuicConfiguration, ticket_store: SessionTicketStore
     ) -> None:
-        # On Windows, the default event loop is ProactorEventLoop but it
-        # doesn't seem to work when aioquic detects a connection loss.
-        # Use SelectorEventLoop to work around the problem.
-        if sys.platform == "win32":
-            self.loop = asyncio.SelectorEventLoop()
-        else:
-            self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
+        try:
+            # On Windows, the default event loop is ProactorEventLoop but it
+            # doesn't seem to work when aioquic detects a connection loss.
+            # Use SelectorEventLoop to work around the problem.
+            if sys.platform == "win32":
+                self.loop = asyncio.SelectorEventLoop()
+            else:
+                self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
 
-        self.loop.run_until_complete(
-            serve(
-                self.host,
-                self.port,
-                configuration=configuration,
-                create_protocol=WebTransportH3Protocol,
-                session_ticket_fetcher=ticket_store.pop,
-                session_ticket_handler=ticket_store.add,
+            self.loop.run_until_complete(
+                serve(
+                    self.host,
+                    self.port,
+                    configuration=configuration,
+                    create_protocol=WebTransportH3Protocol,
+                    session_ticket_fetcher=ticket_store.pop,
+                    session_ticket_handler=ticket_store.add,
+                )
             )
-        )
-        self.loop.run_forever()
+            self.loop.run_forever()
+        except Exception as e:
+            _logger.error("_start_on_server_thread: %s", e)
+            self._thread_exception = e
 
     def stop(self) -> None:
         """Stop the server."""
         if self.started:
+            if not self.server_thread.is_alive():
+                raise self._thread_exception
             asyncio.run_coroutine_threadsafe(self._stop_on_server_thread(), self.loop)
             self.server_thread.join()
             _logger.info(


### PR DESCRIPTION
- **Start adding a web transport test**
- **reformat**
- **Move WebTransportH3Server init work from thread to start()**
- **Avoid changing the global event loop policy**
- **Handle server thread exceptions in WebTransportH3Server.stop()**
- **Wait for the server to start before start returns**
- **Cleanly close the event loop**
- **Move the main server loop to a coroutine**
