### PR TITLE
Add idlharness tests for MathML

### DIFF
--- a/html/dom/idlharness.https.html
+++ b/html/dom/idlharness.https.html
@@ -38,7 +38,7 @@ const waitForLoad = new Promise(resolve => { addEventListener('load', resolve); 
 
 idl_test(
   ['html'],
-  ['wai-aria', 'SVG', 'cssom', 'touch-events', "pointerevents", "uievents", 'dom', 'xhr', 'FileAPI', 'mediacapture-streams', 'performance-timeline', 'trusted-types'],
+  ['wai-aria', 'SVG', 'mathml-core', 'cssom', 'touch-events', "pointerevents", "uievents", 'dom', 'xhr', 'FileAPI', 'mediacapture-streams', 'performance-timeline', 'trusted-types'],
   async idlArray => {
     self.documentWithHandlers = new Document();
     const handler = function(e) {};

--- a/mathml/idlharness.window.js
+++ b/mathml/idlharness.window.js
@@ -1,0 +1,96 @@
+// META: timeout=long
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://w3c.github.io/mathml-core/
+
+'use strict';
+
+let objects = {};
+
+const elements = [
+  'math',
+  'a',
+  'annotation',
+  'annotation-xml',
+  'maction',
+  'math',
+  'merror',
+  'mfrac',
+  'mi',
+  'mmultiscripts',
+  'mn',
+  'mo',
+  'mover',
+  'mpadded',
+  'mphantom',
+  'mprescripts',
+  'mroot',
+  'mrow',
+  'ms',
+  'mspace',
+  'msqrt',
+  'mstyle',
+  'msub',
+  'msubsup',
+  'msup',
+  'mtable',
+  'mtd',
+  'mtext',
+  'mtr',
+  'munder',
+  'munderover',
+  'semantics'
+];
+
+idl_test(
+  ['mathml-core'],
+  ['cssom', 'html', 'dom'],
+  idlArray => {
+    const mathmlUrl = 'http://www.w3.org/1998/Math/MathML';
+    for (const element of elements) {
+      try {
+        objects[element] = document.createElementNS(mathmlUrl, element);
+      } catch (e) {
+        // Will be surfaced by idlharness.js's test_object below.
+      }
+    }
+
+    idlArray.add_objects({
+      MathMLElement: [
+        'objects.annotation',
+        'objects["annotation-xml"]',
+        'objects.maction',
+        'objects.math',
+        'objects.merror',
+        'objects.mfrac',
+        'objects.mi',
+        'objects.mmultiscripts',
+        'objects.mn',
+        'objects.mo',
+        'objects.mover',
+        'objects.mpadded',
+        'objects.mphantom',
+        'objects.mprescripts',
+        'objects.mroot',
+        'objects.mrow',
+        'objects.ms',
+        'objects.mspace',
+        'objects.msqrt',
+        'objects.mstyle',
+        'objects.msub',
+        'objects.msubsup',
+        'objects.msup',
+        'objects.mtable',
+        'objects.mtd',
+        'objects.mtext',
+        'objects.mtr',
+        'objects.munder',
+        'objects.munderover',
+        'objects.semantics'
+      ],
+      MathMLAnchorElement: ['objects.a'],
+    });
+    idlArray.prevent_multiple_testing('MathMLElement');
+  }
+);


### PR DESCRIPTION
This adds basic idlharness coverage over mathml core. Once webref syncs the IDL it'll test the prototype for MathMLAnchor and also test MathMLs inheritance of various Html defined mixins too.