### PR TITLE
script: Ignore synthetic focus events in `<input>` and `<textarea>`

### DIFF
--- a/focus/synthetic-focus-event-crash.html
+++ b/focus/synthetic-focus-event-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="assert" href="Synthetic focus events sent to form controls should not cause a crash">
+<link rel="help" href="https://github.com/servo/servo/issues/44865">
+
+<input id="input">
+<textarea id="textarea"></textarea>
+
+<script>
+  let event = document.createEvent("FocusEvent");
+  event.initEvent('', true);
+  input.dispatchEvent(event);
+
+  let event2 = document.createEvent("FocusEvent");
+  event2.initEvent('', true);
+  textarea.dispatchEvent(event2);
+</script>
+


### PR DESCRIPTION
As you can create these events with JavaScript, it isn't unexpected that
you see unknown kinds of focus events. Just ignore these instead of
panicking.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->44865
Reviewed in servo/servo#44870