### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=222422

### DIFF
--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -368,7 +368,6 @@
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
               assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
-              mediaElement.play();
               sourceBuffer.appendBuffer(mediaData);
               test.expectEvent(sourceBuffer, 'updateend', 'Media data appended to the SourceBuffer');
               test.waitForExpectedEvents(function()


### PR DESCRIPTION
LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration.html: The last test was invalid.
It adds data from 0.095 and expect the mediaElement's play promise to be resolved ; it can't be as with this starting
gap there's nothing to play. Remove the call to play() it's not required for this test
