### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=314008

### DIFF
--- a/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_module.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_module.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Non parser-inserted external module scripts should run with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Non parser-inserted external module scripts should run with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            assert_unreached('No CSP violation report has fired.');
+        });
+
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild-module') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.type = 'module';
+            e.src = 'simpleSourcedModule.js?appendChild-module';
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Module script injected via `appendChild` is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild-module-incorrectNonce') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.type = 'module';
+            e.src = 'simpleSourcedModule.js?appendChild-module-incorrectNonce';
+            e.setAttribute('nonce', 'wrong');
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Module script injected via `appendChild` is allowed with `strict-dynamic`, even if it carries an incorrect nonce.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_module.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_module.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Parser-inserted external module scripts without a correct nonce are not allowed with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Parser-inserted external module scripts without a correct nonce are not allowed with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'markup-module') {
+                    assert_unreached('Parser-inserted external module script in markup without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?markup-module')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+        }, 'Parser-inserted external module script in markup without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?markup-module"></script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-module') {
+                    assert_unreached('Parser-inserted external module script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?documentWrite-module')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+
+            document.write('<scr' + 'ipt type="module" src="simpleSourcedModule.js?documentWrite-module"></scr' + 'ipt>');
+        }, 'Parser-inserted external module script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-module') {
+                    assert_unreached('Parser-inserted external module script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?documentWriteln-module')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+
+            document.writeln('<scr' + 'ipt type="module" src="simpleSourcedModule.js?documentWriteln-module"></scr' + 'ipt>');
+        }, 'Parser-inserted external module script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_module.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/simpleSourcedModule.js
+++ b/content-security-policy/script-src/simpleSourcedModule.js
@@ -1,0 +1,1 @@
+window.postMessage(new URL(import.meta.url).search.substring(1), "*");


### PR DESCRIPTION
WebKit export from bug: [CSP strict-dynamic does not block parser-inserted external module scripts without a nonce ](https://bugs.webkit.org/show_bug.cgi?id=314008)