### PR TITLE
Mark notifications/icon-url-encoding-euc-kr non-tentative

### DIFF
--- a/notifications/icon-url-encoding-euc-kr.https.html
+++ b/notifications/icon-url-encoding-euc-kr.https.html
@@ -2,8 +2,6 @@
 <meta charset="euc-kr">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script>
   // This file is actually ascii, because otherwise text editors would have hard time.
 


### PR DESCRIPTION
This is already required as the URL parser defaults to UTF-8.