### PR TITLE
layout: add support for box-decoration-break

### DIFF
--- a/css/css-break/box-decoration-break-clone-inline-negative-margins-ref.html
+++ b/css/css-break/box-decoration-break-clone-inline-negative-margins-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+  div {
+    width: 100px;
+    background-color: lightgray;
+  }
+  span {
+    width: 50px;
+    border-inline-end: 50px solid;
+  }
+</style>
+<div>
+  <span></span><br><span></span>
+</div>

--- a/css/css-break/box-decoration-break-clone-inline-negative-margins.html
+++ b/css/css-break/box-decoration-break-clone-inline-negative-margins.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>negative margins need to factor into line-breaking with box-decoration-break: clone</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="match" href="box-decoration-break-clone-inline-negative-margins-ref.html">
+<meta name="assert" content="Negative trailing margins can cause cloned trailing inline borders to overlap and thus take up less space for purposes of line breaking.">
+<style>
+  div {
+    width: 100px;
+    background-color: lightgray;
+  }
+  .broken {
+    border-inline-end: 50px solid;
+    box-decoration-break: clone;
+  }
+  .middle {
+    border-inline-end: 0;
+    margin-inline-end: -50px;
+  }
+  .inner > span {
+    display: inline-block;
+    width: 25px;
+  }
+</style>
+<div>
+  <span class="broken">
+  <span class="broken middle">
+  <span class="broken inner">
+    <span></span><span></span><span></span><span></span>
+  </span>
+  </span>
+  </span>
+</div>


### PR DESCRIPTION
This adds initial handling for the `box-decoration-break` CSS property.
The implementation thus far only does line breaks, but in the future this will need to insert paddings/borders/margins when bidi-reordering causes a box to be split as well.

Corresponding stylo PR is at https://github.com/servo/stylo/pull/386

Testing: We now pass some css-break tests. I've also added a new test that exhibits a bug in the current implementation. I am planning to fix this in a follow-up PR, so the test is here for accountability, I guess. Also because other browsers fail it as well and the behavior is currently not being tested for.

Reviewed in servo/servo#45492