### PR TITLE
Attempt to clean up the WPT export of popover=hint from Chromium to WPT

### DIFF
--- a/html/semantics/popovers/popover-events.html
+++ b/html/semantics/popovers/popover-events.html
@@ -244,7 +244,9 @@ window.onload = () => {
     assert_array_equals(events,[
       'beforetoggle closed -> open',
       'button blur',
+      'beforetoggle open -> closed',
       'focusElement focus',
+      'toggle open -> closed',
       'toggle closed -> open'
     ]);
   }, 'The toggle event is still fired if the popover is removed during focus/blur');

--- a/html/semantics/popovers/popover-focus-overflow-visible.html
+++ b/html/semantics/popovers/popover-focus-overflow-visible.html
@@ -11,7 +11,7 @@
 <button popovertarget="popover1" id="invoker">Invoker</button>
 <button id="after">After</button>
 <div popover="auto" style="overflow: visible;" id="popover1">
-  <a id="a" href="#">Focus me</a>
+  <a id="a" href="#" tabindex="0">Focus me</a>
   <input id="input">
 </div>
 <script>

--- a/html/semantics/popovers/popover-hint-hierarchy.html
+++ b/html/semantics/popovers/popover-hint-hierarchy.html
@@ -83,27 +83,6 @@ promise_test(async (t) => {
   assertOpen('after auto click',auto1);
 }, 'Clicking outside consistently closes both auto and hint popovers.');
 
-// Same as "weirdness 3" but with all popovers nested in an outer auto popover
-promise_test(async (t) => {
-  t.add_cleanup(hideAll);
-
-  auto1.showPopover();
-  auto2.showPopover({source: auto1});
-  hint1.showPopover({source: auto1});
-  assertOpen('initial', auto1, auto2, hint1);
-
-  await clickOn(hint1);
-  assertOpen('after hint click', auto1, hint1);
-
-  auto2.showPopover({source: auto1});
-  assertOpen('auto reopen hides hint', auto1, auto2);
-  hint1.showPopover({source: auto1});
-  assertOpen('reopen hint', auto1, auto2, hint1);
-
-  await clickOn(auto2);
-  assertOpen('after auto click', auto1, auto2);
-}, 'Clicking outside consistently closes both auto and hint popovers (nested).');
-
 // this is "weirdness 4" from https://github.com/whatwg/html/issues/12304
 test((t) => {
   t.add_cleanup(hideAll);
@@ -132,10 +111,10 @@ promise_test(async (t) => {
   assertOpen('initial',hint1);
 
   // Imperative
-  assert_throws_dom('InvalidStateError', () => {
-    auto1.showPopover({source: hint1});
-  }, 'Opening auto popover inside hint popover is not allowed');
-  assertOpen('after show',hint1);
+  auto1.showPopover({source: hint1}); // "demoted" to hint
+  assertOpen('after show',auto1,hint1);
+
+  auto1.hidePopover();
 
   // Declarative
   const invoker = document.createElement('button');
@@ -143,6 +122,6 @@ promise_test(async (t) => {
   t.add_cleanup(() => invoker.remove());
   hint1.appendChild(invoker);
   await clickOn(invoker);
-  assertOpen('after click',hint1);
-}, 'Opening an auto popover inside a hint popover is disallowed and will fail.');
+  assertOpen('after click',auto1,hint1);
+}, 'Opening an auto popover inside a hint popover is allowed and it downgrades to hint.');
 </script>

--- a/html/semantics/popovers/popover-light-dismiss-hint.html
+++ b/html/semantics/popovers/popover-light-dismiss-hint.html
@@ -16,14 +16,14 @@
   <div popover id=auto2>auto 2
     <div popover=hint id=innerhint1>inner hint 1
       <div popover=hint id=innerhint2>inner hint 2
-        <div popover id=invalidauto1>Improperly nested auto 1</div>
+        <div popover id=improperlynestedauto1>Improperly nested auto 1</div>
       </div>
     </div>
   </div>
 </div>
 <div popover=hint id=hint1>hint 1
   <div popover=hint id=hint2>hint 2
-    <div popover id=invalidauto2>Improperly nested auto 2</div>
+    <div popover id=improperlynestedauto2>Improperly nested auto 2</div>
   </div>
 </div>
 <div popover=manual id=manual1>Manual</div>
@@ -34,10 +34,10 @@
   #auto2        {left:100px; top:200px;}
   #innerhint1   {left:100px; top:300px;}
   #innerhint2   {left:100px; top:400px;}
-  #invalidauto1 {left:100px; top:500px;}
+  #improperlynestedauto1 {left:100px; top:500px;}
   #hint1        {left:200px; top:100px;}
   #hint2        {left:200px; top:200px;}
-  #invalidauto1 {left:200px; top:400px;}
+  #improperlynestedauto1 {left:200px; top:400px;}
   #manual1      {left:300px; top:100px;}
   #outside {width:25px;height:25px}
 </style>
@@ -108,15 +108,10 @@
 
   promise_test(async (t) => {
     openall(setA, t);
-    assert_throws_dom('InvalidStateError', () => {
-      invalidauto1.showPopover();
-    });
-  },'Auto cannot be nested inside hint (invalidauto1)');
-
-  promise_test(async (t) => {
+    improperlynestedauto1.showPopover();
+    assertState([...setA, improperlynestedauto1] , [true, true, true, true, true, true]);
     openall(setB, t);
-    assert_throws_dom('InvalidStateError', () => {
-      invalidauto2.showPopover();
-    });
-  },'Auto cannot be nested inside hint (invalidauto2)');
+    improperlynestedauto2.showPopover();
+    assertState([...setB, improperlynestedauto2] , [true, true, true, true]);
+  },'Auto can be nested inside hint (nothing should throw, auto demoted to hint)');
 </script>

