### PR TITLE
Intercepted "reload" navigate events shouldn't scroll.

### DIFF
--- a/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html
+++ b/navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html
@@ -16,7 +16,8 @@ promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
   await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
-  assert_equals(window.scrollY, 0);
+  const result = window.scrollY;
+  assert_equals(result, 0);
   await navigation.navigate("#frag").finished;
   // Scroll down 10px from #frag
   window.scrollBy(0, 10);
@@ -38,10 +39,11 @@ promise_test(async t => {
   let scrollY_after_buffer_remove = window.scrollY;
   assert_equals(scrollY_after_buffer_remove, scrollY_frag_plus_10);
 
-  // Finishing should scroll to #frag, which is 10px up from the current location
+  // Finishing should not scroll at all, since `reload` does not result in
+  // #save-persisted-state being called.
   intercept_resolve();
   await reload_promises.finished;
-  assert_equals(window.scrollY, scrollY_after_buffer_remove - 1000 - 10);
+  assert_equals(window.scrollY, result);
 }, "scroll: after-transition should work on a reload navigation");
 </script>
 </body>

--- a/navigation-api/scroll-behavior/after-transition-reload.html
+++ b/navigation-api/scroll-behavior/after-transition-reload.html
@@ -11,7 +11,8 @@ promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
   await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
-  assert_equals(window.scrollY, 0);
+  const result = window.scrollY;
+  assert_equals(result, 0);
   await navigation.navigate("#frag").finished;
   // Scroll down 10px from #frag
   window.scrollBy(0, 10);
@@ -33,10 +34,11 @@ promise_test(async t => {
   let scrollY_after_buffer_remove = window.scrollY;
   assert_equals(scrollY_after_buffer_remove, scrollY_frag_plus_10 - 1000);
 
-  // Finishing should scroll to #frag, which is 10px up from the current location
+  // Finishing should not scroll at all, since `reload` does not result in
+  // #save-persisted-state being called.
   intercept_resolve();
   await reload_promises.finished;
-  assert_equals(window.scrollY, scrollY_after_buffer_remove - 10);
+  assert_equals(window.scrollY, result);
 }, "scroll: after-transition should work on a reload navigation");
 </script>
 </body>

--- a/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html
+++ b/navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html
@@ -16,7 +16,8 @@ promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
   await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
-  assert_equals(window.scrollY, 0);
+  const result = window.scrollY;
+  assert_equals(result, 0);
   await navigation.navigate("#frag").finished;
   // Scroll down 10px from #frag
   window.scrollBy(0, 10);
@@ -38,14 +39,15 @@ promise_test(async t => {
   let scrollY_after_buffer_remove = window.scrollY;
   assert_equals(scrollY_after_buffer_remove, scrollY_frag_plus_10);
 
-  // scroll() should scroll to #frag, which is 10px up from the current location
+  // scroll() should not scroll at all, since `reload` does not result in
+  // #save-persisted-state being called.
   navigate_event.scroll();
-  assert_equals(window.scrollY, scrollY_after_buffer_remove - 1000 - 10);
+  assert_equals(window.scrollY, result);
 
   // Finishing should not scroll.
   intercept_resolve();
   await reload_promises.finished;
-  assert_equals(window.scrollY, scrollY_after_buffer_remove - 1000 - 10);
+  assert_equals(window.scrollY, result);
 }, "scroll: scroll() should work on a reload navigation");
 </script>
 </body>

--- a/navigation-api/scroll-behavior/manual-scroll-reload.html
+++ b/navigation-api/scroll-behavior/manual-scroll-reload.html
@@ -5,13 +5,14 @@
 <body>
 <div id="buffer" style="height: 1000px; width: 200vw;"></div>
 <div id="frag"></div>
-<div style="height: 200vh; width: 200vw;"></div>
+<div style="height: 1000px; width: 1000px;"></div>
 <script>
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
   await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
-  assert_equals(window.scrollY, 0);
+  const result = window.scrollY;
+  assert_equals(result, 0);
   await navigation.navigate("#frag").finished;
   // Scroll down 10px from #frag
   window.scrollBy(0, 10);
@@ -33,14 +34,15 @@ promise_test(async t => {
   let scrollY_after_buffer_remove = window.scrollY;
   assert_equals(scrollY_after_buffer_remove, scrollY_frag_plus_10 - 1000);
 
-  // scroll() should scroll to #frag, which is 10px up from the current location
+  // scroll() should not scroll at all, since `reload` does not result in
+  // #save-persisted-state being called.
   navigate_event.scroll();
-  assert_equals(window.scrollY, scrollY_after_buffer_remove - 10);
+  assert_equals(window.scrollY, result);
 
   // Finishing should not scroll.
   intercept_resolve();
   await reload_promises.finished;
-  assert_equals(window.scrollY, scrollY_after_buffer_remove - 10);
+  assert_equals(window.scrollY, result);
 }, "scroll: scroll() should work on a reload navigation");
 </script>
 </body>


### PR DESCRIPTION
Fixes #60113