### PR TITLE
Add reftest for base-select rendering order

### DIFF
--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering-ref.html
@@ -6,7 +6,6 @@
   rel="help"
   href="https://drafts.csswg.org/css-ui-4/#valdef-appearance-base-select"
 />
-<link rel="match" href="select-appearance-base-ordering-ref.html" />
 
 <style>
   .select {

--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering-ref.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>CSS pseudo element ordering with appearance: base-select</title>
+<link rel="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link
+  rel="help"
+  href="https://drafts.csswg.org/css-ui-4/#valdef-appearance-base-select"
+/>
+<link rel="match" href="select-appearance-base-ordering-ref.html" />
+
+<style>
+  .select {
+    width: 100%;
+    display: flex;
+    border-radius: 0;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid orange;
+    padding: 0;
+    margin: 0;
+    gap: 1rem;
+    align-items: center;
+  }
+  .before {
+    border: 1px solid lime;
+  }
+  .after {
+    border: 1px solid hotpink;
+  }
+  button {
+    appearance: none;
+    font: inherit;
+    display: contents;
+    border: 100px solid red;
+  }
+  .option {
+    display: flex;
+    padding: 0;
+    margin: 0;
+    gap: 1rem;
+    align-items: center;
+  }
+  .checkmark {
+    display: inline-block;
+    border: 1px solid navy;
+    height: 30px;
+  }
+  .picker {
+    position: static;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    border: 1px solid teal;
+  }
+  .picker-icon {
+    border: 1px solid rebeccapurple;
+    margin: 0;
+  }
+</style>
+<div class="select">
+  <div class="before">Before</div>
+  <button>Button</button>
+  <div class="picker">
+    <div class="option">
+      <div class="checkmark">Checkmark</div>
+      <span>Option</span>
+    </div>
+  </div>
+  <div class="after">After</div>
+  <div class="picker-icon">PickerIcon</div>
+</div>

--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>CSS pseudo element ordering with appearance: base-select</title>
+<link rel="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link
+  rel="help"
+  href="https://drafts.csswg.org/css-ui-4/#valdef-appearance-base-select"
+/>
+<link rel="match" href="select-appearance-base-ordering-ref.html" />
+
+<style>
+  select {
+    width: 100%;
+    display: flex;
+    border-radius: 0;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid orange;
+    padding: 0;
+    margin: 0;
+    gap: 1rem;
+    align-items: center;
+  }
+  .base {
+    appearance: base-select;
+    appearance: base;
+  }
+  select::before {
+    content: "Before";
+    border: 1px solid lime;
+  }
+  select::after {
+    content: "After";
+    border: 1px solid hotpink;
+  }
+  button {
+    border: 100px solid red;
+  }
+  option {
+    display: flex;
+    padding: 0;
+    margin: 0;
+    gap: 1rem;
+    align-items: center;
+  }
+  ::checkmark {
+    content: 'Checkmark';
+    border: 1px solid navy;
+    height: 30px;
+  }
+  ::picker(select) {
+    position: static;
+    appearance: base-select;
+    appearance: base;
+    display: inline-block;
+    border: 1px solid teal;
+  }
+  ::picker {
+    position: static;
+    appearance: base-select;
+    appearance: base;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    border: 1px solid teal;
+  }
+  ::picker-icon {
+    content: "PickerIcon";
+    border: 1px solid rebeccapurple;
+    margin: 0;
+  }
+</style>
+<select class="base">
+  <button>Button</button>
+  <option>Option</option>
+</select>

--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-ordering.html
@@ -6,7 +6,7 @@
   rel="help"
   href="https://drafts.csswg.org/css-ui-4/#valdef-appearance-base-select"
 />
-<link rel="match" href="select-appearance-base-ordering-ref.html" />
+<link rel="match" href="select-base-appearance-ordering-ref.html" />
 
 <style>
   select {
@@ -45,7 +45,7 @@
     align-items: center;
   }
   ::checkmark {
-    content: 'Checkmark';
+    content: "Checkmark";
     border: 1px solid navy;
     height: 30px;
   }

--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-writing-modes-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-writing-modes-ref.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+
+<style>
+  body {
+    font-family: monospace;
+    font-size: 16px;
+  }
+  .button {
+    box-sizing: border-box;
+    background-color: transparent;
+    padding-block: 0.25em;
+    padding-inline: 0.5em;
+    border: 1px solid currentColor;
+    border-radius: 0.5em;
+    display: inline-flex;
+    gap: 0.5em;
+    min-inline-size: 24px;
+    min-block-size: max(24px, 1lh);
+    counter-set: fake-counter-name 1;
+  }
+  .button::after {
+    content: counter(fake-counter-name, disclosure-open);
+    display: block;
+    margin-inline-start: auto;
+  }
+  .vertical-rl {
+    writing-mode: vertical-rl;
+  }
+  .vertical-lr {
+    writing-mode: vertical-lr;
+  }
+  .rtl {
+    direction: rtl;
+  }
+</style>
+
+<p class="vertical-rl">
+  <span class="button">One</span>
+</p>
+
+<p class="vertical-lr">
+  <span class="button">One</span>
+</p>
+
+<p class="rtl">
+  <span class="button">One</span>
+</p>

--- a/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-writing-modes.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-writing-modes.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/#the-select-element-2:base-appearance-15"
+/>
+<link rel="match" href="select-base-appearance-writing-modes-ref.html" />
+
+<style>
+  body {
+    font-family: monospace;
+    font-size: 16px;
+  }
+  select,
+  select::picker(select) {
+    appearance: base-select;
+  }
+  select:focus-visible {
+    outline: none;
+  }
+  .vertical-rl {
+    writing-mode: vertical-rl;
+  }
+  .vertical-lr {
+    writing-mode: vertical-lr;
+  }
+  .rtl {
+    direction: rtl;
+  }
+</style>
+
+<p class="vertical-rl">
+  <select>
+    <option>One</option>
+    <option>Two</option>
+  </select>
+</p>
+
+<p class="vertical-lr">
+  <select>
+    <option>One</option>
+    <option>Two</option>
+  </select>
+</p>
+
+<p class="rtl">
+  <select>
+    <option>One</option>
+    <option>Two</option>
+  </select>
+</p>

--- a/html/semantics/forms/the-select-element/customizable-select/select-picker-icon-content-none-ref.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-picker-icon-content-none-ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+
+<style>
+  body {
+    font-family: monospace;
+    font-size: 16px;
+  }
+  .select {
+    box-sizing: border-box;
+    background-color: transparent;
+    padding-block: 0.25em;
+    padding-inline: 0.5em;
+    border: 1px solid currentColor;
+    border-radius: 0.5em;
+    display: inline-flex;
+    min-inline-size: 24px;
+    min-block-size: max(24px, 1lh);
+    gap: 0.5rem;
+  }
+</style>
+
+<span class="select">One</span>
+<span class="select">One<span></span></span>

--- a/html/semantics/forms/the-select-element/customizable-select/select-picker-icon-content-none.html
+++ b/html/semantics/forms/the-select-element/customizable-select/select-picker-icon-content-none.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://drafts.csswg.org/css-forms/#picker-icon" />
+<link rel="match" href="select-picker-icon-content-none-ref.html" />
+<meta
+  name="assert"
+  content="::picker-icon with content:none removes the icon"
+/>
+
+<style>
+  body {
+    font-family: monospace;
+    font-size: 16px;
+  }
+  select {
+    appearance: base-select;
+  }
+  select::picker-icon {
+    content: none;
+  }
+  select.one {
+    gap: 0; /* TODO: Chrome is inconsistent with gap and content:none */
+  }
+  select.two::picker-icon {
+    content: "";
+  }
+</style>
+
+<select class="one">
+  <option>One</option>
+</select>
+
+<select class="two">
+  <option>One</option>
+</select>


### PR DESCRIPTION
This PR introduces two tests:

Ordering confirms the rendering order of all elements & pseudo elements:

- `::before`
- `button`
- `::picker`
  - `::checkmark`
  - `option`
- `::after`
- `::picker-icon`

Writing mode asserts that the writing modes should render correctly, which relies on the `disclosure-open` list type adhering to writing modes.