### PR TITLE
paint: Support pinch-zoom for factors less than 1

### DIFF
--- a/visual-viewport/viewport-scale-clamped.html
+++ b/visual-viewport/viewport-scale-clamped.html
@@ -14,25 +14,15 @@
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-actions.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/visual-viewport/viewport_support.js"></script>
 </head>
 
 <body>
   <div style="font-size: 50px;">This page can not be pinch zoomed, it is clamped using meta viewport scale.</div>
   <script> promise_test(async () => {
-      const x = 200, y = 200;
       const initialScale = window.visualViewport.scale;
-      // Perform pinch zoom
-      await new test_driver.Actions()
-        .addPointer("f1", "touch")
-        .addPointer("f2", "touch")
-        .pointerMove(x, y, { origin: "viewport", sourceName: "f1" })
-        .pointerMove(x + 100, y + 100, { origin: "viewport", sourceName: "f2" })
-        .pointerDown({ sourceName: "f1" })
-        .pointerDown({ sourceName: "f2" })
-        .pointerMove(x - 100, y - 100, { origin: "viewport", sourceName: "f1", duration: 0 })
-        .pointerMove(x + 100, y + 100, { origin: "viewport", sourceName: "f2", duration: 0 })
-        .pointerUp({ sourceName: "f1" })
-        .pointerUp({ sourceName: "f2" }).send();
+      // Perform Pinch Zoom-In
+      await pinchZoomIn();
       assert_equals(window.visualViewport.scale, initialScale, "Scale should be same");
     }) </script>
 </body>

--- a/visual-viewport/viewport-scale-with-pinch-zoom.html
+++ b/visual-viewport/viewport-scale-with-pinch-zoom.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Viewport Scale : Pinch Zoom</title>
+  <link rel=help href="https://github.com/w3c/csswg-drafts/issues/9004">
+  <link rel=help href="https://www.w3.org/TR/2015/WD-mobile-accessibility-mapping-20150226/#zoom-magnification">
+  <link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+  <meta name="assert" content="The page can be pinch zoomed-in and zoomed-out.">
+  <meta name="viewport" content="minimum-scale=0.1, initial-scale=1.0, maximum-scale=10.0">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/visual-viewport/viewport_support.js"></script>
+
+</head>
+
+<body>
+  <div style="font-size: 50px;">Pinch Zoom Test: Zoom In</div>
+  <script>
+    promise_test(async () => {
+      const initialScale = window.visualViewport.scale;
+
+      await pinchZoomIn();
+      assert_greater_than(window.visualViewport.scale, initialScale,
+        "Scale should be greater than initial scale after pinch zoom in");
+      const afterZoomIn = window.visualViewport.scale;
+
+      await pinchZoomOut();
+      assert_less_than(window.visualViewport.scale, afterZoomIn,
+        "Scale should be less than after pinch zoom in scale after pinch zoom out");
+    }) </script>
+</body>
+
+</html>

--- a/visual-viewport/viewport_support.js
+++ b/visual-viewport/viewport_support.js
@@ -25,6 +25,28 @@ function pinchZoomIn() {
       .send();
 }
 
+// Simulates two fingers, 100px apart, pulling closer vertically to 50px of
+// separation.
+function pinchZoomOut() {
+  const viewport = window.visualViewport;
+  const center_x = Math.floor(viewport.width / 2);
+  const center_y = Math.floor(viewport.height / 2);
+
+  return new test_driver.Actions()
+      .setContext(window)
+      .addPointer("finger1", "touch")
+      .addPointer("finger2", "touch")
+      .pointerMove(center_x, center_y, {origin: "viewport", sourceName: "finger1"})
+      .pointerMove(center_x, center_y + 100, {origin: "viewport", sourceName: "finger2"})
+      .pointerDown({sourceName: "finger1"})
+      .pointerDown({sourceName: "finger2"})
+      .pointerMove(center_x, center_y, {origin: "viewport", sourceName: "finger1"})
+      .pointerMove(center_x, center_y + 50, {origin: "viewport", sourceName: "finger2"})
+      .pointerUp({sourceName: "finger1"})
+      .pointerUp({sourceName: "finger2"})
+      .send();
+}
+
 // If scrollbars affect layout (i.e. what the CSS Overflow spec calls "classic
 // scrollbars", as opposed to overlay scrollbars), return the scrollbar
 // thickness in CSS pixels. Returns 0 otherwise.


### PR DESCRIPTION
Now it fully support pinch-zoom over whole range 0.1 to 10.0 

CSSWG Issue: https://github.com/w3c/csswg-drafts/issues/9004

> "minimum-scale-box" - the viewport when zoomed out to the minimum scale factor

Document referencing Case Study: [viewport meta](https://docs.google.com/document/d/1NBu9rC4sHm51I2yOsWJxeDOd17sNIchEhoNLyOFbAJM/edit?usp=sharing) 

Testing: 

- Tested Manually on Mobile Device
- WPT: `visual-viewport/viewport-scale-with-pinch-zoom.html`
- UT: `webview`:`test_viewport_clamp_pinch_min_by_initial_scale_1/2/3`

Fixes: #<!-- nolink -->39002
Fixes: A concern from #<!-- nolink -->40098

https://github.com/servo/servo/pull/40098#discussion_r3032426990

Reviewed in servo/servo#45150