### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=313953

### DIFF
--- a/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata.html
+++ b/html/infrastructure/safe-passing-of-structured-data/transfer-audiodata.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>MessageChannel transfer of AudioData</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    const audioData = new AudioData({
+        data: new Float32Array([0.1, 0.2, 0.3, 0.4]),
+        format: "f32",
+        sampleRate: 44100,
+        numberOfFrames: 4,
+        numberOfChannels: 1,
+        timestamp: 0
+    });
+
+    const channel = new MessageChannel();
+    const received = new Promise(resolve => {
+        channel.port2.onmessage = e => resolve(e.data);
+    });
+
+    channel.port1.postMessage(audioData, [audioData]);
+
+    const copy = await received;
+    assert_true(copy instanceof AudioData);
+    assert_equals(copy.numberOfFrames, 4);
+    assert_equals(copy.numberOfChannels, 1);
+    assert_equals(copy.sampleRate, 44100);
+    copy.close();
+}, "AudioData can be transferred through a MessageChannel");
+</script>

--- a/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle.html
+++ b/html/infrastructure/safe-passing-of-structured-data/transfer-mediasourcehandle.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>MessageChannel transfer of MediaSourceHandle</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    const worker = new Worker(URL.createObjectURL(new Blob([`
+        const ms = new ManagedMediaSource();
+        const handle = ms.handle;
+        self.postMessage(handle, [handle]);
+    `], { type: "text/javascript" })));
+
+    const handle = await new Promise((resolve, reject) => {
+        worker.onmessage = e => resolve(e.data);
+        worker.onerror = e => { e.preventDefault(); reject(e.message); };
+    });
+    worker.terminate();
+
+    const channel = new MessageChannel();
+    const received = new Promise(resolve => {
+        channel.port2.onmessage = e => resolve(e.data);
+    });
+
+    channel.port1.postMessage(handle, [handle]);
+
+    const copy = await received;
+    assert_true(copy instanceof MediaSourceHandle);
+}, "MediaSourceHandle can be transferred through a MessageChannel");
+</script>

--- a/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe.html
+++ b/html/infrastructure/safe-passing-of-structured-data/transfer-videoframe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>MessageChannel transfer of VideoFrame</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    const canvas = new OffscreenCanvas(2, 2);
+    const ctx = canvas.getContext("2d");
+    ctx.fillRect(0, 0, 2, 2);
+    const frame = new VideoFrame(canvas, { timestamp: 0 });
+
+    const channel = new MessageChannel();
+    const received = new Promise(resolve => {
+        channel.port2.onmessage = e => resolve(e.data);
+    });
+
+    channel.port1.postMessage(frame, [frame]);
+
+    const copy = await received;
+    assert_true(copy instanceof VideoFrame);
+    assert_equals(copy.codedWidth, 2);
+    assert_equals(copy.codedHeight, 2);
+    copy.close();
+}, "VideoFrame can be transferred through a MessageChannel");
+</script>

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
@@ -19,7 +19,29 @@ structuredCloneBatteryOfTests.push({
   }
 });
 
-// TODO: ImageBitmap
+structuredCloneBatteryOfTests.push({
+  description: 'ImageBitmap',
+  async f(runner) {
+    const canvas = new OffscreenCanvas(10, 10);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "red";
+    ctx.fillRect(0, 0, 10, 10);
+    const bitmap = await createImageBitmap(canvas);
+    const copy = await runner.structuredClone(bitmap, [bitmap]);
+    assert_equals(copy.width, 10);
+    assert_equals(copy.height, 10);
+  }
+});
+
+structuredCloneBatteryOfTests.push({
+  description: 'OffscreenCanvas',
+  async f(runner) {
+    const canvas = new OffscreenCanvas(10, 10);
+    const copy = await runner.structuredClone(canvas, [canvas]);
+    assert_equals(copy.width, 10);
+    assert_equals(copy.height, 10);
+  }
+});
 
 structuredCloneBatteryOfTests.push({
   description: 'A detached ArrayBuffer cannot be transferred',


### PR DESCRIPTION
WebKit export from bug: [MessageChannel transfer of OffscreenCanvas and other non-IPC-serializable types fails with Site Isolation enabled](https://bugs.webkit.org/show_bug.cgi?id=313953)