### PR TITLE
Add dom as a dependency for the sanitizer-api idlharness test

### DIFF
--- a/sanitizer-api/idlharness.https.window.js
+++ b/sanitizer-api/idlharness.https.window.js
@@ -3,7 +3,7 @@
 
 idl_test(
   ['sanitizer-api'],
-  ['html'],
+  ['html', 'dom'],
   idl_array => {
     idl_array.add_objects({
       Sanitizer: ['new Sanitizer({})']


### PR DESCRIPTION
Changes to the sanitizer-api spec require an additional dependency on `dom` to pick up Element, ShadowRoot and Document.