--- a/html/semantics/popovers/popover-light-dismiss.html
+++ b/html/semantics/popovers/popover-light-dismiss.html
@@ -668,12 +668,12 @@ promise_test(async () => {
   await clickOn(p36);
   // Note: this should *not* reset "hint stack parent".
   assert_true(p34.matches(':popover-open'), 'p34 should remain open');
-  assert_false(p35.matches(':popover-open'), 'p35 should be light dismissed');
-  assert_true(p36.matches(':popover-open'), 'p36 should remain open, because its ancestor p34 is still open');
+  assert_false(p35.matches(':popover-open'), 'p35 should be light dismissed (clicking on the hint dismisses non-ancestor autos)');
+  assert_true(p36.matches(':popover-open'), 'p36 should remain open - clicking the hint shouldn\'t close it');
 
   p34.hidePopover();
   assert_false(p34.matches(':popover-open'), 'p34 should be closed');
-  assert_false(p36.matches(':popover-open'), 'p36 should be closed - p34 is its hint stack parent');
+  assert_false(p36.matches(':popover-open'), 'p36 should be closed - p34 is still its hint stack parent');
 }, 'Test "hint stack parent" behavior');
 
 promise_test(async () => {

--- a/html/semantics/popovers/popover-light-dismiss.html
+++ b/html/semantics/popovers/popover-light-dismiss.html
@@ -475,10 +475,10 @@ promise_test(async () => {
   p17.addEventListener('beforetoggle', logEvents);
   p18.addEventListener('beforetoggle', (e) => {
     logEvents(e);
-    p17.showPopover();
+    assert_throws_dom("InvalidStateError", () => p17.showPopover());
   });
   p16.hidePopover();
-  assert_array_equals(events,['hide p18','show p17','hide p16'],'There should not be a hide event for p17');
+  assert_array_equals(events,['hide p18','hide p16'],'There should not be a hide event for p17');
   assert_false(p16.matches(':popover-open'));
   assert_false(p17.matches(':popover-open'));
   assert_false(p18.matches(':popover-open'));
@@ -496,14 +496,13 @@ promise_test(async () => {
   const logEvents = (e) => {events.push(`${e.newState==='open' ? 'show' : 'hide'} ${e.target.id}`)};
   p19.addEventListener('beforetoggle', (e) => {
     logEvents(e);
-    p20.showPopover();
+    assert_throws_dom("InvalidStateError", () => p20.showPopover());
   });
   p20.addEventListener('beforetoggle', logEvents);
   p19.hidePopover();
-  assert_array_equals(events,['hide p19','show p20'],'There should not be a second hide event for 19');
+  assert_array_equals(events,['hide p19'],'There should not be a second hide event for 19');
   assert_false(p19.matches(':popover-open'));
-  assert_true(p20.matches(':popover-open'));
-  p20.hidePopover(); // Cleanup
+  assert_false(p20.matches(':popover-open'));
 },'Show an unrelated popover during "hide popover"');
 </script>
 
@@ -521,12 +520,12 @@ promise_test(async () => {
   const logEvents = (e) => { events.push(`${e.newState === 'open' ? 'show' : 'hide'} ${e.target.id}`) };
   p22.addEventListener('beforetoggle', (e) => {
     logEvents(e);
-    p24.showPopover()
+    assert_throws_dom("InvalidStateError", () => p24.showPopover());
   });
   p23.addEventListener('beforetoggle', logEvents);
   p24.addEventListener('beforetoggle', logEvents);
   p23.showPopover();
-  assert_array_equals(events, ['show p23', 'hide p22', 'show p24'], 'hiding p24 does not fire event');
+  assert_array_equals(events, ['show p23', 'hide p22'], 'hiding p24 does not fire event');
   assert_false(p22.matches(':popover-open'));
   assert_true(p23.matches(':popover-open'));
   assert_false(p24.matches(':popover-open'));
@@ -547,7 +546,7 @@ promise_test(async () => {
   const logEvents = (e) => { events.push(`${e.newState === 'open' ? 'show' : 'hide'} ${e.target.id}`) };
   p26.addEventListener('beforetoggle', (e) => {
     logEvents(e);
-    p28.showPopover();
+    assert_throws_dom("InvalidStateError", () => p28.showPopover());
   });
   p27.addEventListener('beforetoggle', logEvents);
   p28.addEventListener('beforetoggle', (e) => {
@@ -555,7 +554,8 @@ promise_test(async () => {
     p27.showPopover();
   });
   p27.showPopover();
-  assert_array_equals(events, ['show p27', 'hide p26', 'show p28', 'show p27'], 'Nested showPopover should not fire event for its HideAllPopoversUntil');
+  assert_array_equals(events, ['show p27', 'hide p26'],
+      'Nested showPopover should not fire event for its HideAllPopoversUntil');
   assert_false(p26.matches(':popover-open'));
   assert_true(p27.matches(':popover-open'));
   assert_false(p28.matches(':popover-open'));
@@ -617,3 +617,149 @@ promise_test(async () => {
   assert_true(p30.matches(':popover-open'),'showing after pointerup');
 },`Pointer down inside invoker and up outside that invoker shouldn't dismiss popover`);
 </script>
+
+<div id=p31 popover=auto>p31
+  <button id=buttonp32 popovertarget=p32>Open p32</button>
+  <div id=p33 popover=auto>p33</div>
+</div>
+<div id=p32 popover=auto>p32
+  <button id=buttonp33 popovertarget=p33>Open p33</button>
+</div>
+<script>
+test(() => {
+  assert_false(p31.matches(':popover-open'));
+  assert_false(p32.matches(':popover-open'));
+  assert_false(p33.matches(':popover-open'));
+
+  p31.showPopover();
+  buttonp32.click();
+  buttonp33.click();
+
+  assert_true(p31.matches(':popover-open'), 'p31 should be open');
+  assert_true(p32.matches(':popover-open'), 'p32 should be open');
+  assert_true(p33.matches(':popover-open'), 'p33 should be open');
+
+  p31.hidePopover();
+  assert_false(p31.matches(':popover-open'), 'p31 should be closed');
+  assert_false(p32.matches(':popover-open'), 'p32 should be closed');
+  assert_false(p33.matches(':popover-open'), 'p33 should be closed');
+}, 'Invoker and DOM ancestor relationship - "latest" wins');
+</script>
+
+<div id=p34 popover=auto>p34
+  <div id=p35 popover=auto>p35</div>
+  <div id=p36 popover=hint>p36</div>
+</div>
+<div id=p37 popover=auto>p37</div>
+<script>
+promise_test(async () => {
+  assert_false(p34.matches(':popover-open'));
+  assert_false(p35.matches(':popover-open'));
+  assert_false(p36.matches(':popover-open'));
+
+  p34.showPopover();
+  p35.showPopover();
+  p36.showPopover();
+
+  assert_true(p34.matches(':popover-open'), 'p34 should be open');
+  assert_true(p35.matches(':popover-open'), 'p35 should be open');
+  assert_true(p36.matches(':popover-open'), 'p36 should be open');
+
+  await clickOn(p36);
+  // Note: this should *not* reset "hint stack parent".
+  assert_true(p34.matches(':popover-open'), 'p34 should remain open');
+  assert_false(p35.matches(':popover-open'), 'p35 should be light dismissed');
+  assert_true(p36.matches(':popover-open'), 'p36 should remain open, because its ancestor p34 is still open');
+
+  p34.hidePopover();
+  assert_false(p34.matches(':popover-open'), 'p34 should be closed');
+  assert_false(p36.matches(':popover-open'), 'p36 should be closed - p34 is its hint stack parent');
+}, 'Test "hint stack parent" behavior');
+
+promise_test(async () => {
+  assert_false(p34.matches(':popover-open'));
+  assert_false(p35.matches(':popover-open'));
+  assert_false(p36.matches(':popover-open'));
+  assert_false(p37.matches(':popover-open'));
+
+  const invoker37 = document.createElement('button');
+  invoker37.popoverTargetElement = p37;
+  p34.appendChild(invoker37);
+
+  p34.showPopover();
+  p35.showPopover();
+  p36.showPopover();
+
+  assert_true(p34.matches(':popover-open'), 'p34 should be open');
+  assert_true(p35.matches(':popover-open'), 'p35 should be open');
+  assert_true(p36.matches(':popover-open'), 'p36 should be open');
+
+  p37.showPopover({source: invoker37});
+  assert_true(p37.matches(':popover-open'), 'p37 open');
+  assert_true(p34.matches(':popover-open'), 'p34 stays open');
+  assert_false(p35.matches(':popover-open'), 'p35 closed');
+  assert_false(p36.matches(':popover-open'), 'p36 closed (hints are closed by auto opening)');
+
+  p34.hidePopover();
+  assert_false(p37.matches(':popover-open'), 'p37 closed');
+}, 'Opening a new auto popover should hide all hint popovers, even in the nested case');
+</script>
+
+<div id=p38 popover=auto>p38
+  <div id=p39 popover=auto>p39
+    <div id=p40 popover=hint>p40</div>
+  </div>
+</div>
+<script>
+promise_test(async () => {
+  assert_false(p38.matches(':popover-open'));
+  assert_false(p39.matches(':popover-open'));
+  assert_false(p40.matches(':popover-open'));
+
+  p38.showPopover();
+  p39.showPopover();
+  p40.showPopover();
+
+  assert_true(p38.matches(':popover-open'), 'p38 should be open');
+  assert_true(p39.matches(':popover-open'), 'p39 should be open');
+  assert_true(p40.matches(':popover-open'), 'p40 should be open');
+
+  await clickOn(p40);
+  assert_true(p38.matches(':popover-open'), 'p38 should remain open');
+  assert_true(p39.matches(':popover-open'), 'p39 should remain open');
+  assert_true(p40.matches(':popover-open'), 'p40 should remain open');
+
+  p38.hidePopover();
+  assert_false(p38.matches(':popover-open'), 'p38 should be closed');
+  assert_false(p39.matches(':popover-open'), 'p39 should be closed');
+  assert_false(p40.matches(':popover-open'), 'p40 should be closed - closing grandparent auto popover closes child hint popover');
+}, 'Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint');
+
+promise_test(async () => {
+  assert_false(p38.matches(':popover-open'));
+  assert_false(p39.matches(':popover-open'));
+  assert_false(p40.matches(':popover-open'));
+
+  p38.showPopover();
+  p39.showPopover();
+  p40.showPopover();
+
+  assert_true(p38.matches(':popover-open'), 'p38 should be open');
+  assert_true(p39.matches(':popover-open'), 'p39 should be open');
+  assert_true(p40.matches(':popover-open'), 'p40 should be open');
+
+  await clickOn(p40);
+  assert_true(p38.matches(':popover-open'), 'p38 should remain open');
+  assert_true(p39.matches(':popover-open'), 'p39 should remain open');
+  assert_true(p40.matches(':popover-open'), 'p40 should remain open');
+
+  p39.hidePopover();
+  assert_false(p39.matches(':popover-open'), 'p39 should be closed');
+  assert_false(p40.matches(':popover-open'), 'p40 should be closed - p39 is its hint stack parent');
+  assert_true(p38.matches(':popover-open'), 'p38 should remain open');
+
+  p38.hidePopover();
+  assert_false(p38.matches(':popover-open'), 'p38 should be closed');
+}, 'Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint');
+</script>
+

--- a/html/semantics/popovers/popover-open-in-beforetoggle.html
+++ b/html/semantics/popovers/popover-open-in-beforetoggle.html
@@ -27,7 +27,9 @@
 
   test((t) => {
     p1.showPopover();
-    p1.addEventListener('beforetoggle',() => p2.showPopover(),{signal: getSignal(t)});
+    p1.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p2.showPopover());
+    },{signal: getSignal(t)});
     p1.hidePopover(); // Potential crash here
     assert_false(p1.matches(':popover-open'));
     assert_false(p2.matches(':popover-open'));
@@ -35,8 +37,12 @@
 
   test((t) => {
     p1.showPopover();
-    p1.addEventListener('beforetoggle',() => p2.showPopover(),{signal: getSignal(t)});
-    p2.addEventListener('beforetoggle',() => p3.showPopover(),{signal: getSignal(t)});
+    p1.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p2.showPopover());
+    },{signal: getSignal(t)});
+    p2.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p3.showPopover());
+    },{signal: getSignal(t)});
     p1.hidePopover(); // Potential crash here
     assert_false(p1.matches(':popover-open'));
     assert_false(p2.matches(':popover-open'));
@@ -45,8 +51,12 @@
 
   test(t => {
     p1.showPopover();
-    p1.addEventListener('beforetoggle',() => p2.showPopover(),{signal: getSignal(t)});
-    p2.addEventListener('beforetoggle',() => p3.showPopover(),{signal: getSignal(t)});
+    p1.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p2.showPopover());
+    },{signal: getSignal(t)});
+    p2.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p3.showPopover());
+    },{signal: getSignal(t)});
     dialog.showModal(); // Potential crash here
     assert_false(p1.matches(':popover-open'));
     assert_false(p2.matches(':popover-open'));
@@ -56,11 +66,41 @@
 
   promise_test(async t => {
     p1.showPopover();
-    p1.addEventListener('beforetoggle',() => p2.showPopover(),{signal: getSignal(t)});
-    p2.addEventListener('beforetoggle',() => p3.showPopover(),{signal: getSignal(t)});
+    p1.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p2.showPopover());
+    },{signal: getSignal(t)});
+    p2.addEventListener('beforetoggle',() => {
+      assert_throws_dom("InvalidStateError",() => p3.showPopover());
+    },{signal: getSignal(t)});
     await clickOn(outside); // Potential crash here
     assert_false(p1.matches(':popover-open'));
     assert_false(p2.matches(':popover-open'));
     assert_false(p3.matches(':popover-open'));
   },'Open double-nested popovers from closing beforetoggle event, light dismiss');
 </script>
