### PR TITLE
Fix for AXSubrole in blockquote test to expect None/Nil per spec not …

### DIFF
--- a/core-aam/aamtests/role/blockquote.py
+++ b/core-aam/aamtests/role/blockquote.py
@@ -21,8 +21,8 @@ def test_axapi(axapi, session, inline):
     node = axapi.find_node("test", session.url)
     role = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)[1]
     assert role == "AXGroup"
-    role = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
-    assert role == "AXUnknown"
+    subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
+    assert subrole == None
 
 def test_ia2(ia2, session, inline):
     session.url = inline(TEST_HTML)


### PR DESCRIPTION
Blockquote element (records subtype as Nil/None in Safari and Chrome, but AXUnknown in Firefox). Based on the CORE-AAM, this should be Nil. In the case <Nil> or AXUnknown are interchangeable, this test should do something like `subrole in [None, AXUnknown]`.