### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=316483

### DIFF
--- a/css/css-color/parsing/color-computed-color-mix-function.html
+++ b/css/css-color/parsing/color-computed-color-mix-function.html
@@ -114,8 +114,8 @@
     fuzzy_test_computed_color(`color-mix(in hsl, hsl(30deg 40% 80% / 25%) 0%, hsl(none none none / 0.5))`, `color(srgb 0.88 0.8 0.72 / 0.5)`);
     fuzzy_test_computed_color(`color-mix(in hsl, hsl(30deg 40% 80% / 25%) 0%, hsl(90deg none none / 0.5))`, `color(srgb 0.8 0.88 0.72 / 0.5)`);
 
-    fuzzy_test_computed_color(`color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%) 0%)`, `color(srgb 0 0 0 / 0)`);
-    fuzzy_test_computed_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8) 0%)`, `color(srgb 0 0 0 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%) 0%)`, `color(srgb 0.33 0.36 0.24 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8) 0%)`, `color(srgb 0.372222 0.411111 0.255556 / 0)`);
 
     // hwb()
     fuzzy_test_computed_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color(srgb 0.575 0.7 0.2)`);
@@ -210,8 +210,8 @@
     fuzzy_test_computed_color(`color-mix(in hwb, hwb(30deg 30% 40% / 25%) 0%, hwb(none none none / 0.5))`, `color(srgb 0.6 0.45 0.3 / 0.5)`);
     fuzzy_test_computed_color(`color-mix(in hwb, hwb(30deg 30% 40% / 25%) 0%, hwb(90deg none none / 0.5))`, `color(srgb 0.45 0.6 0.3 / 0.5)`);
 
