### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=309689

### DIFF
--- a/css/css-ui/parsing/cursor-valid.html
+++ b/css/css-ui/parsing/cursor-valid.html
@@ -103,6 +103,33 @@ test_valid_value(
     'image-set(url(https://example.com/) 1x, url(https://example.com/highres) 2x) 5 6, grab'
   ]
 );
+
+test_valid_value(
+  "cursor",
+  'light-dark(url("https://example.com/light"), url("https://example.com/dark")), pointer',
+  [
+    'light-dark(url("https://example.com/light"), url("https://example.com/dark")), pointer',
+    'light-dark(url(https://example.com/light), url(https://example.com/dark)), pointer'
+  ]
+);
+
+test_valid_value(
+  "cursor",
+  'light-dark(url("https://example.com/light"), url("https://example.com/dark")) 5 6, grab',
+  [
+    'light-dark(url("https://example.com/light"), url("https://example.com/dark")) 5 6, grab',
+    'light-dark(url(https://example.com/light), url(https://example.com/dark)) 5 6, grab'
+  ]
+);
+
+test_valid_value(
+  "cursor",
+  'url("https://example.com/"), light-dark(url("https://example.com/light"), url("https://example.com/dark")) 3 4, move',
+  [
+    'url("https://example.com/"), light-dark(url("https://example.com/light"), url("https://example.com/dark")) 3 4, move',
+    'url(https://example.com/), light-dark(url(https://example.com/light), url(https://example.com/dark)) 3 4, move'
+  ]
+);
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [\[css-images\] Add support for light-dark(<image>, <image>)](https://bugs.webkit.org/show_bug.cgi?id=309689)