### PR TITLE
Increase test coverage for nonce-hiding.

### DIFF
--- a/content-security-policy/nonce-hiding/nonces-css-selector.html
+++ b/content-security-policy/nonce-hiding/nonces-css-selector.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js" nonce="abc"></script>
+<script src="/resources/testharnessreport.js" nonce="abc"></script>
+
+<!-- `Content-Security-Policy: script-src 'nonce-abc'` delivered via headers -->
+
+<style>
+  .cssTest[nonce=abc] { background: url(/security/resources/abe.png); }
+</style>
+<body nonce="abc" class="cssTest">
+  <div nonce="abc" class="cssTest">
+    <script nonce="abc" class="cssTest"></script>
+  </div>
+  <svg nonce="abc" class="cssTest">
+    <g nonce="abc" class="cssTest">
+      <script nonce="abc" class="cssTest"></script>
+    </g>
+  </svg>
+  <math nonce="abc" class="cssTest">
+    <mrow nonce="abc" class="cssTest">
+      <mtext nonce="abc" class="cssTest">Hello</mtext>
+    </mrow>
+  </math>
+  <script nonce="abc">
+    Array.from(document.getElementsByClassName('cssTest')).forEach(element => {
+      test(_ => {
+        var style = getComputedStyle(element);
+        assert_equals(style['background-image'], 'none');
+      }, `Nonce on ${element.nodeName} tag don't leak via CSS side-channels.`);
+    });
+  </script>
+</body>

--- a/content-security-policy/nonce-hiding/nonces-css-selector.html.headers
+++ b/content-security-policy/nonce-hiding/nonces-css-selector.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: script-src 'nonce-abc'

--- a/content-security-policy/nonce-hiding/nonces.html
+++ b/content-security-policy/nonce-hiding/nonces.html
@@ -6,6 +6,7 @@
   const namespace_url= {
     "HTML": "http://www.w3.org/1999/xhtml",
     "SVG": "http://www.w3.org/2000/svg",
+    "MathML": "http://www.w3.org/1998/Math/MathML",
   }
   const test_cases = [
     ["meh"    , "HTML"],
@@ -15,7 +16,10 @@
     ["svg"    , "SVG"],
     ["script" , "SVG"],
     ["style"  , "HTML"],
-    ["link"   , "HTML"]
+    ["link"   , "HTML"],
+    ["math"   , "MathML"],
+    ["mrow"   , "MathML"],
+    ["mtext"  , "MathML"],
   ];
 
   test_cases.forEach(([localName, namespace]) => {
@@ -62,5 +66,12 @@
       assert_equals(element.nonce, "");
       assert_equals(element.getAttribute("nonce"), null);
     }, `Test empty nonces for ${localName} in ${namespace} namespace`);
+
+    test(t => {
+      const element = document.createElementNS(namespace_url[namespace], localName);
+      element.setAttribute('nonce', 'x');
+      const clonedElement = element.cloneNode();
+      assert_equals(clonedElement.nonce, 'x', 'IDL attribute');
+    }, `Ensure that cloned node retains nonce for ${localName} in ${namespace} namespace`);
   });
 </script>


### PR DESCRIPTION
- nonces-css-selector.html: Verify that CSS Attribute Selectors don't match for nonce, with miscellaneous HTMLOrSVGOrMathMLElements.
- nonces.html: Verify the cloning step preserves CryptographicNonce, and also check elements in the MathML namespace.

https://html.spec.whatwg.org/multipage/urls-and-fetching.html#nonce-attributes