### PR TITLE
Remove inconsistent capitalization from tags in MathML tests

### DIFF
--- a/mathml/relations/css-styling/width-height-002-ref.html
+++ b/mathml/relations/css-styling/width-height-002-ref.html
@@ -70,7 +70,7 @@
           <mtext>X</mtext>
         </mpadded>
       </math>
-    </diV>
+    </div>
     <div class="box" dir="rtl">
       <math dir="rtl">
         <mpadded lspace="1em" voffset="-1em">
@@ -159,4 +159,4 @@
   </div>
 
 </body>
-</htmL>
+</html>

--- a/mathml/relations/css-styling/width-height-002.html
+++ b/mathml/relations/css-styling/width-height-002.html
@@ -132,4 +132,4 @@
   </div>
 
 </body>
-</htmL>
+</html>

--- a/mathml/relations/css-styling/width-height-003-ref.html
+++ b/mathml/relations/css-styling/width-height-003-ref.html
@@ -175,4 +175,4 @@
   </div>
 
 </body>
-</htmL>
+</html>

--- a/mathml/relations/css-styling/width-height-003.html
+++ b/mathml/relations/css-styling/width-height-003.html
@@ -147,4 +147,4 @@
   </div>
 
 </body>
-</htmL>
+</html>

--- a/mathml/relations/css-styling/width-height-004.html
+++ b/mathml/relations/css-styling/width-height-004.html
@@ -190,4 +190,4 @@
   </div>
 
 </body>
-</htmL>
+</html>


### PR DESCRIPTION
Very minor fix. When syncing tests back to WebKit, I noticed that some of them had some tags with random uppercase letters. This is not really an issue since they work fine, but still, I prefer them to be consistent.