### PR TITLE
Fix a bug in new popover=hint stacking behavior, and update tests

### DIFF
--- a/html/semantics/popovers/popover-light-dismiss.html
+++ b/html/semantics/popovers/popover-light-dismiss.html
@@ -617,3 +617,64 @@ promise_test(async () => {
   assert_true(p30.matches(':popover-open'),'showing after pointerup');
 },`Pointer down inside invoker and up outside that invoker shouldn't dismiss popover`);
 </script>
+
+<div id=p31 popover=auto>p31
+  <button id=buttonp32 popovertarget=p32>Open p32</button>
+  <div id=p33 popover=auto>p33</div>
+</div>
+<div id=p32 popover=auto>p32
+  <button id=buttonp33 popovertarget=p33>Open p33</button>
+</div>
+<script>
+test(() => {
+  assert_false(p31.matches(':popover-open'));
+  assert_false(p32.matches(':popover-open'));
+  assert_false(p33.matches(':popover-open'));
+
+  p31.showPopover();
+  buttonp32.click();
+  buttonp33.click();
+
+  assert_true(p31.matches(':popover-open'), 'p31 should be open');
+  assert_true(p32.matches(':popover-open'), 'p32 should be open');
+  assert_true(p33.matches(':popover-open'), 'p33 should be open');
+
+  p31.hidePopover();
+  assert_false(p31.matches(':popover-open'), 'p31 should be closed');
+  assert_false(p32.matches(':popover-open'), 'p32 should be closed');
+  assert_false(p33.matches(':popover-open'), 'p33 should be closed');
+}, 'Invoker and DOM ancestor relationship - "latest" wins');
+</script>
+
+<div id=p34 popover=auto>p34
+  <div id=p35 popover=auto>p35</div>
+  <div id=p36 popover=hint>p36</div>
+</div>
+<script>
+promise_test(async () => {
+  assert_false(p34.matches(':popover-open'));
+  assert_false(p35.matches(':popover-open'));
+  assert_false(p36.matches(':popover-open'));
+
+  p34.showPopover();
+  p35.showPopover();
+  p36.showPopover();
+
+  assert_true(p34.matches(':popover-open'), 'p34 should be open');
+  assert_true(p35.matches(':popover-open'), 'p35 should be open');
+  assert_true(p36.matches(':popover-open'), 'p36 should be open');
+
+  await clickOn(p36);
+
+  assert_true(p34.matches(':popover-open'), 'p34 should remain open');
+  assert_false(p35.matches(':popover-open'), 'p35 should be light dismissed');
+  assert_true(p36.matches(':popover-open'), 'p36 should remain open, because its ancestor p34 is still open');
+
+  p34.hidePopover();
+  assert_false(p34.matches(':popover-open'), 'p34 should be closed');
+  assert_true(p36.matches(':popover-open'), 'p36 should be left open');
+  p36.hidePopover();
+  assert_false(p36.matches(':popover-open'), 'p36 should be closed');
+}, 'Light dismissing from within an auto popover should not hide a hint whose topmost popover ancestor is not hidden');
+</script>
+

--- a/html/semantics/popovers/popover-open-in-beforetoggle.html
+++ b/html/semantics/popovers/popover-open-in-beforetoggle.html
@@ -64,3 +64,25 @@
     assert_false(p3.matches(':popover-open'));
   },'Open double-nested popovers from closing beforetoggle event, light dismiss');
 </script>
+
+<div id=p4 popover=auto>p4</div>
+<div id=p5 popover=auto>p5</div>
+<div id=p6 popover=hint>p6</div>
+<script>
+test(() => {
+  assert_false(p4.matches(':popover-open'));
+  assert_false(p5.matches(':popover-open'));
+  assert_false(p6.matches(':popover-open'));
+
+  p4.showPopover();
+  p4.onbeforetoggle = (e) => p6.showPopover();
+  assert_true(p4.matches(':popover-open'), 'p4 should be open');
+  p5.showPopover();
+
+  assert_false(p4.matches(':popover-open'), 'p4 should be closed (by opening p5)');
+  assert_false(p5.matches(':popover-open'), 'B2 should be closed (cancelled by new p6)');
+  assert_true(p6.matches(':popover-open'), 'p6 should be open');
+  p6.hidePopover(); // Cleanup
+}, 'Showing a hint during a showPopover that hides an auto should cancel the new auto show');
+</script>
+


### PR DESCRIPTION
This fixes an error in the recently-landed popover=hint behavior at [1], for this case:

Auto popover (A1) is the anchor for a Hint popover (H1). Another Auto popover (A2) is opened on top. The Auto stack is [A1, A2] and the hint_parent is A1.  While hiding all popovers down to A1, the old code would hide H1, even though it left H1's anchor (A1) open.

It also adds two tests for cases discovered during the review of the spec PR [2]. Those were correct in Chromium, but incorrect in the spec.

[1] https://crrev.com/c/7727959
[2] https://github.com/whatwg/html/pull/12345

Bug: 499019927
Change-Id: I917bf939614f9811470444e9f13c942e5c63b1b1
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7765209
Auto-Submit: Mason Freed <masonf@chromium.org>
Reviewed-by: David Baron <dbaron@chromium.org>
Commit-Queue: Mason Freed <masonf@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1616163}

---

Changes from original: Omit `html/semantics/popovers/popover-types-with-hints.html` (to be landed in a dedicated PR that's reconciled with #59237).