### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=295686

### DIFF
--- a/css/css-position/static-position/top-layer-box-uses-icb-bottom-left-ref.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-bottom-left-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/css/css-position/static-position/top-layer-box-uses-icb-bottom-right-ref.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-bottom-right-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-htb-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: horizontal-tb;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-htb-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: horizontal-tb;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-slr-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-lr;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-slr-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-lr;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-srl-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-rl;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-srl-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: sideways-rl;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-top-left-ref.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-top-left-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/css/css-position/static-position/top-layer-box-uses-icb-top-right-ref.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-top-right-ref.html
@@ -1,0 +1,12 @@
+<style>
+  #green {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="green"></div>

--- a/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-vlr-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-lr;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-vlr-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-left-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-lr;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-vrl-ltr.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-top-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-rl;
+    direction: ltr;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>

--- a/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl.html
+++ b/css/css-position/static-position/top-layer-box-uses-icb-vrl-rtl.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Boxes in the top layer use the initial containing block as their static-position rectangle.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#staticpos-rect">
+<link rel="match" href="top-layer-box-uses-icb-bottom-right-ref.html">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<style>
+  :root {
+    writing-mode: vertical-rl;
+    direction: rtl;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #reference {
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+
+  #popover {
+    width: 100px;
+    height: 100px;
+    background: green;
+
+    /* Override popover UA style */
+    border: none;
+    padding: 0;
+
+    inset: auto;
+  }
+</style>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<div id="reference"></div>
+<!-- This green box should fully cover the red box above. -->
+<div id="popover" popover></div>
+
+<script>
+  document.getElementById("popover").showPopover();
+  waitForAtLeastOneFrame().then(takeScreenshot);
+</script>
+
+</html>


### PR DESCRIPTION
WebKit export from bug: [Boxes in the top layer always use the initial containing block as their static-position rectangle](https://bugs.webkit.org/show_bug.cgi?id=295686)