### PR TITLE
Test `text-overflow`'s bidi handling with `unicode-bidi: plaintext`

### DIFF
--- a/css/css-ui/reference/text-overflow-string-008-ref.html
+++ b/css/css-ui/reference/text-overflow-string-008-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Basic User Interface Reference File</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+  div {
+    font-family: monospace;
+    font-size: 10px;
+    width: 130px;
+  }
+  span.ahem {
+    font-family: Ahem;
+    font-size: 30px;
+  }
+</style>
+<body>
+  <p>Test passes if there is a "<strong dir="ltr">ום A</strong>" after a black rectangle below.</p>
+  <div>
+    <span class="ahem">ext</span><span dir="ltr">ום A</span>
+  </div>
+</body>
+</html>

--- a/css/css-ui/reference/text-overflow-string-008-ref.html
+++ b/css/css-ui/reference/text-overflow-string-008-ref.html
@@ -6,7 +6,6 @@
   div {
     font-family: monospace;
     font-size: 10px;
-    width: 130px;
   }
   span.ahem {
     font-family: Ahem;
@@ -20,3 +19,5 @@
   </div>
 </body>
 </html>
+
+    width: 130px;

--- a/css/css-ui/text-overflow-string-008.html
+++ b/css/css-ui/text-overflow-string-008.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Basic User Interface Test: text-overflow with bidi string ellipsis (interaction with unicode-bidi: plaintext)</title>
+<link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12617">
+<link rel="match" href="reference/text-overflow-string-008-ref.html">
+<meta name="assert" content="Test checks text-overflow ellipsis takes their bidi direction from the paragraph. With unicode-bidi: plaintext, this is the bidi paragraph's determined direction, not the value of the `direction` property.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+  div {
+    font-family: monospace;
+    font-size: 10px;
+    overflow: hidden;
+    /* This custom ellipsis string has mixed LTR/RTL characters
+     * ("A" and "ום"), but its base direction (determined by the first strong
+     * char 'ו') is RTL. */
+    text-overflow: "ום A";
+    width: 130px;
+    /* Even though the div has dir="rtl" (and therefore `direction: rtl`), its
+     * actual bidi direction is determined by its content, which is LTR. */
+    unicode-bidi: plaintext;
+  }
+  span {
+    font-family: Ahem;
+    font-size: 30px;
+  }
+</style>
+<body>
+  <p>Test passes if there is a "<strong dir="ltr">ום A</strong>" after a black rectangle below.</p>
+  <div dir="rtl">
+    <span>TestChecksThatTheBrokenContentRepalcedByBidiText</span>
+  </div>
+</body>
+</html>

--- a/css/css-ui/text-overflow-string-008.html
+++ b/css/css-ui/text-overflow-string-008.html
@@ -15,7 +15,7 @@
      * ("A" and "ום"), but its base direction (determined by the first strong
      * char 'ו') is RTL. */
     text-overflow: "ום A";
-    width: 130px;
+    width: calc(90px + 4.1ch);
     /* Even though the div has dir="rtl" (and therefore `direction: rtl`), its
      * actual bidi direction is determined by its content, which is LTR. */
     unicode-bidi: plaintext;


### PR DESCRIPTION
In w3c/csswg-drafts#12617 it was resolved that the `text-overflow` ellipsis text is treated as a bidi isolate, with the same directionality as the containing bidi paragraph. There were previously WPT tests for this, added in #57478.

However, although a bidi paragraph's directionality tends to be the same as its value of the `direction` property, this is not the case with `unicode-bidi: plaintext`, in which case the directionality is determined by the the paragraph's context. This patch adds a test for this.