### PR TITLE
Fix typo 'Decompresion' in fetch/compression-dictionary tests.

### DIFF
--- a/fetch/compression-dictionary/dictionary-compressed.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-compressed.tentative.https.html
@@ -28,7 +28,7 @@ compression_dictionary_promise_test(async (t) => {
   const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
   const data = await (await fetch(data_url)).text();
   assert_equals(data, kExpectedCompressedData);
-}, 'Decompresion using gzip-encoded dictionary works as expected');
+}, 'Decompression using gzip-encoded dictionary works as expected');
 
 compression_dictionary_promise_test(async (t) => {
   const dictionaryUrl =
@@ -42,7 +42,7 @@ compression_dictionary_promise_test(async (t) => {
   const data_url = `${kCompressedDataPath}?content_encoding=dcz`;
   const data = await (await fetch(data_url)).text();
   assert_equals(data, kExpectedCompressedData);
-}, 'Decompresion using Brotli-encoded dictionary works as expected');
+}, 'Decompression using Brotli-encoded dictionary works as expected');
 
 compression_dictionary_promise_test(async (t) => {
   const dictionaryUrl =
@@ -57,7 +57,7 @@ compression_dictionary_promise_test(async (t) => {
   const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
   const data = await (await fetch(data_url)).text();
   assert_equals(data, kExpectedCompressedData);
-}, 'Decompresion using Zstandard-encoded dictionary works as expected');
+}, 'Decompression using Zstandard-encoded dictionary works as expected');
 
 compression_dictionary_promise_test(async (t) => {
   const dictionaryUrl = `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?id=id1`;

--- a/fetch/compression-dictionary/dictionary-decompression.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-decompression.tentative.https.html
@@ -22,7 +22,7 @@ compression_dictionary_promise_test(async (t) => {
   // decompressed.
   const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
   assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
-}, 'Decompresion using Brotli with the dictionary works as expected');
+}, 'Decompression using Brotli with the dictionary works as expected');
 
 compression_dictionary_promise_test(async (t) => {
   const dict = await (await fetch(kRegisterDictionaryPath)).text();
@@ -36,7 +36,7 @@ compression_dictionary_promise_test(async (t) => {
   // decompressed.
   const data_url = `${kCompressedDataPath}?content_encoding=dcz`;
   assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
-}, 'Decompresion using Zstandard with the dictionary works as expected');
+}, 'Decompression using Zstandard with the dictionary works as expected');
 
 compression_dictionary_promise_test(async (t) => {
   const dict =
@@ -52,7 +52,7 @@ compression_dictionary_promise_test(async (t) => {
   const data_url =
       getRemoteHostUrl(`${kCompressedDataPath}?content_encoding=dcb`);
   assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
-}, 'Decompresion of a cross origin resource works as expected');
+}, 'Decompression of a cross origin resource works as expected');
 
 compression_dictionary_promise_test(async (t) => {
   const dict = await (await fetch(kRegisterDictionaryPath)).text();
@@ -64,7 +64,7 @@ compression_dictionary_promise_test(async (t) => {
   const data_url = `${kCompressedDataPath}?content_encoding=dcb&hash_mismatch=true`;
   const res = await fetch(data_url);
   await promise_rejects_js(t, TypeError, res.text());
-}, 'Decompresion using Brotli fails when dictionary hash mismatches');
+}, 'Decompression using Brotli fails when dictionary hash mismatches');
 
 compression_dictionary_promise_test(async (t) => {
   const dict = await (await fetch(kRegisterDictionaryPath)).text();
@@ -76,7 +76,7 @@ compression_dictionary_promise_test(async (t) => {
   const data_url = `${kCompressedDataPath}?content_encoding=dcz&hash_mismatch=true`;
   const res = await fetch(data_url);
   await promise_rejects_js(t, TypeError, res.text());
-}, 'Decompresion using Zstandard fails when dictionary hash mismatches');
+}, 'Decompression using Zstandard fails when dictionary hash mismatches');
 
 </script>
 </body>


### PR DESCRIPTION
`find fetch/compression-dictionary -type f | xargs sed -i 's/ompresion/ompression/g'`