### PR TITLE
XMLHttpRequest: improve Content-Type manipulation coverage

### DIFF
--- a/xhr/setrequestheader-content-type.htm
+++ b/xhr/setrequestheader-content-type.htm
@@ -69,6 +69,12 @@
         "String request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
       )
       request(
+        function _String() { return "test"; },
+        {"Content-Type": "application/xml"},
+        "application/xml",
+        "String request keeps setRequestHeader() Content-Type without charset"
+      )
+      request(
         function _XMLDocument() { return new DOMParser().parseFromString("<xml/>", "application/xml"); },
         {"Content-Type": ""},
         "",
@@ -87,6 +93,12 @@
         "XML Document request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
       )
       request(
+        function _XMLDocument() { return new DOMParser().parseFromString("<xml/>", "application/xml"); },
+        {"Content-Type": "application/xhtml+xml"},
+        "application/xhtml+xml",
+        "XML Document request keeps setRequestHeader() Content-Type without charset"
+      )
+      request(
         function _HTMLDocument() { return new DOMParser().parseFromString("<html></html>", "text/html"); },
         {"Content-Type": ""},
         "",
@@ -103,6 +115,12 @@
         {"Content-Type": "text/html+junk;charset=ASCII"},
         "text/html+junk;charset=UTF-8",
         "HTML Document request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
+      )
+      request(
+        function _HTMLDocument() { return new DOMParser().parseFromString("<html></html>", "text/html"); },
+        {"Content-Type": "text/html+junk"},
+        "text/html+junk",
+        "HTML Document request keeps setRequestHeader() Content-Type without charset"
       )
       request(
         function _Blob() { return new Blob(["test"]); },
@@ -211,9 +229,12 @@
         {"Content-Type": "application/xml;charset=ASCII"},
         "application/xml;charset=UTF-8",
         "URLSearchParams request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
-        // the default Content-Type for URLSearchParams has a charset specified (utf-8) in
-        // https://fetch.spec.whatwg.org/#bodyinit, so the user's must be changed to match it
-        // as per https://xhr.spec.whatwg.org/#the-send%28%29-method step 4.
+      )
+      request(
+        function _URLSearchParams() { return new URLSearchParams("q=testQ&topic=testTopic") },
+        {"Content-Type": "application/xml"},
+        "application/xml",
+        "URLSearchParams request keeps setRequestHeader() Content-Type without charset"
       )
     </script>
   </body>

--- a/xhr/setrequestheader-content-type.htm
+++ b/xhr/setrequestheader-content-type.htm
@@ -206,6 +206,15 @@
         "application/x-www-form-urlencoded;charset=UTF-8",
         'URLSearchParams request has correct default Content-Type of "application/x-www-form-urlencoded;charset=UTF-8"'
       )
+      request(
+        function _URLSearchParams() { return new URLSearchParams("q=testQ&topic=testTopic") },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=UTF-8",
+        "URLSearchParams request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
+        // the default Content-Type for URLSearchParams has a charset specified (utf-8) in
+        // https://fetch.spec.whatwg.org/#bodyinit, so the user's must be changed to match it
+        // as per https://xhr.spec.whatwg.org/#the-send%28%29-method step 4.
+      )
     </script>
   </body>
 </html>


### PR DESCRIPTION
#54561 removed a test case citing https://github.com/whatwg/xhr/pull/205 as reason, but I cannot find in there the reason for why this test was removed and if anything is to be changed it is the expectations. We should only remove test coverage when the exact scenario is already covered elsewhere. It does not seem like this was such a case as I presume Servo fails this test, while WebKit for instance is passing it.