### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=313739

### DIFF
--- a/css/css-flexbox/flex-aspect-ratio-content-box-padding-001-ref.html
+++ b/css/css-flexbox/flex-aspect-ratio-content-box-padding-001-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex item with aspect-ratio and padding should size correctly in column flex (reference)</title>
+<style>
+.box {
+    width: 400px;
+    height: 400px;
+    background: green;
+}
+</style>
+<div class="box"></div>

--- a/css/css-flexbox/flex-aspect-ratio-content-box-padding-001.html
+++ b/css/css-flexbox/flex-aspect-ratio-content-box-padding-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex item with aspect-ratio and padding should size correctly in column flex</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#algo-main-item">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content="A flex item with aspect-ratio: 1, width: 200px, and padding: 100px in a column flex container should be 400x400 (content 200x200 + padding 100 on each side).">
+<link rel="match" href="flex-aspect-ratio-content-box-padding-001-ref.html">
+<style>
+.container {
+    display: flex;
+    flex-direction: column;
+}
+
+.box {
+    width: 200px;
+    aspect-ratio: 1;
+    padding: 100px;
+    overflow: hidden;
+    background: green;
+}
+</style>
+<div class="container">
+    <div class="box"></div>
+</div>

--- a/css/css-flexbox/flex-aspect-ratio-intrinsic-padding-001-ref.html
+++ b/css/css-flexbox/flex-aspect-ratio-intrinsic-padding-001-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex item image with intrinsic ratio and padding should size correctly in column flex (reference)</title>
+<style>
+.container {
+    width: 240px;
+}
+
+div.img {
+    width: 200px;
+    height: 100px;
+    padding: 20px;
+    background: green;
+    background-clip: content-box;
+}
+</style>
+<div class="container">
+    <div class="img"></div>
+</div>

--- a/css/css-flexbox/flex-aspect-ratio-intrinsic-padding-001.html
+++ b/css/css-flexbox/flex-aspect-ratio-intrinsic-padding-001.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex item image with intrinsic ratio and padding should size correctly in column flex</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#algo-main-item">
+<link rel="match" href="flex-aspect-ratio-intrinsic-padding-001-ref.html">
+<meta name="assert" content="An image with intrinsic 2:1 ratio, auto width, and padding in a column flex container should compute its height from the content-box cross size, not the border-box.">
+<style>
+.container {
+    display: flex;
+    flex-direction: column;
+    width: 240px;
+}
+
+img {
+    padding: 20px;
+}
+</style>
+<div class="container">
+    <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='100'><rect fill='green' width='200' height='100'/></svg>">
+</div>


### PR DESCRIPTION
WebKit export from bug: [Flex item with aspect-ratio and content-box padding computes wrong height in column flex](https://bugs.webkit.org/show_bug.cgi?id=313739)