### PR TITLE
Update background/mask computed value serializations to match the spec

### DIFF
--- a/css/css-backgrounds/animations/background-position-interpolation.html
+++ b/css/css-backgrounds/animations/background-position-interpolation.html
@@ -111,27 +111,27 @@ test_interpolation({
   from: 'top 0px left 0px',
   to: 'left 80px top 80px',
 }, [
-  {at: -0.25, expect: '-20px -20px, -20px -20px, -20px -20px, -20px -20px'},
-  {at: 0, expect:     '  0px   0px,   0px   0px,   0px   0px,   0px   0px'},
-  {at: 0.25, expect:  ' 20px  20px,  20px  20px,  20px  20px,  20px  20px'},
-  {at: 0.5, expect:   ' 40px  40px,  40px  40px,  40px  40px,  40px  40px'},
-  {at: 0.75, expect:  ' 60px  60px,  60px  60px,  60px  60px,  60px  60px'},
-  {at: 1, expect:     ' 80px  80px,  80px  80px,  80px  80px,  80px  80px'},
-  {at: 1.25, expect:  '100px 100px, 100px 100px, 100px 100px, 100px 100px'},
+  {at: -0.25, expect: '-20px -20px'},
+  {at: 0, expect:     '  0px   0px'},
+  {at: 0.25, expect:  ' 20px  20px'},
+  {at: 0.5, expect:   ' 40px  40px'},
+  {at: 0.75, expect:  ' 60px  60px'},
+  {at: 1, expect:     ' 80px  80px'},
+  {at: 1.25, expect:  '100px 100px'},
 ]);
 
 // Test mismatched numbers of position values.
 test_interpolation({
   property: 'background-position',
-  from: '0px 0px, 80px 0px',
-  to: '40px 40px, 80px 80px, 0px 80px',
+  from: '0px 0px, 80px 0px',            // intepreted as [  0px  0px, 80px  0px, 0px  0px, 80px  0px,  0px  0px, 80px  0px ] via repetition
+  to: '40px 40px, 80px 80px, 0px 80px', // intepreted as [ 40px 40px, 80px 80px, 0px 80px, 40px 40px, 80px 80px,  0px 80px ] via repetition
 }, [
-  {at: -0.25, expect: '-10px -10px, 80px -20px, 0px -20px, 90px -10px'},
-  {at: 0, expect:     '  0px   0px, 80px   0px, 0px   0px, 80px   0px'},
-  {at: 0.25, expect:  ' 10px  10px, 80px  20px, 0px  20px, 70px  10px'},
-  {at: 0.5, expect:   ' 20px  20px, 80px  40px, 0px  40px, 60px  20px'},
-  {at: 0.75, expect:  ' 30px  30px, 80px  60px, 0px  60px, 50px  30px'},
-  {at: 1, expect:     ' 40px  40px, 80px  80px, 0px  80px, 40px  40px'},
-  {at: 1.25, expect:  ' 50px  50px, 80px 100px, 0px 100px, 30px  50px'},
+  {at: -0.25, expect: '-10px -10px, 80px -20px,  0px -20px, 90px -10px, -20px -20px, 100px -20px'},
+  {at: 0, expect:     '  0px   0px, 80px   0px,  0px   0px, 80px   0px,   0px   0px,  80px   0px'},
+  {at: 0.25, expect:  ' 10px  10px, 80px  20px,  0px  20px, 70px  10px,  20px  20px,  60px  20px'},
+  {at: 0.5, expect:   ' 20px  20px, 80px  40px,  0px  40px, 60px  20px,  40px  40px,  40px  40px'},
+  {at: 0.75, expect:  ' 30px  30px, 80px  60px,  0px  60px, 50px  30px,  60px  60px,  20px  60px'},
+  {at: 1, expect:     ' 40px  40px, 80px  80px,  0px  80px, 40px  40px,  80px  80px,   0px  80px'},
+  {at: 1.25, expect:  ' 50px  50px, 80px  100px, 0px 100px, 30px  50px, 100px 100px, -20px 100px'},
 ]);
 </script>

