### PR TITLE
Make the service-worker and downloads tests as tentative

### DIFF
--- a/service-workers/service-worker/tentative/fetch-event-download-fallback.https.html
+++ b/service-workers/service-worker/tentative/fetch-event-download-fallback.https.html
@@ -5,8 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="resources/test-helpers.sub.js"></script>
-<script src="resources/fetch-event-download-helpers.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
+<script src="../resources/fetch-event-download-helpers.js"></script>
 <body>
 <script>
 'use strict';

--- a/service-workers/service-worker/tentative/fetch-event-download-out-of-scope.https.html
+++ b/service-workers/service-worker/tentative/fetch-event-download-out-of-scope.https.html
@@ -5,8 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="resources/test-helpers.sub.js"></script>
-<script src="resources/fetch-event-download-helpers.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
+<script src="../resources/fetch-event-download-helpers.js"></script>
 <body>
 <script>
 'use strict';

--- a/service-workers/service-worker/tentative/fetch-event-download-respond-with.https.html
+++ b/service-workers/service-worker/tentative/fetch-event-download-respond-with.https.html
@@ -5,8 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="resources/test-helpers.sub.js"></script>
-<script src="resources/fetch-event-download-helpers.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
+<script src="../resources/fetch-event-download-helpers.js"></script>
 <body>
 <script>
 'use strict';

--- a/service-workers/service-worker/tentative/fetch-event-download.https.html
+++ b/service-workers/service-worker/tentative/fetch-event-download.https.html
@@ -5,8 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="resources/test-helpers.sub.js"></script>
-<script src="resources/fetch-event-download-helpers.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
+<script src="../resources/fetch-event-download-helpers.js"></script>
 <body>
 <script>
 'use strict';


### PR DESCRIPTION
The HTML spec is still discussing (eg, [issue #5548](https://github.com/whatwg/html/issues/5548)) about the nature of the downloads requests, whether they should be "navigations" or direct "fetch" request, or both, as well as the implications for the CORS attributes. 