### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=316067

### DIFF
--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -3154,5 +3154,12 @@
         "groups": {"0": "barbaz"}
       }
     }
+  },
+  {
+    "pattern": [{ "pathname": "/:𠀀" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "𠀀": "foo" } }
+    }
   }
 ]


### PR DESCRIPTION
WebKit export from bug: [URLPattern fails to accept non-BMP code points in named groups](https://bugs.webkit.org/show_bug.cgi?id=316067)