### PR TITLE
script: Use correct slotchange event type for inline event handler.

### DIFF
--- a/shadow-dom/slotchange.html
+++ b/shadow-dom/slotchange.html
@@ -43,6 +43,21 @@ async_test((test) => {
   let d1 = document.createElement('div');
   d1.setAttribute('slot', 'slot1');
 
+  n.host1.shadowRoot.onslotchange = test.step_func(() => {
+    arraysEqual(n.s1.assignedNodes(), [n.c1, d1]);
+    test.done()
+  });
+
+  n.host1.appendChild(d1);
+}, 'slotchange event: Append a child to a host (onslotchange).');
+
+async_test((test) => {
+  let n = createTestTree(test1);
+  removeWhiteSpaceOnlyTextNodes(n.test1);
+
+  let d1 = document.createElement('div');
+  d1.setAttribute('slot', 'slot1');
+
   doneIfSlotChange([n.s1], [[n.c1, d1]], test);
 
   n.host1.appendChild(d1);


### PR DESCRIPTION
The ShadowRoot.onslotchange handler was defined incorrectly, and writing a test for it exposed that our slotchange events were not bubbling as they should.

Testing: New test added for onslotchange handler, and new passing tests for bubbling.
Reviewed in servo/servo#44688