### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314969

### DIFF
--- a/css/CSS2/box-display/block-in-inline-at-start-with-margin-top-collapses-with-parent-ref.html
+++ b/css/CSS2/box-display/block-in-inline-at-start-with-margin-top-collapses-with-parent-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.prior { width: 100px; height: 20px; background: green; }
+.parent { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-top: 40px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap.</p>
+<div class="prior"></div>
+<div class="parent">
+    <div class="inner"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-at-start-with-margin-top-collapses-with-parent.html
+++ b/css/CSS2/box-display/block-in-inline-at-start-with-margin-top-collapses-with-parent.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline at parent start with margin-top collapses with parent</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-at-start-with-margin-top-collapses-with-parent-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A block-in-inline's margin-top at the start of its parent collapses with the parent's margin-top and out to its preceding sibling.">
+<style>
+.prior { width: 100px; height: 20px; background: green; }
+.parent { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-top: 40px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap.</p>
+<div class="prior"></div>
+<div class="parent">
+    <span><div class="inner"></div></span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-followed-by-empty-span-ref.html
+++ b/css/CSS2/box-display/block-in-inline-followed-by-empty-span-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.parent { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (trailing empty span ignored).</p>
+<div class="parent">
+    <div class="inner"></div>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-followed-by-empty-span.html
+++ b/css/CSS2/box-display/block-in-inline-followed-by-empty-span.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline followed by trailing empty inline does not inflate parent</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#phantom-line-box">
+<link rel="match" href="block-in-inline-followed-by-empty-span-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A trailing empty inline after a block-in-inline does not separate margins; the block's margin-bottom propagates out of the parent.">
+<style>
+.parent { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (trailing empty span ignored).</p>
+<div class="parent">
+    <span><div class="inner"></div></span><span></span>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-followed-by-line-break-and-text-ref.html
+++ b/css/CSS2/box-display/block-in-inline-followed-by-line-break-and-text-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>Green square, 40px gap, an empty line, then 'XX' on the next line.</p>
+<div class="container">
+    <div class="inner"></div><br>XX
+</div>

--- a/css/CSS2/box-display/block-in-inline-followed-by-line-break-and-text.html
+++ b/css/CSS2/box-display/block-in-inline-followed-by-line-break-and-text.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline followed by line break and text starts text after the block's margin</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="block-in-inline-followed-by-line-break-and-text-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A line break followed by text after a block-in-inline starts at the block's bottom plus margin-bottom plus one line height.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>Green square, 40px gap, an empty line, then 'XX' on the next line.</p>
+<div class="container">
+    <span><div class="inner"></div><br>XX</span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-bottom-with-trailing-block-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-bottom-with-trailing-block-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap; no overlap.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-bottom-with-trailing-block.html
+++ b/css/CSS2/box-display/block-in-inline-margin-bottom-with-trailing-block.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline margin-bottom propagates to next sibling block</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-margin-bottom-with-trailing-block-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A block inside an inline contributes its margin-bottom to the next block sibling's position.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap; no overlap.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-collapses-with-parent-bottom-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-collapses-with-parent-bottom-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.parent { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (margin propagates through parent).</p>
+<div class="parent">
+    <div class="inner"></div>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-margin-collapses-with-parent-bottom.html
+++ b/css/CSS2/box-display/block-in-inline-margin-collapses-with-parent-bottom.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline margin-bottom collapses out through parent</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-margin-collapses-with-parent-bottom-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A trailing block-in-inline's margin-bottom collapses with its parent's margin-bottom and propagates outside the parent.">
+<style>
+.parent { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (margin propagates through parent).</p>
+<div class="parent">
+    <span><div class="inner"></div></span>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-leading-and-trailing-text-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-leading-and-trailing-text-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>'AA' on a line, green square below, 40px gap, then 'BB' on a line.</p>
+<div class="container">
+    AA<div class="inner"></div>BB
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-leading-and-trailing-text.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-leading-and-trailing-text.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline sandwiched between text on both sides</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="block-in-inline-margin-with-leading-and-trailing-text-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Inline text on both sides of a block-in-inline forms separate lines around the block, with margin-bottom advancing the trailing line.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>'AA' on a line, green square below, 40px gap, then 'BB' on a line.</p>
+<div class="container">
+    <span>AA<div class="inner"></div>BB</span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-leading-text-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-leading-text-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>'XX' on a line, green square below, 40px gap, then a green square.</p>
+<div class="container">
+    XX<div class="inner"></div>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-leading-text.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-leading-text.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: text before block-in-inline sits on its own line above the block</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="block-in-inline-margin-with-leading-text-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Inline text before a block-in-inline forms its own line that ends before the block begins.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>'XX' on a line, green square below, 40px gap, then a green square.</p>
+<div class="container">
+    <span>XX<div class="inner"></div></span>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-after-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-after-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 60px; font: 20px/1 Ahem; color: green; }
+.inner { width: 60px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>Green square, 40px gap, then 'XX', then 'XX' on the next line.</p>
+<div class="container">
+    <div class="inner"></div>XX XX
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-after.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-after.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: multi-line text after block-in-inline starts after the block's margin</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="block-in-inline-margin-with-multi-line-text-after-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Multiple lines of text after a block-in-inline begin at the block's bottom plus margin-bottom.">
+<style>
+.container { width: 60px; font: 20px/1 Ahem; color: green; }
+.inner { width: 60px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>Green square, 40px gap, then 'XX', then 'XX' on the next line.</p>
+<div class="container">
+    <span><div class="inner"></div>XX XX</span>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-before-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-before-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 60px; font: 20px/1 Ahem; color: green; }
+.inner { width: 60px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 60px; height: 20px; background: green; }
+</style>
+<p>'XX' on three lines, green square, 40px gap, then a green square.</p>
+<div class="container">
+    XX XX XX<div class="inner"></div>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-before.html
+++ b/css/CSS2/box-display/block-in-inline-margin-with-multi-line-text-before.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: wrapped multi-line text before block-in-inline</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="block-in-inline-margin-with-multi-line-text-before-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Multiple wrapped lines of text before a block-in-inline form their own lines, with the block following on a new line.">
+<style>
+.container { width: 60px; font: 20px/1 Ahem; color: green; }
+.inner { width: 60px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 60px; height: 20px; background: green; }
+</style>
+<p>'XX' on three lines, green square, 40px gap, then a green square.</p>
+<div class="container">
+    <span>XX XX XX<div class="inner"></div></span>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-margins-collapse-with-trailing-block-ref.html
+++ b/css/CSS2/box-display/block-in-inline-margins-collapse-with-trailing-block-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; margin-top: 30px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (margins collapse, max wins).</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-margins-collapse-with-trailing-block.html
+++ b/css/CSS2/box-display/block-in-inline-margins-collapse-with-trailing-block.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inline margin-bottom collapses with following sibling's margin-top</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-margins-collapse-with-trailing-block-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A block-in-inline's margin-bottom collapses with the next block sibling's margin-top.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; margin-top: 30px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (margins collapse, max wins).</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-self-collapsing-only-child-ref.html
+++ b/css/CSS2/box-display/block-in-inline-self-collapsing-only-child-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.prior { width: 100px; height: 20px; background: green; }
+.gap { width: 100px; height: 40px; background: white; }
+.next { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares with a 40px gap; no red.</p>
+<div class="prior"></div>
+<div class="gap"></div>
+<div class="next"></div>

--- a/css/CSS2/box-display/block-in-inline-self-collapsing-only-child.html
+++ b/css/CSS2/box-display/block-in-inline-self-collapsing-only-child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: self-collapsing block-in-inline as only child of parent</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-self-collapsing-only-child-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A self-collapsing block-in-inline that is the only child of its parent collapses all adjoining margins through both itself and its parent.">
+<style>
+.prior { width: 100px; height: 20px; background: green; }
+.parent { width: 100px; font: 20px/1 Ahem; }
+.empty { width: 100px; height: 0; margin-top: 30px; margin-bottom: 40px; background: red; }
+.next { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares with a 40px gap; no red.</p>
+<div class="prior"></div>
+<div class="parent">
+    <span><div class="empty"></div></span>
+</div>
+<div class="next"></div>

--- a/css/CSS2/box-display/block-in-inline-vertical-margins-on-span-ignored-ref.html
+++ b/css/CSS2/box-display/block-in-inline-vertical-margins-on-span-ignored-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two adjacent green squares with no gap.</p>
+<div class="container">
+    <div class="inner"></div>
+    <div class="sibling"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-vertical-margins-on-span-ignored.html
+++ b/css/CSS2/box-display/block-in-inline-vertical-margins-on-span-ignored.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test: vertical margins on the span ancestor are ignored</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#margin-properties">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="match" href="block-in-inline-vertical-margins-on-span-ignored-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Vertical margins specified on the inline span containing a block-in-inline are ignored and do not shift the block.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.span { margin-top: 50px; margin-bottom: 50px; }
+.inner { width: 100px; height: 20px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two adjacent green squares with no gap.</p>
+<div class="container">
+    <span class="span"><div class="inner"></div></span>
+    <div class="sibling"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-with-padded-parent-ref.html
+++ b/css/CSS2/box-display/block-in-inline-with-padded-parent-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.parent { width: 100px; padding-bottom: 20px; background: cyan; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Green square inside cyan parent with 40px gap below to padding edge, then 20px padding, then a green square.</p>
+<div class="parent">
+    <div class="inner"></div>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-with-padded-parent.html
+++ b/css/CSS2/box-display/block-in-inline-with-padded-parent.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: padding on parent prevents block-in-inline margin-bottom from collapsing out</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-with-padded-parent-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="When parent has bottom padding, block-in-inline's margin-bottom does not collapse with parent and remains inside the parent's content area.">
+<style>
+.parent { width: 100px; padding-bottom: 20px; background: cyan; font: 20px/1 Ahem; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.sibling { width: 100px; height: 20px; background: green; }
+</style>
+<p>Green square inside cyan parent with 40px gap below to padding edge, then 20px padding, then a green square.</p>
+<div class="parent">
+    <span><div class="inner"></div></span>
+</div>
+<div class="sibling"></div>

--- a/css/CSS2/box-display/block-in-inline-zero-height-margin-collapse-ref.html
+++ b/css/CSS2/box-display/block-in-inline-zero-height-margin-collapse-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.before { width: 100px; height: 20px; background: green; }
+.gap { width: 100px; height: 40px; background: white; }
+.after { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares with a 40px gap; no red.</p>
+<div class="container">
+    <div class="before"></div>
+    <div class="gap"></div>
+    <div class="after"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inline-zero-height-margin-collapse.html
+++ b/css/CSS2/box-display/block-in-inline-zero-height-margin-collapse.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: empty block-in-inline collapses through its own margins</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inline-zero-height-margin-collapse-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A zero-height block-in-inline with margin-top and margin-bottom has its top and bottom margins adjoin and collapse together.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.before { width: 100px; height: 20px; background: green; }
+.empty { width: 100px; height: 0; margin-top: 30px; margin-bottom: 40px; background: red; }
+.after { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares with a 40px gap; no red.</p>
+<div class="container">
+    <div class="before"></div>
+    <span><div class="empty"></div></span>
+    <div class="after"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inlines-in-different-spans-margin-collapse-ref.html
+++ b/css/CSS2/box-display/block-in-inlines-in-different-spans-margin-collapse-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; margin-top: 30px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (margins collapse).</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/block-in-inlines-in-different-spans-margin-collapse.html
+++ b/css/CSS2/box-display/block-in-inlines-in-different-spans-margin-collapse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: block-in-inlines in different spans collapse like flat blocks</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="block-in-inlines-in-different-spans-margin-collapse-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Block-in-inlines in different sibling spans collapse adjacent margins like flat block siblings would.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; margin-top: 30px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap (margins collapse).</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <span><div class="second"></div></span>
+</div>

--- a/css/CSS2/box-display/inline-block-after-block-in-inline-with-intervening-float-ref.html
+++ b/css/CSS2/box-display/inline-block-after-block-in-inline-with-intervening-float-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 10px; margin-bottom: 50px; background: blue; }
+.intervening { float: left; width: 90px; height: 50px; background: green; }
+.atomic { display: inline-block; width: 50px; height: 10px; vertical-align: top; background: orange; }
+</style>
+<p>A blue rectangle, a green floated rectangle below it, and an orange inline-block past the float.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="intervening"></div>
+    <span class="atomic"></span>
+</div>

--- a/css/CSS2/box-display/inline-block-after-block-in-inline-with-intervening-float.html
+++ b/css/CSS2/box-display/inline-block-after-block-in-inline-with-intervening-float.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: Inline-block after a block-in-inline and an intervening float lands past the float</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#floats">
+<link rel="match" href="inline-block-after-block-in-inline-with-intervening-float-ref.html">
+<meta name="assert" content="An inline-block following a block-in-inline (with margin-bottom) and an intervening full-width-blocking float collapses with the block's margin-bottom and is pushed past the float when it doesn't fit alongside.">
+<style>
+.container { width: 100px; }
+.first { width: 100px; height: 10px; margin-bottom: 50px; background: blue; }
+.intervening { float: left; width: 90px; height: 50px; background: green; }
+.atomic { display: inline-block; width: 50px; height: 10px; vertical-align: top; background: orange; }
+</style>
+<p>A blue rectangle, a green floated rectangle below it, and an orange inline-block past the float.</p>
+<div class="container">
+    <span><div class="first"></div></span>
+    <div class="intervening"></div>
+    <span class="atomic"></span>
+</div>

--- a/css/CSS2/box-display/inline-text-after-block-in-inline-margin-ref.html
+++ b/css/CSS2/box-display/inline-text-after-block-in-inline-margin-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 200px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>Green square, 40px gap, then 'XX' on its own line.</p>
+<div class="container">
+    <div class="inner"></div>XX
+</div>

--- a/css/CSS2/box-display/inline-text-after-block-in-inline-margin.html
+++ b/css/CSS2/box-display/inline-text-after-block-in-inline-margin.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: inline text after block-in-inline starts after the block's margin-bottom</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="inline-text-after-block-in-inline-margin-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Inline content following a block-in-inline starts after the block's margin-bottom on a new line.">
+<style>
+.container { width: 200px; font: 20px/1 Ahem; color: green; }
+.inner { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+</style>
+<p>Green square, 40px gap, then 'XX' on its own line.</p>
+<div class="container">
+    <span><div class="inner"></div>XX</span>
+</div>

--- a/css/CSS2/box-display/multiple-block-in-inlines-margins-collapse-ref.html
+++ b/css/CSS2/box-display/multiple-block-in-inlines-margins-collapse-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.a { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.b { width: 100px; height: 20px; margin-top: 30px; background: green; }
+.c { width: 100px; height: 20px; margin-top: 50px; background: green; }
+</style>
+<p>Three green squares: 40px gap, then 50px gap.</p>
+<div class="container">
+    <div class="a"></div>
+    <div class="b"></div>
+    <div class="c"></div>
+</div>

--- a/css/CSS2/box-display/multiple-block-in-inlines-margins-collapse.html
+++ b/css/CSS2/box-display/multiple-block-in-inlines-margins-collapse.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: stacked block-in-inlines collapse adjacent margins</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="multiple-block-in-inlines-margins-collapse-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Three stacked block-in-inlines collapse their adjacent margins like flat block siblings.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.a { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.b { width: 100px; height: 20px; margin-top: 30px; background: green; }
+.c { width: 100px; height: 20px; margin-top: 50px; background: green; }
+</style>
+<p>Three green squares: 40px gap, then 50px gap.</p>
+<div class="container">
+    <span><div class="a"></div><div class="b"></div><div class="c"></div></span>
+</div>

--- a/css/CSS2/box-display/nested-spans-with-block-in-inline-margin-ref.html
+++ b/css/CSS2/box-display/nested-spans-with-block-in-inline-margin-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap.</p>
+<div class="container">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/nested-spans-with-block-in-inline-margin.html
+++ b/css/CSS2/box-display/nested-spans-with-block-in-inline-margin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: nested spans with block-in-inline preserve margin behavior</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/box.html#collapsing-margins">
+<link rel="match" href="nested-spans-with-block-in-inline-margin-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="A block inside multiple nested inlines has the same margin behavior as a flat block sibling.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Two green squares separated by a 40px gap.</p>
+<div class="container">
+    <span><span><span><div class="first"></div></span></span></span>
+    <div class="second"></div>
+</div>

--- a/css/CSS2/box-display/two-block-in-inlines-with-text-between-ref.html
+++ b/css/CSS2/box-display/two-block-in-inlines-with-text-between-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Green square, 40px gap, 'XX' on a line, then a green square.</p>
+<div class="container">
+    <div class="first"></div>XX<div class="second"></div>
+</div>

--- a/css/CSS2/box-display/two-block-in-inlines-with-text-between.html
+++ b/css/CSS2/box-display/two-block-in-inlines-with-text-between.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: two block-in-inlines with text between them</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">
+<link rel="match" href="two-block-in-inlines-with-text-between-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Two block-in-inlines separated by inline text produce three vertical regions: first block, text line, second block, with margins applied between blocks.">
+<style>
+.container { width: 100px; font: 20px/1 Ahem; color: green; }
+.first { width: 100px; height: 20px; margin-bottom: 40px; background: green; }
+.second { width: 100px; height: 20px; background: green; }
+</style>
+<p>Green square, 40px gap, 'XX' on a line, then a green square.</p>
+<div class="container">
+    <span><div class="first"></div>XX<div class="second"></div></span>
+</div>

--- a/css/CSS2/normal-flow/block-in-inline-after-block-in-inline-with-margin-collapse-ref.html
+++ b/css/CSS2/normal-flow/block-in-inline-after-block-in-inline-with-margin-collapse-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<style>
+.container {
+  width: 100px;
+  height: 70px;
+}
+
+.strip {
+  width: 100px;
+  height: 10px;
+  background-color: green;
+}
+
+.gap {
+  width: 100px;
+  height: 50px;
+}
+</style>
+<p>Test passes if there are two green horizontal strips below, separated by a 50px gap, with no extra empty area.</p>
+<div class="container">
+  <div class="strip"></div>
+  <div class="gap"></div>
+  <div class="strip"></div>
+</div>

--- a/css/CSS2/normal-flow/block-in-inline-after-block-in-inline-with-margin-collapse.html
+++ b/css/CSS2/normal-flow/block-in-inline-after-block-in-inline-with-margin-collapse.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Test: A block-level box inside an inline box, following another block-in-inline with margin-bottom, should be positioned with margin-collapse applied</title>
+<link rel="help" href="https://www.w3.org/TR/CSS22/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="match" href="block-in-inline-after-block-in-inline-with-margin-collapse-ref.html">
+<style>
+.container {
+  width: 100px;
+  height: 70px;
+}
+
+.first {
+  margin-bottom: 50px;
+  width: 100px;
+  height: 10px;
+  background-color: green;
+}
+
+.second {
+  width: 100px;
+  height: 10px;
+  background-color: green;
+}
+</style>
+<p>Test passes if there are two green horizontal strips below, separated by a 50px gap, with no extra empty area.</p>
+<div class="container">
+  <span><div class="first"></div></span>
+  <span><div class="second"></div></span>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[block-in-inline\] Apply margin of preceding block content at line start eagerly](https://bugs.webkit.org/show_bug.cgi?id=314969)