--- a/css/css-backgrounds/animations/background-size-interpolation.html
+++ b/css/css-backgrounds/animations/background-size-interpolation.html
@@ -36,16 +36,16 @@
 // neutral
 test_interpolation({
   property: 'background-size',
-  from: neutralKeyframe,
+  from: neutralKeyframe, // intepreted as [ 10px 10px, 10px 10px] via repetition
   to: '20px 20px, 0px 0px',
 }, [
-  {at: -0.25, expect: ' 7.5px  7.5px, 12.5px 12.5px,  7.5px  7.5px, 12.5px 12.5px'},
-  {at: 0, expect:     '10.0px 10.0px, 10.0px 10.0px, 10.0px 10.0px, 10.0px 10.0px'},
-  {at: 0.25, expect:  '12.5px 12.5px,  7.5px  7.5px, 12.5px 12.5px,  7.5px  7.5px'},
-  {at: 0.5, expect:   '15.0px 15.0px,  5.0px  5.0px, 15.0px 15.0px,  5.0px  5.0px'},
-  {at: 0.75, expect:  '17.5px 17.5px,  2.5px  2.5px, 17.5px 17.5px,  2.5px  2.5px'},
-  {at: 1, expect:     '20.0px 20.0px,  0.0px  0.0px, 20.0px 20.0px,  0.0px  0.0px'},
-  {at: 1.25, expect:  '22.5px 22.5px,  0.0px  0.0px, 22.5px 22.5px,  0.0px  0.0px'},
+  {at: -0.25, expect: ' 7.5px 7.5px , 12.5px 12.5px'},
+  {at: 0, expect:     '10.0px 10.0px, 10.0px 10.0px'},
+  {at: 0.25, expect:  '12.5px 12.5px,  7.5px  7.5px'},
+  {at: 0.5, expect:   '15.0px 15.0px,  5.0px  5.0px'},
+  {at: 0.75, expect:  '17.5px 17.5px,  2.5px  2.5px'},
+  {at: 1, expect:     '20.0px 20.0px,  0.0px  0.0px'},
+  {at: 1.25, expect:  '22.5px 22.5px,  0.0px  0.0px'},
 ]);
 
 // initial
