### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=316787

### DIFF
--- a/css/css-borders/border-shape/border-shape-ignore-radius-computed.html
+++ b/css/css-borders/border-shape/border-shape-ignore-radius-computed.html
@@ -19,9 +19,9 @@ test(() => {
     assert_equals(style.borderTopRightRadius, '999px');
     assert_equals(style.borderBottomRightRadius, '999px');
     assert_equals(style.borderBottomLeftRadius, '999px');
-    assert_equals(style.cornerTopLeftShape, 'bevel');
-    assert_equals(style.cornerTopRightShape, 'bevel');
-    assert_equals(style.cornerBottomRightShape, 'bevel');
-    assert_equals(style.cornerBottomLeftShape, 'bevel');
+    assert_equals(style.cornerTopLeftShape, 'superellipse(0)');
+    assert_equals(style.cornerTopRightShape, 'superellipse(0)');
+    assert_equals(style.cornerBottomRightShape, 'superellipse(0)');
+    assert_equals(style.cornerBottomLeftShape, 'superellipse(0)');
 }, "border-radius and corner-shape are NOT reset in computed style when border-shape is specified");
 </script>


### PR DESCRIPTION
border-shape-ignore-radius-computed.html checks that corner-shape: bevel is preserved in computed style when border-shape is specified. The assertions were written expecting "bevel"
as the serialized computed value.

However, per the CSS Borders 4 spec, corner-shape computed values are expressed in canonical superellipse(K) form,  bevel computes to superellipse(0), round to superellipse(1), etc.
This is the same behavior verified by the corner-shape-computed WPT test, which explicitly checks that keywords resolve to their superellipse(K) equivalents in computed style.
Spec reference: https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value