### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308752

### DIFF
--- a/content-security-policy/blob/frame-src-blob-matches-blob.sub.html
+++ b/content-security-policy/blob/frame-src-blob-matches-blob.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; frame-src blob:;">
+    <title>frame-src-blob-matches-blob</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS (1/1)"]'></script>
+    <script src='../support/alertAssert.sub.js?alerts=[]'></script>
+</head>
+
+<body>
+    <p>
+        blob: URLs should match if the blob: scheme is explicitly specified in the frame-src directive.
+    </p>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("FAIL");
+        });
+
+        var b = new Blob(['<html><body></body></html>'], {
+            type: 'text/html'
+        });
+        var iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(b);
+        iframe.onload = function() {
+            log("PASS (1/1)");
+        };
+        document.body.appendChild(iframe);
+
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/blob/frame-src-self-does-not-match-blob.sub.html
+++ b/content-security-policy/blob/frame-src-self-does-not-match-blob.sub.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; frame-src 'self';">
+    <title>frame-src-self-does-not-match-blob</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["violated-directive=frame-src"]'></script>
+    <script src='../support/alertAssert.sub.js?alerts=[]'></script>
+</head>
+
+<body>
+    <p>
+        blob: URLs should not match the &apos;self&apos; source in a frame-src directive because blob: is a non-HTTP(S) scheme that must be explicitly listed.
+    </p>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("violated-directive=" + e.violatedDirective);
+        });
+
+        var b = new Blob(['<html><body>FAIL</body></html>'], {
+            type: 'text/html'
+        });
+        var iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(b);
+        document.body.appendChild(iframe);
+
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>


### PR DESCRIPTION
WebKit export from bug: [blob: URLs are allowed in <iframe>s when CSP’s frame-src contains self](https://bugs.webkit.org/show_bug.cgi?id=308752)