### PR TITLE
Remove `shadowrealm` scopes from `DOMException-stack-accessor.any.js`

### DIFF
--- a/webidl/ecmascript-binding/es-exceptions/DOMException-stack-accessor.any.js
+++ b/webidl/ecmascript-binding/es-exceptions/DOMException-stack-accessor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,shadowrealm
+// META: global=window,dedicatedworker
 
 // https://tc39.es/proposal-error-stack-accessor/
 // https://github.com/whatwg/webidl/pull/1421


### PR DESCRIPTION
`shadowrealm` testing was dropped in #59794.