### PR TITLE
Navigation.activation.from should be null when previous entry is init…

### DIFF
--- a/navigation-api/navigation-activation/activation-initial-about-blank.html
+++ b/navigation-api/navigation-activation/activation-initial-about-blank.html
@@ -16,8 +16,7 @@ promise_test(async t => {
   assert_equals(i.contentWindow.navigation.entries().length, 1);
   assert_equals(i.contentWindow.navigation.activation.entry,
                 i.contentWindow.navigation.currentEntry);
-  assert_equals(i.contentWindow.navigation.activation.from.url, "about:blank");
-  assert_equals(i.contentWindow.navigation.activation.from.index, -1);
+  assert_equals(i.contentWindow.navigation.activation.from, null);
   assert_equals(i.contentWindow.navigation.activation.navigationType, "replace");
 }, "navigation.activation interaction with initial about:blank");
 </script>


### PR DESCRIPTION
…ial about:blank.

Closes #60002

Change-Id: I8d3bffc13d0ca43c1ca18b0f5e4ecd4ff659267b