### PR TITLE
script: Interpret every byte as ASCII for FileReader{Sync}.ReadAsBinaryString

### DIFF
--- a/FileAPI/FileReaderSync.worker.js
+++ b/FileAPI/FileReaderSync.worker.js
@@ -42,6 +42,12 @@ test(() => {
 }, "readAsBinaryString with empty blob");
 
 test(() => {
+    var data = readerSync.readAsBinaryString(new Blob(["σ"]));
+    assert_equals(data.length, 2, "The result length is 2");
+    assert_equals(data, "\xcf\x83", "The result is \xcf\x83");
+}, "readAsBinaryString with multi-byte UTF-8 char");
+
+test(() => {
     var data = readerSync.readAsArrayBuffer(blob);
     assert_true(data instanceof ArrayBuffer);
     assert_equals(data.byteLength, "test".length);


### PR DESCRIPTION
Spec:
> > Return bytes as a binary string, in which every byte
> > is represented by a code unit of equal value [0..255].

I was copying the implementation from `FileReaderSync` in https://github.com/servo/servo/pull/44858.
Apparently it is wrong. It went unnoticed as there was no test coverage for FileReaderSync, multi-byte UTF-8 char.

Testing: New passing in existing. Added a new test for `FileReaderSync` too.
Reviewed in servo/servo#44921