### PR TITLE
Use the correct pseudo-classes

### DIFF
--- a/html/semantics/selectors/pseudo-classes/readwrite-readonly-type-change.html
+++ b/html/semantics/selectors/pseudo-classes/readwrite-readonly-type-change.html
@@ -10,10 +10,10 @@
     color: red;
     background-color: pink;
   }
-  :required + span {
+  :read-write + span {
     color: green;
   }
-  :not(:optional) + span {
+  :not(:read-only) + span {
     background-color: lime;
   }
 </style>
@@ -22,15 +22,15 @@
 <script>
   test(() => {
     assert_equals(getComputedStyle(sibling).color, "rgb(255, 0, 0)",
-      "Not matching :required for type=hidden");
+      "Not matching :read-write for type=hidden");
     assert_equals(getComputedStyle(sibling).backgroundColor, "rgb(255, 192, 203)",
-      "Matching :optional for type=hidden");
+      "Matching :read-only for type=hidden");
 
     hiddenInput.type = "text";
 
     assert_equals(getComputedStyle(sibling).color, "rgb(0, 128, 0)",
-      "Matching :required for type=text");
+      "Matching :read-write for type=text");
     assert_equals(getComputedStyle(sibling).backgroundColor, "rgb(0, 255, 0)",
-      "Matching :not(:optional) for type=text");
-  }, "Evaluation of :required and :optional changes for input type change.");
+      "Matching :not(:read-only) for type=text");
+  }, "Evaluation of :read-write and :read-only changes for input type change.");
 </script>


### PR DESCRIPTION
The test title is: 

"Selector: pseudo-classes (**`:read-write`, `:read-only`**) input type change" 

but `:optional` and `:required` are used to select test elements. It is probably a copy of https://github.com/web-platform-tests/wpt/blob/master/html/semantics/selectors/pseudo-classes/required-optional-hidden.html.