### PR TITLE
Render 'none' in light-dark() image as transparent

### DIFF
--- a/css/css-color/light-dark-image.html
+++ b/css/css-color/light-dark-image.html
@@ -45,6 +45,10 @@ test_light_dark_image(
   'dark.png")'
 );
 
+// 'none' inside light-dark() image computes to image(transparent) per CSS
+// Color 5, which then resolves to image(rgba(0, 0, 0, 0)) per the
+// computed-value rules for <color>.
+// https://drafts.csswg.org/css-color-5/#valdef-light-dark-none
 test_light_dark_image(
   "background-image",
   "light-dark(none, url('dark.png'))",


### PR DESCRIPTION
Per the CSSWG resolution[1], a selected none arm inside a light-dark() image value computes to image(transparent), which then resolves to image(rgba(0, 0, 0, 0)) per the standard computed-value rules for <color>[2].

[1]: https://github.com/w3c/csswg-drafts/issues/13866#issuecomment-4390052390
[2]: https://drafts.csswg.org/css-color-4/#transparent-color

Bug: 491829958
Change-Id: I2df4e7ab066652078a0ed1ee8608f5af9c2683c8
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7806112
Reviewed-by: Rune Lillesveen <futhark@chromium.org>
Commit-Queue: Jason Leo <cgqaq@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1632236}

---

Changes from original: Merge with #59754, which landed concurrently but is functionally equivalent. The Chromium CL adds a comment.