### PR TITLE
Allow relative scrolls in unrelated-gesture-scroll-during-snap.html

### DIFF
--- a/css/css-scroll-snap/unrelated-gesture-scroll-during-snap.html
+++ b/css/css-scroll-snap/unrelated-gesture-scroll-during-snap.html
@@ -83,8 +83,13 @@
         ];
         let last_scroll_top = snapcontainer.scrollTop;
         async function scroll_listener() {
-          // If we are scrolling back to 0, we are snapping.
-          if (snapcontainer.scrollTop < last_scroll_top) {
+          // If scrollTop is decreasing we are snapping back (absolute-scroll
+          // case).
+          // If scrollTop is increasing past the initial scroll amount we are
+          // snapping forward (relative-scroll case).
+          if (snapcontainer.scrollTop < last_scroll_top ||
+              (snapcontainer.scrollTop > last_scroll_top &&
+               snapcontainer.scrollTop > snap_scroll_amt)) {
             snapcontainer.removeEventListener("scroll", scroll_listener);
             await new test_driver.Actions().scroll(0, 0, 0, inputs.scroll_amt,
                                             { origin: other_container }).send();
@@ -101,8 +106,12 @@
                                          .send();
 
         await Promise.all(scrollend_promises);
-        assert_equals(snapcontainer.scrollTop, 0,
-          "snapcontainer snaps back to 0");
+        const second_snap_offset =
+            snapcontainer.querySelectorAll(".snaparea")[1].offsetTop;
+        assert_true(snapcontainer.scrollTop === 0 ||
+                    snapcontainer.scrollTop === second_snap_offset,
+          "snapcontainer snaps to a snap point (0 or " +
+          second_snap_offset + "), got " + snapcontainer.scrollTop);
         assert_equals(other_container.scrollTop, expectations.expectedScrollTop,
           `${other_container.id} is at expected scroll offset.`);
       }


### PR DESCRIPTION
At the moment, `unrelated-gesture-scroll-during-snap.html` expects to snap back to 0, which can only be the case for absolute scrolls, because they don't have an intended direction.

Relative scrolls however, must have an intended direction and therefore snap forward in that intended direction.

WebDriver scroll actions can use wheel events, which are relative scrolls. Or they could use pan gestures, which will soon will be treated as relative scrolls, too: [csswg-drafts #12840](https://github.com/w3c/csswg-drafts/issues/12840).

Withouth the suggested change, the test currently:
- Firefox:
**Fails**, because Firefox treats both wheel events and pan gestures as relative scrolls with an intended direction already.
- Chrome:
**Passes**, because Chrome does not yet add an intended direction to pixel-precise relative scrolls. (see [InputHandler::CreateSnapStrategy](https://source.chromium.org/chromium/chromium/src/+/main:cc/input/input_handler.cc;drc=6bd89e56257f6ba76e1ad3f5c680f739aeded909;l=2717-2740?q=input_handler.cc&ss=chromium))
- Safari:
Not tested.

See issue:
https://github.com/web-platform-tests/interop/issues/1288