+
+<div id=p4 popover=auto>p4</div>
+<div id=p5 popover=auto>p5</div>
+<div id=p6 popover=hint>p6</div>
+<script>
+test(() => {
+  assert_false(p4.matches(':popover-open'));
+  assert_false(p5.matches(':popover-open'));
+  assert_false(p6.matches(':popover-open'));
+
+  p4.showPopover();
+  p4.onbeforetoggle = (e) => {
+    if (e.newState === "closed") {
+      assert_throws_dom("InvalidStateError",() => p6.showPopover());
+    }
+  };
+  assert_true(p4.matches(':popover-open'), 'p4 should be open');
+  p5.showPopover();
+
+  assert_false(p4.matches(':popover-open'), 'p4 should be closed (by opening p5)');
+  assert_true(p5.matches(':popover-open'), 'p5 should be open');
+  assert_false(p6.matches(':popover-open'), 'p6 should be closed');
+  p5.hidePopover(); // Cleanup
+}, 'Showing a hint during a showPopover that hides an auto should throw InvalidStateError');
+</script>
+

--- a/html/semantics/popovers/popover-remove-attribute-during-focusing-steps.html
+++ b/html/semantics/popovers/popover-remove-attribute-during-focusing-steps.html
@@ -9,11 +9,11 @@
 <script>
 "use strict";
 promise_test(async () => {
-  let hasPopover, toggleEvent;
+  let hasPopover;
+  let toggleEvents = [];
   popover.addEventListener("toggle", (e) => {
-    assert_equals(toggleEvent, undefined, "only one toggle event should be dispatched");
     hasPopover = popover.hasAttribute("popover");
-    toggleEvent = e;
+    toggleEvents.push(e);
   });
   input.addEventListener("focus", () => {
     popover.removeAttribute("popover");
@@ -21,12 +21,12 @@ promise_test(async () => {
   popover.showPopover();
   // wait for events to fire
   await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-  assert_not_equals(toggleEvent, undefined, "toggle event should be dispatched");
-  // Despite the fact that the popover is now closed, only a toggle event with newState = open is fired.
-  // This is because nestedHide is true in "hide a popover", so fireEvents is set to false.
-  assert_equals(toggleEvent.oldState, "closed", "toggle event should have oldState = closed");
-  assert_equals(toggleEvent.newState, "open", "toggle event should have newState = open");
-  assert_false(hasPopover, "toggle event should be dispatched after removeAttribute is called");
+  assert_equals(toggleEvents.length, 2, "two toggle events should be dispatched");
+  assert_equals(toggleEvents[0].oldState, "open");
+  assert_equals(toggleEvents[0].newState, "closed");
+  assert_equals(toggleEvents[1].oldState, "closed");
+  assert_equals(toggleEvents[1].newState, "open");
+  assert_false(hasPopover, "toggle events should be dispatched after removeAttribute is called");
 });
 </script>
 </body>

--- a/html/semantics/popovers/popover-types-with-hints.html
+++ b/html/semantics/popovers/popover-types-with-hints.html
@@ -104,13 +104,11 @@
     const auto = getPopovers()[1];
     hint.showPopover();
     assertState([true,false]);
-    assert_throws_dom('InvalidStateError', () => {
-      auto.showPopover();
-    });
-    assertState([true,false]);
+    auto.showPopover();
+    assertState([true,true]);
     hint.hidePopover();
-    assertState([false,false]);
-  },'If a popover=auto is shown, it should hide any open popover=hint, including if the popover=hint is an ancestral popover of the popover=auto. (You can\'t nest a popover=auto inside a popover=hint)');
+    assertState([false,false], 'closing the parent hint should close downgraded, nested auto');
+    },'Opening an auto popover inside a hint popover is allowed and it downgrades to hint.');
   </script>
 </div>
 
