### PR TITLE
Run aamtests for wpt.fyi collection

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -46,6 +46,11 @@ components:
     vars:
       test-type: test262
 
+  wpt-aamtest:
+    chunks: 1
+    vars:
+      test-type: aamtest
+
   run-options:
     options:
       xvfb: true
@@ -397,11 +402,13 @@ tasks:
                   of ${chunks.total}), run in the ${vars.channel} release of
                   ${vars.browser}.
 
-  # print-reftest are currently only supported by Chrome and Firefox.
+  # print-reftest amd aamtest are currently only supported by Chrome and Firefox.
   - $map:
       for:
         - vars:
             suite: print-reftest
+        - vars:
+            suite: aamtest
       do:
         $map:
           for:

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -238,6 +238,8 @@ def test_command(event_path, event_update, task, expected):
       'wpt-chrome-canary-reftest-6',
       'wpt-firefox-nightly-print-reftest-1',
       'wpt-chrome-canary-print-reftest-1',
+      'wpt-firefox-nightly-aamtest-1',
+      'wpt-chrome-canary-aamtest-1',
       'lint']),
     ("pr_event.json", True, {".taskcluster.yml", ".travis.yml", "tools/ci/start.sh"},
      ['lint',
@@ -591,7 +593,11 @@ def test_command(event_path, event_update, task, expected):
       'wpt-firefox-beta-print-reftest-1',
       'wpt-firefox-stable-print-reftest-1',
       'wpt-chromium-nightly-print-reftest-1',
-      'wpt-chrome-stable-print-reftest-1'])
+      'wpt-chrome-stable-print-reftest-1',
+      'wpt-firefox-beta-aamtest-1',
+      'wpt-firefox-stable-aamtest-1',
+      'wpt-chromium-nightly-aamtest-1',
+      'wpt-chrome-stable-aamtest-1'])
 ])
 def test_schedule_tasks(event_path, is_pr, files_changed, expected):
     with mock.patch("tools.ci.tc.decision.get_fetch_rev", return_value=(None, None, None)):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -308,7 +308,8 @@ Consider installing certutil via your OS package manager or directly.""")
 
             kwargs["certutil_binary"] = certutil
 
-        if kwargs["webdriver_binary"] is None and "wdspec" in kwargs["test_types"]:
+        wd_tests = ("wdspec", "aamtest")
+        if kwargs["webdriver_binary"] is None and any(t in kwargs["test_types"] for t in wd_tests):
             webdriver_binary = None
             if not kwargs["install_webdriver"]:
                 webdriver_binary = self.browser.find_webdriver()
@@ -328,8 +329,10 @@ Consider installing certutil via your OS package manager or directly.""")
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
-                logger.info("Unable to find or install geckodriver, skipping wdspec tests")
-                kwargs["test_types"].remove("wdspec")
+                logger.info("Unable to find or install geckodriver, skipping wdspec/aamtest tests")
+                for t in wd_tests:
+                    if t in kwargs["test_types"]:
+                        kwargs["test_types"].remove(t)
 
         if kwargs["prefs_root"] is None:
             prefs_root = self.browser.install_prefs(kwargs["binary"],


### PR DESCRIPTION
Update `tools/ci/tc/tasks/test.yml` to get these tests to run on changes to WPT - for firefox and chrome wpt.fyi data collection.

These tests already run on PR branches for firefox and chrome.