### PR TITLE
Remove `glyph-orientation-horizontal` from presentation-attribute test case

### DIFF
--- a/css/css-cascade/all-prop-revert-layer.html
+++ b/css/css-cascade/all-prop-revert-layer.html
@@ -146,7 +146,6 @@
   font-variation-settings: "smcp" 1;
   font-weight: 123;
   forced-color-adjust: none;
-  glyph-orientation-horizontal: 123deg;
   glyph-orientation-vertical: 123deg;
   grid-auto-columns: 123px;
   grid-auto-flow: column;

--- a/css/css-variables/variable-presentation-attribute.html
+++ b/css/css-variables/variable-presentation-attribute.html
@@ -72,7 +72,6 @@
             { property: "font-stretch", valuesToTest:["100%", "50%", "62.5%", "75%", "87.5%", "112.5%", "125%", "150%", "200%"], default: "100%" },
             { property: "font-style", valuesToTest:["normal", "italic"], default: "normal" },
             { property: "font-weight", valuesToTest:["100", "200", "300", "400", "500", "600", "700", "800", "900"], default: "400" },
-            { property: "glyph-orientation-horizontal", valuesToTest:["13deg"], default: "0deg" },
             { property: "glyph-orientation-vertical", valuesToTest:["auto", "19deg"], default: "auto" },
             { property: "kerning", valuesToTest:["auto", "15"], default: "auto" },
             { property: "letter-spacing", valuesToTest:["normal", "21px"], default: "normal" },

--- a/svg/styling/glyph-orientation-horizontal.historical.html
+++ b/svg/styling/glyph-orientation-horizontal.historical.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG glyph-orientation-horizontal is not supported</title>
+<link rel="help" href="https://www.w3.org/TR/SVG11/text.html#GlyphOrientationHorizontalProperty">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationHorizontalProperty">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg">
+  <text id="text">text</text>
+</svg>
+<script>
+// glyph-orientation-horizontal was a property in SVG 1.1 but was removed in
+// SVG 2.
+
+test(() => {
+  assert_false(CSS.supports("glyph-orientation-horizontal", "0deg"));
+  assert_false(CSS.supports("glyph-orientation-horizontal", "90deg"));
+  assert_false(CSS.supports("glyph-orientation-horizontal", "initial"));
+}, "glyph-orientation-horizontal is not a supported CSS property");
+
+test(() => {
+  const text = document.getElementById("text");
+  text.style.setProperty("glyph-orientation-horizontal", "90deg");
+  assert_equals(text.style.getPropertyValue("glyph-orientation-horizontal"), "",
+    "value should not parse in a style declaration");
+  assert_equals(text.style.length, 0,
+    "declaration should remain empty");
+}, "glyph-orientation-horizontal is not parsed in a style declaration");
+
+test(() => {
+  const text = document.getElementById("text");
+  // An unsupported presentation attribute must not contribute a value to the
+  // computed style of the element.
+  text.setAttribute("glyph-orientation-horizontal", "90deg");
+  assert_equals(
+    getComputedStyle(text).getPropertyValue("glyph-orientation-horizontal"), "",
+    "computed value should be empty for an unsupported property");
+  text.removeAttribute("glyph-orientation-horizontal");
+}, "glyph-orientation-horizontal is not a supported SVG presentation attribute");
+</script>


### PR DESCRIPTION
…t case

This is gone from all browsers, so there is nothing to test and deprecated by standard (as per SVG2 [1]).

[1] https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationHorizontalProperty

For `vertical`, refer to https://github.com/w3c/svgwg/issues/1140 and https://github.com/w3c/svgwg/issues/1122
(Once specification decision is made, only then we can remove it).