### PR TITLE
script: Limit write lock guard in `CSSKeyframesRuleMethods::AppendRule`

### DIFF
--- a/css/cssom/CSSRuleList-appendRule-keyframe-crash.html
+++ b/css/cssom/CSSRuleList-appendRule-keyframe-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Servo crash when modifying keyframe rules </title>
+<link rel="help" href="https://github.com/servo/servo/issues/44990">
+<style>
+  @keyframes keyframes0 {}
+</style>
+<script>
+  onload = _ =>
+    document.styleSheets[0].cssRules[0].appendRule("0% {}");
+</script>


### PR DESCRIPTION
Keeping this guard alive while calling `CSSKeyFramesRule::rulelist`
leads to a double-borrow. This change limits the guard, fixing the
original panic.

Testing: This change includes a WPT crash test.
Fixes: #<!-- nolink -->44990.

Reviewed in servo/servo#45173