### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314978

### DIFF
--- a/css/CSS2/box-display/block-in-inline-large-margin-bottom-ref.html
+++ b/css/CSS2/box-display/block-in-inline-large-margin-bottom-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 10px; margin-bottom: 200px; background: blue; }
+.second { width: 100px; height: 10px; background: green; }
+</style>
+<p>Blue rectangle, 200px gap, then green rectangle.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-large-margin-bottom.html
+++ b/css/CSS2/box-display/block-in-inline-large-margin-bottom.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline with large margin-bottom propagates correctly to next sibling</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-large-margin-bottom-ref.html">
+<meta name="assert" content="A block-in-inline with a large margin-bottom positions the next sibling at exactly that distance below.">
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 10px; margin-bottom: 200px; background: blue; }
+.second { width: 100px; height: 10px; background: green; }
+</style>
+<p>Blue rectangle, 200px gap, then green rectangle.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-collapses-through-intervening-float-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-collapses-through-intervening-float-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 200px; }
+.first { width: 200px; height: 20px; margin-bottom: 40px; background: blue; }
+.intervening { float: left; width: 80px; height: 60px; background: yellow; }
+.second { width: 200px; height: 20px; background: blue; }
+</style>
+<p>Two blue rectangles separated by a 40px gap; a yellow float intersects the second.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="intervening"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-collapses-through-intervening-float.html
+++ b/css/CSS2/box-display/block-in-inline-margin-collapses-through-intervening-float.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline margin collapses through an intervening float</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#floats">
+<link rel="match" href="block-in-inline-margin-collapses-through-intervening-float-ref.html">
+<meta name="assert" content="A floated box between two block-in-inlines does not consume the preceding block's margin-bottom; it collapses with the following block-in-inline as if the float were not there.">
+<style>
+.container { width: 200px; }
+.first { width: 200px; height: 20px; margin-bottom: 40px; background: blue; }
+.intervening { float: left; width: 80px; height: 60px; background: yellow; }
+.second { width: 200px; height: 20px; background: blue; }
+</style>
+<p>Two blue rectangles separated by a 40px gap; a yellow float intersects the second.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="intervening"></div>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-collapses-through-multiple-floats-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-collapses-through-multiple-floats-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 200px; }
+.first { width: 200px; height: 20px; margin-bottom: 40px; background: blue; }
+.float-a { float: left; width: 50px; height: 30px; background: yellow; }
+.float-b { float: right; width: 50px; height: 30px; background: orange; }
+.second { width: 200px; height: 20px; background: blue; }
+</style>
+<p>Two blue rectangles 40px apart; yellow and orange floats sit between them.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="float-a"></div>
+    <div class="float-b"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-collapses-through-multiple-floats.html
+++ b/css/CSS2/box-display/block-in-inline-margin-collapses-through-multiple-floats.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline margin collapses through multiple intervening floats</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#floats">
+<link rel="match" href="block-in-inline-margin-collapses-through-multiple-floats-ref.html">
+<meta name="assert" content="Multiple floats between two block-in-inlines do not interfere with the margin collapsing between the two blocks.">
+<style>
+.container { width: 200px; }
+.first { width: 200px; height: 20px; margin-bottom: 40px; background: blue; }
+.float-a { float: left; width: 50px; height: 30px; background: yellow; }
+.float-b { float: right; width: 50px; height: 30px; background: orange; }
+.second { width: 200px; height: 20px; background: blue; }
+</style>
+<p>Two blue rectangles 40px apart; yellow and orange floats sit between them.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="float-a"></div>
+    <div class="float-b"></div>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-line-break-then-block-in-inline-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-line-break-then-block-in-inline-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: blue; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Blue rectangle, an empty line of 20px, 40px gap, then green rectangle.</p>
+<div class="container">
+    <div class="first"></div><br>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-line-break-then-block-in-inline.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-line-break-then-block-in-inline.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline with line break and trailing block-in-inline collapses margin once</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-margin-with-line-break-then-block-in-inline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A line break between two block-in-inlines does not introduce additional margin advance for the second block.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: blue; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Blue rectangle, an empty line of 20px, 40px gap, then green rectangle.</p>
+<div class="container">
+    <span><div class="first"></div><br></span>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-text-then-block-in-inline-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-text-then-block-in-inline-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.first { width: 100px; height: 20px; margin-bottom: 30px; background: blue; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Blue rectangle, 30px gap, 'XX', then green rectangle.</p>
+<div class="container">
+    <div class="first"></div>XX<div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-text-then-block-in-inline.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-text-then-block-in-inline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline followed by inline text then another block-in-inline</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-margin-with-text-then-block-in-inline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A block-in-inline, followed by inline text, followed by another block-in-inline, advances the inline text by the first block's margin-bottom and the second block by the inline-line-height.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.first { width: 100px; height: 20px; margin-bottom: 30px; background: blue; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Blue rectangle, 30px gap, 'XX', then green rectangle.</p>
+<div class="container">
+    <span><div class="first"></div>XX<div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-negative-margin-bottom-with-trailing-block-ref.html
+++ b/css/CSS2/box-display/block-in-inline-negative-margin-bottom-with-trailing-block-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 30px; margin-bottom: -10px; background: blue; }
+.second { width: 100px; height: 30px; background: green; }
+</style>
+<p>A blue rectangle and a green rectangle overlapping by 10px.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-negative-margin-bottom-with-trailing-block.html
+++ b/css/CSS2/box-display/block-in-inline-negative-margin-bottom-with-trailing-block.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline with negative margin-bottom overlaps following sibling</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-negative-margin-bottom-with-trailing-block-ref.html">
+<meta name="assert" content="A block-in-inline with negative margin-bottom causes the following sibling to overlap upward by the absolute margin amount.">
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 30px; margin-bottom: -10px; background: blue; }
+.second { width: 100px; height: 30px; background: green; }
+</style>
+<p>A blue rectangle and a green rectangle overlapping by 10px.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-negative-margin-with-intervening-float-ref.html
+++ b/css/CSS2/box-display/block-in-inline-negative-margin-with-intervening-float-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 200px; }
+.first { width: 200px; height: 30px; margin-bottom: -10px; background: blue; }
+.intervening { float: left; width: 80px; height: 30px; background: yellow; }
+.second { width: 200px; height: 30px; background: green; }
+</style>
+<p>Blue and green rectangles overlapping by 10px; yellow float intersects them.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="intervening"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-negative-margin-with-intervening-float.html
+++ b/css/CSS2/box-display/block-in-inline-negative-margin-with-intervening-float.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline negative margin with intervening float</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#floats">
+<link rel="match" href="block-in-inline-negative-margin-with-intervening-float-ref.html">
+<meta name="assert" content="A negative margin-bottom on a block-in-inline propagates through an intervening float to overlap the next block-in-inline.">
+<style>
+.container { width: 200px; }
+.first { width: 200px; height: 30px; margin-bottom: -10px; background: blue; }
+.intervening { float: left; width: 80px; height: 30px; background: yellow; }
+.second { width: 200px; height: 30px; background: green; }
+</style>
+<p>Blue and green rectangles overlapping by 10px; yellow float intersects them.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="intervening"></div>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-negative-mb-collapses-with-positive-mt-ref.html
+++ b/css/CSS2/box-display/block-in-inline-negative-mb-collapses-with-positive-mt-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 20px; margin-bottom: -20px; background: blue; }
+.second { width: 100px; height: 20px; margin-top: 50px; background: green; }
+</style>
+<p>Blue rectangle, 30px gap (50 - 20), green rectangle.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-negative-mb-collapses-with-positive-mt.html
+++ b/css/CSS2/box-display/block-in-inline-negative-mb-collapses-with-positive-mt.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline negative margin-bottom collapses with positive margin-top of following sibling</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-negative-mb-collapses-with-positive-mt-ref.html">
+<meta name="assert" content="When a block-in-inline has negative margin-bottom and the following sibling has positive margin-top, the collapsed margin is positive_max - negative_max.">
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 20px; margin-bottom: -20px; background: blue; }
+.second { width: 100px; height: 20px; margin-top: 50px; background: green; }
+</style>
+<p>Blue rectangle, 30px gap (50 - 20), green rectangle.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/inline-text-after-block-in-inline-with-intervening-float-ref.html
+++ b/css/CSS2/box-display/inline-text-after-block-in-inline-with-intervening-float-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 200px; font: 20px/1 Ahem; color: green; }
+.first { width: 200px; height: 20px; margin-bottom: 40px; background: blue; }
+.intervening { float: left; width: 80px; height: 60px; background: yellow; }
+</style>
+<p>Blue rectangle, 40px gap, then 'XX' alongside the yellow float.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="intervening"></div>
+    XX
+</div>