-    fuzzy_test_computed_color(`color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%) 0%)`, `color(srgb 0 0 0 / 0)`);
-    fuzzy_test_computed_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8) 0%)`, `color(srgb 0 0 0 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%) 0%)`, `color(srgb 0.575 0.7 0.2 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8) 0%)`, `color(srgb 0.558333 0.666667 0.233333 / 0)`);
 
     // lch()
     fuzzy_test_computed_color(`color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg))`, `lch(30 40 50)`);
@@ -308,8 +308,9 @@
     // Achromatic colors should have powerless hues. https://www.w3.org/TR/css-color-4/#lab-to-lch
     fuzzy_test_computed_color(`color-mix(in lch, lab(50 0 0), black)`, `lch(25 0 none)`);
 
-    fuzzy_test_computed_color(`color-mix(in lch, lch(10% 20 30deg) 0%, lch(50% 60 70deg) 0%)`, `lch(0 0 none / 0)`);
-    fuzzy_test_computed_color(`color-mix(in lch, lch(10% 20 30deg / .4) 0%, lch(50% 60 70deg / .8) 0%)`, `lch(0 0 none / 0)`);
+    fuzzy_test_computed_color(`color-mix(in lch, lch(10% 20 30deg) 0%, lch(50% 60 70deg) 0%)`, `lch(30 40 50 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in lch, lch(10% 20 30deg / .4) 0%, lch(50% 60 70deg / .8) 0%)`, `lch(36.666664 46.666664 50 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in lch, lch(none 20 30deg) 0%, lch(none 60 70deg) 0%)`, `lch(none 40 50 / 0)`);
 
     // oklch()
     fuzzy_test_computed_color(`color-mix(in oklch, oklch(0.1 0.2 30deg), oklch(0.5 0.6 70deg))`, `oklch(0.3 0.4 50)`);
@@ -406,8 +407,9 @@
     // Achromatic colors should have powerless hues. https://www.w3.org/TR/css-color-4/#lab-to-lch
     fuzzy_test_computed_color(`color-mix(in oklch, oklab(0.5 0 0), black)`, `oklch(0.25 0 none)`);
 
-    fuzzy_test_computed_color(`color-mix(in oklch, oklch(10% 20 30deg) 0%, oklch(50% 60 70deg) 0%)`, `oklch(0 0 none / 0)`);
-    fuzzy_test_computed_color(`color-mix(in oklch, oklch(10% 20 30deg / .4) 0%, oklch(50% 60 70deg / .8) 0%)`, `oklch(0 0 none / 0)`);
+    fuzzy_test_computed_color(`color-mix(in oklch, oklch(10% 20 30deg) 0%, oklch(50% 60 70deg) 0%)`, `oklch(0.3 40 50 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in oklch, oklch(10% 20 30deg / .4) 0%, oklch(50% 60 70deg / .8) 0%)`, `oklch(0.366667 46.666664 50 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in oklch, oklch(none 20 30deg) 0%, oklch(none 60 70deg) 0%)`, `oklch(none 40 50 / 0)`);
 
     // lab()
     fuzzy_test_computed_color(`color-mix(in lab, lab(10 20 30), lab(50 60 70))`, `lab(30 40 50)`);
@@ -455,8 +457,9 @@
     fuzzy_test_computed_color(`color-mix(in lab, lab(10 20 30 / 25%) 0%, lab(none none none / 0.5))`, `lab(10 20 30 / 0.5)`);
     fuzzy_test_computed_color(`color-mix(in lab, lab(10 20 30 / 25%) 0%, lab(50 none none / 0.5))`, `lab(50 20 30 / 0.5)`);
 
-    fuzzy_test_computed_color(`color-mix(in lab, lab(10% 20 30) 0%, lab(50% 60 70) 0%)`, `lab(0 0 0 / 0)`);
-    fuzzy_test_computed_color(`color-mix(in lab, lab(10% 20 30 / .4) 0%, lab(50% 60 70 / .8) 0%)`, `lab(0 0 0 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in lab, lab(10% 20 30) 0%, lab(50% 60 70) 0%)`, `lab(30 40 50 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in lab, lab(10% 20 30 / .4) 0%, lab(50% 60 70 / .8) 0%)`, `lab(36.666664 46.666664 56.666664 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in lab, lab(none 20 30) 0%, lab(none 60 70) 0%)`, `lab(none 40 50 / 0)`);
 
     // oklab()
     // Absence of colorspace means OKLab.
@@ -506,8 +509,9 @@
         fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(0.1 0.2 0.3 / 25%) 0%, oklab(none none none / 0.5))`, `oklab(0.1 0.2 0.3 / 0.5)`);
         fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(0.1 0.2 0.3 / 25%) 0%, oklab(0.5 none none / 0.5))`, `oklab(0.5 0.2 0.3 / 0.5)`);
 
-        fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(10% 20 30) 0%, oklab(50% 60 70) 0%)`, `oklab(0 0 0 / 0)`);
-        fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(10% 20 30 / .4) 0%, oklab(50% 60 70 / .8) 0%)`, `oklab(0 0 0 / 0)`);
+        fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(10% 20 30) 0%, oklab(50% 60 70) 0%)`, `oklab(0.3 40 50 / 0)`);
+        fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(10% 20 30 / .4) 0%, oklab(50% 60 70 / .8) 0%)`, `oklab(0.366667 46.666664 56.666664 / 0)`);
+        fuzzy_test_computed_color(`color-mix(${colorSpace}oklab(none 20 30) 0%, oklab(none 60 70) 0%)`, `oklab(none 40 50 / 0)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "display-p3-linear", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -562,8 +566,9 @@
         fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / 25%) 0%, color(${colorSpace} none none none / 50%))`, `color(${resultColorSpace} 0.1 0.2 0.3 / 0.5)`);
         fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / 25%) 0%, color(${colorSpace} 0.5 none none / 50%))`, `color(${resultColorSpace} 0.5 0.2 0.3 / 0.5)`);
 
