### PR TITLE
[wptrunner] Enable Web Install API and <install> element feature flags

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -152,6 +152,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
         "MediaStreamTrackWebSpeech",
         "WebSpeechRecognitionContext",
     ]))
+    # For Web Install API and <install> element tests.
+    chrome_options["args"].append("--enable-features=WebAppInstallation,InstallElement")
     # For testing WebExtensions using WebDriver.
     chrome_options["args"].append("--enable-unsafe-extension-debugging")
     # Connection between ChromeDriver and Chrome will be over pipes.


### PR DESCRIPTION
WPTs for navigator.install and `<install>` were previously added in
https://github.com/web-platform-tests/wpt/pull/59113 and https://github.com/web-platform-tests/wpt/pull/58919

However we explicitly excluded their runtime flags from experimental-web-platform-features, so each requires their own flag - `WebAppInstallation` and `InstallElement`