### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=315254

### DIFF
--- a/css/css-flexbox/flex-aspect-ratio-cross-size-002-ref.html
+++ b/css/css-flexbox/flex-aspect-ratio-cross-size-002-ref.html
@@ -1,0 +1,10 @@
+<title>Reference</title>
+<style>
+.container {
+  width: 200px;
+  height: 50px;
+  background: green;
+}
+</style>
+<p>Test passes if the green strip below is 200x50 and not taller.</p>
+<div class="container"></div>

--- a/css/css-flexbox/flex-aspect-ratio-cross-size-002.html
+++ b/css/css-flexbox/flex-aspect-ratio-cross-size-002.html
@@ -1,0 +1,32 @@
+<title>Nested flex containers with aspect-ratio do not inflate container height through content min-size feedback</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#definite-sizes">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">
+<link rel="match" href="flex-aspect-ratio-cross-size-002-ref.html">
+<style>
+.container {
+  width: 200px;
+  background: green;
+}
+.outer {
+  display: flex;
+  aspect-ratio: 4;
+}
+.inner {
+  display: flex;
+  aspect-ratio: 1;
+}
+.box {
+  height: 100%;
+  aspect-ratio: 2;
+}
+</style>
+<p>Test passes if the green strip below is 200x50 and not taller.</p>
+<div class="container">
+  <div class="outer">
+    <div class="inner">
+      <div>
+        <div class="box"></div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[Flex\] Stretch-fit width with aspect-ratio should not provide definite cross size to flex items](https://bugs.webkit.org/show_bug.cgi?id=315254)