### PR TITLE
[css-grid] WebKit export of https://bugs.webkit.org/show_bug.cgi?id=227283

### DIFF
--- a/css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001.html
+++ b/css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; width: fit-content; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001.html
+++ b/css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; float: left; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001.html
+++ b/css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: inline-grid; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001.html
+++ b/css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; width: max-content; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001.html
+++ b/css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; width: min-content; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
[CSS Grid] Resolve grid item percent block-size against definite row tracks during column intrinsic sizing

Tests: grid-fit-content-width, grid-float-intrinsic-width, grid-inline-grid-intrinsic-width, grid-max-content-width, grid-min-content-width with percent-height aspect-ratio items.

WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=227283