### PR TITLE
test: fix get_element_tag_name test to expect lowercase tagname

### DIFF
--- a/webdriver/tests/classic/get_element_tag_name/get.py
+++ b/webdriver/tests/classic/get_element_tag_name/get.py
@@ -92,4 +92,4 @@ def test_get_element_tag_name(session, inline):
     element = session.find.css("input", all=False)
 
     result = get_element_tag_name(session, element.id)
-    assert_success(result, "INPUT")
+    assert_success(result, "input")


### PR DESCRIPTION
See https://github.com/w3c/webdriver/issues/1956 & https://github.com/w3c/webdriver/pull/1962