### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314734

### DIFF
--- a/css/css-flexbox/flex-aspect-ratio-cross-size-001-ref.html
+++ b/css/css-flexbox/flex-aspect-ratio-cross-size-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Reference</title>
+<style>
+.flex {
+  display: flex;
+  width: 400px;
+  height: 200px;
+}
+
+img {
+  display: block;
+}
+</style>
+<p>Test passes if the two images below are the same size.</p>
+<div class="flex">
+  <img src="../support/1x1-green.png">
+</div>
+<div class="flex">
+  <img src="../support/1x1-green.png">
+</div>

--- a/css/css-flexbox/flex-aspect-ratio-cross-size-001.html
+++ b/css/css-flexbox/flex-aspect-ratio-cross-size-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Flex container with aspect-ratio-derived height provides definite cross size to flex items</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#definite-sizes">
+<link rel="match" href="flex-aspect-ratio-cross-size-001-ref.html">
+<style>
+.flex {
+  display: flex;
+  width: 400px;
+  aspect-ratio: 2 / 1;
+}
+
+img {
+  display: block;
+}
+</style>
+<p>Test passes if the two images below are the same size.</p>
+<div class="flex">
+  <img src="../support/1x1-green.png">
+</div>
+<div class="flex" style="aspect-ratio: auto; height: 200px;">
+  <img src="../support/1x1-green.png">
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[Flex\] Flex container with aspect-ratio-derived height does not provide definite cross size to flex items](https://bugs.webkit.org/show_bug.cgi?id=314734)