### PR TITLE
update-wasm-tests workflow: Update OCaml packages and action versions

### DIFF
--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -1,7 +1,6 @@
 name: Update Wasm tests
 
 on:
-  pull_request:
   # Trigger at every Sunday UTC noon, or manually.
   schedule:
     - cron: 0 12 * * 0
@@ -53,7 +52,7 @@ jobs:
           COMMIT_TITLE: "Update Wasm tests"
       - name: Create PR
         # Check outcome for success as continue-on-error will mask failure.
-        if: false()
+        if: ${{ steps.commit.outcome == 'success' }}
         run: |
           cd wpt
           git push --set-upstream origin $BRANCH_NAME

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -53,7 +53,7 @@ jobs:
           COMMIT_TITLE: "Update Wasm tests"
       - name: Create PR
         # Check outcome for success as continue-on-error will mask failure.
-        if: false()
+        if: false
         run: |
           cd wpt
           git push --set-upstream origin $BRANCH_NAME

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: WebAssembly/spec
-{          path: wasm-spec
+          path: wasm-spec
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -1,6 +1,7 @@
 name: Update Wasm tests
 
 on:
+  pull_request:
   # Trigger at every Sunday UTC noon, or manually.
   schedule:
     - cron: 0 12 * * 0
@@ -52,7 +53,7 @@ jobs:
           COMMIT_TITLE: "Update Wasm tests"
       - name: Create PR
         # Check outcome for success as continue-on-error will mask failure.
-        if: ${{ steps.commit.outcome == 'success' }}
+        if: false()
         run: |
           cd wpt
           git push --set-upstream origin $BRANCH_NAME

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout WPT repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: wpt
       - name: Checkout Wasm repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: WebAssembly/spec
-          path: wasm-spec
+{          path: wasm-spec
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14.x
+          ocaml-compiler: 5.04.x
       - name: Setup OCaml tools
-        run: opam install --yes ocamlfind.1.9.5 js_of_ocaml.4.0.0 js_of_ocaml-ppx.4.0.0
+        run: opam install --yes ocamlfind js_of_ocaml js_of_ocaml-ppx
       - name: Build interpreter
         run: cd wasm-spec/interpreter && opam exec make
       - name: Convert WAST tests to WPT

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -53,7 +53,7 @@ jobs:
           COMMIT_TITLE: "Update Wasm tests"
       - name: Create PR
         # Check outcome for success as continue-on-error will mask failure.
-        if: false
+        if: false()
         run: |
           cd wpt
           git push --set-upstream origin $BRANCH_NAME


### PR DESCRIPTION
The workflow is currently failing because of a version conflict in the opam packages.
AFAIK the spec builds just fine without pinning those specific versions. I've updated
to the compiler version used by the upstream spec workflow (which also doesn't pin
the versions of the other tools).

Also update the checkout version to avoid the deprecation warning.