### PR TITLE
[css-backgrounds] Remove non-standard text-fill-color: transparent declarations

### DIFF
--- a/css/css-backgrounds/background-gradient-interpolation-002-notref.html
+++ b/css/css-backgrounds/background-gradient-interpolation-002-notref.html
@@ -17,7 +17,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }

--- a/css/css-backgrounds/background-gradient-interpolation-002.html
+++ b/css/css-backgrounds/background-gradient-interpolation-002.html
@@ -34,7 +34,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }

--- a/css/css-backgrounds/background-gradient-interpolation-003.html
+++ b/css/css-backgrounds/background-gradient-interpolation-003.html
@@ -37,7 +37,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }


### PR DESCRIPTION
`text-fill-color` is not a standard CSS property; only `-webkit-text-fill-color` exists (for web compatibility). The unprefixed declarations alongside the prefixed ones are redundant.

Removes `text-fill-color: transparent;` from:
- `css/css-backgrounds/background-gradient-interpolation-002-notref.html`
- `css/css-backgrounds/background-gradient-interpolation-002.html`
- `css/css-backgrounds/background-gradient-interpolation-003.html`

Related WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=315154