### PR TITLE
Update clip-path-circle-4 fuzziness for AA

### DIFF
--- a/css/css-masking/clip-path/clip-path-circle-closest-corner.html
+++ b/css/css-masking/clip-path/clip-path-circle-closest-corner.html
@@ -5,7 +5,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="reference/clip-path-circle-4-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-61; totalPixels=0-2000">
+    <meta name="fuzzy" content="maxDifference=0-545; totalPixels=0-2000">
     <meta name="assert" content="The clip-path property takes the basic shape
     'circle' for clipping, with the 'closest-corner' size. There should be a full green circle.">
     <style>


### PR DESCRIPTION
Like Gecko, we also need to increase the fuzzy matching on this test. While 545 may seem like a lot, it is a giant circle, and the intent of the test is preserved.

Fixed: 515776658
Change-Id: I63162fa19ddbf4e31819f3de08b2ca3468abfd08
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7876670
Commit-Queue: Philip Rogers <pdr@chromium.org>
Auto-Submit: Philip Rogers <pdr@chromium.org>
Reviewed-by: Stephen Chenney <schenney@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1636604}

---

Changes from original: Overwrite #60122.