### PR TITLE
Upstream fuzzy annotations from WebKit changes in `css/css-backgrounds`

### DIFF
--- a/css/css-backgrounds/background-clip-padding-box-with-border-radius.html
+++ b/css/css-backgrounds/background-clip-padding-box-with-border-radius.html
@@ -8,7 +8,7 @@
 <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-clip" />
 <link rel="help" href="http://www.w3.org/TR/css3-background/#corner-shaping" />
 <link rel="match" href="reference/background-clip-padding-box-with-border-radius-ref.html" />
-<meta name="fuzzy" content="maxDifference=0-29;totalPixels=0-80" />
+<meta name="fuzzy" content="maxDifference=0-32;totalPixels=0-198" />
 <meta name="assert" content="Backgrounds clipped to the padding box should follow the padding box curve, which should be equal to the outer border radius minus the corresponding border thickness." />
 <style>
 div {

--- a/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html
@@ -4,7 +4,7 @@
 <title>CSS Backgrounds Test:  background-clip:border-area</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
 <link rel="match" href="clip-border-area-box-decoration-break-ref.html">
-<meta name="fuzzy" content="maxDifference=0-150; totalPixels=0-200">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-480" />
 <meta name="assert" content="background-clip: border-area respects box-decoration-break">
 <style>
     div {

--- a/css/css-backgrounds/background-repeat-space-1a.html
+++ b/css/css-backgrounds/background-repeat-space-1a.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-1-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/css/css-backgrounds/background-repeat-space-1b.html
+++ b/css/css-backgrounds/background-repeat-space-1b.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-1-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/css/css-backgrounds/background-repeat-space-1c.html
+++ b/css/css-backgrounds/background-repeat-space-1c.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-1-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/css/css-backgrounds/background-repeat-space-3.html
+++ b/css/css-backgrounds/background-repeat-space-3.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-3-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'no-repeat space' and 'space no-repeat' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-5300">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-5550">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/css/css-backgrounds/background-repeat-space-4.html
+++ b/css/css-backgrounds/background-repeat-space-4.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-4-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'repeat space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7908">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8250">
     <style type="text/css">
       .outer {
         width: 96px;

--- a/css/css-backgrounds/background-repeat-space-5.html
+++ b/css/css-backgrounds/background-repeat-space-5.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-5-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space repeat' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7960">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8350">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/css/css-backgrounds/background-rounded-image-clip-001.html
+++ b/css/css-backgrounds/background-rounded-image-clip-001.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Background Clip Follows Rounded Corner</title>
-<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-22547">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-27000">
 <link rel="match" href="reference/background-rounded-image-clip.html">
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">
 <style>

--- a/css/css-backgrounds/border-image-image-type-001.htm
+++ b/css/css-backgrounds/border-image-image-type-001.htm
@@ -7,7 +7,7 @@
         <link rel="match" href="reference/border-image-image-type-001-ref.html" />
         <meta name="flags" content="svg" />
         <meta name="assert" content="This test checks that the SVG image used for the border image is sliced into nine regions with inward offsets of: '40 30 20 10' vector coordinates from the top, right, bottom, and left edges of the image set by the 'border-image-slice' property." />
-        <meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-400"/>
+        <meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-600"/>
         <style type="text/css">
             div
             {

--- a/css/css-backgrounds/border-image-slice-005.htm
+++ b/css/css-backgrounds/border-image-slice-005.htm
@@ -10,7 +10,7 @@
         -->
         <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-image-slice">
         <link rel="match" href="reference/border-image-slice-005-ref.html">
-        <meta name="fuzzy" content="maxDifference=0-92;totalPixels=0-5314">
+        <meta name="fuzzy" content="maxDifference=0-102;totalPixels=0-5316">
         <meta name="assert" content="This test checks that the border image is sliced into nine regions with inward offsets, '40%' from the top, '30%' from the right,'20%' from the bottom, and '10%' from the left edges of the image. Percentages are relative to the size of the image: the width of the image for the horizontal offsets, the height for vertical offsets.">
         <style>
             div

--- a/css/css-backgrounds/border-image-slice-007.htm
+++ b/css/css-backgrounds/border-image-slice-007.htm
@@ -10,7 +10,7 @@
         -->
         <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-image-slice">
         <link rel="match" href="reference/border-image-slice-007-ref.html">
-        <meta name="fuzzy" content="maxDifference=0-92;totalPixels=0-5314">
+        <meta name="fuzzy" content="maxDifference=0-102;totalPixels=0-5316">
         <meta name="assert" content="This test checks that the 'fill' keyword, if present, causes the middle part of the border-image to be preserved.">
         <style>
             div

--- a/css/css-backgrounds/linear-gradient-currentcolor-first-line.html
+++ b/css/css-backgrounds/linear-gradient-currentcolor-first-line.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#first-line-background">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-line-inheritance">
 <link rel="match" href="linear-gradient-currentcolor-first-line-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-265">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-266">
 <style>
   div { color: red; }
   div::first-line { color: green; }


### PR DESCRIPTION
The following webkit revisions updated fuzzy annotations in css/css-backgrounds, so upstream them:

304621@main
306349@main
305533@main

60af735 clobbered fuzziness in css/css-backgrounds/border-image-repeat-round.html so restore that.