@@ -58,16 +58,16 @@ test_no_interpolation({
 // inherit
 test_interpolation({
   property: 'background-size',
-  from: 'inherit',
+  from: 'inherit',  // intepreted as [ 100px 100px, 100px 100px ] via repetition
   to: '20px 20px, 0px 0px',
 }, [
-  {at: -0.25, expect: '120px 120px, 125px 125px, 120px 120px, 125px 125px'},
-  {at: 0, expect:     '100px 100px, 100px 100px, 100px 100px, 100px 100px'},
-  {at: 0.25, expect:  ' 80px  80px,  75px  75px,  80px  80px,  75px  75px'},
-  {at: 0.5, expect:   ' 60px  60px,  50px  50px,  60px  60px,  50px  50px'},
-  {at: 0.75, expect:  ' 40px  40px,  25px  25px,  40px  40px,  25px  25px'},
-  {at: 1, expect:     ' 20px  20px,   0px   0px,  20px  20px,   0px   0px'},
-  {at: 1.25, expect:  '  0px   0px,   0px   0px,   0px   0px,   0px   0px'},
+  {at: -0.25, expect: '120px 120px, 125px 125px'},
+  {at: 0, expect:     '100px 100px, 100px 100px'},
+  {at: 0.25, expect:  ' 80px  80px,  75px  75px'},
+  {at: 0.5, expect:   ' 60px  60px,  50px  50px'},
+  {at: 0.75, expect:  ' 40px  40px,  25px  25px'},
+  {at: 1, expect:     ' 20px  20px,   0px   0px'},
+  {at: 1.25, expect:  '  0px   0px,   0px   0px'},
 ]);
 
 // unset
@@ -126,13 +126,13 @@ test_interpolation({
   from: '0px 0px',
   to: '80px 80px',
 }, [
-  {at: -0.25, expect: '  0px   0px,   0px   0px,   0px   0px,   0px   0px'},
-  {at: 0, expect:     '  0px   0px,   0px   0px,   0px   0px,   0px   0px'},
-  {at: 0.25, expect:  ' 20px  20px,  20px  20px,  20px  20px,  20px  20px'},
-  {at: 0.5, expect:   ' 40px  40px,  40px  40px,  40px  40px,  40px  40px'},
-  {at: 0.75, expect:  ' 60px  60px,  60px  60px,  60px  60px,  60px  60px'},
-  {at: 1, expect:     ' 80px  80px,  80px  80px,  80px  80px,  80px  80px'},
-  {at: 1.25, expect:  '100px 100px, 100px 100px, 100px 100px, 100px 100px'},
+  {at: -0.25, expect: '  0px   0px'},
+  {at: 0, expect:     '  0px   0px'},
+  {at: 0.25, expect:  ' 20px  20px'},
+  {at: 0.5, expect:   ' 40px  40px'},
+  {at: 0.75, expect:  ' 60px  60px'},
+  {at: 1, expect:     ' 80px  80px'},
+  {at: 1.25, expect:  '100px 100px'},
 ]);
 
 test_interpolation({
@@ -140,27 +140,27 @@ test_interpolation({
   from: '0px',
   to: '80px',
 }, [
-  {at: -0.25, expect: '  0px,   0px,   0px,   0px'},
-  {at: 0, expect:     '  0px,   0px,   0px,   0px'},
-  {at: 0.25, expect:  ' 20px,  20px,  20px,  20px'},
-  {at: 0.5, expect:   ' 40px,  40px,  40px,  40px'},
-  {at: 0.75, expect:  ' 60px,  60px,  60px,  60px'},
-  {at: 1, expect:     ' 80px,  80px,  80px,  80px'},
-  {at: 1.25, expect:  '100px, 100px, 100px, 100px'},
+  {at: -0.25, expect: '  0px'},
+  {at: 0, expect:     '  0px'},
+  {at: 0.25, expect:  ' 20px'},
+  {at: 0.5, expect:   ' 40px'},
+  {at: 0.75, expect:  ' 60px'},
+  {at: 1, expect:     ' 80px'},
+  {at: 1.25, expect:  '100px'},
 ]);
 
 // Mismatched numbers of size values.
 test_interpolation({
   property: 'background-size',
-  from: '0px 0px, 80px 0px',
-  to: '40px 40px, 80px 80px, 0px 80px',
+  from: '0px 0px, 80px 0px',            // intepreted as [ 0px  0px, 80px  0px, 0px  0px, 80px  0px,  0px  0px, 80px  0px] via repetition
+  to: '40px 40px, 80px 80px, 0px 80px', // intepreted as [40px 40px, 80px 80px, 0px 80px, 40px 40px, 80px 80px,  0px 80px] via repetition
 }, [
-  {at: -0.25, expect: ' 0px  0px, 80px   0px, 0px   0px, 90px  0px'},
-  {at: 0, expect:     ' 0px  0px, 80px   0px, 0px   0px, 80px  0px'},
-  {at: 0.25, expect:  '10px 10px, 80px  20px, 0px  20px, 70px 10px'},
-  {at: 0.5, expect:   '20px 20px, 80px  40px, 0px  40px, 60px 20px'},
-  {at: 0.75, expect:  '30px 30px, 80px  60px, 0px  60px, 50px 30px'},
-  {at: 1, expect:     '40px 40px, 80px  80px, 0px  80px, 40px 40px'},
-  {at: 1.25, expect:  '50px 50px, 80px 100px, 0px 100px, 30px 50px'},
+  {at: -0.25, expect: ' 0px  0px, 80px   0px, 0px   0px, 90px  0px,   0px   0px, 100px   0px'},
+  {at: 0, expect:     ' 0px  0px, 80px   0px, 0px   0px, 80px  0px,   0px   0px,  80px   0px'},
+  {at: 0.25, expect:  '10px 10px, 80px  20px, 0px  20px, 70px 10px,  20px  20px,  60px  20px'},
+  {at: 0.5, expect:   '20px 20px, 80px  40px, 0px  40px, 60px 20px,  40px  40px,  40px  40px'},
+  {at: 0.75, expect:  '30px 30px, 80px  60px, 0px  60px, 50px 30px,  60px  60px,  20px  60px'},
+  {at: 1, expect:     '40px 40px, 80px  80px, 0px  80px, 40px 40px,  80px  80px,   0px  80px'},
+  {at: 1.25, expect:  '50px 50px, 80px 100px, 0px 100px, 30px 50px, 100px 100px,   0px 100px'},
 ]);
 </script>

--- a/css/css-backgrounds/parsing/background-attachment-computed.html
+++ b/css/css-backgrounds/parsing/background-attachment-computed.html
@@ -13,9 +13,12 @@
 <div id="target"></div>
 <script>
 test_computed_value("background-attachment", "fixed");
+test_computed_value("background-attachment", "scroll, fixed, local");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-attachment", "scroll, fixed, local", "scroll");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-attachment", "scroll", "scroll", "multiple base values");
+test_computed_value("background-attachment", "scroll, fixed", "scroll, fixed", "multiple base values");
+test_computed_value("background-attachment", "scroll, fixed, local", "scroll, fixed, local", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-clip-computed.html
+++ b/css/css-backgrounds/parsing/background-clip-computed.html
@@ -16,12 +16,16 @@ test_computed_value("background-clip", "border-box");
 test_computed_value("background-clip", "padding-box");
 test_computed_value("background-clip", "content-box");
 test_computed_value("background-clip", "border-area");
+test_computed_value("background-clip", "border-box, padding-box, content-box, border-area");
+
 test_computed_value("background-clip", "text");
 test_computed_value("background-clip", "border-area text");
 test_computed_value("background-clip", "text border-area", "border-area text");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-clip", "border-box, padding-box, content-box, border-area", "border-box");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-clip", "border-box", "border-box", "multiple base values");
+test_computed_value("background-clip", "border-box, padding-box", "border-box, padding-box", "multiple base values");
+test_computed_value("background-clip", "border-box, padding-box, content-box", "border-box, padding-box, content-box", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-computed.html
+++ b/css/css-backgrounds/parsing/background-computed.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Backgrounds and Borders: getComputedStyle().background with multiple layers</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background">
-<meta name="assert" content="The number of layers is determined by the number of comma-separated values in the background-image property. .">
+<meta name="assert" content="The number of computed value layers for a property is not influenced by the background-image property.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
@@ -18,53 +18,52 @@
 <body>
 <div id="target"></div>
 <script>
-test_computed_value("background-attachment", "local", "local, local, local");
-test_computed_value("background-attachment", "scroll, fixed", "scroll, fixed, scroll");
+test_computed_value("background-attachment", "local", "local");
+test_computed_value("background-attachment", "scroll, fixed");
 test_computed_value("background-attachment", "local, fixed, scroll");
-test_computed_value("background-attachment", "local, fixed, scroll, fixed", "local, fixed, scroll");
+test_computed_value("background-attachment", "local, fixed, scroll, fixed");
 
-test_computed_value("background-clip", "border-box", "border-box, border-box, border-box");
-test_computed_value("background-clip", "content-box, border-box", "content-box, border-box, content-box");
+test_computed_value("background-clip", "border-box");
+test_computed_value("background-clip", "content-box, border-box");
 test_computed_value("background-clip", "border-box, padding-box, content-box");
-test_computed_value("background-clip", "content-box, border-box, padding-box, content-box", "content-box, border-box, padding-box");
-test_computed_value("background-clip", "content-box, border-box, padding-box", "content-box, border-box, padding-box");
-test_computed_value("background-clip", "content-box, border-box, border-area", "content-box, border-box, border-area");
-test_computed_value("background-clip", "border-area text", "border-area text, border-area text, border-area text");
-test_computed_value("background-clip", "border-area text, content-box", "border-area text, content-box, border-area text");
+test_computed_value("background-clip", "content-box, border-box, padding-box, content-box");
+test_computed_value("background-clip", "content-box, border-box, padding-box");
+test_computed_value("background-clip", "content-box, border-box, border-area");
+test_computed_value("background-clip", "border-area text");
+test_computed_value("background-clip", "border-area text, content-box");
 
 // background-color always computes as a single color.
 test_computed_value("background-color", "rgb(255, 0, 0)");
 
-test_computed_value("background-origin", "border-box", "border-box, border-box, border-box");
-test_computed_value("background-origin", "content-box, border-box", "content-box, border-box, content-box");
+test_computed_value("background-origin", "border-box");
+test_computed_value("background-origin", "content-box, border-box");
 test_computed_value("background-origin", "border-box, padding-box, content-box");
-test_computed_value("background-origin", "content-box, border-box, padding-box, content-box", "content-box, border-box, padding-box");
+test_computed_value("background-origin", "content-box, border-box, padding-box, content-box");
 
-test_computed_value("background-position", "50% 6px", "50% 6px, 50% 6px, 50% 6px");
-test_computed_value("background-position", "12px 13px, 50% 6px", "12px 13px, 50% 6px, 12px 13px");
+test_computed_value("background-position", "50% 6px");
+test_computed_value("background-position", "12px 13px, 50% 6px");
 test_computed_value("background-position", "12px 13px, 50% 6px, 30px -10px");
-test_computed_value("background-position", "12px 13px, 50% 6px, 30px -10px, -7px 8px", "12px 13px, 50% 6px, 30px -10px");
+test_computed_value("background-position", "12px 13px, 50% 6px, 30px -10px, -7px 8px");
 
-test_computed_value("background-position-x", "0.5em", "20px, 20px, 20px");
-test_computed_value("background-position-x", "-20%, 10px", "-20%, 10px, -20%");
-
+test_computed_value("background-position-x", "0.5em", "20px");
+test_computed_value("background-position-x", "-20%, 10px");
 test_computed_value("background-position-x", "center, left, right", "50%, 0%, 100%");
-test_computed_value("background-position-x", "calc(10px - 0.5em), -20%, right, 15%", "-10px, -20%, 100%");
+test_computed_value("background-position-x", "calc(10px - 0.5em), -20%, right, 15%", "-10px, -20%, 100%, 15%");
 
-test_computed_value("background-position-y", "0.5em", "20px, 20px, 20px");
-test_computed_value("background-position-y", "-20%, 10px", "-20%, 10px, -20%");
+test_computed_value("background-position-y", "0.5em", "20px");
+test_computed_value("background-position-y", "-20%, 10px", "-20%, 10px");
 test_computed_value("background-position-y", "center, top, bottom", "50%, 0%, 100%");
-test_computed_value("background-position-y", "calc(10px - 0.5em), -20%, bottom, 15%", "-10px, -20%, 100%");
+test_computed_value("background-position-y", "calc(10px - 0.5em), -20%, bottom, 15%", "-10px, -20%, 100%, 15%");
 
-test_computed_value("background-repeat", "round", "round, round, round");
-test_computed_value("background-repeat", "repeat-x, repeat", "repeat-x, repeat, repeat-x");
+test_computed_value("background-repeat", "round");
+test_computed_value("background-repeat", "repeat-x, repeat");
 test_computed_value("background-repeat", "repeat space, round no-repeat, repeat-x");
-test_computed_value("background-repeat", "repeat-y, round no-repeat, repeat-x, repeat", "repeat-y, round no-repeat, repeat-x");
+test_computed_value("background-repeat", "repeat-y, round no-repeat, repeat-x, repeat");
 
-test_computed_value("background-size", "contain", "contain, contain, contain");
-test_computed_value("background-size", "auto 1px, 2% 3%", "auto 1px, 2% 3%, auto 1px");
+test_computed_value("background-size", "contain");
+test_computed_value("background-size", "auto 1px, 2% 3%");
 test_computed_value("background-size", "auto 1px, 2% 3%, contain");
-test_computed_value("background-size", "auto 1px, 2% 3%, contain, 7px 8px", "auto 1px, 2% 3%, contain");
+test_computed_value("background-size", "auto 1px, 2% 3%, contain, 7px 8px");
 
 // Verify background shorthand correctly computes background-clip.
 test(() => {

--- a/css/css-backgrounds/parsing/background-origin-computed.html
+++ b/css/css-backgrounds/parsing/background-origin-computed.html
@@ -15,9 +15,12 @@
 test_computed_value("background-origin", "border-box");
 test_computed_value("background-origin", "padding-box");
 test_computed_value("background-origin", "content-box");
+test_computed_value("background-origin", "border-box, padding-box, content-box");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-origin", "border-box, padding-box, content-box", "border-box");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-origin", "border-box", "border-box", "multiple base values");
+test_computed_value("background-origin", "border-box, padding-box", "border-box, padding-box", "multiple base values");
+test_computed_value("background-origin", "border-box, padding-box, content-box", "border-box, padding-box, content-box", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-position-computed.html
+++ b/css/css-backgrounds/parsing/background-position-computed.html
@@ -45,9 +45,12 @@ test_computed_value("background-position", "top left", "0% 0%");
 test_computed_value("background-position", "bottom right 19%", "81% 100%");
 test_computed_value("background-position", "calc(10px + 0.5em) calc(10px - 0.5em)", "30px -10px");
 test_computed_value("background-position", "calc(10px - 0.5em) calc(10px + 0.5em)", "-10px 30px");
+test_computed_value("background-position", "12px 13px, 50% 6px, 30px -10px", "12px 13px, 50% 6px, 30px -10px");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-position", "12px 13px, 50% 6px, 30px -10px", "12px 13px");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-position", "center", "50% 50%", "multiple base values");
+test_computed_value("background-position", "center, left", "50% 50%, 0% 50%", "multiple base values");
+test_computed_value("background-position", "center, left, bottom", "50% 50%, 0% 50%, 50% 100%", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-position-x-computed.html
+++ b/css/css-backgrounds/parsing/background-position-x-computed.html
@@ -27,13 +27,16 @@ test_computed_value("background-position-x", "0.5em", "20px");
 test_computed_value("background-position-x", "calc(10px - 0.5em)", "-10px");
 test_computed_value("background-position-x", "left -20%", "-20%");
 test_computed_value("background-position-x", "right -10px", "calc(100% + 10px)");
-test_computed_value("background-position-x", "-20%, 10px", "-20%");
-test_computed_value("background-position-x", "center, left, right", "50%");
-test_computed_value("background-position-x", "0.5em, x-start, x-end", "20px");
+test_computed_value("background-position-x", "-20%, 10px", "-20%, 10px");
+test_computed_value("background-position-x", "center, left, right", "50%, 0%, 100%");
+test_computed_value("background-position-x", "0.5em, x-start, x-end", "20px, 0%, 100%");
+test_computed_value("background-position-x", "calc(10px - 0.5em), -20%, 10px", "-10px, -20%, 10px");
+test_computed_value("background-position-x", "calc(10px - 0.5em), left -20%, right 10px", "-10px, -20%, calc(100% - 10px)");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-position-x", "calc(10px - 0.5em), -20%, 10px", "-10px");
-test_computed_value("background-position-x", "calc(10px - 0.5em), left -20%, right 10px", "-10px");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-position-x", "center", "50%", "multiple base values");
+test_computed_value("background-position-x", "center, left", "50%, 0%", "multiple base values");
+test_computed_value("background-position-x", "center, left, right", "50%, 0%, 100%", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-position-y-computed.html
+++ b/css/css-backgrounds/parsing/background-position-y-computed.html
@@ -27,13 +27,16 @@ test_computed_value("background-position-y", "0.5em", "20px");
 test_computed_value("background-position-y", "calc(10px - 0.5em)", "-10px");
 test_computed_value("background-position-y", "top -20%", "-20%");
 test_computed_value("background-position-y", "bottom -10px", "calc(100% + 10px)");
-test_computed_value("background-position-y", "-20%, 10px", "-20%");
-test_computed_value("background-position-y", "center, top, bottom", "50%");
-test_computed_value("background-position-y", "0.5em, y-start, y-end", "20px");
+test_computed_value("background-position-y", "-20%, 10px");
+test_computed_value("background-position-y", "center, top, bottom", "50%, 0%, 100%");
+test_computed_value("background-position-y", "0.5em, y-start, y-end", "20px, 0%, 100%");
+test_computed_value("background-position-y", "calc(10px - 0.5em), -20%, 10px", "-10px, -20%, 10px");
+test_computed_value("background-position-y", "calc(10px - 0.5em), top -20%, bottom 10px", "-10px, -20%, calc(100% - 10px)");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-position-y", "calc(10px - 0.5em), -20%, 10px", "-10px");
-test_computed_value("background-position-y", "calc(10px - 0.5em), top -20%, bottom 10px", "-10px");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-position-y", "center", "50%", "multiple base values");
+test_computed_value("background-position-y", "center, top", "50%, 0%", "multiple base values");
+test_computed_value("background-position-y", "center, top, bottom", "50%, 0%, 100%", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-repeat-computed.html
+++ b/css/css-backgrounds/parsing/background-repeat-computed.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Backgrounds and Borders: getComputedStyle().backgroundRepeat</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background-repeat">
-<meta name="assert" content="background-attachment repeat value is as specified.">
+<meta name="assert" content="background-repeat value is as specified.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
@@ -18,13 +18,15 @@ test_computed_value("background-repeat", "repeat");
 test_computed_value("background-repeat", "space");
 test_computed_value("background-repeat", "round");
 test_computed_value("background-repeat", "no-repeat");
-
 test_computed_value("background-repeat", "repeat space");
 test_computed_value("background-repeat", "round no-repeat");
 test_computed_value("background-repeat", "repeat repeat", "repeat");
+test_computed_value("background-repeat", "repeat-x, repeat-y, repeat");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-repeat", "repeat-x, repeat-y, repeat", "repeat-x");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-repeat", "repeat-x", "repeat-x", "multiple base values");
+test_computed_value("background-repeat", "repeat-x, repeat-y", "repeat-x, repeat-y", "multiple base values");
+test_computed_value("background-repeat", "repeat-x, repeat-y, repeat", "repeat-x, repeat-y, repeat", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-size-computed.html
+++ b/css/css-backgrounds/parsing/background-size-computed.html
@@ -27,9 +27,14 @@ test_computed_value("background-size", "contain");
 test_computed_value("background-size", "cover");
 test_computed_value("background-size", "calc(10px + 0.5em) calc(10px - 0.5em)", "30px 0px");
 test_computed_value("background-size", "calc(10px - 0.5em) calc(10px + 0.5em)", "0px 30px");
+test_computed_value("background-size", "auto 1px, 2% 3%, contain");
 
-// See background-computed.html for a test with multiple background images.
-test_computed_value("background-size", "auto 1px, 2% 3%, contain", "auto 1px");
+document.getElementById("target").style['background-image'] = "none, none";
+test_computed_value("background-size", "auto", "auto", "multiple base values");
+test_computed_value("background-size", "auto, auto", "auto, auto", "multiple base values");
+test_computed_value("background-size", "auto, auto, auto", "auto, auto, auto", "multiple base values");
+test_computed_value("background-size", "auto, 100%", "auto, 100% auto", "multiple base values");
+test_computed_value("background-size", "100%", "100% auto", "multiple base values");
 </script>
 </body>
 </html>

--- a/css/css-masking/parsing/mask-size-computed.html
+++ b/css/css-masking/parsing/mask-size-computed.html
@@ -28,12 +28,14 @@ test_computed_value("mask-size", "contain");
 test_computed_value("mask-size", "cover");
 test_computed_value("mask-size", "calc(10px + 0.5em) calc(10px - 0.5em)", "30px 0px");
 test_computed_value("mask-size", "calc(10px - 0.5em) calc(10px + 0.5em)", "0px 30px");
-test_computed_value("mask-size", "auto 1px, 2% 3%, contain", "auto 1px");
+test_computed_value("mask-size", "auto 1px, 2% 3%, contain");
 
 document.getElementById("target").style['mask-image'] = "none, none";
-test_computed_value("mask-size", "auto", "auto, auto", "multiple values");
-test_computed_value("mask-size", "auto, 100%", "auto, 100% auto", "multiple values");
-test_computed_value("mask-size", "100%", "100% auto, 100% auto", "multiple values");
+test_computed_value("mask-size", "auto", "auto", "multiple base values");
+test_computed_value("mask-size", "auto, auto", "auto, auto", "multiple base values");
+test_computed_value("mask-size", "auto, auto, auto", "auto, auto, auto", "multiple base values");
+test_computed_value("mask-size", "auto, 100%", "auto, 100% auto", "multiple base values");
+test_computed_value("mask-size", "100%", "100% auto", "multiple base values");
 </script>
 </body>
 </html>


### PR DESCRIPTION
Exports WebKit changes from https://commits.webkit.org/314242@main.

As resolved in CSSWG https://github.com/w3c/csswg-drafts/issues/12791. 