### PR TITLE
Split {Blob,File}-constructor-endings.html

### DIFF
--- a/FileAPI/blob/Blob-constructor-endings.any.js
+++ b/FileAPI/blob/Blob-constructor-endings.any.js
@@ -1,0 +1,35 @@
+// META: title=Blob constructor: endings option
+[
+  'transparent',
+  'native'
+].forEach(value => test(t => {
+  assert_class_string(new Blob([], {endings: value}), 'Blob',
+                      `Constructor should allow "${value}" endings`);
+}, `Valid "endings" value: ${JSON.stringify(value)}`));
+
+[
+  null,
+  '',
+  'invalidEnumValue',
+  'Transparent',
+  'NATIVE',
+  0,
+  {}
+].forEach(value => test(t => {
+  assert_throws_js(TypeError, () => new Blob([], {endings: value}),
+                   'Blob constructor should throw');
+}, `Invalid "endings" value: ${JSON.stringify(value)}`));
+
+test(t => {
+  const test_error = {name: 'test'};
+  assert_throws_exactly(
+    test_error,
+    () => new Blob([], { get endings() { throw test_error; }}),
+    'Blob constructor should propagate exceptions from "endings" property');
+}, 'Exception propagation from options');
+
+test(t => {
+  let got = false;
+  new Blob([], { get endings() { got = true; } });
+  assert_true(got, 'The "endings" property was accessed during construction.');
+}, 'The "endings" options property is used');

--- a/FileAPI/blob/Blob-constructor-endings.html
+++ b/FileAPI/blob/Blob-constructor-endings.html
@@ -20,41 +20,6 @@ function readBlobAsPromise(blob) {
 }
 
 [
-  'transparent',
-  'native'
-].forEach(value => test(t => {
-  assert_class_string(new Blob([], {endings: value}), 'Blob',
-                      `Constructor should allow "${value}" endings`);
-}, `Valid "endings" value: ${JSON.stringify(value)}`));
-
-[
-  null,
-  '',
-  'invalidEnumValue',
-  'Transparent',
-  'NATIVE',
-  0,
-  {}
-].forEach(value => test(t => {
-  assert_throws_js(TypeError, () => new Blob([], {endings: value}),
-                   'Blob constructor should throw');
-}, `Invalid "endings" value: ${JSON.stringify(value)}`));
-
-test(t => {
-  const test_error = {name: 'test'};
-  assert_throws_exactly(
-    test_error,
-    () => new Blob([], { get endings() { throw test_error; }}),
-    'Blob constructor should propagate exceptions from "endings" property');
-}, 'Exception propagation from options');
-
-test(t => {
-  let got = false;
-  new Blob([], { get endings() { got = true; } });
-  assert_true(got, 'The "endings" property was accessed during construction.');
-}, 'The "endings" options property is used');
-
-[
   {name: 'LF', input: '\n', native: native_ending},
   {name: 'CR', input: '\r', native: native_ending},
 

--- a/FileAPI/file/File-constructor-endings.any.js
+++ b/FileAPI/file/File-constructor-endings.any.js
@@ -1,0 +1,35 @@
+// META: title=File constructor: endings option
+[
+  'transparent',
+  'native'
+].forEach(value => test(t => {
+  assert_class_string(new File([], "name", {endings: value}), 'File',
+                      `Constructor should allow "${value}" endings`);
+}, `Valid "endings" value: ${JSON.stringify(value)}`));
+
+[
+  null,
+  '',
+  'invalidEnumValue',
+  'Transparent',
+  'NATIVE',
+  0,
+  {}
+].forEach(value => test(t => {
+  assert_throws_js(TypeError, () => new File([], "name", {endings: value}),
+                   'File constructor should throw');
+}, `Invalid "endings" value: ${JSON.stringify(value)}`));
+
+test(t => {
+  const test_error = {name: 'test'};
+  assert_throws_exactly(
+    test_error,
+    () => new File([], "name", { get endings() { throw test_error; }}),
+    'File constructor should propagate exceptions from "endings" property');
+}, 'Exception propagation from options');
+
+test(t => {
+  let got = false;
+  new File([], "name", { get endings() { got = true; } });
+  assert_true(got, 'The "endings" property was accessed during construction.');
+}, 'The "endings" options property is used');

--- a/FileAPI/file/File-constructor-endings.html
+++ b/FileAPI/file/File-constructor-endings.html
@@ -20,41 +20,6 @@ function readBlobAsPromise(blob) {
 }
 
 [
-  'transparent',
-  'native'
-].forEach(value => test(t => {
-  assert_class_string(new File([], "name", {endings: value}), 'File',
-                      `Constructor should allow "${value}" endings`);
-}, `Valid "endings" value: ${JSON.stringify(value)}`));
-
-[
-  null,
-  '',
-  'invalidEnumValue',
-  'Transparent',
-  'NATIVE',
-  0,
-  {}
-].forEach(value => test(t => {
-  assert_throws_js(TypeError, () => new File([], "name", {endings: value}),
-                   'File constructor should throw');
-}, `Invalid "endings" value: ${JSON.stringify(value)}`));
-
-test(t => {
-  const test_error = {name: 'test'};
-  assert_throws_exactly(
-    test_error,
-    () => new File([], "name", { get endings() { throw test_error; }}),
-    'File constructor should propagate exceptions from "endings" property');
-}, 'Exception propagation from options');
-
-test(t => {
-  let got = false;
-  new File([], "name", { get endings() { got = true; } });
-  assert_true(got, 'The "endings" property was accessed during construction.');
-}, 'The "endings" options property is used');
-
-[
   {name: 'LF', input: '\n', native: native_ending},
   {name: 'CR', input: '\r', native: native_ending},
 


### PR DESCRIPTION
The tests that don't rely on the system OS can easily be run more widely. In particular I'd like to run them against non-web runtimes, which is easier if they're not wrapped in HTML.