### PR TITLE
net: Allow internal requests to be fetched regardless of CSP

### DIFF
--- a/content-security-policy/img-src/img-src-none-blocks-css-background-image.html
+++ b/content-security-policy/img-src/img-src-none-blocks-css-background-image.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="img-src 'none';">
+<html>
+<head>
+    <title>CSS background-image is blocked by img-src.</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+    <script>
+      var t_spv = async_test("Test that spv event is fired");
+      window.addEventListener("securitypolicyviolation", t_spv.step_func_done(function(e) {
+        assert_equals(e.violatedDirective, 'img-src');
+        assert_equals(e.target, document);
+        assert_true(e.blockedURI.endsWith('/support/fail.png'));
+      }));
+    </script>
+
+    <style>
+      #container {
+        background-image: url('../support/fail.png');
+      }
+    </style>
+
+    <div id="container">
+      <p>This text should NOT have a red background.</p>
+    </div>
+</body>
+</html>

--- a/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
+++ b/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG without scripting should load</title>
+    <link rel="match" href="resources/svg-inline-only-path-without-csp.html">
+</head>
+
+<body>
+    <p>Tests that an SVG loaded without any scripting should load.</p>
+    <?xml version="1.0" standalone="no"?>
+
+    <svg width="6cm" height="5cm" viewBox="0 0 600 500"
+        xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+      <circle cx="300" cy="225" r="100" fill="green"/>
+
+      <text x="300" y="250"
+            font-family="Verdana"
+            font-size="50"
+            text-anchor="middle">
+          PASS
+      </text>
+    </svg>
+</body>
+</html>

--- a/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
+++ b/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
@@ -2,12 +2,10 @@
 <html>
 <head>
     <title>SVG without scripting should load</title>
-    <link rel="match" href="resources/svg-inline-only-path-without-csp.html">
 </head>
 
 <body>
     <p>Tests that an SVG loaded without any scripting should load.</p>
-    <?xml version="1.0" standalone="no"?>
 
     <svg width="6cm" height="5cm" viewBox="0 0 600 500"
         xmlns="http://www.w3.org/2000/svg" version="1.1">

--- a/content-security-policy/svg/svg-inline-without-scripting.html
+++ b/content-security-policy/svg/svg-inline-without-scripting.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG without scripting should load</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline';">
+    <link rel="match" href="resources/svg-inline-without-scripting-without-csp.html">
+</head>
+
+<body>
+    <p>Tests that an SVG loaded without any scripting should load.</p>
+    <?xml version="1.0" standalone="no"?>
+
+    <svg width="6cm" height="5cm" viewBox="0 0 600 500"
+        xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+      <circle cx="300" cy="225" r="100" fill="green"/>
+
+      <text x="300" y="250"
+            font-family="Verdana"
+            font-size="50"
+            text-anchor="middle">
+          PASS
+      </text>
+    </svg>
+</body>
+</html>

--- a/content-security-policy/svg/svg-inline-without-scripting.html
+++ b/content-security-policy/svg/svg-inline-without-scripting.html
@@ -8,7 +8,6 @@
 
 <body>
     <p>Tests that an SVG loaded without any scripting should load.</p>
-    <?xml version="1.0" standalone="no"?>
 
     <svg width="6cm" height="5cm" viewBox="0 0 600 500"
         xmlns="http://www.w3.org/2000/svg" version="1.1">


### PR DESCRIPTION
For Servo internal machinery that makes requests, we should not enforce CSP. This is relevant for inline SVG's, which are currently implemented as data URLs.

Also adds missing test coverage for `background-image` URLs blocked by `img-src`.

Testing: Adds a new WPT test
Fixes: #<!-- nolink -->42189
Reviewed in servo/servo#44974