### PR TITLE
WebRTC: adjust Interop 2026 subtest selection in four tests

### DIFF
--- a/webrtc/RTCConfiguration-iceServers.html
+++ b/webrtc/RTCConfiguration-iceServers.html
@@ -327,6 +327,8 @@ if (rest) {
       }] }));
   }, 'with http url should throw SyntaxError');
 
+}
+if (interop2026) {
   config_test(makePc => {
     assert_throws_dom("SyntaxError", () =>
       makePc({ iceServers: [{
@@ -336,8 +338,6 @@ if (rest) {
       }] }));
   }, 'with invalid turn url should throw SyntaxError');
 
-}
-if (interop2026) {
   config_test(makePc => {
     assert_throws_dom("SyntaxError", () =>
       makePc({ iceServers: [{

--- a/webrtc/RTCError.html
+++ b/webrtc/RTCError.html
@@ -89,9 +89,7 @@ nullableAttributes.forEach(attribute => {
     });
   }, 'RTCError.' + attribute + ' is readonly');
 });
-}
 
-if (rest) {
 test(function() {
   assert_false("httpRequestStatusCode" in RTCError.prototype,
                "Should not be supported on the prototype");

--- a/webrtc/RTCRtpParameters-codec.html
+++ b/webrtc/RTCRtpParameters-codec.html
@@ -530,10 +530,6 @@ if (interop2026) {
     assert_array_equals(codecs, [vp8.mimeType]);
   }, `Stats output-rtp should match the selected codec in non-simulcast usecase on a video sender`);
 
-}
-
-if (rest) {
-
   promise_test(async (t) => {
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
@@ -579,6 +575,10 @@ if (rest) {
 
     assert_array_equals(codecs, [vp8.mimeType, vp8.mimeType, vp8.mimeType]);
   }, `Stats output-rtp should match the selected codec in simulcast usecase on a video sender`);
+
+}
+
+if (rest) {
 
   promise_test(async (t) => {
     const pc1 = new RTCPeerConnection();

--- a/webrtc/RTCSctpTransport-maxChannels.html
+++ b/webrtc/RTCSctpTransport-maxChannels.html
@@ -30,6 +30,8 @@ promise_test(async (t) => {
   assert_equals(pc.sctp.maxChannels, null, 'maxChannels must not be set');
   assert_equals(pc.sctp.maxMessageSize, null, 'maxMessageSize must be null');
 }, 'An unconnected peerconnection must not have maxChannels set');
+}
+if (rest) {
 
 promise_test(async (t) => {
   const pc = new RTCPeerConnection();


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-pc/issues/3100.

Adjustments:
- webrtc/RTCConfiguration-iceServers.html
  - Move to ?interop-2026:
    - new RTCPeerConnection(config) - with invalid turn url should throw SyntaxError
    - setConfiguration(config) - with invalid turn url should throw SyntaxError

- webrtc/RTCError.html
  - Move to ?interop-2026:
    - RTCError httpRequestStatusCode should not be supported.

- webrtc/RTCRtpParameters-codec.html
  - Move to ?interop-2026:
    - Stats output-rtp should match the selected codec in simulcast usecase on a video sender

- webrtc/RTCSctpTransport-maxChannels.html
  - Move to ?rest:
    - Sctp transport has null maxChannels and maxMessageSize in have-local-offer
    - Sctp transport has null maxChannels and maxMessageSize in have-remote-offer
  - Not moved (being fixed in https://github.com/web-platform-tests/wpt/pull/59875 instead):
    - An unconnected peerconnection must not have maxChannels set

See also:
- https://github.com/web-platform-tests/wpt-metadata/pull/8943