### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=313681

### DIFF
--- a/css/css-transitions/transition-cancel-elapsed-time-on-removal.html
+++ b/css/css-transitions/transition-cancel-elapsed-time-on-removal.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#event-transitionevent">
+<style>
+.target {
+    transition: margin-left 10s linear;
+    margin-left: 0px;
+}
+</style>
+</head>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/helper.js"></script>
+<script>
+
+promise_test(async t => {
+    const div = document.createElement('div');
+    div.classList.add('target');
+    document.body.appendChild(div);
+
+    getComputedStyle(div).marginLeft;
+    div.style.marginLeft = '100px';
+
+    const animation = div.getAnimations()[0];
+    await animation.ready;
+
+    // Two rAFs are needed. animation.ready can resolve in the same frame as the first rAF,
+    // so the timeline hasn't advanced yet and elapsedTime would be 0.
+    await waitForAnimationFrames(2);
+
+    const cancelEvent = new Promise(resolve => {
+        div.addEventListener('transitioncancel', resolve, { once: true });
+    });
+
+    div.remove();
+
+    // Force a rendering frame so the pending animation event queue is processed.
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    const event = await cancelEvent;
+    assert_greater_than(event.elapsedTime, 0,
+        'elapsedTime should be non-zero when removed mid-transition');
+}, 'transitioncancel elapsedTime is non-zero when element is removed mid-transition');
+
+</script>
+</body>
+</html>

--- a/web-animations/interfaces/Animation/cancel-event-on-element-removal.html
+++ b/web-animations/interfaces/Animation/cancel-event-on-element-removal.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Cancel events on element removal</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations/#canceling-an-animation-section">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@keyframes anim { to { opacity: 0; } }
+</style>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const div = document.createElement('div');
+    div.style.animation = 'anim 10s';
+    document.body.appendChild(div);
+
+    const animation = div.getAnimations()[0];
+    await animation.ready;
+
+    const cancelFired = new Promise(resolve => {
+        animation.addEventListener('cancel', resolve);
+    });
+
+    div.remove();
+
+    const result = await Promise.race([
+        cancelFired.then(() => 'fired'),
+        new Promise(resolve => step_timeout(() => resolve('timeout'), 100))
+    ]);
+
+    assert_equals(result, 'fired',
+        'Web Animations API cancel event should fire on element removal');
+}, 'Animation.cancel event fires when element is removed');
+
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [Skip unnecessary animation cancel work during render tree teardown](https://bugs.webkit.org/show_bug.cgi?id=313681)