### PR TITLE
Manual export: Forbid generated images as cursor via light-dark()

### DIFF
--- a/css/css-ui/crashtests/cursor-light-dark-generated-image-crash.html
+++ b/css/css-ui/crashtests/cursor-light-dark-generated-image-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS UI: cursor with a light-dark() generated image must not crash</title>
+<link rel="author" title="Jason Leo" href="mailto:cgqaq@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#cursor">
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#light-dark">
+<link rel="help" href="https://crbug.com/518872187">
+<!-- Regression test for https://crbug.com/518872187: light-dark() used to let a
+     generated image (e.g. a gradient) become a cursor image even though the
+     cursor property forbids them. Gradients are re-instantiated on every style
+     recalc, so the image-observer bookkeeping drifted and tearing down the
+     layout tree hit a SECURITY_CHECK in CSSImageGeneratorValue::RemoveClient.
+     PASS if it does not crash. -->
+<style>
+.gradient-cursor {
+  cursor: light-dark(linear-gradient(red), none) 0 0, pointer;
+}
+</style>
+<script>
+onload = () => {
+  document.body.insertBefore(document.createElement("br"),
+                             document.body.firstChild);
+  document.designMode = "on";
+  document.execCommand("selectAll");
+  document.execCommand("InsertHTML");
+};
+</script>
+<p class="gradient-cursor">crash</p>

--- a/css/css-ui/parsing/cursor-invalid.html
+++ b/css/css-ui/parsing/cursor-invalid.html
@@ -19,6 +19,13 @@ test_invalid_value("cursor", 'url("https://example.com/"), url("https://example.
 
 test_invalid_value("cursor", 'url("https://example.com/") 1px 2px, copy');
 test_invalid_value("cursor", 'url("https://example.com/"), url("https://example.com/") 3% 4%, move');
+
+// The cursor property does not accept generated images, including inside
+// light-dark().
+test_invalid_value("cursor", "linear-gradient(red), pointer");
+test_invalid_value("cursor", "light-dark(linear-gradient(red), none), pointer");
+test_invalid_value("cursor", 'light-dark(url("https://example.com/"), linear-gradient(red)), pointer');
+test_invalid_value("cursor", 'light-dark(radial-gradient(red), url("https://example.com/")), pointer');
 </script>
 </body>
 </html>

--- a/css/css-ui/parsing/cursor-valid.html
+++ b/css/css-ui/parsing/cursor-valid.html
@@ -130,6 +130,15 @@ test_valid_value(
     'url(https://example.com/), light-dark(url(https://example.com/light), url(https://example.com/dark)) 3 4, move'
   ]
 );
+
+test_valid_value(
+  "cursor",
+  'light-dark(image-set("https://example.com/" 1x), url("https://example.com/")) 5 6, grab',
+  [
+    'light-dark(image-set(url("https://example.com/") 1x), url("https://example.com/")) 5 6, grab',
+    'light-dark(image-set(url(https://example.com/) 1x), url(https://example.com/)) 5 6, grab'
+  ]
+);
 </script>
 </body>
 </html>


### PR DESCRIPTION
The 'cursor' property forbids generated images, but light-dark() resolved its branches without honoring that policy, letting a gradient become a cursor image. Gradients are re-instantiated on every style recalc, so the per-instance image-observer bookkeeping in UpdateCursorImages drifted and RemoveClient() hit a SECURITY_CHECK during layout teardown.

Bug: 518872187
Change-Id: I45cab2c148b60a673f1381e560d90d6ce9d57e9c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7898340
Reviewed-by: Rune Lillesveen <futhark@chromium.org>
Commit-Queue: Jason Leo <cgqaq@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1642106}