### PR TITLE
Add tentative tests for aria-checked on both gridcell and row roles

### DIFF
--- a/wai-aria/checked/checked.gridcell.tentative.html
+++ b/wai-aria/checked/checked.gridcell.tentative.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/wai-aria/scripts/aria-utils.js"></script>
+
+<div role="grid" aria-label="Gridcell aria-checked tests">
+  <div role="row">
+    <div data-testname="gridcell with aria-checked true" role="gridcell" aria-checked="true" data-expectedproperties='{ "checked": "true" }' class="ex-props">gridcell with aria-checked true</div>
+  </div>
+  <div role="row">
+    <div data-testname="gridcell with aria-checked false" role="gridcell" aria-checked="false" data-expectedproperties='{ "checked": "false" }' class="ex-props">gridcell with aria-checked false</div>
+  </div>
+  <div role="row">
+    <div data-testname="gridcell with aria-checked mixed" role="gridcell" aria-checked="mixed" data-expectedproperties='{ "checked": "mixed" }' class="ex-props">gridcell with aria-checked mixed</div>
+  </div>
+</div>
+
+<script>
+AriaUtils.verifyPropertiesBySelector(".ex-props");
+</script>


### PR DESCRIPTION
This PR adds tentative Web Platform Tests (WPT) to verify the expected accessibility API mappings for the aria-checked attribute when applied to the gridcell and row roles within a grid container, as per https://github.com/w3c/aria/pull/2390.

Specifically, it introduces checked.gridcell.tentative.html to verify that a gridcell and rows can correctly accept all valid aria-checked values (true, false, and mixed) in the computed properties. Validation uses the verifyPropertiesBySelector helper in a similar way to other tests.
