### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249307

### DIFF
--- a/svg/painting/animated-dashoffset-odd-dasharray-ref.html
+++ b/svg/painting/animated-dashoffset-odd-dasharray-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<title>Animated stroke-dashoffset crossing zero with odd-length stroke-dasharray (reference)</title>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="250">
+    <!-- Row 1: even-length equivalent dasharray="60 60", static offsets -->
+    <path d="M20,20 L580,20" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="-10"/>
+    <path d="M20,40 L580,40" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="-5"/>
+    <path d="M20,60 L580,60" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="0"/>
+    <path d="M20,80 L580,80" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="5"/>
+    <path d="M20,100 L580,100" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60 60" stroke-dashoffset="10"/>
+
+    <!-- Row 2: even-length equivalent dasharray="40 20 10 40 20 10", static offsets -->
+    <path d="M20,140 L580,140" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-10"/>
+    <path d="M20,160 L580,160" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-5"/>
+    <path d="M20,180 L580,180" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="0"/>
+    <path d="M20,200 L580,200" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="5"/>
+    <path d="M20,220 L580,220" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="10"/>
+</svg>
+</body>
+</html>

--- a/svg/painting/animated-dashoffset-odd-dasharray.html
+++ b/svg/painting/animated-dashoffset-odd-dasharray.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Animated stroke-dashoffset crossing zero with odd-length stroke-dasharray</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">
+<link rel="match" href="animated-dashoffset-odd-dasharray-ref.html">
+<meta name="assert" content="Animating stroke-dashoffset from negative to positive with an odd-length stroke-dasharray should not produce a visual jump at the zero crossing. Each row shows an animation paused at evenly spaced offsets from -10 to +10; the progression should be smooth.">
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="250">
+    <!-- Row 1: dasharray="60" (odd), offsets stepping from -10 to +10 -->
+    <path id="a1" d="M20,20 L580,20" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a2" d="M20,40 L580,40" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a3" d="M20,60 L580,60" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a4" d="M20,80 L580,80" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+    <path id="a5" d="M20,100 L580,100" stroke="black" stroke-width="6" fill="none" stroke-dasharray="60"/>
+
+    <!-- Row 2: dasharray="40 20 10" (odd), offsets stepping from -10 to +10 -->
+    <path id="b1" d="M20,140 L580,140" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b2" d="M20,160 L580,160" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b3" d="M20,180 L580,180" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b4" d="M20,200 L580,200" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+    <path id="b5" d="M20,220 L580,220" stroke="black" stroke-width="6" fill="none" stroke-dasharray="40 20 10"/>
+</svg>
+<script>
+window.onload = () => {
+    requestAnimationFrame(() => {
+        const offsets = [-10, -5, 0, 5, 10];
+        const groups = [
+            { ids: ['a1','a2','a3','a4','a5'], from: -60, to: 60 },
+            { ids: ['b1','b2','b3','b4','b5'], from: -60, to: 60 },
+        ];
+
+        for (const { ids, from, to } of groups) {
+            const range = to - from;
+            ids.forEach((id, i) => {
+                const el = document.getElementById(id);
+                const anim = el.animate(
+                    [{ strokeDashoffset: from + 'px' }, { strokeDashoffset: to + 'px' }],
+                    { duration: 1000, fill: 'forwards' }
+                );
+                anim.pause();
+                anim.currentTime = ((offsets[i] - from) / range) * 1000;
+            });
+        }
+
+        requestAnimationFrame(() => {
+            document.documentElement.removeAttribute('class');
+        });
+    });
+};
+</script>
+</body>
+</html>

--- a/svg/painting/negative-dashoffset-odd-dasharray-ref.html
+++ b/svg/painting/negative-dashoffset-odd-dasharray-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Negative stroke-dashoffset with odd-length stroke-dasharray (reference)</title>
+</head>
+<body>
+<p>Each pair of lines should be identical. The odd-length dasharray (left value)
+should render the same as the equivalent even-length dasharray (right value).</p>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+    <path d="M20,30 L280,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+    <path d="M320,30 L580,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+
+    <path d="M20,70 L280,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+    <path d="M320,70 L580,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+
+    <path d="M20,110 L280,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+    <path d="M320,110 L580,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+
+    <path d="M20,150 L280,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+    <path d="M320,150 L580,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+</svg>
+</body>
+</html>

--- a/svg/painting/negative-dashoffset-odd-dasharray.html
+++ b/svg/painting/negative-dashoffset-odd-dasharray.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Negative stroke-dashoffset with odd-length stroke-dasharray</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing">
+<link rel="match" href="negative-dashoffset-odd-dasharray-ref.html">
+<meta name="assert" content="Odd-length stroke-dasharray with negative stroke-dashoffset should render identically to the equivalent even-length dasharray.">
+</head>
+<body>
+<p>Each pair of lines should be identical. The odd-length dasharray (left value)
+should render the same as the equivalent even-length dasharray (right value).</p>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+    <!-- dasharray="60" is equivalent to dasharray="60 60" per spec -->
+    <path d="M20,30 L280,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60" stroke-dashoffset="-30"/>
+    <path d="M320,30 L580,30" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="60 60" stroke-dashoffset="-30"/>
+
+    <!-- dasharray="40 20 10" is equivalent to dasharray="40 20 10 40 20 10" -->
+    <path d="M20,70 L280,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10" stroke-dashoffset="-15"/>
+    <path d="M320,70 L580,70" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="40 20 10 40 20 10" stroke-dashoffset="-15"/>
+
+    <!-- dasharray="30" with large negative offset -->
+    <path d="M20,110 L280,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30" stroke-dashoffset="-45"/>
+    <path d="M320,110 L580,110" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="30 30" stroke-dashoffset="-45"/>
+
+    <!-- dasharray="50 30 20" with offset equal to negative total length -->
+    <path d="M20,150 L280,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20" stroke-dashoffset="-200"/>
+    <path d="M320,150 L580,150" stroke="black" stroke-width="8" fill="none"
+          stroke-dasharray="50 30 20 50 30 20" stroke-dashoffset="-200"/>
+</svg>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [SVG stroke-dashoffset negative values are rendered with wrong offsets](https://bugs.webkit.org/show_bug.cgi?id=249307)