@@ -129,9 +127,9 @@
     assertState([true,true,false]);
     hint.showPopover(); // This should NOT hide auto2, since hint doesn't close unrelated autos.
     assertState([true,true,true]);
-    auto.hidePopover(); // Should hide both auto and hint.
+    auto.hidePopover(); // Hiding an auto hides its descendant hint stack.
     assertState([false,false,false]);
-  },'If you: a) show a popover=auto (call it D), then b) show a descendent popover=hint of D (call it T), then c) hide D, then T should be hidden. (A popover=hint can be nested inside a popover=auto)');
+  },'If you: a) show a popover=auto (call it D), then b) show a descendent popover=hint of D (call it T), then c) hide D, then T should be hidden. (A popover=hint gets hidden when its ancestral popover=auto is hidden)');
   </script>
 </div>
 
@@ -140,7 +138,7 @@
   <div popover=hint>Non-Nested hint</div>
   <script>
   test(() => {
-    const auto = getPopovers()[0]
+    const auto = getPopovers()[0];
     const hint = getPopovers()[1];
     auto.showPopover();
     hint.showPopover();
@@ -149,6 +147,30 @@
     assertState([false,true]);
     hint.hidePopover();
     assertState([false,false]);
-  },'If you: a) show a popover=auto (call it D), then b) show a non-descendent popover=hint of D (call it T), then c) hide D, then T should not be hidden. (Non-nested popover=hint are not hidden when unrelated popover=autos are hidden)');
+    },'If you: a) show a popover=auto (call it D), then b) show a non-descendent popover=hint of D (call it T), then c) hide D, then T should stay open. (Non-nested popover=hint does not get hidden when unrelated popover=autos are hidden)');
+  </script>
+</div>
+
+<div>
+  <div popover>Auto
+    <div popover>Auto2</div>
+    <div popover=hint>Hint</div>
+    <div popover>Auto3</div>
+  </div>
+  <script>
+  test(() => {
+    const auto1 = getPopovers()[0];
+    const auto2 = getPopovers()[1];
+    const hint1 = getPopovers()[2];
+    const auto3 = getPopovers()[3];
+    auto1.showPopover();
+    auto2.showPopover();
+    hint1.showPopover();
+    const events = [];
+    auto2.addEventListener("beforetoggle", (e) => { if (e.newState === "closed") events.push("auto"); });
+    hint1.addEventListener("beforetoggle", (e) => { if (e.newState === "closed") events.push("hint"); });
+    auto3.showPopover();
+    assert_array_equals(events, ["hint", "auto"], "Hint should be hidden before Auto");
+  },"When showing an auto popover, hint popovers should be closed before auto popovers.");
   </script>
 </div>


### PR DESCRIPTION
This PR pushes the latest state of `popover=hint` tests from Chromium (prior to the landing of https://crrev.com/c/7851723, which was a temporary stopgap to unbreak the infra) to WPT.

This one PR should completely replace any PRs that come out of any still-unlanded PRs in this list:

https://github.com/whatwg/html/pull/12345#issuecomment-4307937952

Change-Id: I363b411aa8f6979fbde3766c27afe229703dfc1f
Change-Id: Ibd6af063310585b9044de63a06e36ffd79d011d4
Change-Id: I917bf939614f9811470444e9f13c942e5c63b1b1