### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314552

### DIFF
--- a/css/css-sizing/intrinsic-percent-non-replaced-007-ref.html
+++ b/css/css-sizing/intrinsic-percent-non-replaced-007-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Reference</title>
+<style>
+.ref {
+  width: 200px;
+  height: 100px;
+}
+
+.left {
+  float: left;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+
+.right {
+  overflow: hidden;
+  height: 100px;
+  background: blue;
+}
+</style>
+<p>Test passes if there is a 200x100 rectangle (green left half, blue right half).</p>
+<div class="ref">
+  <div class="left"></div>
+  <div class="right"></div>
+</div>

--- a/css/css-sizing/intrinsic-percent-non-replaced-007.html
+++ b/css/css-sizing/intrinsic-percent-non-replaced-007.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Percentage max-width on aspect-ratio box is ignored during intrinsic size contribution.</title>
+<link rel="help" href="https://www.w3.org/TR/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="match" href="intrinsic-percent-non-replaced-007-ref.html">
+<style>
+.container {
+  width: max-content;
+}
+
+.aspect-ratio-box {
+  aspect-ratio: 2 / 1;
+  height: 100px;
+  max-width: 50%;
+  background: green;
+}
+</style>
+<p>Test passes if there is a 200x100 rectangle (green left half, blue right half).</p>
+<div class="container" style="background: blue;">
+  <div class="aspect-ratio-box"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [Non-replaced block with aspect-ratio and percentage max-width produces zero width during intrinsic sizing](https://bugs.webkit.org/show_bug.cgi?id=314552)