--- a/css/CSS2/box-display/inline-text-after-block-in-inline-with-intervening-float.html
+++ b/css/CSS2/box-display/inline-text-after-block-in-inline-with-intervening-float.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: inline text after block-in-inline with intervening float lands alongside the float</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#floats">
+<link rel="match" href="inline-text-after-block-in-inline-with-intervening-float-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Inline text following a block-in-inline and an intervening float collapses with the block's margin-bottom and lands alongside the float.">
+<style>
+.container { width: 200px; font: 20px/1 Ahem; color: green; }
+.first { width: 200px; height: 20px; margin-bottom: 40px; background: blue; }
+.intervening { float: left; width: 80px; height: 60px; background: yellow; }
+</style>
+<p>Blue rectangle, 40px gap, then 'XX' alongside the yellow float.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="intervening"></div>
+    <span>XX</span>
+</div>

--- a/css/CSS2/box-display/three-block-in-inlines-cascading-margins-ref.html
+++ b/css/CSS2/box-display/three-block-in-inlines-cascading-margins-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 100px; }
+.a { width: 100px; height: 20px; margin-bottom: 30px; background: blue; }
+.b { width: 100px; height: 20px; margin-top: 20px; margin-bottom: 40px; background: green; }
+.c { width: 100px; height: 20px; margin-top: 50px; background: orange; }
+</style>
+<p>Three rectangles separated by 30px and 50px gaps respectively.</p>
+<div class="container">
+    <div class="a"></div>
+    <div class="b"></div>
+    <div class="c"></div>
+</div>

--- a/css/CSS2/box-display/three-block-in-inlines-cascading-margins.html
+++ b/css/CSS2/box-display/three-block-in-inlines-cascading-margins.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test: three consecutive block-in-inlines with cascading margins</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="three-block-in-inlines-cascading-margins-ref.html">
+<meta name="assert" content="Three block-in-inlines in different spans collapse adjacent margins as flat blocks would.">
+<style>
+.container { width: 100px; }
+.a { width: 100px; height: 20px; margin-bottom: 30px; background: blue; }
+.b { width: 100px; height: 20px; margin-top: 20px; margin-bottom: 40px; background: green; }
+.c { width: 100px; height: 20px; margin-top: 50px; background: orange; }
+</style>
+<p>Three rectangles separated by 30px and 50px gaps respectively.</p>
+<div class="container">
+    <span><div class="a"></div></span>
+    <span><div class="b"></div></span>
+    <span><div class="c"></div></span>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[block-in-inline\] Broken layout with paragraph spacing on Apple Support page](https://bugs.webkit.org/show_bug.cgi?id=314978)