### PR TITLE
font: Properly handle when shaping produces no glyphs

### DIFF
--- a/css/css-text/shaping/shaping-no-glyphs-crash.html
+++ b/css/css-text/shaping/shaping-no-glyphs-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta name="assert" content="Shaped runs that produce no glyphs should not cause a crash.">
+<link rel="help" href="https://github.com/servo/servo/issues/45174">
+<style>
+  span { font-family: 'MyCustomFont'; }
+  @font-face {
+      src: url('/css/css-values/resources/ExTest-NoSpace.woff') format('woff');
+      font-family: 'MyCustomFont';
+  }
+</style>
+<span>&ZeroWidthSpace;</span>


### PR DESCRIPTION
When shaping produces no glyphs, which can happen when a zero-width
space is shaped for a font that has no space or zero-width space glyph,
just return an empty `ShapedText` instead of trying to process any
glyphs. This prevents logic issues due to the rest of the code assuming
there are glyphs.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->45174.

Reviewed in servo/servo#45176