### PR TITLE
Fix disablePictureInPicture attribute for HTMLVideoElement tests

### DIFF
--- a/picture-in-picture/disable-picture-in-picture.html
+++ b/picture-in-picture/disable-picture-in-picture.html
@@ -34,16 +34,6 @@ promise_test(async t => {
 
 promise_test(async t => {
   const video = await loadVideo();
-  await test_driver.bless('request Picture-in-Picture');
-  const promise = video.requestPictureInPicture();
-  video.disablePictureInPicture = true;
-  await promise_rejects_dom(t, 'InvalidStateError', promise);
-  assert_equals(document.pictureInPictureElement, null);
-}, 'Request Picture-in-Picture rejects if disablePictureInPicture becomes ' +
-   'true before promise resolves.');
-
-promise_test(async t => {
-  const video = await loadVideo();
   return requestPictureInPictureWithTrustedClick(video)
   .then(() => {
     video.disablePictureInPicture = true;

--- a/picture-in-picture/disable-picture-in-picture.html
+++ b/picture-in-picture/disable-picture-in-picture.html
@@ -35,11 +35,11 @@ promise_test(async t => {
 promise_test(async t => {
   const video = await loadVideo();
   return requestPictureInPictureWithTrustedClick(video)
-  .then(() => {
+  .then(async () => {
+    // Note that request has completed here. This does *not* abort an on-going request.
     video.disablePictureInPicture = true;
-    video.addEventListener('leavepictureinpicture', t.step_func(() => {
-      assert_equals(document.pictureInPictureElement, null);
-    }));
+    await new Promise((resolve) => video.addEventListener('leavepictureinpicture', resolve));
+    assert_equals(document.pictureInPictureElement, null);
   });
 }, 'pictureInPictureElement is unset if disablePictureInPicture becomes true');
 


### PR DESCRIPTION
Closes #59722

Does the following:

- Removes the mid-flight expectation because this is is not spec'ed behavior.
- Fixes test that doesn't run it's event handler