### PR TITLE
layout: Don't normalize radii for `clip-path` shapes

### DIFF
--- a/css/css-masking/clip-path/clip-path-circle-010.html
+++ b/css/css-masking/clip-path/clip-path-circle-010.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Masking: Test clip-path property and circle function with big radius</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-masking-1/#clipping-paths">
+<link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
+<link rel="help" href="https://github.com/servo/servo/issues/45469">
+<link rel="match" href="reference/clip-path-semicircle-ref.html">
+<meta name="fuzzy" content="maxDifference=0-120; totalPixels=0-900">
+<meta name="assert" content="
+  The circle has a radius of 100px, and thus a diameter of 200px.
+  That's twice as big as the height of the element, producing a semicircle.
+  The radius should NOT shrink so that the entire circle would fit.
+">
+
+<p>The test passes if there is a semicircle.</p>
+<div style="width: 200px; height: 100px; background: black;
+            clip-path: circle(100px at 100px 100px)"></div>

--- a/css/css-masking/clip-path/reference/clip-path-semicircle-ref.html
+++ b/css/css-masking/clip-path/reference/clip-path-semicircle-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<p>The test passes if there is a semicircle.</p>
+<div style="width: 200px; height: 100px; background: black;
+            border-radius: 100px 100px 0 0"></div>


### PR DESCRIPTION
WebRender already takes care of normalizing radii when they are too big, so no need to do that work twice.

Additionally, we were doing it wrong for `rect()` and `circle()`, since we were normalizing using the size of the element instead of the size of the shape.

For example, an element with a zero size would normalize the radii to zero, even though the clip rect could be larger due to negative insets.

And a `circle()` with big enough radii would have them reduced in a way that produced a square with rounded corners instead of a circle.

`ellipse()` was normalizing with the right rectangle, so it behaved correctly, but again it was unnecessary because WebRender can handle it.

Testing: An existing test passes, and adding a new one
Fixes: #<!-- nolink -->45469

Reviewed in servo/servo#45468