### PR TITLE
Make navigate event intercept popstate tests behave correctly.

### DIFF
--- a/navigation-api/navigate-event/intercept-popstate-no-handler.html
+++ b/navigation-api/navigate-event/intercept-popstate-no-handler.html
@@ -2,6 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
@@ -10,21 +11,23 @@ promise_test(async t => {
 
   let onpopstate_fired = false;
   let last_state;
+  const {promise, resolve} = Promise.withResolvers();
   window.onpopstate = e => {
     onpopstate_fired = true;
     last_state = e.state;
+    resolve();
   }
-  navigation.onnavigate = t.step_func(e => e.intercept({handler: () => {
-    const {promise, resolve} = Promise.withResolvers();
-    t.step_timeout(resolve, 5);
-    return promise;
-  }}));
+  navigation.onnavigate = t.step_func(e => e.intercept());
 
   await navigation.navigate("#").finished;
   assert_true(navigation.canGoBack);
 
   await navigation.back().finished;
+  assert_false(onpopstate_fired);
+
+  await promise;
   assert_true(onpopstate_fired);
+
   assert_not_equals(last_state, null);
-}, "event.intercept() should provide popstate with a valid state object 2");
+}, "event.intercept() should provide popstate with a valid state object");
 </script>


### PR DESCRIPTION
The order of `popstate` and the reaction to the navigation tracker `.finished` promise depends on the existance of an intercept handler that delays execution to after the upcoming microtask checkpoint, so we adjust the existing intercept popstate test to account for that and we add a new test that ajust the expectations.