### PR TITLE
navigation API cross-document-event-order tests with a pagehide variant

### DIFF
--- a/navigation-api/ordering-and-transition/back-cross-document-event-order-with-pagehide.html
+++ b/navigation-api/ordering-and-transition/back-cross-document-event-order-with-pagehide.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i" src="resources/notify-top-early.html"></iframe>
+<script>
+  async_test((t) => {
+    let events = [];
+    function finish() {
+      assert_array_equals(events, [
+        "onnavigate",
+        "onpagehide",
+        "readystateinteractive",
+        "domcontentloaded",
+        "readystatecomplete",
+        "onload",
+        "onpageshow",
+      ]);
+      t.done();
+    }
+
+    window.onload = t.step_func(() => {
+      i.contentWindow.navigation.navigate("?1");
+      i.onload = t.step_func(() => {
+        window.childStarted = () => {
+          i.contentWindow.navigation.onnavigatesuccess = () =>
+            events.push("onnavigatesuccess");
+          i.contentWindow.navigation.onnavigateerror = () =>
+            events.push("onnavigateerror");
+          i.contentWindow.onpageshow = () => events.push("onpageshow");
+          i.contentWindow.onhashchange = () => events.push("onhashchange");
+          i.contentWindow.onpopstate = () => events.push("onpopstate");
+          i.onload = t.step_func(() => {
+            events.push("onload");
+            t.step_timeout(finish, 0);
+          });
+          i.contentDocument.addEventListener("DOMContentLoaded", () =>
+            events.push("domcontentloaded"),
+          );
+          i.contentDocument.onreadystatechange = () =>
+            events.push("readystate" + i.contentDocument.readyState);
+        };
+        i.contentWindow.onpagehide = () => events.push("onpagehide");
+        i.contentWindow.navigation.onnavigate = () => events.push("onnavigate");
+        i.contentWindow.navigation.back().committed.then(
+          () => events.push("promisefulfilled"),
+          () => events.push("promiserejected"),
+        );
+      });
+    });
+  }, "back() event ordering for cross-document traversal");
+</script>

--- a/navigation-api/ordering-and-transition/navigate-cross-document-event-order-with-pagehide.html
+++ b/navigation-api/ordering-and-transition/navigate-cross-document-event-order-with-pagehide.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i" src="resources/notify-top-early.html"></iframe>
+<script>
+  async_test((t) => {
+    let events = [];
+    function finish() {
+      assert_array_equals(events, [
+        "onnavigate",
+        "onpagehide",
+        "readystateinteractive",
+        "domcontentloaded",
+        "readystatecomplete",
+        "onload",
+        "onpageshow",
+      ]);
+      t.done();
+    }
+
+    window.onload = t.step_func(() => {
+      window.childStarted = () => {
+        i.contentWindow.navigation.onnavigatesuccess = () =>
+          events.push("onnavigatesuccess");
+        i.contentWindow.navigation.onnavigateerror = () =>
+          events.push("onnavigateerror");
+        i.contentWindow.onpageshow = () => events.push("onpageshow");
+        i.contentWindow.onhashchange = () => events.push("onhashchange");
+        i.contentWindow.onpopstate = () => events.push("onpopstate");
+        i.onload = t.step_func(() => {
+          events.push("onload");
+          t.step_timeout(finish, 0);
+        });
+        i.contentDocument.addEventListener("DOMContentLoaded", () =>
+          events.push("domcontentloaded"),
+        );
+        i.contentDocument.onreadystatechange = () =>
+          events.push("readystate" + i.contentDocument.readyState);
+      };
+      i.contentWindow.onpagehide = () => events.push("onpagehide");
+      i.contentWindow.navigation.onnavigate = () => events.push("onnavigate");
+      i.contentWindow.navigation.navigate("?1").committed.then(
+        () => events.push("promisefulfilled"),
+        () => events.push("promiserejected"),
+      );
+    });
+  }, "navigate() event ordering for cross-document navigation");
+</script>


### PR DESCRIPTION
The current test rely on unload which is slowly being deprecated in chromium.
The newly added tests should be part of interop 2026 instead of the originals.
Those are exact duplicates of 2 existing tests in  https://github.com/web-platform-tests/interop/issues/1274, with `pagehide` instead of `unload`