### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=315488

### DIFF
--- a/css/css-text-decor/text-decoration-thickness-from-font-variable.html
+++ b/css/css-text-decor/text-decoration-thickness-from-font-variable.html
@@ -7,6 +7,7 @@
 <meta name="assert" content="text-decoration-thickness from-font respects MVAR table of variable fonts for variable metrics">
 <link rel="author" title="Dominik Röttsches" href="mailto:drott@chromium.org">
 <link rel="match" href="reference/text-decoration-thickness-from-font-variable-ref.html">
+<meta name="fuzzy" content="maxDifference=0-10;totalPixels=0-20">
 <style>
 @font-face {
 font-family: underline-variable;


### PR DESCRIPTION
WebKit export from bug: [fix fuziness issue for imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-from-font-variable.html](https://bugs.webkit.org/show_bug.cgi?id=315488)