### PR TITLE
wpt: Fix link element tests

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization.html
+++ b/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization.html
@@ -7,25 +7,30 @@
 
 <script>
 
-function testLinkRelModification(testDiv, testLink) {
+async function testLinkRelModification(t, testDiv, testLink) {
+  const watcher = new EventWatcher(t, testLink, [ 'load' ]);
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
   testLink.setAttribute("rel", "test\u000Bstylesheet");
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
   testLink.setAttribute("rel", "test\u000Cstylesheet");
+  await watcher.wait_for('load');
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
   testLink.removeAttribute("rel");
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
   testLink.setAttribute("rel", "\u0009\u000A\u000C\u000D\u0020stylesheet");
+  await watcher.wait_for('load');
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
   testLink.removeAttribute("rel");
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
   testLink.setAttribute("rel", "\u0009\u000A\u000C\u000D\u0020stylesheet\u0009\u000A\u000C\u000D\u0020††††");
+  await watcher.wait_for('load');
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
 }
 
-test (() => {
-  testLinkRelModification(document.querySelector("#light-div"),
-                          document.querySelector("#light-link"));
+promise_test(async (t) => {
+  await testLinkRelModification(t,
+                                document.querySelector("#light-div"),
+                                document.querySelector("#light-link"));
 }, "The rel attribute needs to handle ASCII whitespace correctly");
 
 </script>

--- a/html/semantics/document-metadata/the-link-element/link-rel-attribute.html
+++ b/html/semantics/document-metadata/the-link-element/link-rel-attribute.html
@@ -17,28 +17,31 @@
 
 <script>
 
-function testLinkRelModification(testDiv, testLink) {
+async function testLinkRelModification(t, testDiv, testLink) {
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
   testLink.setAttribute("rel", "no-stylesheet");
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
   testLink.setAttribute("rel", "stylesheet");
+  await new EventWatcher(t, testLink, [ 'load' ]).wait_for('load');
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
   testLink.removeAttribute("rel");
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
 }
 
-test (() => {
-  testLinkRelModification(document.querySelector("#light-div"),
-                          document.querySelector("#light-link"));
+promise_test(async (t) => {
+  await testLinkRelModification(t,
+                                      document.querySelector("#light-div"),
+                                      document.querySelector("#light-link"));
 }, "Removing stylesheet from link rel attribute should remove the stylesheet for light DOM");
 
-test (() => {
+promise_test(async (t) => {
   var host = document.querySelector("#host");
   var shadow = host.attachShadow({ mode: "open" });
   var tmpl = document.querySelector("template#shadow-dom");
   var clone = document.importNode(tmpl.content, true);
   shadow.appendChild(clone);
-  testLinkRelModification(shadow.querySelector("#shadow-div"),
-                          shadow.querySelector("#shadow-link"));
+  await testLinkRelModification(t,
+                                shadow.querySelector("#shadow-div"),
+                                shadow.querySelector("#shadow-link"));
 }, "Removing stylesheet from link rel attribute should remove the stylesheet for shadow DOM");
 </script>


### PR DESCRIPTION
Per discussion in WHATWG [1] these tests are wrong and should wait for the load event instead of being main thread blocked.

Relates to whatwg/html#12258

[1]: https://matrix.to/#/!AGetWbsMpFPdSgUrbs:matrix.org/$UicaT9m71QFd4FgtevWQeQjS8zFiVDQfVywk6gB25ns?via=matrix.org&via=mozilla.org&via=igalia.com

Testing: Updates existing tests
Reviewed in servo/servo#45012