### PR TITLE
aamtest: fix runs for non-firefox/non-chrome browsers

### DIFF
--- a/core-aam/aamtests/support/fixtures_a11y_api.py
+++ b/core-aam/aamtests/support/fixtures_a11y_api.py
@@ -3,13 +3,12 @@ from sys import platform
 
 
 def pid_from(capabilities):
-    # TODO: add support for Edge, Safari.
+    # TODO: add support for getting the PID from other browsers.
     if capabilities["browserName"] == "chrome":
         return capabilities["goog:processID"], "chrome"
     if capabilities["browserName"] == "firefox":
         return capabilities["moz:processID"], "firefox"
-    if capabilities["browserName"] == "servo":
-        return 0, "servo"
+    return 0, capabilities["browserName"]
 
 
 @pytest.fixture


### PR DESCRIPTION
Runs of Edge were failing due to this bug: https://wpt.fyi/results/core-aam/aamtests/role/blockquote.py?run_id=5152180100399104&run_id=5122728570126336&run_id=5156950332669952&run_id=5074111931088896