-        fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3) 0%, color(${colorSpace} .5 .6 .7) 0%)`, `color(${resultColorSpace} 0 0 0 / 0)`);
-        fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 0%, color(${colorSpace} .5 .6 .7 / .8) 0%)`, `color(${resultColorSpace} 0 0 0 / 0)`);
+        fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3) 0%, color(${colorSpace} .5 .6 .7) 0%)`, `color(${resultColorSpace} 0.3 0.4 0.5 / 0)`);
+        fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 0%, color(${colorSpace} .5 .6 .7 / .8) 0%)`, `color(${resultColorSpace} 0.366667 0.466667 0.566667 / 0)`);
+        fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} none .2 .3) 0%, color(${colorSpace} none .6 .7) 0%)`, `color(${resultColorSpace} none 0.4 0.5 / 0)`);
     }
 
     // Test percent normalization
@@ -573,7 +578,7 @@
     fuzzy_test_computed_color(`color-mix(in srgb, red 40%,       blue 50%)`,          `color(srgb 0.444444 0 0.555556 / 0.9)`); // `color-mix(in srgb, red 40%, blue 50%)`    only one is 50% (p2)
     fuzzy_test_computed_color(`color-mix(in srgb, red 30%,       blue 40%)`,          `color(srgb 0.428571 0 0.571429 / 0.7)`); // `color-mix(in srgb, red 30%, blue 40%)`    sum to less than 100%
     fuzzy_test_computed_color(`color-mix(in srgb, red 75%,       blue 75%)`,          `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red 75%, blue 75%)`    sum to more than 100%
-    fuzzy_test_computed_color(`color-mix(in srgb, red 0%,        blue 0%)`,           `color(srgb 0 0 0 / 0)`);                 // `color-mix(in srgb, red 0%,  blue  0%)`    sum to 0%
+    fuzzy_test_computed_color(`color-mix(in srgb, red 0%,        blue 0%)`,           `color(srgb 0.5 0 0.5 / 0)`);             // `color-mix(in srgb, red 0%,  blue  0%)`    sum to 0%
     fuzzy_test_computed_color(`color-mix(in srgb, red calc(10%), blue 50%)`,          `color(srgb 0.166667 0 0.833333 / 0.6)`); // `color-mix(in srgb, red 10%, blue 50%)`    one is `calc()` (p1)
     fuzzy_test_computed_color(`color-mix(in srgb, red 50%,       blue calc(10%))`,    `color(srgb 0.833333 0 0.166667 / 0.6)`); // `color-mix(in srgb, red 50%, blue 10%))`   one is `calc()` (p2)
     fuzzy_test_computed_color(`color-mix(in srgb, red calc(10%), blue calc(90%))`,    `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red, blue)`            both are `calc()`, sum to 100%
@@ -601,8 +606,10 @@
     fuzzy_test_computed_color(`color-mix(in srgb, red 50%, green 30%, blue 20%)`, `color(srgb 0.5 0.150588 0.2)`);
     fuzzy_test_computed_color(`color-mix(in srgb, red 30%, green 60%, blue 90%)`, `color(srgb 0.166667 0.167320 0.5)`);
     fuzzy_test_computed_color(`color-mix(in srgb, red, green, blue, white)`, `color(srgb 0.5 0.375490 0.5)`);
-    fuzzy_test_computed_color(`color-mix(in srgb, red 0%)`, `color(srgb 0 0 0 / 0)`);
-    fuzzy_test_computed_color(`color-mix(in srgb, red 0%, green 0%, blue 0%)`, `color(srgb 0 0 0 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in srgb, red 0%)`, `color(srgb 1 0 0 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in srgb, red 0%, green 0%, blue 0%)`, `color(srgb 0.25 0.12549 0.5 / 0)`);
+    fuzzy_test_computed_color(`color-mix(in srgb, red 0%, green 0%, blue 100%)`, `color(srgb 0 0 1)`);
+    fuzzy_test_computed_color(`color-mix(in srgb, red 0%, green 0%, blue 50%)`, `color(srgb 0 0 1 / 0.5)`);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Updates css/css-color/parsing/color-computed-color-mix-function.html for:

https://github.com/w3c/csswg-drafts/issues/14013 - [css-color-5] color-mix() algorithm requires division by zero
https://github.com/w3c/csswg-drafts/issues/14014 - [css-color-5] Remove special casing of 100% leftover from the color-mix() calculation algorithm
