### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=315238

### DIFF
--- a/webrtc/RTCRtpReceiver-jitterBufferTarget-stats-helper.js
+++ b/webrtc/RTCRtpReceiver-jitterBufferTarget-stats-helper.js
@@ -58,7 +58,8 @@ async function applyJitterBufferTarget(t, kind, target) {
   assert_equals(receiver.jitterBufferTarget, target,
     `jitterBufferTarget increase target for ${kind}`);
 
-  result = await measureDelayFromStats(t, receiver, 10, target, 20);
+  const tolerance = target / 10;
+  result = await measureDelayFromStats(t, receiver, 20, target, tolerance);
   assert_true(result, 'jitterBuffer does not reach target');
 
   receiver.jitterBufferTarget = 0;


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(310285@main): \[macOS\] imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats.html is a flaky TEXT failure](https://bugs.webkit.org/show_bug.cgi?id=315238)