### PR TITLE
Update webrtc-encoded-transform tests to latest SFrame APIs

### DIFF
--- a/webrtc-encoded-transform/idlharness.https.window.js
+++ b/webrtc-encoded-transform/idlharness.https.window.js
@@ -1,5 +1,5 @@
-// META: variant=?exclude=(SFrameDecrypterStream|SFrameEncrypterStream|SFrameSenderTransform|SFrameReceiverTransform|SFrameTransform.*)
-// META: variant=?include=(SFrameDecrypterStream|SFrameEncrypterStream|SFrameSenderTransform|SFrameReceiverTransform|SFrameTransform.*)
+// META: variant=?exclude=.*SFrame.*
+// META: variant=?include=.*SFrame.*
 // META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js

--- a/webrtc-encoded-transform/script-late-transform.https.html
+++ b/webrtc-encoded-transform/script-late-transform.https.html
@@ -49,11 +49,11 @@ async function checkVideoIsUpdated(test, shouldBeUpdated, count, referenceData)
 promise_test(async (test) => {
     await setMediaPermission("granted", ["camera"]);
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
-    const senderTransform = new SFrameTransform({ compatibilityMode: "H264" });
-    const receiverTransform = new SFrameTransform({ compatibilityMode: "H264" });
+    const senderTransform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const receiverTransform = new RTCRtpSFrameDecrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => {
        senderTransform.setEncryptionKey(key);
-       receiverTransform.setEncryptionKey(key);
+       receiverTransform.addDecryptionKey(key);
     });
 
     let sender, receiver;

--- a/webrtc-encoded-transform/sframe-keys.https.html
+++ b/webrtc-encoded-transform/sframe-keys.https.html
@@ -17,7 +17,7 @@ let key1, key2, key3, key4;
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
-    const transform = new SFrameTransform;
+    const transform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
 
     await transform.setEncryptionKey(key);
     await transform.setEncryptionKey(key, 1);
@@ -42,16 +42,16 @@ promise_test(async (test) => {
     const stream = await new Promise((resolve, reject) => {
         const connections = createConnections(test, (firstConnection) => {
             sender = firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
-            let transform = new SFrameTransform;
+            let transform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
             transform.setEncryptionKey(key1);
             sender.transform = transform;
         }, (secondConnection) => {
             secondConnection.ontrack = (trackEvent) => {
-                let transform = new SFrameTransform;
-                transform.setEncryptionKey(key1);
-                transform.setEncryptionKey(key2);
-                transform.setEncryptionKey(key3, 1000);
-                transform.setEncryptionKey(key4, BigInt('18446744073709551615'));
+                let transform = new RTCRtpSFrameDecrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+                transform.addDecryptionKey(key1);
+                transform.addDecryptionKey(key2);
+                transform.addDecryptionKey(key3, 1000);
+                transform.addDecryptionKey(key4, BigInt('18446744073709551615'));
                 receiver = trackEvent.receiver;
                 receiver.transform = transform;
                 resolve(trackEvent.streams[0]);

--- a/webrtc-encoded-transform/sframe-transform-buffer-source.html
+++ b/webrtc-encoded-transform/sframe-transform-buffer-source.html
@@ -17,9 +17,9 @@ async function getEncryptedData(transform)
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
-    const transform1 = new SFrameTransform;
-    const transform2 = new SFrameTransform;
-    const transform3 = new SFrameTransform;
+    const transform1 = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const transform2 = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const transform3 = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
 
     await transform1.setEncryptionKey(key);
     await transform2.setEncryptionKey(key);
@@ -44,7 +44,7 @@ promise_test(async (test) => {
 
     assert_array_equals(result1, result2, "result2");
     assert_array_equals(result1, result3, "result3");
-}, "Uint8Array as input to SFrameTransform");
+}, "Uint8Array as input to SFrameEncrypterStream");
         </script>
     </body>
 </html>

--- a/webrtc-encoded-transform/sframe-transform-in-worker.https.html
+++ b/webrtc-encoded-transform/sframe-transform-in-worker.https.html
@@ -29,7 +29,7 @@ promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({ video: true });
 
     let sender, receiver;
-    const senderTransform = new SFrameTransform({ compatibilityMode: "H264" });
+    const senderTransform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const receiverTransform = new RTCRtpScriptTransform(worker, "SFrameRTCRtpTransform");
 
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);

--- a/webrtc-encoded-transform/sframe-transform-readable.html
+++ b/webrtc-encoded-transform/sframe-transform-readable.html
@@ -10,7 +10,7 @@
         <script>
 promise_test(async (test) => {
     const frameDOMException = frame.contentWindow.DOMException;
-    const transform = new frame.contentWindow.SFrameTransform;
+    const transform = new frame.contentWindow.SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     frame.remove();
     assert_throws_dom("InvalidStateError", frameDOMException, () => transform.readable);
 });

--- a/webrtc-encoded-transform/sframe-transform-worker.js
+++ b/webrtc-encoded-transform/sframe-transform-worker.js
@@ -1,6 +1,6 @@
 onrtctransform = (event) => {
-    const sframeTransform = new SFrameTransform({ role : "decrypt", authenticationSize: "10", compatibilityMode: "H264" });
-    crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => sframeTransform.setEncryptionKey(key));
+    const sframeTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => sframeTransform.addDecryptionKey(key));
     const transformer = event.transformer;
     transformer.readable.pipeThrough(sframeTransform).pipeTo(transformer.writable);
 }

--- a/webrtc-encoded-transform/sframe-transform-worker.js
+++ b/webrtc-encoded-transform/sframe-transform-worker.js
@@ -1,5 +1,5 @@
 onrtctransform = (event) => {
-    const sframeTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const sframeTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_32" });
     crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => sframeTransform.addDecryptionKey(key));
     const transformer = event.transformer;
     transformer.readable.pipeThrough(sframeTransform).pipeTo(transformer.writable);

--- a/webrtc-encoded-transform/sframe-transform.html
+++ b/webrtc-encoded-transform/sframe-transform.html
@@ -10,8 +10,8 @@
 
 promise_test(async (test) => {
     const pc = new RTCPeerConnection();
-    const senderTransform = new SFrameTransform();
-    const receiverTransform = new SFrameTransform();
+    const senderTransform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const receiverTransform = new RTCRtpSFrameDecrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const sender1 = pc.addTransceiver('audio').sender;
     const sender2 = pc.addTransceiver('video').sender;
     const receiver1 = pc.getReceivers()[0];
@@ -30,51 +30,20 @@ promise_test(async (test) => {
 }, "Cannot reuse attached transforms");
 
 test(() => {
-    const senderTransform = new SFrameTransform();
+    const stream = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
 
-    assert_true(senderTransform.readable instanceof ReadableStream);
-    assert_true(senderTransform.writable instanceof WritableStream);
-}, "SFrameTransform exposes readable and writable");
-
-promise_test(async (test) => {
-    const pc = new RTCPeerConnection();
-    const senderTransform = new SFrameTransform();
-    const receiverTransform = new SFrameTransform();
-    const sender1 = pc.addTransceiver('audio').sender;
-    const sender2 = pc.addTransceiver('video').sender;
-    const receiver1 = pc.getReceivers()[0];
-    const receiver2 = pc.getReceivers()[1];
-
-    assert_false(senderTransform.readable.locked, "sender readable before");
-    assert_false(senderTransform.writable.locked, "sender writable before");
-    assert_false(receiverTransform.readable.locked, "receiver readable before");
-    assert_false(receiverTransform.writable.locked, "receiver writable before");
-
-    sender1.transform = senderTransform;
-    receiver1.transform = receiverTransform;
-
-    assert_true(senderTransform.readable.locked, "sender readable during");
-    assert_true(senderTransform.writable.locked, "sender writable during");
-    assert_true(receiverTransform.readable.locked, "receiver readable during");
-    assert_true(receiverTransform.writable.locked, "receiver writable during");
-
-    sender1.transform = null;
-    receiver1.transform = null;
-
-    assert_true(senderTransform.readable.locked, "sender readable after");
-    assert_true(senderTransform.writable.locked, "sender writable after");
-    assert_true(receiverTransform.readable.locked, "receiver readable after");
-    assert_true(receiverTransform.writable.locked, "receiver writable after");
-}, "readable/writable are locked when attached and after being attached");
+    assert_true(stream.readable instanceof ReadableStream);
+    assert_true(stream.writable instanceof WritableStream);
+}, "SFrameEncrypterStream exposes readable and writable");
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
-    const senderTransform = new SFrameTransform({ role : 'encrypt', authenticationSize: 10 });
+    const senderTransform = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     senderTransform.setEncryptionKey(key);
 
-    const receiverTransform = new SFrameTransform({ role : 'decrypt', authenticationSize: 10 });
-    receiverTransform.setEncryptionKey(key);
+    const receiverTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    receiverTransform.addDecryptionKey(key);
 
     const writer = senderTransform.writable.getWriter();
     const reader = receiverTransform.readable.getReader();
@@ -93,21 +62,21 @@ promise_test(async (test) => {
     const view2 = new Int8Array(received.value);
     for (let cptr = 0; cptr < sent.byteLength; ++cptr)
         assert_equals(view2[cptr], view[cptr]);
-}, "SFrame with array buffer - authentication size 10");
+}, "SFrame with array buffer - AES_128_CTR_HMAC_SHA256_80");
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
-    const senderTransform = new SFrameTransform({ role : 'encrypt', authenticationSize: 10 });
+    const senderTransform = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const senderWriter = senderTransform.writable.getWriter();
     const senderReader = senderTransform.readable.getReader();
 
-    const receiverTransform = new SFrameTransform({ role : 'decrypt', authenticationSize: 10 });
+    const receiverTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const receiverWriter = receiverTransform.writable.getWriter();
     const receiverReader = receiverTransform.readable.getReader();
 
     senderTransform.setEncryptionKey(key);
-    receiverTransform.setEncryptionKey(key);
+    receiverTransform.addDecryptionKey(key);
 
     const chunk = new ArrayBuffer(8);
 
@@ -127,9 +96,9 @@ promise_test(async (test) => {
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
-    const receiverTransform = new SFrameTransform({ role : 'decrypt', authenticationSize: 10 });
+    const receiverTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const receiverWriter = receiverTransform.writable.getWriter();
-    receiverTransform.setEncryptionKey(key);
+    receiverTransform.addDecryptionKey(key);
 
     // decryption should fail, leading to erroring the transform.
     await promise_rejects_js(test, TypeError, receiverWriter.write({ }));


### PR DESCRIPTION
Update tests to match https://github.com/w3c/webrtc-encoded-transform/pull/308.

Also touches META= so requires a simultaneous PR for wpt-metadata