### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=316382

### DIFF
--- a/dom/nodes/MutationObserver-sanity.html
+++ b/dom/nodes/MutationObserver-sanity.html
@@ -92,4 +92,29 @@
       m.disconnect();
   }, "Should not throw if characterDataOldValue is true and characterData is true");
 
+  test(() => {
+      var m = new MutationObserver(() => {});
+      m.observe(document, { attributeOldValue: false });
+      m.disconnect();
+  }, "Should not throw if attributeOldValue is false and attributes is omitted");
+
+  test(() => {
+      var m = new MutationObserver(() => {});
+      m.observe(document, { characterDataOldValue: false });
+      m.disconnect();
+  }, "Should not throw if characterDataOldValue is false and characterData is omitted");
+
+  async_test(t => {
+      var target = document.createElement("div");
+      var m = new MutationObserver(t.step_func_done(records => {
+          assert_equals(records.length, 1);
+          assert_equals(records[0].type, "attributes");
+          assert_equals(records[0].attributeName, "data-x");
+          assert_equals(records[0].oldValue, null);
+          m.disconnect();
+      }));
+      m.observe(target, { attributeOldValue: false });
+      target.setAttribute("data-x", "1");
+  }, "attributeOldValue:false (present) auto-enables attribute observation");
+
 </script>


### PR DESCRIPTION
WebKit export from bug: [MutationObserver.observe() incorrectly throws when attributeOldValue or characterDataOldValue is present with value false](https://bugs.webkit.org/show_bug.cgi?id=316382)