### PR TITLE
[lint] Add a distinct exit code for uncaught exceptions

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import traceback
 from collections import defaultdict
 from typing import (Any, Callable, Dict, IO, Iterable, List, Optional, Sequence, Set, Text, Tuple,
                     Type, TypeVar)
@@ -1146,8 +1147,17 @@ def all_paths_lints() -> Any:
     return paths
 
 
-if __name__ == "__main__":
-    args = create_parser().parse_args()
-    error_count = main(**vars(args))
+def _run_main(argv: List[Text]) -> None:
+    try:
+        error_count = main(**vars(create_parser().parse_args(argv)))
+    except SystemExit:
+        raise
+    except Exception:
+        traceback.print_exc()
+        sys.exit(3)
     if error_count > 0:
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    _run_main(sys.argv[1:])

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -5,6 +5,8 @@ import os
 import sys
 from unittest import mock
 
+import pytest
+
 from ...localpaths import repo_root
 from .. import lint as lint_mod
 from ..lint import filter_ignorelist_errors, parse_ignorelist, lint, create_parser
@@ -438,3 +440,33 @@ def test_main_all():
                 m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None, None, 0)
     finally:
         sys.argv = orig_argv
+
+
+
+def test_run_main_no_errors_returns():
+    with mock.patch.object(lint_mod, 'main', return_value=0):
+        lint_mod._run_main(['--all'])  # should not raise
+
+
+def test_run_main_errors_exits_1():
+    with mock.patch.object(lint_mod, 'main', return_value=5):
+        with pytest.raises(SystemExit) as exc_info:
+            lint_mod._run_main(['--all'])
+    assert exc_info.value.code == 1
+
+
+def test_run_main_argument_error_exits_2():
+    with pytest.raises(SystemExit) as exc_info:
+        lint_mod._run_main(['--json', '--markdown'])
+    assert exc_info.value.code == 2
+
+
+def test_run_main_exception_exits_3(capsys):
+    with mock.patch.object(lint_mod, 'main', side_effect=RuntimeError('simulated crash')):
+        with pytest.raises(SystemExit) as exc_info:
+            lint_mod._run_main(['--all'])
+    assert exc_info.value.code == 3
+
+    captured = capsys.readouterr()
+    assert 'Traceback (most recent call last):' in captured.err
+    assert 'RuntimeError: simulated crash' in captured.err


### PR DESCRIPTION
CPython exits with 1 when there's an uncaught exception; this is
ambiguous with us exiting with 1 when there's lint errors. When
processing the output (e.g., as JSON) it would be good to know if we
just have lint errors or if the linter failed to run to completion.
