### PR TITLE
`window.stop()` should be able to cancel intercepted hash navigations

### DIFF
--- a/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit.html
+++ b/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit.html
@@ -22,20 +22,22 @@ promise_test(async t => {
     e.intercept({ precommitHandler: () => new Promise(r => t.step_timeout(r, 10)) });
   });
 
-  navigation.onnavigateerror = t.unreached_func("navigateerror must not fire");
+  let navigateerror_called = false;
+  navigation.onnavigateerror = t.step_func(() => {
+    navigateerror_called = true;
+    assert_equals(location.hash, "#2");
+  })
   let navigatesuccess_called = false;
   navigation.onnavigatesuccess = t.step_func(() => {
     navigatesuccess_called = true;
     assert_equals(location.hash, "#1");
   });
 
-  // window.stop() does not abort traversals, since "stop loading" only clears
-  // the ongoing navigation when it is a navigation ID, not "traversal".
-  await assertBothFulfillEntryNotAvailable(t, navigation.back());
+  await assertBothRejectDOM(t, navigation.back(), "AbortError");
 
-  assert_equals(navigation.currentEntry.index, start_index + 1);
-  assert_equals(location.hash, "#1");
-  assert_true(navigatesuccess_called);
+  assert_equals(navigation.currentEntry.index, start_index + 2);
+  assert_equals(location.hash, "#2");
+  assert_true(navigateerror_called);
 }, "precommitHandler traversal is not aborted by window.stop() before commit");
 </script>
 </body>

--- a/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit.html
+++ b/navigation-api/precommit-handler/precommitHandler-window-stop-before-commit.html
@@ -38,20 +38,19 @@ promise_test(async t => {
   };
 
   navigation.onnavigateerror = t.unreached_func("onnavigateerror must not fire");
-  let navigatesuccess_called = false;
-  navigation.onnavigatesuccess = t.step_func(() => {
-    navigatesuccess_called = true;
-    assert_equals(location.hash, "#ShouldCommit");
+  navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess must not fire");
+  navigation.onnavigateerror = t.step_func(() => {
+    navigateerror_called = true;
   });
 
   let promises = navigation.navigate("#ShouldCommit");
   assert_equals(location.hash, "");
 
   window.stop();
-  await assertBothFulfillEntryNotAvailable(t, promises);
+  await assertBothRejectDOM(t, promises, "AbortError");
 
-  assert_equals(location.hash, "#ShouldCommit");
-  assert_true(navigatesuccess_called);
+  assert_equals(location.hash, "");
+  assert_true(navigateerror_called);
 }, " precommitHandler with window.stop() before fragment navigation commit");
 </script>
 </body>


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/12519