### PR TITLE
script: Fix definition of active parser

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/abort-document-window-stop.sub.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/abort-document-window-stop.sub.window.js
@@ -1,0 +1,17 @@
+// META: title=Child that immediately stops window during loading does not crash
+// META: script=../resources/helpers.js
+
+// This test reproduces Servo issue https://github.com/servo/servo/issues/44720
+
+async_test((test) => {
+  addIframe().then(iframe => {
+    iframe.contentWindow.addEventListener("unload", test.step_func_done(() => {
+      assert_equals(
+        iframe.contentWindow.location.href,
+        "http://{{hosts[][]}}:{{ports[http][0]}}/html/browsers/browsing-the-web/navigating-across-documents/resources/child-immediately-stops-during-loading.html"
+      );
+    }));
+
+    iframe.src = "./resources/child-immediately-stops-during-loading.html";
+  });
+});

--- a/html/browsers/browsing-the-web/navigating-across-documents/resources/child-immediately-stops-during-loading.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/resources/child-immediately-stops-during-loading.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<script>onload = _ => window.stop();</script>
+<iframe onload="document.onreadystatechange = document.createElement('body').onload">


### PR DESCRIPTION
The spec states that a document has an active parser if it hasn't aborted yet. We weren't using that in `Document::abort` and hence we would double abort the parser.

Similarly, `Document::Open` now also correctly uses the active parser and has spec comments added where they were missing.

Fixes #<!-- nolink -->44720
Testing: This change adds a new WPT crash test.
Reviewed in servo/servo#44804