### PR TITLE
layout: Preserve active `display: contents` when handling anonymous table parts

### DIFF
--- a/css/css-tables/display-contents-001-ref.html
+++ b/css/css-tables/display-contents-001-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<div style="font: 25px/1 Ahem; color: green">
+  XXX<br>
+  X<br>
+  X
+</div>

--- a/css/css-tables/display-contents-001.html
+++ b/css/css-tables/display-contents-001.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>CSS Test: `display: contents` inside table</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-tables-3/#fixup">
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-001-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="
+  The contents of the table (anonymous or not) should inherit the green color from the
+  element with `display: contents`.
+">
+
+<div style="display: table; font: 25px/1 Ahem; color: red">
+  <div style="display: contents; color: green">
+    X
+    <div style="display: table-cell">X</div>
+    X
+    <div style="display: table-row">X</div>
+    X
+  </div>
+</div>

--- a/css/css-tables/display-contents-002.html
+++ b/css/css-tables/display-contents-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Test: `display: contents` inside table</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-tables-3/#fixup">
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-001-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="
+  The contents of the table (anonymous or not) should inherit the green color from the
+  element with `display: contents`.
+">
+
+<div style="display: table; font: 25px/1 Ahem; color: red">
+  <div style="display: table-row-group">
+    <div style="display: contents; color: green">
+      X
+      <div style="display: table-cell">X</div>
+      X
+      <div style="display: table-row">X</div>
+      X
+    </div>
+  </div>
+</div>

--- a/css/css-tables/display-contents-003-ref.html
+++ b/css/css-tables/display-contents-003-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<div style="font: 25px/1 Ahem; color: green">
+  XXX<br>
+  &nbsp;&nbsp;X<br>
+  &nbsp;&nbsp;X
+</div>

--- a/css/css-tables/display-contents-003.html
+++ b/css/css-tables/display-contents-003.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Test: `display: contents` inside table</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-tables-3/#fixup">
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-003-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="
+  The contents of the table (anonymous or not) should inherit the green color from the
+  element with `display: contents`.
+">
+
+<div style="display: table; font: 25px/1 Ahem; color: red">
+  <div style="display: table-row">
+    <div style="display: contents; color: green">
+      X
+      <div style="display: table-cell">X</div>
+      X
+      <div style="display: table-row">X</div>
+      X
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
We weren't handling `display: contents` elements properly when dealing with contents inside tables that may need to be wrapped inside anonymous containers.

This could result in calling `leave_display_contents()` without having used `enter_display_contents()` beforehand, thus breaking the assumption that all inline formatting context should have at least one shared inline style.

Now we make sure to preserve unclosed `AnonymousTableContent::EnterDisplayContents` for later.

Testing: Adding new reftests
Fixes: #<!-- nolink -->45085
Fixes: #<!-- nolink -->45172
Reviewed in servo/servo#45287