### PR TITLE
Mark infrastructure/testdriver/bidi/emulation/set_touch_override.https.html as expected to error in Safari.

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html.ini
@@ -1,4 +1,7 @@
 [set_touch_override.https.html]
+  expected:
+    if product == "safari": ERROR
+
   [emulate touch and clear override]
     expected:
       if product != "chrome": FAIL


### PR DESCRIPTION
Closes #59882.