### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=315489

### DIFF
--- a/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js
+++ b/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js
@@ -1,0 +1,17 @@
+// META: global=window,worker
+
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compileStreaming(response));
+}, "WebAssembly.compileStreaming() is blocked");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.instantiateStreaming(response));
+}, "WebAssembly.instantiateStreaming() is blocked");

--- a/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js.headers
+++ b/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: default-src 'self' 'unsafe-inline'

--- a/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js
+++ b/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js
@@ -1,8 +1,21 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
   return promise_rejects_js(
       t, WebAssembly.CompileError,
-      WebAssembly.instantiate(
-          new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0])));
-});
+      WebAssembly.instantiate(bytes));
+}, "WebAssembly.instantiate() is blocked");
+
+promise_test(t => {
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compile(bytes));
+}, "WebAssembly.compile() is blocked");
+
+test(() => {
+  assert_throws_js(
+      WebAssembly.CompileError,
+      () => new WebAssembly.Module(bytes));
+}, "new WebAssembly.Module() is blocked");

--- a/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.js
+++ b/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.js
+++ b/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js
+++ b/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js
@@ -1,0 +1,17 @@
+// META: global=window,worker
+
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compileStreaming(response));
+}, "WebAssembly.compileStreaming() is blocked");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.instantiateStreaming(response));
+}, "WebAssembly.instantiateStreaming() is blocked");

--- a/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js.headers
+++ b/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: script-src 'self' 'unsafe-inline'

--- a/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js
+++ b/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js
@@ -1,8 +1,21 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
   return promise_rejects_js(
       t, WebAssembly.CompileError,
-      WebAssembly.instantiate(
-          new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0])));
-});
+      WebAssembly.instantiate(bytes));
+}, "WebAssembly.instantiate() is blocked");
+
+promise_test(t => {
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compile(bytes));
+}, "WebAssembly.compile() is blocked");
+
+test(() => {
+  assert_throws_js(
+      WebAssembly.CompileError,
+      () => new WebAssembly.Module(bytes));
+}, "new WebAssembly.Module() is blocked");

--- a/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.js
+++ b/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.js
+++ b/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");


### PR DESCRIPTION
WebKit export from bug: [CSP wasm-unsafe-eval directive is not enforced during WebAssembly byte compilation](https://bugs.webkit.org/show_bug.cgi?id=315489)