### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314885

### DIFF
--- a/css/css-sizing/abspos-stretch-indefinite-cb-ref.html
+++ b/css/css-sizing/abspos-stretch-indefinite-cb-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: no red rectangle visible</title>
+<style>
+html, body {
+    margin: 0;
+}
+.outer {
+    position: absolute;
+}
+.inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200px;
+    background: red;
+}
+img {
+    display: block;
+    height: 100%;
+}
+</style>
+<p>Test passes if there is no red rectangle visible.</p>
+<div class="outer">
+    <div class="inner"><img></div>
+</div>

--- a/css/css-sizing/abspos-stretch-indefinite-cb.html
+++ b/css/css-sizing/abspos-stretch-indefinite-cb.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>position:absolute with height:stretch falls back when abs-pos containing block is indefinite</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="match" href="abspos-stretch-indefinite-cb-ref.html">
+<meta name="assert" content="When an out-of-flow element has height:stretch but its abs-pos containing block has an indefinite height, stretch does not resolve and the element falls back to its content size.">
+<style>
+html, body {
+    margin: 0;
+}
+.outer {
+    position: absolute;
+}
+.inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: stretch;
+    background: red;
+}
+img {
+    display: block;
+    height: 100%;
+}
+</style>
+<p>Test passes if there is no red rectangle visible.</p>
+<div class="outer">
+    <div class="inner"><img></div>
+</div>

--- a/css/css-sizing/abspos-stretch-replaced-percentage-child-ref.html
+++ b/css/css-sizing/abspos-stretch-replaced-percentage-child-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: tall green rectangle on the left edge of the viewport</title>
+<style>
+html, body {
+    margin: 0;
+}
+div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100vh;
+    background: green;
+}
+</style>
+<p>Test passes if there is a tall green rectangle on the left edge of the viewport.</p>
+<div></div>

--- a/css/css-sizing/abspos-stretch-replaced-percentage-child.html
+++ b/css/css-sizing/abspos-stretch-replaced-percentage-child.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>position:absolute with height:stretch resolves for replaced child with height:100%</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-auto-size">
+<link rel="match" href="abspos-stretch-replaced-percentage-child-ref.html">
+<meta name="assert" content="An out-of-flow element with height:stretch resolves against its abs-pos containing block (the initial containing block here, which has a definite height), so a replaced descendant with height:100% resolves to the same height.">
+<style>
+html, body {
+    margin: 0;
+}
+div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: stretch;
+    background: green;
+}
+img {
+    display: block;
+    height: 100%;
+}
+</style>
+<p>Test passes if there is a tall green rectangle on the left edge of the viewport.</p>
+<div><img></div>

--- a/css/css-sizing/stretch/stretch-anonymous-block-001-ref.html
+++ b/css/css-sizing/stretch/stretch-anonymous-block-001-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference Case</title>
+<style>
+  .container {
+    height: 200px;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: 200px;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div class="container">
+    <div style="height: 0"></div>
+    <iframe></iframe>
+  </div>
+</body>

--- a/css/css-sizing/stretch/stretch-anonymous-block-001.html
+++ b/css/css-sizing/stretch/stretch-anonymous-block-001.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: 'stretch' heights resolve through an anonymous block wrapper</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-values">
+<link rel="match" href="stretch-anonymous-block-001-ref.html">
+<meta name="assert"
+      content="When a block container has mixed block-level and inline-level children, the inline children are wrapped in an anonymous block box. height:stretch on those inline children should still resolve against the (non-anonymous) containing block, not be treated as indefinite due to the anonymous block wrapper sitting between.">
+<style>
+  .container {
+    height: 200px;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: stretch;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div class="container">
+    <!-- The block-level <div> forces .container's children to be non-inline,
+         wrapping the following inline iframe in an anonymous block box. -->
+    <div style="height: 0"></div>
+    <iframe></iframe>
+  </div>
+</body>

--- a/css/css-sizing/stretch/stretch-quirk-002-ref.html
+++ b/css/css-sizing/stretch/stretch-quirk-002-ref.html
@@ -1,0 +1,20 @@
+<!-- no doctype, to trigger quirks mode -->
+<meta charset="utf-8">
+<title>CSS Reference Case</title>
+<style>
+  body {
+    margin: 0;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: 100vh;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div style="height: 0"></div>
+  <iframe></iframe>
+</body>

--- a/css/css-sizing/stretch/stretch-quirk-002.html
+++ b/css/css-sizing/stretch/stretch-quirk-002.html
@@ -1,0 +1,27 @@
+<!-- no doctype, to trigger quirks mode -->
+<meta charset="utf-8">
+<title>CSS Test: 'stretch' heights resolve through an anonymous block wrapper</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-values">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-body-element-fills-the-html-element-quirk">
+<link rel="match" href="stretch-quirk-002-ref.html">
+<meta name="assert"
+      content="When body has mixed block-level and inline-level children, the inline children are wrapped in an anonymous block box. height:stretch on those inline children should still resolve against the body, not be treated as indefinite due to the anonymous block wrapper sitting between.">
+<style>
+  body {
+    margin: 0;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: stretch;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <!-- The block-level <div> forces body's children to be non-inline,
+       wrapping the following inline iframe in an anonymous block box. -->
+  <div style="height: 0"></div>
+  <iframe></iframe>
+</body>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (309405@main): CSS stretch and anonymous wrappers](https://bugs.webkit.org/show_bug.cgi?id=314885)