### PR TITLE
layout: fix UA stylesheet for `<input type="radio"/>`

### DIFF
--- a/html/rendering/widgets/input-radio-with-width-attribute.html
+++ b/html/rendering/widgets/input-radio-with-width-attribute.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>HTML Widget Test</title>
+<link rel="author" title="Richard Tjokroutomo href="mailto:richard.tjokro2@gmail.com">
+<link rel="match" href="reference/white-space-intrinsic-size-022-ref.html">
+<meta name="assert" content="The width of the <input type='radio'> should respect the 'width' attribute if specified.">
+
+<script src="/resources/check-layout-th.js"></script>
+<div>
+    <input type="radio" style="width: 100px;" data-expected-width="100"/>
+</div>
+<div>
+    <input type="radio" style="width: 200px;" data-expected-width="200"/>
+</div>
+

--- a/html/rendering/widgets/input-radio-with-width-attribute.html
+++ b/html/rendering/widgets/input-radio-with-width-attribute.html
@@ -2,8 +2,7 @@
 <meta charset="UTF-8">
 <title>HTML Widget Test</title>
 <link rel="author" title="Richard Tjokroutomo href="mailto:richard.tjokro2@gmail.com">
-<link rel="match" href="reference/white-space-intrinsic-size-022-ref.html">
-<meta name="assert" content="The width of the <input type='radio'> should respect the 'width' attribute if specified.">
+<meta name="assert" content="The width of the <input type='radio'> should respect the 'width' property if specified.">
 
 <script src="/resources/check-layout-th.js"></script>
 <div>


### PR DESCRIPTION
Fix Servo's UA styling for `<input type="radio"/>` to allow Servo to render the `width` of `<input type="radio"/>` if specified by user.

Test case:
```html
<span style="border-style: solid;">
    <input type="radio" style="width: 180px;"/>
</span>
```
Reviewed in servo/servo#44627