### PR TITLE
Add more URL parser encoding parameter tests

### DIFF
--- a/beacon/beacon-url-encoding-euc-kr.https.html
+++ b/beacon/beacon-url-encoding-euc-kr.https.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="euc-kr">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  // This file is actually ascii, because otherwise text editors would have hard time.
+
+  promise_test(async (t) => {
+    // "icon" in Korean language
+    const iconKorean = "\uc544\uc744\ucf58";
+    const id = crypto.randomUUID();
+
+    assert_true(navigator.sendBeacon(
+        `/beacon/resources/url-echo.py?cmd=store&id=${id}&icon=${iconKorean}`, "x"));
+
+    // Poll the echo endpoint until the beacon is received. The stored value
+    // is the raw query string sendBeacon() sent.
+    const statUrl = `/beacon/resources/url-echo.py?cmd=stat&id=${id}`;
+    for (let i = 0; i < 30; i++) {
+      const response = await fetch(statUrl);
+      const text = await response.text();
+      if (text) {
+        assert_equals(text, `cmd=store&id=${id}&icon=%EC%95%84%EC%9D%84%EC%BD%98`, "URL encoded with utf-8");
+        return;
+      }
+      await new Promise(resolve => t.step_timeout(resolve, 200));
+    }
+    assert_unreached("sendBeacon was not received");
+  });
+</script>

--- a/beacon/beacon-url-encoding-euc-kr.https.html
+++ b/beacon/beacon-url-encoding-euc-kr.https.html
@@ -7,7 +7,7 @@
 
   promise_test(async (t) => {
     // "icon" in Korean language
-    const iconKorean = "\uc544\uc744\ucf58";
+    const iconKorean = "\uc544\uc774\ucf58";
     const id = crypto.randomUUID();
 
     assert_true(navigator.sendBeacon(
@@ -20,7 +20,7 @@
       const response = await fetch(statUrl);
       const text = await response.text();
       if (text) {
-        assert_equals(text, `cmd=store&id=${id}&icon=%EC%95%84%EC%9D%84%EC%BD%98`, "URL encoded with utf-8");
+        assert_equals(text, `cmd=store&id=${id}&icon=%EC%95%84%EC%9D%B4%EC%BD%98`, "URL encoded with utf-8");
         return;
       }
       await new Promise(resolve => t.step_timeout(resolve, 200));

--- a/beacon/resources/url-echo.py
+++ b/beacon/resources/url-echo.py
@@ -1,0 +1,18 @@
+def main(request, response):
+    """Helper handler for testing the URL encoding used by sendBeacon().
+
+    The 'store' command stashes the request's raw (percent-encoded) query
+    string keyed by the 'id' UUID query parameter. The 'stat' command takes
+    that stashed string back out.
+    """
+    cmd = request.GET.first(b"cmd")
+    id = request.GET.first(b"id")
+
+    if cmd == b"store":
+        request.server.stash.put(id, request.url_parts.query)
+    elif cmd == b"stat":
+        stored = request.server.stash.take(id)
+        response.headers.set(b"Content-Type", b"text/plain")
+        response.content = stored.encode("ascii") if stored is not None else b""
+    else:
+        response.status = 400

--- a/mediasession/artwork-url-encoding-euc-kr.html
+++ b/mediasession/artwork-url-encoding-euc-kr.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="euc-kr">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  // This file is actually ascii, because otherwise text editors would have hard time.
+
+  test(() => {
+    // "icon" in Korean language
+    const iconKorean = "\uc544\uc744\ucf58";
+    const metadata = new MediaMetadata({ artwork: [{ src: `?icon=${iconKorean}` }] });
+
+    assert_equals(new URL(metadata.artwork[0].src).search, "?icon=%EC%95%84%EC%9D%84%EC%BD%98", "artwork src encoded with utf-8");
+  });
+</script>

--- a/mediasession/artwork-url-encoding-euc-kr.html
+++ b/mediasession/artwork-url-encoding-euc-kr.html
@@ -7,9 +7,9 @@
 
   test(() => {
     // "icon" in Korean language
-    const iconKorean = "\uc544\uc744\ucf58";
+    const iconKorean = "\uc544\uc774\ucf58";
     const metadata = new MediaMetadata({ artwork: [{ src: `?icon=${iconKorean}` }] });
 
-    assert_equals(new URL(metadata.artwork[0].src).search, "?icon=%EC%95%84%EC%9D%84%EC%BD%98", "artwork src encoded with utf-8");
+    assert_equals(new URL(metadata.artwork[0].src).search, "?icon=%EC%95%84%EC%9D%B4%EC%BD%98", "artwork src encoded with utf-8");
   });
 </script>

--- a/notifications/icon-url-encoding-euc-kr.https.html
+++ b/notifications/icon-url-encoding-euc-kr.https.html
@@ -7,10 +7,10 @@
 
   promise_test(async (t) => {
     // "icon" in Korean language
-    const iconKorean = "\uc544\uc744\ucf58";
+    const iconKorean = "\uc544\uc774\ucf58";
     const n = new Notification("title", { icon: `?icon=${iconKorean}` })
     t.add_cleanup(() => n.close());
 
-    assert_equals(new URL(n.icon).search, "?icon=%EC%95%84%EC%9D%84%EC%BD%98", "icon encoded with utf-8");
+    assert_equals(new URL(n.icon).search, "?icon=%EC%95%84%EC%9D%B4%EC%BD%98", "icon encoded with utf-8");
   })
 </script>


### PR DESCRIPTION
In particular for sendBeacon() and the Media Session API.

(Inspired by a test from Kagami for the Notifications API.)