### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=313243

### DIFF
--- a/css/css-font-loading/fontface-invalid-family.tentative.html
+++ b/css/css-font-loading/fontface-invalid-family.tentative.html
@@ -16,6 +16,9 @@ const kInvalidValues = [
   "inherit",
   "a 1",
   "",
+  "a  b",
+  " a b",
+  "a b ",
 ];
 
 for (let familyName of kInvalidValues) {


### PR DESCRIPTION
WebKit export from bug: [Serialize multi-word font family names without quotes when possible](https://bugs.webkit.org/show_bug.cgi?id=313243)