### PR TITLE
[css-flexbox] WebKit export of https://bugs.webkit.org/show_bug.cgi?id=313354

### DIFF
--- a/css/css-flexbox/flex-baseline-overflow-hidden.html
+++ b/css/css-flexbox/flex-baseline-overflow-hidden.html
@@ -81,6 +81,14 @@ test(function() {
 
 test(function() {
   assert_equals(
+    document.getElementById('test-hidden').offsetHeight,
+    42,
+    "container height should be inline-flex height plus strut descent"
+  );
+}, "inline-flex with overflow:hidden does not inflate line box from overflowing content");
+
+test(function() {
+  assert_equals(
     document.getElementById('test-scroll').offsetHeight,
     document.getElementById('ref-hidden').offsetHeight,
     "should match inline-block with overflow:hidden"


### PR DESCRIPTION
Flex container baseline should be clamped to border edge for scroll containers

Adds a test verifying that inline-flex with overflow:hidden does not inflate the line box from overflowing content.

WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=313354