### PR TITLE
[compression-dictionary] Make "Dictionary registration does not inval…

### DIFF
--- a/fetch/compression-dictionary/dictionary-registration.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-registration.tentative.https.html
@@ -79,8 +79,12 @@ compression_dictionary_promise_test(async (t) => {
 
   const entries = performance.getEntriesByName(dictionaryUrl);
   assert_equals(entries.length, 2);
-  assert_not_equals(entries[0].transferSize, 0);
-  assert_equals(entries[1].transferSize, 0);
+
+  // transferSize should be either 0 or 300 when hitting cache and 300 + encoded size otherwise.
+  // See https://github.com/web-platform-tests/wpt/issues/60428
+  const encodedSize = "This is a test dictionary.\n".length;
+  assert_equals(entries[0].transferSize, 300 + encodedSize, 0, "Initial compression dictionary triggered a network load.");
+  assert_in_array(entries[1].transferSize, [0, 300], "Second compression dictionary hit cache.");
 }, 'Dictionary registration does not invalidate cache entry');
 
 compression_dictionary_promise_test(async (t) => {

--- a/fetch/compression-dictionary/dictionary-registration.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-registration.tentative.https.html
@@ -82,8 +82,7 @@ compression_dictionary_promise_test(async (t) => {
 
   // transferSize should be either 0 or 300 when hitting cache and 300 + encoded size otherwise.
   // See https://github.com/web-platform-tests/wpt/issues/60428
-  const encodedSize = "This is a test dictionary.\n".length;
-  assert_equals(entries[0].transferSize, 300 + encodedSize, 0, "Initial compression dictionary triggered a network load.");
+  assert_equals(entries[0].transferSize, 300 + entries[0].encodedBodySize, "Initial compression dictionary triggered a network load.");
   assert_in_array(entries[1].transferSize, [0, 300], "Second compression dictionary hit cache.");
 }, 'Dictionary registration does not invalidate cache entry');
 


### PR DESCRIPTION
…idate cache entry" more robust.

Currently, it's relying on transferSize, assuming it's zero for a resource taken from the cache and non-zero otherwise, but that does not match what the spec
https://w3c.github.io/resource-timing/#performanceresourcetiming-transfersize

Fixes https://github.com/web-platform-tests/wpt/issues/60428