### PR TITLE
script: Use "application/octet-stream" for unspecified Blob type for `FileReaderSync.ReadAsDataURL`

### DIFF
--- a/FileAPI/FileReaderSync.worker.js
+++ b/FileAPI/FileReaderSync.worker.js
@@ -28,7 +28,7 @@ test(() => {
 
 test(() => {
     var data = readerSync.readAsDataURL(empty_blob);
-    assert_equals(data.indexOf("data:"), 0);
+    assert_equals(data, "data:application/octet-stream;base64,");
 }, "readAsDataURL with empty blob");
 
 test(() => {


### PR DESCRIPTION
In https://github.com/servo/servo/pull/44897, I only did this for `FileReader` but not `FileReaderSync`. 

Testing: Similar to https://github.com/servo/servo/pull/44921, there was no such test for `FileReaderSync` but only `FileReader`.
We update the existing test to cover this. It seems in general, test coverage for `FileReader` is much better.
Reviewed in servo/servo#44924