### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308775

### DIFF
--- a/content-security-policy/object-src/object-src-no-url-embed-blocked.html
+++ b/content-security-policy/object-src/object-src-no-url-embed-blocked.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="object-src 'none'; script-src 'self' 'unsafe-inline';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script>
+       var t = async_test("Should block the embed and fire a spv");
+       window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+         assert_equals(e.violatedDirective, "object-src");
+       }));
+    </script>
+
+    <embed type="text/html">
+</body>
+
+</html>

--- a/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked.html
+++ b/content-security-policy/object-src/object-src-no-url-empty-source-list-blocked.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="object-src; script-src 'self' 'unsafe-inline';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script>
+       var t = async_test("Empty object-src source list should block the object and fire a spv");
+       window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+         assert_equals(e.violatedDirective, "object-src");
+       }));
+    </script>
+
+    <object type="text/html"></object>
+</body>
+
+</html>

--- a/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked.html
+++ b/content-security-policy/object-src/object-src-no-url-empty-source-list-embed-blocked.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="object-src; script-src 'self' 'unsafe-inline';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <script>
+       var t = async_test("Empty object-src source list should block the embed and fire a spv");
+       window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+         assert_equals(e.violatedDirective, "object-src");
+       }));
+    </script>
+
+    <embed type="text/html">
+</body>
+
+</html>


### PR DESCRIPTION
WebKit export from bug [Inconsistent handling of CSP’s object-src with empty or invalid source list for empty object and embed elements](https://bugs.webkit.org/show_bug.cgi?id=308775)