### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314097

### DIFF
--- a/css/css-text/white-space/reference/white-space-intrinsic-size-025-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-025-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  div {
+    width: 20px;
+    outline: 2px solid green;
+    font: 20px/1 Ahem;
+  }
+</style>
+<p>Test passes if the green outline tightly hugs the two X glyphs (no extra space on the right).</p>
+<div>X<br>X</div>

--- a/css/css-text/white-space/white-space-intrinsic-size-025.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-025.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: max-content trims trailing whitespace before a forced line break in its own text node</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property">
+<link rel="match" href="reference/white-space-intrinsic-size-025-ref.html">
+<meta name="assert" content="A forced line break that occupies its own RenderText (e.g. produced by ::before content: '\A') still trims trailing whitespace at the end of the previous line for max-content sizing.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  div {
+    width: max-content;
+    outline: 2px solid green;
+    font: 20px/1 Ahem;
+  }
+  span::before {
+    content: '\A';
+    white-space: pre-line;
+  }
+</style>
+<p>Test passes if the green outline tightly hugs the two X glyphs (no extra space on the right).</p>
+<div><img>X <span>X</span></div>


### PR DESCRIPTION
WebKit export from bug: [CSS: weird interaction between img with max-width and other elements causes parent element width to go berserk](https://bugs.webkit.org/show_bug.cgi?id=314097)