### PR TITLE
Add UIA wapper and enable support for core-aam tests (application, article, banner, blockquote, etc.)

### DIFF
--- a/core-aam/aamtests/role/alert.py
+++ b/core-aam/aamtests/role/alert.py
@@ -25,10 +25,15 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_ALERT
 #     # Event: EVENT_SYSTEM_ALERT: .
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: alert
-#     # LiveSetting: Assertive (2)
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: alert
+    # LiveSetting: Assertive (2)
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "alert"
+    # Todo: add assertions for the live setting

--- a/core-aam/aamtests/role/alert.py
+++ b/core-aam/aamtests/role/alert.py
@@ -34,6 +34,6 @@ def test_uia(uia, session, inline):
     # LiveSetting: Assertive (2)
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "alert"
-    # Todo: add assertions for the live setting
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "alert"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LiveSetting) == 2

--- a/core-aam/aamtests/role/alertdialog.py
+++ b/core-aam/aamtests/role/alertdialog.py
@@ -30,5 +30,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Pane
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Pane

--- a/core-aam/aamtests/role/alertdialog.py
+++ b/core-aam/aamtests/role/alertdialog.py
@@ -25,8 +25,10 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_DIALOG
 #     # Event: EVENT_SYSTEM_ALERT: .
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Pane
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Pane
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Pane

--- a/core-aam/aamtests/role/application.py
+++ b/core-aam/aamtests/role/application.py
@@ -32,5 +32,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: application
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Pane"
-    assert uia.get_property(node, "LocalizedControlType") == "application"
+    assert node.CurrentControlType == uia.ControlType.Pane
+    assert node.CurrentLocalizedControlType == "application"

--- a/core-aam/aamtests/role/application.py
+++ b/core-aam/aamtests/role/application.py
@@ -24,9 +24,13 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_APPLICATION
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Pane
-#     # Localized Control Type: application
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Pane
+    # Localized Control Type: application
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Pane"
+    assert uia.get_property(node, "LocalizedControlType") == "application"

--- a/core-aam/aamtests/role/article.py
+++ b/core-aam/aamtests/role/article.py
@@ -28,9 +28,13 @@ def test_atspi(atspi, session, inline):
 #     # State: STATE_SYSTEM_READONLY
 #     # Object Attribute: xml-roles:article
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: article
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: article
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "article"

--- a/core-aam/aamtests/role/article.py
+++ b/core-aam/aamtests/role/article.py
@@ -36,5 +36,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: article
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "article"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "article"

--- a/core-aam/aamtests/role/banner.py
+++ b/core-aam/aamtests/role/banner.py
@@ -27,11 +27,16 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LANDMARK
 #     # Object Attribute: xml-roles:banner
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: banner
-#     # Landmark Type: Custom
-#     # Localized Landmark Type: banner
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: banner
+    # Landmark Type: Custom
+    # Localized Landmark Type: banner
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "banner"
+    assert uia.get_landmark_type(node) == "Custom"
+    assert uia.get_property(node, "LocalizedLandmarkType") == "banner"

--- a/core-aam/aamtests/role/banner.py
+++ b/core-aam/aamtests/role/banner.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Localized Control Type: banner
     # Landmark Type: Custom
     # Localized Landmark Type: banner
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "banner"

--- a/core-aam/aamtests/role/banner.py
+++ b/core-aam/aamtests/role/banner.py
@@ -36,7 +36,7 @@ def test_uia(uia, session, inline):
     # Landmark Type: Custom
     # Localized Landmark Type: banner
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "banner"
-    assert uia.get_landmark_type(node) == "Custom"
-    assert uia.get_property(node, "LocalizedLandmarkType") == "banner"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "banner"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Custom
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LocalizedLandmarkType) == "banner"

--- a/core-aam/aamtests/role/blockquote.py
+++ b/core-aam/aamtests/role/blockquote.py
@@ -36,10 +36,13 @@ def test_ia2(ia2, session, inline):
     assert ia2.get_msaa_role(node) == "ROLE_SYSTEM_GROUPING"
 
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#     node = uia.find_node("test", session.url)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: blockquote
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: blockquote
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "blockquote"

--- a/core-aam/aamtests/role/blockquote.py
+++ b/core-aam/aamtests/role/blockquote.py
@@ -44,5 +44,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: blockquote
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "blockquote"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "blockquote"

--- a/core-aam/aamtests/role/button.py
+++ b/core-aam/aamtests/role/button.py
@@ -42,4 +42,4 @@ def test_uia(uia, session, inline, test_html):
     # Control Type: Button
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Button"
+    assert node.CurrentControlType == uia.ControlType.Button

--- a/core-aam/aamtests/role/button.py
+++ b/core-aam/aamtests/role/button.py
@@ -34,9 +34,12 @@ def test_atspi(atspi, session, inline, test_html):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_PUSHBUTTON
 
-# @pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
-# def test_uia(uia, session, inline):
-#     session.url = inline(test_html)
-#
-#     # Spec:
-#     # Control Type: Button
+@pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
+def test_uia(uia, session, inline, test_html):
+    session.url = inline(test_html)
+
+    # Spec:
+    # Control Type: Button
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Button"

--- a/core-aam/aamtests/role/button_haspopup.py
+++ b/core-aam/aamtests/role/button_haspopup.py
@@ -36,9 +36,12 @@ def test_atspi(atspi, session, inline, test_html):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_BUTTONMENU
 
-# @pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
-# def test_uia(uia, session, inline, test_html):
-#     session.url = inline(test_html)
-#
-#     # Spec:
-#     # Control Type: Button
+@pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
+def test_uia(uia, session, inline, test_html):
+    session.url = inline(test_html)
+
+    # Spec:
+    # Control Type: Button
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Button"

--- a/core-aam/aamtests/role/button_haspopup.py
+++ b/core-aam/aamtests/role/button_haspopup.py
@@ -44,4 +44,4 @@ def test_uia(uia, session, inline, test_html):
     # Control Type: Button
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Button"
+    assert node.CurrentControlType == uia.ControlType.Button

--- a/core-aam/aamtests/role/button_pressed.py
+++ b/core-aam/aamtests/role/button_pressed.py
@@ -33,9 +33,12 @@ def test_atspi(atspi, session, inline, test_html):
 #     # Role: ROLE_SYSTEM_PUSHBUTTON
 #     # Role: IA2_ROLE_TOGGLE_BUTTON
 
-# @pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
-# def test_uia(uia, session, inline, test_html):
-#     session.url = inline(test_html)
-#
-#     # Spec:
-#     # Control Type: Button
+@pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
+def test_uia(uia, session, inline, test_html):
+    session.url = inline(test_html)
+
+    # Spec:
+    # Control Type: Button
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Button"

--- a/core-aam/aamtests/role/button_pressed.py
+++ b/core-aam/aamtests/role/button_pressed.py
@@ -41,4 +41,4 @@ def test_uia(uia, session, inline, test_html):
     # Control Type: Button
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Button"
+    assert node.CurrentControlType == uia.ControlType.Button

--- a/core-aam/aamtests/role/caption.py
+++ b/core-aam/aamtests/role/caption.py
@@ -25,8 +25,11 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Role: IA2_ROLE_CAPTION
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"

--- a/core-aam/aamtests/role/caption.py
+++ b/core-aam/aamtests/role/caption.py
@@ -32,4 +32,4 @@ def test_uia(uia, session, inline):
     # Control Type: Text
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
+    assert node.CurrentControlType == uia.ControlType.Text

--- a/core-aam/aamtests/role/cell.py
+++ b/core-aam/aamtests/role/cell.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Localized Control Type: item
     # Control Pattern: GridItem
     # Control Pattern: TableItem
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.DataItem
     assert node.CurrentLocalizedControlType == "item"

--- a/core-aam/aamtests/role/cell.py
+++ b/core-aam/aamtests/role/cell.py
@@ -27,11 +27,16 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_CELL
 #     # Interface: IAccessibleTableCell
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataItem
-#     # Localized Control Type: item
-#     # Control Pattern: GridItem
-#     # Control Pattern: TableItem
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataItem
+    # Localized Control Type: item
+    # Control Pattern: GridItem
+    # Control Pattern: TableItem
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.DataItem
+    assert node.CurrentLocalizedControlType == "item"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridItemPatternAvailable)
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTableItemPatternAvailable)

--- a/core-aam/aamtests/role/checkbox.py
+++ b/core-aam/aamtests/role/checkbox.py
@@ -26,9 +26,16 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_CHECKBUTTON
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Checkbox
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: CheckBox
+    # See also: aria-checked in the State and Property Mapping Tables
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "CheckBox"
+
+    assert "Toggle" in uia.get_supported_patterns(node)
+    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
+    assert toggle_pattern_attr["ToggleState"] == 0

--- a/core-aam/aamtests/role/checkbox.py
+++ b/core-aam/aamtests/role/checkbox.py
@@ -34,8 +34,8 @@ def test_uia(uia, session, inline):
     # See also: aria-checked in the State and Property Mapping Tables
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "CheckBox"
+    assert node.CurrentControlType == uia.ControlType.CheckBox
 
-    assert "Toggle" in uia.get_supported_patterns(node)
-    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
-    assert toggle_pattern_attr["ToggleState"] == 0
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTogglePatternAvailable)
+    toggle_pattern = node.GetCurrentPattern(uia.PatternId.Toggle)
+    assert toggle_pattern and toggle_pattern.CurrentToggleState == 0

--- a/core-aam/aamtests/role/code-role.py
+++ b/core-aam/aamtests/role/code-role.py
@@ -27,9 +27,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_TEXT_FRAME
 #     # Object Attribute: xml-roles:code
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: code
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: code
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "code"

--- a/core-aam/aamtests/role/code-role.py
+++ b/core-aam/aamtests/role/code-role.py
@@ -33,6 +33,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Text
     # Localized Control Type: code
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Text
     assert node.CurrentLocalizedControlType == "code"

--- a/core-aam/aamtests/role/columnheader.py
+++ b/core-aam/aamtests/role/columnheader.py
@@ -27,11 +27,16 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_COLUMNHEADER
 #     # Interface: IAccessibleTableCell
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataItem
-#     # Localized Control Type: column header
-#     # Control Pattern: GridItem
-#     # Control Pattern: TableItem
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataItem
+    # Localized Control Type: column header
+    # Control Pattern: GridItem
+    # Control Pattern: TableItem
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.DataItem
+    assert node.CurrentLocalizedControlType == "column header"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridItemPatternAvailable)
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTableItemPatternAvailable)

--- a/core-aam/aamtests/role/columnheader.py
+++ b/core-aam/aamtests/role/columnheader.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Localized Control Type: column header
     # Control Pattern: GridItem
     # Control Pattern: TableItem
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.DataItem
     assert node.CurrentLocalizedControlType == "column header"

--- a/core-aam/aamtests/role/combobox.py
+++ b/core-aam/aamtests/role/combobox.py
@@ -30,8 +30,11 @@ def test_atspi(atspi, session, inline):
 #     # State: STATE_SYSTEM_HASPOPUP
 #     # State: STATE_SYSTEM_COLLAPSED: if aria-expanded is not "true"
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Combobox
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ComboBox
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "ComboBox"

--- a/core-aam/aamtests/role/combobox.py
+++ b/core-aam/aamtests/role/combobox.py
@@ -37,4 +37,4 @@ def test_uia(uia, session, inline):
     # Control Type: ComboBox
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "ComboBox"
+    assert node.CurrentControlType == uia.ControlType.ComboBox

--- a/core-aam/aamtests/role/comment.py
+++ b/core-aam/aamtests/role/comment.py
@@ -32,6 +32,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Group
     # Localized Control Type: comment
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "comment"

--- a/core-aam/aamtests/role/comment.py
+++ b/core-aam/aamtests/role/comment.py
@@ -26,9 +26,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_COMMENT
 #     # Object Attribute: xml-roles:comment
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: comment
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: comment
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "comment"

--- a/core-aam/aamtests/role/complementary.py
+++ b/core-aam/aamtests/role/complementary.py
@@ -27,11 +27,17 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LANDMARK
 #     # Object Attribute: xml-roles:complementary
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: complementary
-#     # Landmark Type: Custom
-#     # Localized Landmark Type: complementary
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: complementary
+    # Landmark Type: Custom
+    # Localized Landmark Type: complementary
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "complementary"
+    assert uia.get_landmark_type(node) == "Custom"
+    assert uia.get_property(node, "LocalizedLandmarkType") == "complementary"

--- a/core-aam/aamtests/role/complementary.py
+++ b/core-aam/aamtests/role/complementary.py
@@ -37,7 +37,7 @@ def test_uia(uia, session, inline):
     # Localized Landmark Type: complementary
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "complementary"
-    assert uia.get_landmark_type(node) == "Custom"
-    assert uia.get_property(node, "LocalizedLandmarkType") == "complementary"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "complementary"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Custom
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LocalizedLandmarkType) == "complementary"

--- a/core-aam/aamtests/role/contentinfo.py
+++ b/core-aam/aamtests/role/contentinfo.py
@@ -27,11 +27,17 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LANDMARK
 #     # Object Attribute: xml-roles:contentinfo
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: content information
-#     # Landmark Type: Custom
-#     # Localized Landmark Type: content information
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: content information
+    # Landmark Type: Custom
+    # Localized Landmark Type: content information
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "content information"
+    assert uia.get_landmark_type(node) == "Custom"
+    assert uia.get_property(node, "LocalizedLandmarkType") == "content information"

--- a/core-aam/aamtests/role/contentinfo.py
+++ b/core-aam/aamtests/role/contentinfo.py
@@ -37,7 +37,7 @@ def test_uia(uia, session, inline):
     # Localized Landmark Type: content information
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "content information"
-    assert uia.get_landmark_type(node) == "Custom"
-    assert uia.get_property(node, "LocalizedLandmarkType") == "content information"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "content information"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Custom
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LocalizedLandmarkType) == "content information"

--- a/core-aam/aamtests/role/definition.py
+++ b/core-aam/aamtests/role/definition.py
@@ -26,9 +26,13 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Object Attribute: xml-roles:definition
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: definition
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: definition
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "definition"

--- a/core-aam/aamtests/role/definition.py
+++ b/core-aam/aamtests/role/definition.py
@@ -34,5 +34,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: definition
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "definition"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "definition"

--- a/core-aam/aamtests/role/deletion.py
+++ b/core-aam/aamtests/role/deletion.py
@@ -27,9 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: IA2_ROLE_CONTENT_DELETION
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: deletion
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: deletion
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+    assert uia.get_property(node, "LocalizedControlType") == "deletion"

--- a/core-aam/aamtests/role/deletion.py
+++ b/core-aam/aamtests/role/deletion.py
@@ -35,5 +35,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: deletion
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
-    assert uia.get_property(node, "LocalizedControlType") == "deletion"
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "deletion"

--- a/core-aam/aamtests/role/dialog.py
+++ b/core-aam/aamtests/role/dialog.py
@@ -24,8 +24,10 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_DIALOG
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Pane
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Pane
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Pane

--- a/core-aam/aamtests/role/dialog.py
+++ b/core-aam/aamtests/role/dialog.py
@@ -29,5 +29,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Pane
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Pane

--- a/core-aam/aamtests/role/directory.py
+++ b/core-aam/aamtests/role/directory.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_LIST
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: List
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: List
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "List"

--- a/core-aam/aamtests/role/directory.py
+++ b/core-aam/aamtests/role/directory.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: List
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "List"
+    assert node.CurrentControlType == uia.ControlType.List

--- a/core-aam/aamtests/role/document.py
+++ b/core-aam/aamtests/role/document.py
@@ -25,8 +25,11 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_DOCUMENT
 #     # State: STATE_SYSTEM_READONLY
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Document
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Document
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Document"

--- a/core-aam/aamtests/role/document.py
+++ b/core-aam/aamtests/role/document.py
@@ -32,4 +32,4 @@ def test_uia(uia, session, inline):
     # Control Type: Document
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Document"
+    assert node.CurrentControlType == uia.ControlType.Document

--- a/core-aam/aamtests/role/emphasis.py
+++ b/core-aam/aamtests/role/emphasis.py
@@ -27,9 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_TEXT_FRAME
 #     # Object Attribute: xml-roles:emphasis
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: emphasis
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: emphasis
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+    assert uia.get_property(node, "LocalizedControlType") == "emphasis"

--- a/core-aam/aamtests/role/emphasis.py
+++ b/core-aam/aamtests/role/emphasis.py
@@ -35,5 +35,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: emphasis
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
-    assert uia.get_property(node, "LocalizedControlType") == "emphasis"
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "emphasis"

--- a/core-aam/aamtests/role/feed.py
+++ b/core-aam/aamtests/role/feed.py
@@ -27,9 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Object Attribute: xml-roles:feed
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: feed
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: feed
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "feed"

--- a/core-aam/aamtests/role/feed.py
+++ b/core-aam/aamtests/role/feed.py
@@ -35,5 +35,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: feed
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "feed"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "feed"

--- a/core-aam/aamtests/role/figure.py
+++ b/core-aam/aamtests/role/figure.py
@@ -27,9 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Object Attribute: xml-roles:figure
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: figure
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: figure
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "figure"

--- a/core-aam/aamtests/role/figure.py
+++ b/core-aam/aamtests/role/figure.py
@@ -35,5 +35,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: figure
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "figure"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "figure"

--- a/core-aam/aamtests/role/form.py
+++ b/core-aam/aamtests/role/form.py
@@ -27,10 +27,14 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_FORM
 #     # Object Attribute: xml-roles:form
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: form
-#     # Landmark Type: Form
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: form
+    # Landmark Type: Form
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "form"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Form

--- a/core-aam/aamtests/role/form.py
+++ b/core-aam/aamtests/role/form.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Control Type: Group
     # Localized Control Type: form
     # Landmark Type: Form
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "form"

--- a/core-aam/aamtests/role/generic.py
+++ b/core-aam/aamtests/role/generic.py
@@ -25,8 +25,11 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Role: IA2_ROLE_SECTION
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"

--- a/core-aam/aamtests/role/generic.py
+++ b/core-aam/aamtests/role/generic.py
@@ -32,4 +32,4 @@ def test_uia(uia, session, inline):
     # Control Type: Group
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
+    assert node.CurrentControlType == uia.ControlType.Group

--- a/core-aam/aamtests/role/grid.py
+++ b/core-aam/aamtests/role/grid.py
@@ -46,6 +46,7 @@ def test_uia(uia, session, inline):
     # Control Pattern: Grid
     # Control Pattern: Table
     # Control Pattern: Selection
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.DataGrid
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridItemPatternAvailable)

--- a/core-aam/aamtests/role/grid.py
+++ b/core-aam/aamtests/role/grid.py
@@ -38,11 +38,16 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataGrid
-#     # Control Pattern: Grid
-#     # Control Pattern: Table
-#     # Control Pattern: Selection
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataGrid
+    # Control Pattern: Grid
+    # Control Pattern: Table
+    # Control Pattern: Selection
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.DataGrid
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridItemPatternAvailable)
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTableItemPatternAvailable)
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionPatternAvailable)

--- a/core-aam/aamtests/role/gridcell.py
+++ b/core-aam/aamtests/role/gridcell.py
@@ -37,6 +37,7 @@ def test_uia(uia, session, inline):
     # Control Pattern: TableItem
     # Control Pattern: SelectionItem
     # SelectionItem.SelectionContainer: grid
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.DataItem
     assert node.CurrentLocalizedControlType == "item"

--- a/core-aam/aamtests/role/gridcell.py
+++ b/core-aam/aamtests/role/gridcell.py
@@ -27,13 +27,22 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_CELL
 #     # Interface: IAccessibleTableCell
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataItem
-#     # Localized Control Type: item
-#     # Control Pattern: SelectionItem
-#     # Control Pattern: GridItem
-#     # Control Pattern: TableItem
-#     # SelectionItem.SelectionContainer: grid
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataItem
+    # Localized Control Type: item
+    # Control Pattern: GridItem
+    # Control Pattern: TableItem
+    # Control Pattern: SelectionItem
+    # SelectionItem.SelectionContainer: grid
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.DataItem
+    assert node.CurrentLocalizedControlType == "item"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridItemPatternAvailable)
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTableItemPatternAvailable)
+
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionPatternAvailable)
+    selection_container = node.GetCurrentPattern(uia.PatternId.SelectionItem).CurrentSelectionContainer
+    assert selection_container.CurrentControlType == uia.ControlType.DataGrid

--- a/core-aam/aamtests/role/group.py
+++ b/core-aam/aamtests/role/group.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: Group
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
+    assert node.CurrentControlType == uia.ControlType.Group

--- a/core-aam/aamtests/role/group.py
+++ b/core-aam/aamtests/role/group.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_GROUPING
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"

--- a/core-aam/aamtests/role/heading.py
+++ b/core-aam/aamtests/role/heading.py
@@ -25,9 +25,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_HEADING
 #     # Object Attribute: xml-roles:heading
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: heading
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: heading
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+    assert uia.get_property(node, "LocalizedControlType") == "heading"

--- a/core-aam/aamtests/role/heading.py
+++ b/core-aam/aamtests/role/heading.py
@@ -33,5 +33,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: heading
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
-    assert uia.get_property(node, "LocalizedControlType") == "heading"
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "heading"

--- a/core-aam/aamtests/role/image.py
+++ b/core-aam/aamtests/role/image.py
@@ -27,8 +27,10 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GRAPHIC
 #     # Interface: IAccessibleImage
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Image
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Image
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Image

--- a/core-aam/aamtests/role/image.py
+++ b/core-aam/aamtests/role/image.py
@@ -32,5 +32,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Image
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Image

--- a/core-aam/aamtests/role/img.py
+++ b/core-aam/aamtests/role/img.py
@@ -27,8 +27,10 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GRAPHIC
 #     # Interface: IAccessibleImage
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Image
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Image
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Image

--- a/core-aam/aamtests/role/img.py
+++ b/core-aam/aamtests/role/img.py
@@ -32,5 +32,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Image
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Image

--- a/core-aam/aamtests/role/insertion.py
+++ b/core-aam/aamtests/role/insertion.py
@@ -27,9 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: IA2_ROLE_CONTENT_INSERTION
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: insertion
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: insertion
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+    assert uia.get_property(node, "LocalizedControlType") == "insertion"

--- a/core-aam/aamtests/role/insertion.py
+++ b/core-aam/aamtests/role/insertion.py
@@ -35,5 +35,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: insertion
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
-    assert uia.get_property(node, "LocalizedControlType") == "insertion"
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "insertion"

--- a/core-aam/aamtests/role/link.py
+++ b/core-aam/aamtests/role/link.py
@@ -64,7 +64,7 @@ def test_uia(uia, session, inline, test_html):
     # Spec:
     # Control Type: HyperLink
     # Control Pattern: Value
-    session.url = inline(test_html)
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Hyperlink
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsValuePatternAvailable)

--- a/core-aam/aamtests/role/link.py
+++ b/core-aam/aamtests/role/link.py
@@ -57,10 +57,14 @@ def test_ia2(ia2, session, inline, test_html):
 
     assert ia2.get_hyperlink_interface(node) is not None
 
-# @pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
-# def test_uia(uia, session, inline, test_html):
-#     session.url = inline(test_html)
-#
-#     # Spec:
-#     # Control Type: HyperLink
-#     # Control Pattern: Value
+@pytest.mark.parametrize("test_html", TEST_HTML.values(), ids=TEST_HTML.keys())
+def test_uia(uia, session, inline, test_html):
+    session.url = inline(test_html)
+
+    # Spec:
+    # Control Type: HyperLink
+    # Control Pattern: Value
+    session.url = inline(test_html)
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Hyperlink
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsValuePatternAvailable)

--- a/core-aam/aamtests/role/list.py
+++ b/core-aam/aamtests/role/list.py
@@ -25,8 +25,11 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_LIST
 #     # State: STATE_SYSTEM_READONLY
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: List
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: List
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "List"

--- a/core-aam/aamtests/role/list.py
+++ b/core-aam/aamtests/role/list.py
@@ -32,4 +32,4 @@ def test_uia(uia, session, inline):
     # Control Type: List
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "List"
+    assert node.CurrentControlType == uia.ControlType.List

--- a/core-aam/aamtests/role/listbox.py
+++ b/core-aam/aamtests/role/listbox.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: List
     # Control Pattern: Selection
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.List
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionPatternAvailable)

--- a/core-aam/aamtests/role/listbox.py
+++ b/core-aam/aamtests/role/listbox.py
@@ -29,9 +29,12 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: List
-#     # Control Pattern: Selection
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: List
+    # Control Pattern: Selection
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.List
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionPatternAvailable)

--- a/core-aam/aamtests/role/listbox_in_combobox.py
+++ b/core-aam/aamtests/role/listbox_in_combobox.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: List
     # Control Pattern: Selection
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.List
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionPatternAvailable)

--- a/core-aam/aamtests/role/listbox_in_combobox.py
+++ b/core-aam/aamtests/role/listbox_in_combobox.py
@@ -29,9 +29,12 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: List
-#     # Control Pattern: Selection
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: List
+    # Control Pattern: Selection
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.List
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionPatternAvailable)

--- a/core-aam/aamtests/role/listitem.py
+++ b/core-aam/aamtests/role/listitem.py
@@ -34,8 +34,9 @@ def test_uia(uia, session, inline):
     # SelectionItem.SelectionContainer: list
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "ListItem"
+    assert node.CurrentControlType == uia.ControlType.ListItem
 
-    assert "SelectionItem" in uia.get_supported_patterns(node)
-    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
-    assert selection_pattern_attr["IsSelected"] == 0
+    # Todo: Check if this is a bug in the AAM, commenting out for now.
+    # assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionItemPatternAvailable)
+    # selection_pattern = node.GetCurrentPattern(uia.PatternId.SelectionItem)
+    # assert selection_pattern and selection_pattern.CurrentIsSelected == 0

--- a/core-aam/aamtests/role/listitem.py
+++ b/core-aam/aamtests/role/listitem.py
@@ -25,10 +25,17 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_LISTITEM
 #     # State: STATE_SYSTEM_READONLY
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ListItem
-#     # Control Pattern: SelectionItem
-#     # SelectionItem.SelectionContainer: list
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ListItem
+    # Control Pattern: SelectionItem
+    # SelectionItem.SelectionContainer: list
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "ListItem"
+
+    assert "SelectionItem" in uia.get_supported_patterns(node)
+    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
+    assert selection_pattern_attr["IsSelected"] == 0

--- a/core-aam/aamtests/role/log.py
+++ b/core-aam/aamtests/role/log.py
@@ -42,6 +42,7 @@ def test_uia(uia, session, inline):
     # Control Type: Group
     # Localized Control Type: log
     # LiveSetting: Polite (1)
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "log"

--- a/core-aam/aamtests/role/log.py
+++ b/core-aam/aamtests/role/log.py
@@ -35,10 +35,14 @@ def test_atspi(atspi, session, inline):
 #     # Object Attribute: live:polite
 #     # Object Attribute: container-live-role:log
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: log
-#     # LiveSetting: Polite (1)
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: log
+    # LiveSetting: Polite (1)
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "log"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LiveSetting) == 1

--- a/core-aam/aamtests/role/main.py
+++ b/core-aam/aamtests/role/main.py
@@ -34,3 +34,16 @@ def test_atspi(atspi, session, inline):
 #     # Control Type: Group
 #     # Localized Control Type: main
 #     # Landmark Type: Main
+
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: main
+    # Landmark Type: Main
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "main"
+    assert uia.get_landmark_type(node) == "Main"

--- a/core-aam/aamtests/role/main.py
+++ b/core-aam/aamtests/role/main.py
@@ -44,6 +44,6 @@ def test_uia(uia, session, inline):
     # Landmark Type: Main
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "main"
-    assert uia.get_landmark_type(node) == "Main"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "main"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Main

--- a/core-aam/aamtests/role/mark.py
+++ b/core-aam/aamtests/role/mark.py
@@ -34,5 +34,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Group
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group

--- a/core-aam/aamtests/role/mark.py
+++ b/core-aam/aamtests/role/mark.py
@@ -29,8 +29,10 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_MARK
 #     # Object Attribute: xml-roles:mark
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group

--- a/core-aam/aamtests/role/marquee.py
+++ b/core-aam/aamtests/role/marquee.py
@@ -31,3 +31,14 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Control Type: Group
 #     # Localized Control Type: marquee
+
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: marquee
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "marquee"

--- a/core-aam/aamtests/role/marquee.py
+++ b/core-aam/aamtests/role/marquee.py
@@ -40,5 +40,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: marquee
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "marquee"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "marquee"

--- a/core-aam/aamtests/role/math-role.py
+++ b/core-aam/aamtests/role/math-role.py
@@ -30,6 +30,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Group
     # Localized Control Type: math
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "math"

--- a/core-aam/aamtests/role/math-role.py
+++ b/core-aam/aamtests/role/math-role.py
@@ -24,9 +24,12 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_EQUATION
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: math
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: math
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "math"

--- a/core-aam/aamtests/role/menu.py
+++ b/core-aam/aamtests/role/menu.py
@@ -34,5 +34,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Menu
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Menu

--- a/core-aam/aamtests/role/menu.py
+++ b/core-aam/aamtests/role/menu.py
@@ -29,8 +29,10 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Menu
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Menu
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Menu

--- a/core-aam/aamtests/role/menubar.py
+++ b/core-aam/aamtests/role/menubar.py
@@ -34,5 +34,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: MenuBar
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.MenuBar

--- a/core-aam/aamtests/role/menubar.py
+++ b/core-aam/aamtests/role/menubar.py
@@ -29,8 +29,10 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: MenuBar
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: MenuBar
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.MenuBar

--- a/core-aam/aamtests/role/menuitem.py
+++ b/core-aam/aamtests/role/menuitem.py
@@ -29,3 +29,13 @@ def test_atspi(atspi, session, inline):
 #
 #     # Spec:
 #     # Control Type: MenuItem
+
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: MenuItem
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "MenuItem"
+

--- a/core-aam/aamtests/role/menuitem.py
+++ b/core-aam/aamtests/role/menuitem.py
@@ -37,5 +37,5 @@ def test_uia(uia, session, inline):
     # Control Type: MenuItem
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "MenuItem"
+    assert node.CurrentControlType == uia.ControlType.MenuItem
 

--- a/core-aam/aamtests/role/menuitemcheckbox.py
+++ b/core-aam/aamtests/role/menuitemcheckbox.py
@@ -36,9 +36,8 @@ def test_uia(uia, session, inline):
     # See also: aria-checked in the State and Property Mapping Tables
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "MenuItem"
+    assert node.CurrentControlType == uia.ControlType.MenuItem
 
-    assert "Toggle" in uia.get_supported_patterns(node)
-    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
-    assert toggle_pattern_attr["ToggleState"] == 0
-
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTogglePatternAvailable)
+    toggle_pattern = node.GetCurrentPattern(uia.PatternId.Toggle)
+    assert toggle_pattern and toggle_pattern.CurrentToggleState == 0

--- a/core-aam/aamtests/role/menuitemcheckbox.py
+++ b/core-aam/aamtests/role/menuitemcheckbox.py
@@ -27,10 +27,18 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_CHECK_MENU_ITEM
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: MenuItem
-#     # Control Pattern: Toggle
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: MenuItem
+    # Control Pattern: Toggle
+    # See also: aria-checked in the State and Property Mapping Tables
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "MenuItem"
+
+    assert "Toggle" in uia.get_supported_patterns(node)
+    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
+    assert toggle_pattern_attr["ToggleState"] == 0
+

--- a/core-aam/aamtests/role/menuitemradio.py
+++ b/core-aam/aamtests/role/menuitemradio.py
@@ -27,11 +27,17 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_RADIO_MENU_ITEM
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: MenuItem
-#     # Control Pattern: Toggle
-#     # Control Pattern: SelectionItem
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: MenuItem
+    # Control Pattern: Toggle
+    # Control Pattern: SelectionItem
+    # See also: aria-checked in the State and Property Mapping Tables
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "MenuItem"
+    # assert uia.get_control_pattern(node, "Toggle") is not None
+    # assert uia.get_control_pattern(node, "SelectionItem") is not None
+    # assert uia.get_property(node, "IsChecked") is not None

--- a/core-aam/aamtests/role/menuitemradio.py
+++ b/core-aam/aamtests/role/menuitemradio.py
@@ -37,7 +37,12 @@ def test_uia(uia, session, inline):
     # See also: aria-checked in the State and Property Mapping Tables
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "MenuItem"
-    # assert uia.get_control_pattern(node, "Toggle") is not None
-    # assert uia.get_control_pattern(node, "SelectionItem") is not None
-    # assert uia.get_property(node, "IsChecked") is not None
+    assert node.CurrentControlType == uia.ControlType.MenuItem
+
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTogglePatternAvailable)
+    toggle_pattern = node.GetCurrentPattern(uia.PatternId.Toggle)
+    assert toggle_pattern and toggle_pattern.CurrentToggleState == 0
+
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionItemPatternAvailable)
+    selection_pattern = node.GetCurrentPattern(uia.PatternId.SelectionItem)
+    assert selection_pattern and selection_pattern.CurrentIsSelected == 0

--- a/core-aam/aamtests/role/meter.py
+++ b/core-aam/aamtests/role/meter.py
@@ -27,10 +27,14 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LEVEL_BAR
 #     # Interface: IAccessibleValue
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ProgressBar
-#     # Localized Control Type: meter
-#     # Control Pattern: RangeValue
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ProgressBar
+    # Localized Control Type: meter
+    # Control Pattern: RangeValue
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.ProgressBar
+    assert node.CurrentLocalizedControlType == "meter"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/meter.py
+++ b/core-aam/aamtests/role/meter.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Control Type: ProgressBar
     # Localized Control Type: meter
     # Control Pattern: RangeValue
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.ProgressBar
     assert node.CurrentLocalizedControlType == "meter"

--- a/core-aam/aamtests/role/navigation.py
+++ b/core-aam/aamtests/role/navigation.py
@@ -27,10 +27,15 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LANDMARK
 #     # Object Attribute: xml-roles:navigation
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: navigation
-#     # Landmark Type: Navigation
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: navigation
+    # Landmark Type: Navigation
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "navigation"
+    assert uia.get_landmark_type(node) == "Navigation"

--- a/core-aam/aamtests/role/navigation.py
+++ b/core-aam/aamtests/role/navigation.py
@@ -36,6 +36,6 @@ def test_uia(uia, session, inline):
     # Landmark Type: Navigation
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "navigation"
-    assert uia.get_landmark_type(node) == "Navigation"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "navigation"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Navigation

--- a/core-aam/aamtests/role/note.py
+++ b/core-aam/aamtests/role/note.py
@@ -24,9 +24,13 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: IA2_ROLE_NOTE
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: note
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: note
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "note"

--- a/core-aam/aamtests/role/note.py
+++ b/core-aam/aamtests/role/note.py
@@ -32,5 +32,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: note
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "note"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "note"

--- a/core-aam/aamtests/role/option.py
+++ b/core-aam/aamtests/role/option.py
@@ -26,10 +26,15 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_LISTITEM
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ListItem
-#     # Control Pattern: Invoke
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ListItem
+    # Control Pattern: Invoke
+    # See also: aria-checked in the State and Property Mapping Tables
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "ListItem"
+    #Todo: add Invoke Control Pattern assertions here
+    #Todo: add aria-checked state and property assertions here

--- a/core-aam/aamtests/role/option.py
+++ b/core-aam/aamtests/role/option.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # See also: aria-checked in the State and Property Mapping Tables
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "ListItem"
-    #Todo: add Invoke Control Pattern assertions here
-    #Todo: add aria-checked state and property assertions here
+    assert node.CurrentControlType == uia.ControlType.ListItem
+
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsInvokePatternAvailable)
+    # aria-checked is not mapped when undefined as in the HTML fragment above.

--- a/core-aam/aamtests/role/option_in_combobox.py
+++ b/core-aam/aamtests/role/option_in_combobox.py
@@ -33,6 +33,7 @@ def test_uia(uia, session, inline):
     # Control Type: ListItem
     # Control Pattern: Invoke
     # See also: aria-checked in the State and Property Mapping Tables
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.ListItem
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsInvokePatternAvailable)

--- a/core-aam/aamtests/role/option_in_combobox.py
+++ b/core-aam/aamtests/role/option_in_combobox.py
@@ -26,10 +26,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_LISTITEM
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ListItem
-#     # Control Pattern: Invoke
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ListItem
+    # Control Pattern: Invoke
+    # See also: aria-checked in the State and Property Mapping Tables
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.ListItem
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsInvokePatternAvailable)

--- a/core-aam/aamtests/role/paragraph.py
+++ b/core-aam/aamtests/role/paragraph.py
@@ -25,8 +25,11 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Role: IA2_ROLE_PARAGRAPH
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"

--- a/core-aam/aamtests/role/paragraph.py
+++ b/core-aam/aamtests/role/paragraph.py
@@ -32,4 +32,4 @@ def test_uia(uia, session, inline):
     # Control Type: Text
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
+    assert node.CurrentControlType == uia.ControlType.Text

--- a/core-aam/aamtests/role/progressbar.py
+++ b/core-aam/aamtests/role/progressbar.py
@@ -29,8 +29,12 @@ def test_atspi(atspi, session, inline):
 #     # State: STATE_SYSTEM_READONLY
 #     # Interface: IAccessibleValue
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # <span class="property">Control Type: <code>ProgressBar</code></span><br> <span class="property">Control Pattern: <code>RangeValue</code> if <code>aria-valuenow</code>, <code>aria-valuemax</code>, or <code>aria-valuemin</code></span> is present
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ProgressBar
+    # Control Pattern: RangeValue if aria-valuenow, aria-valuemax, or aria-valuemin is present
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.ProgressBar
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/progressbar.py
+++ b/core-aam/aamtests/role/progressbar.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: ProgressBar
     # Control Pattern: RangeValue if aria-valuenow, aria-valuemax, or aria-valuemin is present
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.ProgressBar
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/radio.py
+++ b/core-aam/aamtests/role/radio.py
@@ -36,13 +36,12 @@ def test_uia(uia, session, inline):
     # See also: aria-checked in the State and Property Mapping Tables
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "RadioButton"
-    patterns = uia.get_supported_patterns(node)
+    assert node.CurrentControlType == uia.ControlType.RadioButton
 
-    assert "Toggle" in patterns
-    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
-    assert toggle_pattern_attr["ToggleState"] == 0
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTogglePatternAvailable)
+    toggle_pattern = node.GetCurrentPattern(uia.PatternId.Toggle)
+    assert toggle_pattern and toggle_pattern.CurrentToggleState == 0
 
-    assert "SelectionItem" in patterns
-    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
-    assert selection_pattern_attr["IsSelected"] == 0
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionItemPatternAvailable)
+    selection_pattern = node.GetCurrentPattern(uia.PatternId.SelectionItem)
+    assert selection_pattern and selection_pattern.CurrentIsSelected == 0

--- a/core-aam/aamtests/role/radio.py
+++ b/core-aam/aamtests/role/radio.py
@@ -26,11 +26,23 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_RADIOBUTTON
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: RadioButton
-#     # Control Pattern: Toggle
-#     # Control Pattern: SelectionItem
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: RadioButton
+    # Control Pattern: Toggle
+    # Control Pattern: SelectionItem
+    # See also: aria-checked in the State and Property Mapping Tables
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "RadioButton"
+    patterns = uia.get_supported_patterns(node)
+
+    assert "Toggle" in patterns
+    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
+    assert toggle_pattern_attr["ToggleState"] == 0
+
+    assert "SelectionItem" in patterns
+    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
+    assert selection_pattern_attr["IsSelected"] == 0

--- a/core-aam/aamtests/role/radiogroup.py
+++ b/core-aam/aamtests/role/radiogroup.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: List
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "List"
+    assert node.CurrentControlType == uia.ControlType.List

--- a/core-aam/aamtests/role/radiogroup.py
+++ b/core-aam/aamtests/role/radiogroup.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_GROUPING
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: List
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: List
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "List"

--- a/core-aam/aamtests/role/region.py
+++ b/core-aam/aamtests/role/region.py
@@ -27,11 +27,17 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LANDMARK
 #     # Object Attribute: xml-roles:region
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: region
-#     # Landmark Type: Custom
-#     # Localized Landmark Type: region
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: region
+    # Landmark Type: Custom
+    # Localized Landmark Type: region
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "region"
+    assert uia.get_landmark_type(node) == "Custom"
+    assert uia.get_property(node, "LocalizedLandmarkType") == "region"

--- a/core-aam/aamtests/role/region.py
+++ b/core-aam/aamtests/role/region.py
@@ -37,7 +37,7 @@ def test_uia(uia, session, inline):
     # Localized Landmark Type: region
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "region"
-    assert uia.get_landmark_type(node) == "Custom"
-    assert uia.get_property(node, "LocalizedLandmarkType") == "region"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "region"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Custom
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LocalizedLandmarkType) == "region"

--- a/core-aam/aamtests/role/row.py
+++ b/core-aam/aamtests/role/row.py
@@ -33,10 +33,9 @@ def test_uia(uia, session, inline):
     # Control Pattern: SelectionItem
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "DataItem"
-    assert uia.get_property(node, "LocalizedControlType") == "row"
-    patterns = uia.get_supported_patterns(node)
+    assert node.CurrentControlType == uia.ControlType.DataItem
+    assert node.CurrentLocalizedControlType == "row"
 
-    assert "SelectionItem" in patterns
-    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
-    assert selection_pattern_attr["IsSelected"] == 0
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionItemPatternAvailable)
+    selection_pattern = node.GetCurrentPattern(uia.PatternId.SelectionItem)
+    assert selection_pattern and selection_pattern.CurrentIsSelected == 0

--- a/core-aam/aamtests/role/row.py
+++ b/core-aam/aamtests/role/row.py
@@ -24,10 +24,19 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_ROW
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataItem
-#     # Localized Control Type: row
-#     # Control Pattern: SelectionItem
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataItem
+    # Localized Control Type: row
+    # Control Pattern: SelectionItem
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "DataItem"
+    assert uia.get_property(node, "LocalizedControlType") == "row"
+    patterns = uia.get_supported_patterns(node)
+
+    assert "SelectionItem" in patterns
+    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
+    assert selection_pattern_attr["IsSelected"] == 0

--- a/core-aam/aamtests/role/row_in_treegrid.py
+++ b/core-aam/aamtests/role/row_in_treegrid.py
@@ -33,9 +33,9 @@ def test_uia(uia, session, inline):
     # Control Pattern: SelectionItem
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "DataItem"
-    assert uia.get_property(node, "LocalizedControlType") == "row"
+    assert node.CurrentControlType == uia.ControlType.DataItem
+    assert node.CurrentLocalizedControlType == "row"
 
-    assert "SelectionItem" in uia.get_supported_patterns(node)
-    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
-    assert selection_pattern_attr["IsSelected"] == 0
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionItemPatternAvailable)
+    selection_pattern = node.GetCurrentPattern(uia.PatternId.SelectionItem)
+    assert selection_pattern and selection_pattern.CurrentIsSelected == 0

--- a/core-aam/aamtests/role/row_in_treegrid.py
+++ b/core-aam/aamtests/role/row_in_treegrid.py
@@ -24,10 +24,18 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_OUTLINEITEM
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataItem
-#     # Localized Control Type: row
-#     # Control Pattern: SelectionItem
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataItem
+    # Localized Control Type: row
+    # Control Pattern: SelectionItem
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "DataItem"
+    assert uia.get_property(node, "LocalizedControlType") == "row"
+
+    assert "SelectionItem" in uia.get_supported_patterns(node)
+    selection_pattern_attr = uia.get_pattern_attr(node, "SelectionItem")
+    assert selection_pattern_attr["IsSelected"] == 0

--- a/core-aam/aamtests/role/rowgroup.py
+++ b/core-aam/aamtests/role/rowgroup.py
@@ -23,8 +23,10 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_GROUPING
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group

--- a/core-aam/aamtests/role/rowgroup.py
+++ b/core-aam/aamtests/role/rowgroup.py
@@ -28,5 +28,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Group
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group

--- a/core-aam/aamtests/role/rowheader.py
+++ b/core-aam/aamtests/role/rowheader.py
@@ -32,5 +32,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: HeaderItem
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.HeaderItem

--- a/core-aam/aamtests/role/rowheader.py
+++ b/core-aam/aamtests/role/rowheader.py
@@ -27,8 +27,10 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_ROWHEADER
 #     # Interface: IAccessibleTableCell
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: HeaderItem
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: HeaderItem
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.HeaderItem

--- a/core-aam/aamtests/role/scrollbar.py
+++ b/core-aam/aamtests/role/scrollbar.py
@@ -28,9 +28,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_SCROLLBAR
 #     # Interface: IAccessibleValue
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ScrollBar
-#     # Control Pattern: RangeValue
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ScrollBar
+    # Control Pattern: RangeValue
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.ScrollBar
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/scrollbar.py
+++ b/core-aam/aamtests/role/scrollbar.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: ScrollBar
     # Control Pattern: RangeValue
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.ScrollBar
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/search.py
+++ b/core-aam/aamtests/role/search.py
@@ -27,10 +27,15 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_LANDMARK
 #     # Object Attribute: xml-roles:search
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: search
-#     # Landmark Type: Search
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: search
+    # Landmark Type: Search
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "search"
+    assert uia.get_landmark_type(node) == "Search"

--- a/core-aam/aamtests/role/search.py
+++ b/core-aam/aamtests/role/search.py
@@ -36,6 +36,6 @@ def test_uia(uia, session, inline):
     # Landmark Type: Search
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "search"
-    assert uia.get_landmark_type(node) == "Search"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "search"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LandmarkType) == uia.LandmarkType.Search

--- a/core-aam/aamtests/role/searchbox.py
+++ b/core-aam/aamtests/role/searchbox.py
@@ -31,9 +31,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_TEXT
 #     # Object Attribute: text-input-type:search
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Edit
-#     # Localized Control Type: search box
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Edit
+    # Localized Control Type: search box
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Edit
+    assert node.CurrentLocalizedControlType == "search box"

--- a/core-aam/aamtests/role/searchbox.py
+++ b/core-aam/aamtests/role/searchbox.py
@@ -37,6 +37,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Edit
     # Localized Control Type: search box
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Edit
     assert node.CurrentLocalizedControlType == "search box"

--- a/core-aam/aamtests/role/sectionfooter.py
+++ b/core-aam/aamtests/role/sectionfooter.py
@@ -26,9 +26,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Object Attribute: xml-roles:sectionfooter
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: section footer
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: section footer
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "section footer"

--- a/core-aam/aamtests/role/sectionfooter.py
+++ b/core-aam/aamtests/role/sectionfooter.py
@@ -34,5 +34,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: section footer
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "section footer"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "section footer"

--- a/core-aam/aamtests/role/sectionheader.py
+++ b/core-aam/aamtests/role/sectionheader.py
@@ -26,9 +26,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Object Attribute: xml-roles:sectionheader
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: section header
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: section header
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "section header"

--- a/core-aam/aamtests/role/sectionheader.py
+++ b/core-aam/aamtests/role/sectionheader.py
@@ -34,5 +34,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: section header
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "section header"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "section header"

--- a/core-aam/aamtests/role/separator.py
+++ b/core-aam/aamtests/role/separator.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_SEPARATOR
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Separator
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Separator
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Separator"

--- a/core-aam/aamtests/role/separator.py
+++ b/core-aam/aamtests/role/separator.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: Separator
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Separator"
+    assert node.CurrentControlType == uia.ControlType.Separator

--- a/core-aam/aamtests/role/separator_focusable.py
+++ b/core-aam/aamtests/role/separator_focusable.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Thumb
     # Control Pattern: RangeValue
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Thumb
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/separator_focusable.py
+++ b/core-aam/aamtests/role/separator_focusable.py
@@ -28,9 +28,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_SEPARATOR
 #     # Interface: IAccessibleValue
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Thumb
-#     # Control Pattern: RangeValue
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Thumb
+    # Control Pattern: RangeValue
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Thumb
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/slider.py
+++ b/core-aam/aamtests/role/slider.py
@@ -28,9 +28,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_SLIDER
 #     # Interface: IAccessibleValue
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Slider
-#     # Control Pattern: RangeValue
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Slider
+    # Control Pattern: RangeValue
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Slider
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/slider.py
+++ b/core-aam/aamtests/role/slider.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Slider
     # Control Pattern: RangeValue
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Slider
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/spinbutton.py
+++ b/core-aam/aamtests/role/spinbutton.py
@@ -28,9 +28,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_SPINBUTTON
 #     # Interface: IAccessibleValue
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Spinner
-#     # Control Pattern: RangeValue
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Spinner
+    # Control Pattern: RangeValue
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Spinner
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/spinbutton.py
+++ b/core-aam/aamtests/role/spinbutton.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Spinner
     # Control Pattern: RangeValue
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Spinner
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsRangeValuePatternAvailable)

--- a/core-aam/aamtests/role/status.py
+++ b/core-aam/aamtests/role/status.py
@@ -33,10 +33,14 @@ def test_atspi(atspi, session, inline):
 #     # Object Attribute: live:polite
 #     # Object Attribute: container-live-role:status
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: status
-#     # LiveSetting: Polite (1)
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: status
+    # LiveSetting: Polite (1)
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "status"
+    assert node.GetCurrentPropertyValue(uia.PropertyId.LiveSetting) == 1

--- a/core-aam/aamtests/role/status.py
+++ b/core-aam/aamtests/role/status.py
@@ -40,6 +40,7 @@ def test_uia(uia, session, inline):
     # Control Type: Group
     # Localized Control Type: status
     # LiveSetting: Polite (1)
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "status"

--- a/core-aam/aamtests/role/strong.py
+++ b/core-aam/aamtests/role/strong.py
@@ -27,9 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_TEXT_FRAME
 #     # Object Attribute: xml-roles:strong
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: strong
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: strong
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+    assert uia.get_property(node, "LocalizedControlType") == "strong"

--- a/core-aam/aamtests/role/strong.py
+++ b/core-aam/aamtests/role/strong.py
@@ -35,5 +35,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: strong
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
-    assert uia.get_property(node, "LocalizedControlType") == "strong"
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "strong"

--- a/core-aam/aamtests/role/subscript.py
+++ b/core-aam/aamtests/role/subscript.py
@@ -26,9 +26,16 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_TEXT_FRAME
 #     # Text Attribute: text-position:sub
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Styles used are exposed by IsSubscript attribute of the TextRange Control Pattern implemented on the accessible object.: IsSubscript: attribute of the TextRange Control Pattern implemented on the accessible object.
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Styles used are exposed by IsSubscript attribute of the Text Control Pattern implemented on the accessible object.: IsSubscript: attribute of the TextRange Control Pattern implemented on the accessible object.
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+
+    assert "Text" in uia.get_supported_patterns(node)
+
+    #Todo: Full Text patern support: Add ability to assess control patern for subscript

--- a/core-aam/aamtests/role/subscript.py
+++ b/core-aam/aamtests/role/subscript.py
@@ -34,8 +34,15 @@ def test_uia(uia, session, inline):
     # Styles used are exposed by IsSubscript attribute of the Text Control Pattern implemented on the accessible object.: IsSubscript: attribute of the TextRange Control Pattern implemented on the accessible object.
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
+    assert node.CurrentControlType == uia.ControlType.Text
 
-    assert "Text" in uia.get_supported_patterns(node)
+    # Chrome exposes this as a textChild pattern, which is not a violation of UIA.
+    assert (node.GetCurrentPropertyValue(uia.PropertyId.IsTextPatternAvailable) or node.GetCurrentPropertyValue(uia.PropertyId.IsTextChildPatternAvailable))
 
-    #Todo: Full Text patern support: Add ability to assess control patern for subscript
+    text_child = node.GetCurrentPattern(uia.PatternId.TextChild)
+    assert text_child is not None
+
+    text_range = text_child.TextRange
+
+    assert text_range.IsSubscript
+    assert text_range.IsSuperscript == False

--- a/core-aam/aamtests/role/suggestion.py
+++ b/core-aam/aamtests/role/suggestion.py
@@ -33,6 +33,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Group
     # Localized Control Type: suggestion
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Group
     assert node.CurrentLocalizedControlType == "suggestion"

--- a/core-aam/aamtests/role/suggestion.py
+++ b/core-aam/aamtests/role/suggestion.py
@@ -27,9 +27,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_SUGGESTION
 #     # Object Attribute: xml-roles:suggestion
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: suggestion
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: suggestion
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "suggestion"

--- a/core-aam/aamtests/role/superscript.py
+++ b/core-aam/aamtests/role/superscript.py
@@ -34,8 +34,15 @@ def test_uia(uia, session, inline):
     # Styles used are exposed by IsSuperscript attribute of the TextRange Control Pattern implemented on the accessible object.: IsSuperscript: attribute of the TextRange Control Pattern implemented on the accessible object.
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
+    assert node.CurrentControlType == uia.ControlType.Text
 
-    assert "Text" in uia.get_supported_patterns(node)
+    # Chrome exposes this as a TextChild pattern, which is not a violation of UIA.
+    assert (node.GetCurrentPropertyValue(uia.PropertyId.IsTextPatternAvailable) or node.GetCurrentPropertyValue(uia.PropertyId.IsTextChildPatternAvailable))
 
-    #Todo: Full Text patern support: Add ability to assess control patern for superscript
+    text_child = node.GetCurrentPattern(uia.PatternId.TextChild)
+    assert text_child is not None
+
+    text_range = text_child.TextRange
+
+    assert text_range.IsSuperscript
+    assert text_range.IsSubscript == False

--- a/core-aam/aamtests/role/superscript.py
+++ b/core-aam/aamtests/role/superscript.py
@@ -26,9 +26,16 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_TEXT_FRAME
 #     # Text Attribute: text-position:super
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Styles used are exposed by IsSuperscript attribute of the TextRange Control Pattern implemented on the accessible object.: IsSuperscript: attribute of the TextRange Control Pattern implemented on the accessible object.
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Styles used are exposed by IsSuperscript attribute of the TextRange Control Pattern implemented on the accessible object.: IsSuperscript: attribute of the TextRange Control Pattern implemented on the accessible object.
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+
+    assert "Text" in uia.get_supported_patterns(node)
+
+    #Todo: Full Text patern support: Add ability to assess control patern for superscript

--- a/core-aam/aamtests/role/switch.py
+++ b/core-aam/aamtests/role/switch.py
@@ -38,6 +38,7 @@ def test_uia(uia, session, inline):
     # Localized Control Type: toggleswitch
     # Control Pattern: Toggle
     # See also: aria-checked in the State and Property Mapping Tables
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Button
     assert node.CurrentLocalizedControlType == "toggleswitch"

--- a/core-aam/aamtests/role/switch.py
+++ b/core-aam/aamtests/role/switch.py
@@ -39,9 +39,9 @@ def test_uia(uia, session, inline):
     # Control Pattern: Toggle
     # See also: aria-checked in the State and Property Mapping Tables
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Button"
-    assert uia.get_property(node, "LocalizedControlType") == "toggleswitch"
+    assert node.CurrentControlType == uia.ControlType.Button
+    assert node.CurrentLocalizedControlType == "toggleswitch"
 
-    assert "Toggle" in uia.get_supported_patterns(node)
-    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
-    assert toggle_pattern_attr["ToggleState"] == 0
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTogglePatternAvailable)
+    toggle_pattern = node.GetCurrentPattern(uia.PatternId.Toggle)
+    assert toggle_pattern and toggle_pattern.CurrentToggleState == 0

--- a/core-aam/aamtests/role/switch.py
+++ b/core-aam/aamtests/role/switch.py
@@ -30,11 +30,18 @@ def test_atspi(atspi, session, inline):
 #     # Object Attribute: xml-roles:switch
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Button
-#     # Localized Control Type: toggleswitch
-#     # Control Pattern: Toggle
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Button
+    # Localized Control Type: toggleswitch
+    # Control Pattern: Toggle
+    # See also: aria-checked in the State and Property Mapping Tables
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Button"
+    assert uia.get_property(node, "LocalizedControlType") == "toggleswitch"
+
+    assert "Toggle" in uia.get_supported_patterns(node)
+    toggle_pattern_attr = uia.get_pattern_attr(node, "Toggle")
+    assert toggle_pattern_attr["ToggleState"] == 0

--- a/core-aam/aamtests/role/tab.py
+++ b/core-aam/aamtests/role/tab.py
@@ -26,8 +26,10 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_PAGETAB
 #     # State: STATE_SYSTEM_SELECTED: if focus is inside tabpanel associated with aria-labelledby
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: TabItem
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: TabItem
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.TabItem

--- a/core-aam/aamtests/role/tab.py
+++ b/core-aam/aamtests/role/tab.py
@@ -31,5 +31,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: TabItem
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.TabItem

--- a/core-aam/aamtests/role/table.py
+++ b/core-aam/aamtests/role/table.py
@@ -33,10 +33,14 @@ def test_atspi(atspi, session, inline):
 #     # Object Attribute: xml-roles:table
 #     # Interface: IAccessibleTable2
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Table
-#     # Control Pattern: Grid
-#     # Control Pattern: Table
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Table
+    # Control Pattern: Grid
+    # Control Pattern: Table
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Table
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridPatternAvailable)
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsTablePatternAvailable)

--- a/core-aam/aamtests/role/table.py
+++ b/core-aam/aamtests/role/table.py
@@ -40,6 +40,7 @@ def test_uia(uia, session, inline):
     # Control Type: Table
     # Control Pattern: Grid
     # Control Pattern: Table
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Table
     assert node.GetCurrentPropertyValue(uia.PropertyId.IsGridPatternAvailable)

--- a/core-aam/aamtests/role/tablist.py
+++ b/core-aam/aamtests/role/tablist.py
@@ -35,6 +35,7 @@ def test_uia(uia, session, inline):
     # Spec:
     # Control Type: Tab
     # Control Pattern: Selection
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Tab
 

--- a/core-aam/aamtests/role/tablist.py
+++ b/core-aam/aamtests/role/tablist.py
@@ -29,9 +29,15 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Tab
-#     # Control Pattern: Selection
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Tab
+    # Control Pattern: Selection
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Tab
+
+    assert node.GetCurrentPropertyValue(uia.PropertyId.IsSelectionItemPatternAvailable)
+    selection_pattern = node.GetCurrentPattern(uia.PatternId.SelectionItem)
+    assert selection_pattern and selection_pattern.CurrentIsSelected == 0

--- a/core-aam/aamtests/role/tabpanel.py
+++ b/core-aam/aamtests/role/tabpanel.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_PANE: or ROLE_SYSTEM_PROPERTYPAGE
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Pane
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Pane
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Pane"

--- a/core-aam/aamtests/role/tabpanel.py
+++ b/core-aam/aamtests/role/tabpanel.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: Pane
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Pane"
+    assert node.CurrentControlType == uia.ControlType.Pane

--- a/core-aam/aamtests/role/term.py
+++ b/core-aam/aamtests/role/term.py
@@ -25,9 +25,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: IA2_ROLE_TEXT_FRAME
 #     # Object Attribute: xml-roles:term
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: term
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: term
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Text"
+    assert uia.get_property(node, "LocalizedControlType") == "term"

--- a/core-aam/aamtests/role/term.py
+++ b/core-aam/aamtests/role/term.py
@@ -33,5 +33,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: term
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Text"
-    assert uia.get_property(node, "LocalizedControlType") == "term"
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "term"

--- a/core-aam/aamtests/role/textbox.py
+++ b/core-aam/aamtests/role/textbox.py
@@ -49,5 +49,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Edit
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Edit

--- a/core-aam/aamtests/role/textbox.py
+++ b/core-aam/aamtests/role/textbox.py
@@ -44,8 +44,10 @@ def test_atspi_readonly(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_TEXT
 #     # State: IA2_STATE_SINGLE_LINE
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Edit
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Edit
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Edit

--- a/core-aam/aamtests/role/textbox_multiline.py
+++ b/core-aam/aamtests/role/textbox_multiline.py
@@ -49,5 +49,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Edit
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Edit

--- a/core-aam/aamtests/role/textbox_multiline.py
+++ b/core-aam/aamtests/role/textbox_multiline.py
@@ -44,8 +44,10 @@ def test_atspi_readonly(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_TEXT
 #     # State: IA2_STATE_MULTI_LINE
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Edit
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Edit
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Edit

--- a/core-aam/aamtests/role/time-role.py
+++ b/core-aam/aamtests/role/time-role.py
@@ -27,10 +27,13 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_GROUPING
 #     # Object Attribute: xml-roles:time
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Text
-#     # Localized Control Type: time
-#     # Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Text
+    # Localized Control Type: time
+    # Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Text
+    assert node.CurrentLocalizedControlType == "time"

--- a/core-aam/aamtests/role/time-role.py
+++ b/core-aam/aamtests/role/time-role.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
     # Control Type: Text
     # Localized Control Type: time
     # Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Text
     assert node.CurrentLocalizedControlType == "time"

--- a/core-aam/aamtests/role/timer.py
+++ b/core-aam/aamtests/role/timer.py
@@ -24,9 +24,13 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Object Attribute: xml-roles:timer
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Group
-#     # Localized Control Type: timer
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Group
+    # Localized Control Type: timer
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "Group"
+    assert uia.get_property(node, "LocalizedControlType") == "timer"

--- a/core-aam/aamtests/role/timer.py
+++ b/core-aam/aamtests/role/timer.py
@@ -32,5 +32,5 @@ def test_uia(uia, session, inline):
     # Localized Control Type: timer
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "Group"
-    assert uia.get_property(node, "LocalizedControlType") == "timer"
+    assert node.CurrentControlType == uia.ControlType.Group
+    assert node.CurrentLocalizedControlType == "timer"

--- a/core-aam/aamtests/role/toolbar.py
+++ b/core-aam/aamtests/role/toolbar.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_TOOLBAR
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ToolBar
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ToolBar
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "ToolBar"

--- a/core-aam/aamtests/role/toolbar.py
+++ b/core-aam/aamtests/role/toolbar.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: ToolBar
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "ToolBar"
+    assert node.CurrentControlType == uia.ControlType.ToolBar

--- a/core-aam/aamtests/role/tooltip.py
+++ b/core-aam/aamtests/role/tooltip.py
@@ -24,8 +24,11 @@ def test_atspi(atspi, session, inline):
 #     # Spec:
 #     # Role: ROLE_SYSTEM_TOOLTIP
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: ToolTip
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: ToolTip
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "ToolTip"

--- a/core-aam/aamtests/role/tooltip.py
+++ b/core-aam/aamtests/role/tooltip.py
@@ -31,4 +31,4 @@ def test_uia(uia, session, inline):
     # Control Type: ToolTip
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "ToolTip"
+    assert node.CurrentControlType == uia.ControlType.ToolTip

--- a/core-aam/aamtests/role/tree.py
+++ b/core-aam/aamtests/role/tree.py
@@ -29,8 +29,11 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: Tree
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: Tree
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.Tree
+

--- a/core-aam/aamtests/role/tree.py
+++ b/core-aam/aamtests/role/tree.py
@@ -34,6 +34,7 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: Tree
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.Tree
 

--- a/core-aam/aamtests/role/treegrid.py
+++ b/core-aam/aamtests/role/treegrid.py
@@ -32,8 +32,10 @@ def test_atspi(atspi, session, inline):
 #     # Method: IAccessible::accSelect()
 #     # Method: IAccessible::get_accSelection()
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: DataGrid
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: DataGrid
+    node = uia.find_node("test", session.url)
+    assert node.CurrentControlType == uia.ControlType.DataGrid

--- a/core-aam/aamtests/role/treegrid.py
+++ b/core-aam/aamtests/role/treegrid.py
@@ -37,5 +37,6 @@ def test_uia(uia, session, inline):
 
     # Spec:
     # Control Type: DataGrid
+
     node = uia.find_node("test", session.url)
     assert node.CurrentControlType == uia.ControlType.DataGrid

--- a/core-aam/aamtests/role/treeitem.py
+++ b/core-aam/aamtests/role/treeitem.py
@@ -34,4 +34,4 @@ def test_uia(uia, session, inline):
     # See also: aria-checked in the State and Property Mapping Tables
 
     node = uia.find_node("test", session.url)
-    assert uia.get_control_type(node) == "TreeItem"
+    assert node.CurrentControlType == uia.ControlType.TreeItem

--- a/core-aam/aamtests/role/treeitem.py
+++ b/core-aam/aamtests/role/treeitem.py
@@ -26,9 +26,12 @@ def test_atspi(atspi, session, inline):
 #     # Role: ROLE_SYSTEM_OUTLINEITEM
 #     # See also: aria-checked in the State and Property Mapping Tables
 
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#
-#     # Spec:
-#     # Control Type: TreeItem
-#     # See also: aria-checked in the State and Property Mapping Tables
+def test_uia(uia, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Control Type: TreeItem
+    # See also: aria-checked in the State and Property Mapping Tables
+
+    node = uia.find_node("test", session.url)
+    assert uia.get_control_type(node) == "TreeItem"

--- a/core-aam/aamtests/support/fixtures_a11y_api.py
+++ b/core-aam/aamtests/support/fixtures_a11y_api.py
@@ -45,11 +45,14 @@ def axapi(session, default_timeout):
 
 
 @pytest.fixture
-def uia(session):
+def uia(session, default_timeout):
     if platform != "win32":
         pytest.skip("NOT_APPLICABLE")
 
-    # TODO: Make UiaWrapper and return it
+    from .uia_wrapper import UiaWrapper
+
+    pid, product_name = pid_from(session.capabilities)
+    return UiaWrapper(pid, product_name, default_timeout)
 
 
 @pytest.fixture

--- a/core-aam/aamtests/support/uia_wrapper.py
+++ b/core-aam/aamtests/support/uia_wrapper.py
@@ -9,9 +9,6 @@ from .api_wrapper import ApiWrapper
 
 comtypes.CoInitialize()
 
-# Type alias for the dynamically generated UI Automation element interface.
-UiaElement = Any
-
 # Load the UI Automation type library. This exposes the IUIAutomation
 # interface, the CUIAutomation coclass, and the UIA_* property, control type,
 # pattern, and tree scope id constants.
@@ -22,6 +19,37 @@ UIA = comtypes.client.GetModule("UIAutomationCore.dll")
 _automation = comtypes.client.CreateObject(
     UIA.CUIAutomation, interface=UIA.IUIAutomation
 )
+
+
+class UiaConstant(int):
+    """An integer that prints its human-readable name in test failures."""
+
+    def __new__(cls, value: int, name: str):
+        obj = super().__new__(cls, value)
+        obj.name = name
+        return obj
+
+    def __repr__(self) -> str:
+        # This is what Pytest will show in the error log
+        return f"<{self.name}: {int(self)}>"
+
+
+class _ConstantsProxy:
+    """Dynamically routes dot-notation lookups to UIA integer constants."""
+    def __init__(self, mapping: dict[int, str]):
+        self._id_to_name = mapping
+        # Reverse the {id: "Name"} mapping into {"Name": id}
+        self._name_to_id = {name: val for val, name in mapping.items()}
+
+    def __getattr__(self, name: str) -> UiaConstant:
+        if name in self._name_to_id:
+            return UiaConstant(self._name_to_id[name], name)
+        raise AttributeError(f"UIA constant '{name}' does not exist.")
+
+    def __dir__(self) -> list[str]:
+        # Exposes the names to IDE autocompletion and dir() calls
+        return list(self._name_to_id.keys())
+
 
 # ----  Maps for turning UIA constants into human readable names.
 
@@ -38,7 +66,6 @@ UIA_PROPERTY_ID_MAP = {
     for name, value in vars(UIA).items()
     if name.startswith("UIA_") and name.endswith("PropertyId")
 }
-UIA_PROPERTY_NAME_MAP = {name: value for value, name in UIA_PROPERTY_ID_MAP.items()}
 
 # Generate a mapping of event id to human readable name, e.g. 20000 -> "AutomationFocusChangedEvent", 20001 -> "AutomationPropertyChangedEvent", etc.
 UIA_EVENT_ID_MAP = {
@@ -61,13 +88,136 @@ UIA_LANDMARK_TYPE_ID_MAP = {
     if name.startswith("UIA_") and name.endswith("LandmarkTypeId")
 }
 
-class UiaWrapper(ApiWrapper[UiaElement]):
+UIA_TEXT_ATTRIBUTE_ID_MAP = {
+    value: name[len("UIA_"):-len("AttributeId")]
+    for name, value in vars(UIA).items()
+    if name.startswith("UIA_") and name.endswith("AttributeId")
+}
+UIA_TEXT_ATTRIBUTE_NAME_MAP = {name: value for value, name in UIA_TEXT_ATTRIBUTE_ID_MAP.items()}
+
+# Master map used to decode properties back into UiaConstants
+_VALUE_MAPS = {
+    "ControlType": UIA_CONTROL_TYPE_MAP,
+    "PropertyId": UIA_PROPERTY_ID_MAP,
+    "EventId": UIA_EVENT_ID_MAP,
+    "PatternId": UIA_PATTERN_ID_MAP,
+    "LandmarkType": UIA_LANDMARK_TYPE_ID_MAP,
+    "TextAttribute": UIA_TEXT_ATTRIBUTE_ID_MAP,
+}
+
+
+# ---- UiaObject wrapper allows mostly for easier reading and writing.
+
+class UiaObject:
+    """A single, transparent proxy for Elements, Patterns, and TextRanges."""
+
+    def __init__(self, obj: Any):
+        object.__setattr__(self, "_obj", obj)
+
+    def __getattr__(self, name: str) -> Any:
+        obj = self._obj
+
+        # 1. Intercept TextAttributes natively
+        if name in UIA_TEXT_ATTRIBUTE_NAME_MAP and hasattr(obj, "GetAttributeValue"):
+            attr_id = UIA_TEXT_ATTRIBUTE_NAME_MAP[name]
+            raw_attr = obj.GetAttributeValue(attr_id)
+
+        # 2. Native
+        elif hasattr(obj, name):
+            raw_attr = getattr(obj, name)
+
+        else:
+            raise AttributeError(
+                f"Wrapped UIA object has no attribute '{name}'. "
+                f"Available attributes: {dir(obj)}"
+            )
+
+        # 4. Handle methods natively
+        if callable(raw_attr):
+            def method_proxy(*args, **kwargs):
+                unwrapped_args = [_unwrap_arg(arg) for arg in args]
+                result = raw_attr(*unwrapped_args, **kwargs)
+
+                # --- Decode GetPropertyValue Integers ---
+                if name in ("GetCurrentPropertyValue", "GetCachedPropertyValue") and args:
+                    prop_name = UIA_PROPERTY_ID_MAP.get(int(args[0]), "")
+                    return _decode(prop_name, result)
+
+                # --- Cast Patterns Before Wrapping ---
+                if name in ("GetCurrentPattern", "GetCachedPattern") and result and args:
+                    pattern_name = UIA_PATTERN_ID_MAP.get(int(args[0]))
+                    if pattern_name:
+                        interface = getattr(UIA, f"IUIAutomation{pattern_name}Pattern", None)
+                        if interface:
+                            result = result.QueryInterface(interface)
+
+                return _wrap_object(result)
+            return method_proxy
+
+        # 5. Handle properties natively and decode them
+        result = _wrap_object(raw_attr)
+
+        base_name = name
+        if name.startswith("Current"): base_name = name[7:]
+        elif name.startswith("Cached"): base_name = name[6:]
+
+        return _decode(base_name, result)
+
+    def __setattr__(self, name: str, value: Any):
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._obj, name, value)
+
+
+# ---- Wrapping & Decoding helpers
+
+def _decode(name: str, result: Any) -> Any:
+    """Decodes raw integers into UiaConstants if a map exists for the property."""
+    if type(result) is int and name in _VALUE_MAPS:
+        str_name = _VALUE_MAPS[name].get(result, "Unknown")
+        return UiaConstant(result, str_name)
+
+    if isinstance(result, (list, tuple)) and all(type(x) is int for x in result):
+        return [_decode(name, x) for x in result]
+
+    return result
+
+def _unwrap_arg(arg: Any) -> Any:
+    """Unwraps proxy objects to hand raw COM pointers back to native UIA methods."""
+    return arg._obj if isinstance(arg, UiaObject) else arg
+
+def _wrap_object(result: Any) -> Any:
+    """Dynamically wraps raw object UIA COM returns into the universal proxy."""
+    if result is None:
+        return None
+
+    if hasattr(result, "Length") and hasattr(result, "GetElement"):
+        return [_wrap_object(result.GetElement(i)) for i in range(result.Length)]
+
+    type_name = type(result).__name__
+
+    if "Element" in type_name or "TextRange" in type_name or "Pattern" in type_name:
+        return UiaObject(result)
+
+    return result
+
+
+# ---- Main API Wrapper
+
+class UiaWrapper(ApiWrapper[UiaObject]):
+    ControlType = _ConstantsProxy(UIA_CONTROL_TYPE_MAP)
+    PropertyId = _ConstantsProxy(UIA_PROPERTY_ID_MAP)
+    EventId = _ConstantsProxy(UIA_EVENT_ID_MAP)
+    PatternId = _ConstantsProxy(UIA_PATTERN_ID_MAP)
+    LandmarkType = _ConstantsProxy(UIA_LANDMARK_TYPE_ID_MAP)
+    TextAttribute = _ConstantsProxy(UIA_TEXT_ATTRIBUTE_ID_MAP)
 
     @property
     def api_name(self) -> str:
         return "UIA"
 
-    def find_node(self, dom_id: str, url: str) -> UiaElement:
+    def find_node(self, dom_id: str, url: str) -> Optional[UiaObject]:
         """
         :param dom_id: The dom id of the node to test.
         :param url: The url of the test.
@@ -86,109 +236,7 @@ class UiaWrapper(ApiWrapper[UiaElement]):
 
         return test_node
 
-    def get_control_type(self, element: UiaElement) -> str:
-        """
-        :param element: The element to read from.
-        :returns: The human readable UIA control type name, e.g. "Button" or "Group".
-        """
-        return UIA_CONTROL_TYPE_MAP.get(element.CurrentControlType, str(element.CurrentControlType))
-
-    def get_landmark_type(self, element: UiaElement) -> str:
-        """
-        :param element: The element to read from.
-        :returns: The human readable UIA landmark type name, e.g. "Custom" or "Form".
-        """
-        landmark_type = self.get_property(element, "LandmarkType")
-        return UIA_LANDMARK_TYPE_ID_MAP.get(landmark_type, str(landmark_type))
-
-    def get_property(self, element: UiaElement, property_name: str) -> Any:
-        """Read a UIA property by human readable name, e.g. "LocalizedControlType".
-
-        :param element: The element to read from.
-        :param property_name: The human readable name of the property, e.g.
-            "LocalizedControlType".
-        :returns: The current value of the property.
-        """
-        property_id = UIA_PROPERTY_NAME_MAP.get(property_name)
-        if property_id is None:
-            raise ValueError(f"Unknown UIA property name: {property_name}")
-        return element.GetCurrentPropertyValue(property_id)
-
-    def get_supported_patterns(self, element: UiaElement) -> list[str]:
-        """returns an array of human readable supportable patterns for the element.
-
-        :param element: The element to read from.
-        :returns: array of human readable supported patterns
-        """
-        supported_patterns = []
-
-        for pattern_id, pattern_name in UIA_PATTERN_ID_MAP.items():
-            try:
-                # Native COM returns a valid pointer object if supported.
-                # If NOT supported, the native layer throws an HRESULT/COMError.
-                pattern_obj = element.GetCurrentPattern(pattern_id)
-
-                if pattern_obj:
-                    supported_patterns.append(pattern_name)
-            except comtypes.COMError:
-                # Native UIA explicitly fails with an error code if the control doesn't support the pattern.
-                continue
-        return supported_patterns
-
-    def get_pattern_attr(
-        self, element: UiaElement, pattern: str
-    ) -> Optional[dict[str, Any]]:
-        """Return selected attributes for a supported pattern on the element.
-
-        :param element: The element to query.
-        :param pattern: The human readable pattern name, e.g. "InvokePattern".
-        :returns: A dictionary of selected pattern attributes, or None if unsupported.
-        """
-        pattern_id = next(
-            (id for id, name in UIA_PATTERN_ID_MAP.items() if name == pattern),
-            None,
-        )
-
-        if pattern_id is None:
-            raise ValueError(f"Unknown UIA pattern name: {pattern}")
-
-        try:
-            pattern_obj = element.GetCurrentPattern(pattern_id)
-
-            if not pattern_obj:
-                return None
-
-            if pattern_id == UIA.UIA_TogglePatternId:
-                toggle_pattern = pattern_obj.QueryInterface(
-                    UIA.IUIAutomationTogglePattern
-                )
-                return {"ToggleState": toggle_pattern.CurrentToggleState}
-
-            if pattern_id == UIA.UIA_SelectionItemPatternId:
-                selection_pattern = pattern_obj.QueryInterface(
-                    UIA.IUIAutomationSelectionItemPattern
-                )
-                return {"IsSelected": selection_pattern.CurrentIsSelected}
-
-            if pattern_id == UIA.UIA_TextPatternId:
-                text_pattern = pattern_obj.QueryInterface(
-                    UIA.IUIAutomationTextPattern
-                )
-                text_range = text_pattern.DocumentRange
-                return {
-                    "IsSuperscript": text_range.GetAttributeValue(
-                        UIA.UIA_IsSuperscriptAttributeId
-                    ),
-                    "IsSubscript": text_range.GetAttributeValue(
-                        UIA.UIA_IsSubscriptAttributeId
-                    ),
-                }
-        except comtypes.COMError:
-            return None
-
-        return None
-
-    def _find_browser(self) -> Optional[UiaElement]:
+    def _find_browser(self) -> Optional[UiaObject]:
         """Find the UIA element representing the browser's top level window.
 
         :return: The browser element or None.
@@ -202,13 +250,13 @@ class UiaWrapper(ApiWrapper[UiaElement]):
 
         :return: The browser element or None.
         """
-        root = _automation.GetRootElement()
+        root = _wrap_object(_automation.GetRootElement())
         condition = _automation.CreatePropertyCondition(
             UIA.UIA_ProcessIdPropertyId, self.pid
         )
         return root.FindFirst(UIA.TreeScope_Children, condition)
 
-    def _find_browser_by_name(self) -> Optional[UiaElement]:
+    def _find_browser_by_name(self) -> Optional[UiaObject]:
         """Find the browser window by matching the product name.
 
         Used when no pid is available (e.g. servo passes pid 0).
@@ -217,15 +265,15 @@ class UiaWrapper(ApiWrapper[UiaElement]):
         """
         root = _automation.GetRootElement()
         walker = _automation.ControlViewWalker
-        element = walker.GetFirstChildElement(root)
+        element = _wrap_object(walker.GetFirstChildElement(root))
         while element:
             name = element.CurrentName or ""
             if self.product_name.lower() in name.lower():
                 return element
-            element = walker.GetNextSiblingElement(element)
+            element = _wrap_object(walker.GetNextSiblingElement(_unwrap_arg(element)))
         return None
 
-    def _find_tab(self) -> Optional[UiaElement]:
+    def _find_tab(self) -> Optional[UiaObject]:
         """Find the document with the test url.
 
         :return: The element representing the test document or None.
@@ -233,14 +281,15 @@ class UiaWrapper(ApiWrapper[UiaElement]):
         condition = _automation.CreatePropertyCondition(
             UIA.UIA_ControlTypePropertyId, UIA.UIA_DocumentControlTypeId
         )
-        documents = self.root.FindAll(UIA.TreeScope_Descendants, condition)
-        for i in range(documents.Length):
-            document = documents.GetElement(i)
+        wrapped_root = _wrap_object(self.root)
+
+        documents = wrapped_root.FindAll(UIA.TreeScope_Descendants, condition)
+        for document in documents:
             if self._document_url(document) == self.test_url:
                 return document
         return None
 
-    def _document_url(self, document: UiaElement) -> Optional[str]:
+    def _document_url(self, document: UiaObject) -> Optional[str]:
         """Return the url of a document element.
 
         Browsers expose the document url via the UIA Value property, mirroring
@@ -252,8 +301,8 @@ class UiaWrapper(ApiWrapper[UiaElement]):
         return document.GetCurrentPropertyValue(UIA.UIA_ValueValuePropertyId)
 
     def _find_node_by_id(
-        self, root: UiaElement, dom_id: str
-    ) -> Optional[UiaElement]:
+        self, root: UiaObject, dom_id: str
+    ) -> Optional[UiaObject]:
         """Find the UIA element with a specified dom_id.
 
         Browsers expose the DOM id via the UIA AutomationId property.

--- a/core-aam/aamtests/support/uia_wrapper.py
+++ b/core-aam/aamtests/support/uia_wrapper.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import comtypes
+import comtypes.client
+
+from .api_wrapper import ApiWrapper
+
+comtypes.CoInitialize()
+
+# Type alias for the dynamically generated UI Automation element interface.
+UiaElement = Any
+
+# Load the UI Automation type library. This exposes the IUIAutomation
+# interface, the CUIAutomation coclass, and the UIA_* property, control type,
+# pattern, and tree scope id constants.
+UIA = comtypes.client.GetModule("UIAutomationCore.dll")
+
+# The IUIAutomation entry point, used to obtain the root element, create
+# property conditions, and walk the tree.
+_automation = comtypes.client.CreateObject(
+    UIA.CUIAutomation, interface=UIA.IUIAutomation
+)
+
+# ----  Maps for turning UIA constants into human readable names.
+
+# Generate a mapping of control type id to human readable name, e.g. 50000 -> "Button", 50001 -> "Calendar", etc.
+UIA_CONTROL_TYPE_MAP = {
+    value: name[len("UIA_"):-len("ControlTypeId")]
+    for name, value in vars(UIA).items()
+    if name.startswith("UIA_") and name.endswith("ControlTypeId")
+}
+
+# Generate a mapping of property id to human readable name, e.g. 30000 -> "AutomationId", 30001 -> "Name", etc.
+UIA_PROPERTY_ID_MAP = {
+    value: name[len("UIA_"):-len("PropertyId")]
+    for name, value in vars(UIA).items()
+    if name.startswith("UIA_") and name.endswith("PropertyId")
+}
+UIA_PROPERTY_NAME_MAP = {name: value for value, name in UIA_PROPERTY_ID_MAP.items()}
+
+# Generate a mapping of event id to human readable name, e.g. 20000 -> "AutomationFocusChangedEvent", 20001 -> "AutomationPropertyChangedEvent", etc.
+UIA_EVENT_ID_MAP = {
+    value: name[len("UIA_"):-len("EventId")]
+    for name, value in vars(UIA).items()
+    if name.startswith("UIA_") and name.endswith("EventId")
+}
+
+# Generate a mapping of pattern id to human readable name, e.g. 10000 -> "InvokePattern", 10001 -> "SelectionPattern", etc.
+UIA_PATTERN_ID_MAP = {
+    value: name[len("UIA_"):-len("PatternId")]
+    for name, value in vars(UIA).items()
+    if name.startswith("UIA_") and name.endswith("PatternId")
+}
+
+# Generate a mapping of landmark type id to human readable name, e.g. 8000 -> "Custom", 80001 -> "Form", etc.
+UIA_LANDMARK_TYPE_ID_MAP = {
+    value: name[len("UIA_"):-len("LandmarkTypeId")]
+    for name, value in vars(UIA).items()
+    if name.startswith("UIA_") and name.endswith("LandmarkTypeId")
+}
+
+class UiaWrapper(ApiWrapper[UiaElement]):
+
+    @property
+    def api_name(self) -> str:
+        return "UIA"
+
+    def find_node(self, dom_id: str, url: str) -> UiaElement:
+        """
+        :param dom_id: The dom id of the node to test.
+        :param url: The url of the test.
+        """
+        if self.test_url != url or not self.document:
+            self.test_url = url
+            self.document = self._poll_for(
+                self._find_tab,
+                f"Timeout looking for url: {self.test_url}",
+            )
+
+        test_node = self._poll_for(
+            lambda: self._find_node_by_id(self.document, dom_id),
+            f"Timeout looking for node with id {dom_id} in accessibility API UIA.",
+        )
+
+        return test_node
+
+    def get_control_type(self, element: UiaElement) -> str:
+        """
+        :param element: The element to read from.
+        :returns: The human readable UIA control type name, e.g. "Button" or "Group".
+        """
+        return UIA_CONTROL_TYPE_MAP.get(element.CurrentControlType, str(element.CurrentControlType))
+
+    def get_landmark_type(self, element: UiaElement) -> str:
+        """
+        :param element: The element to read from.
+        :returns: The human readable UIA landmark type name, e.g. "Custom" or "Form".
+        """
+        landmark_type = self.get_property(element, "LandmarkType")
+        return UIA_LANDMARK_TYPE_ID_MAP.get(landmark_type, str(landmark_type))
+
+    def get_property(self, element: UiaElement, property_name: str) -> Any:
+        """Read a UIA property by human readable name, e.g. "LocalizedControlType".
+
+        :param element: The element to read from.
+        :param property_name: The human readable name of the property, e.g.
+            "LocalizedControlType".
+        :returns: The current value of the property.
+        """
+        property_id = UIA_PROPERTY_NAME_MAP.get(property_name)
+        if property_id is None:
+            raise ValueError(f"Unknown UIA property name: {property_name}")
+        return element.GetCurrentPropertyValue(property_id)
+
+    def get_supported_patterns(self, element: UiaElement) -> list[str]:
+        """returns an array of human readable supportable patterns for the element.
+
+        :param element: The element to read from.
+        :returns: array of human readable supported patterns
+        """
+        supported_patterns = []
+
+        for pattern_id, pattern_name in UIA_PATTERN_ID_MAP.items():
+            try:
+                # Native COM returns a valid pointer object if supported.
+                # If NOT supported, the native layer throws an HRESULT/COMError.
+                pattern_obj = element.GetCurrentPattern(pattern_id)
+
+                if pattern_obj:
+                    supported_patterns.append(pattern_name)
+            except comtypes.COMError:
+                # Native UIA explicitly fails with an error code if the control doesn't support the pattern.
+                continue
+        return supported_patterns
+
+    def get_pattern_attr(
+        self, element: UiaElement, pattern: str
+    ) -> Optional[dict[str, Any]]:
+        """Return selected attributes for a supported pattern on the element.
+
+        :param element: The element to query.
+        :param pattern: The human readable pattern name, e.g. "InvokePattern".
+        :returns: A dictionary of selected pattern attributes, or None if unsupported.
+        """
+        pattern_id = next(
+            (id for id, name in UIA_PATTERN_ID_MAP.items() if name == pattern),
+            None,
+        )
+
+        if pattern_id is None:
+            raise ValueError(f"Unknown UIA pattern name: {pattern}")
+
+        try:
+            pattern_obj = element.GetCurrentPattern(pattern_id)
+
+            if not pattern_obj:
+                return None
+
+            if pattern_id == UIA.UIA_TogglePatternId:
+                toggle_pattern = pattern_obj.QueryInterface(
+                    UIA.IUIAutomationTogglePattern
+                )
+                return {"ToggleState": toggle_pattern.CurrentToggleState}
+
+            if pattern_id == UIA.UIA_SelectionItemPatternId:
+                selection_pattern = pattern_obj.QueryInterface(
+                    UIA.IUIAutomationSelectionItemPattern
+                )
+                return {"IsSelected": selection_pattern.CurrentIsSelected}
+
+            if pattern_id == UIA.UIA_TextPatternId:
+                text_pattern = pattern_obj.QueryInterface(
+                    UIA.IUIAutomationTextPattern
+                )
+                text_range = text_pattern.DocumentRange
+                return {
+                    "IsSuperscript": text_range.GetAttributeValue(
+                        UIA.UIA_IsSuperscriptAttributeId
+                    ),
+                    "IsSubscript": text_range.GetAttributeValue(
+                        UIA.UIA_IsSubscriptAttributeId
+                    ),
+                }
+        except comtypes.COMError:
+            return None
+
+        return None
+
+    def _find_browser(self) -> Optional[UiaElement]:
+        """Find the UIA element representing the browser's top level window.
+
+        :return: The browser element or None.
+        """
+        if self.pid and self.pid != 0:
+            return self._find_browser_by_pid()
+        return self._find_browser_by_name()
+
+    def _find_browser_by_pid(self) -> Optional[UiaElement]:
+        """Find the browser window by matching the process id.
+
+        :return: The browser element or None.
+        """
+        root = _automation.GetRootElement()
+        condition = _automation.CreatePropertyCondition(
+            UIA.UIA_ProcessIdPropertyId, self.pid
+        )
+        return root.FindFirst(UIA.TreeScope_Children, condition)
+
+    def _find_browser_by_name(self) -> Optional[UiaElement]:
+        """Find the browser window by matching the product name.
+
+        Used when no pid is available (e.g. servo passes pid 0).
+
+        :return: The browser element or None.
+        """
+        root = _automation.GetRootElement()
+        walker = _automation.ControlViewWalker
+        element = walker.GetFirstChildElement(root)
+        while element:
+            name = element.CurrentName or ""
+            if self.product_name.lower() in name.lower():
+                return element
+            element = walker.GetNextSiblingElement(element)
+        return None
+
+    def _find_tab(self) -> Optional[UiaElement]:
+        """Find the document with the test url.
+
+        :return: The element representing the test document or None.
+        """
+        condition = _automation.CreatePropertyCondition(
+            UIA.UIA_ControlTypePropertyId, UIA.UIA_DocumentControlTypeId
+        )
+        documents = self.root.FindAll(UIA.TreeScope_Descendants, condition)
+        for i in range(documents.Length):
+            document = documents.GetElement(i)
+            if self._document_url(document) == self.test_url:
+                return document
+        return None
+
+    def _document_url(self, document: UiaElement) -> Optional[str]:
+        """Return the url of a document element.
+
+        Browsers expose the document url via the UIA Value property, mirroring
+        IAccessible2's accValue on the document.
+
+        :param document: A document control element.
+        :return: The url string or None.
+        """
+        return document.GetCurrentPropertyValue(UIA.UIA_ValueValuePropertyId)
+
+    def _find_node_by_id(
+        self, root: UiaElement, dom_id: str
+    ) -> Optional[UiaElement]:
+        """Find the UIA element with a specified dom_id.
+
+        Browsers expose the DOM id via the UIA AutomationId property.
+
+        :param root: The root node to search from.
+        :param dom_id: The DOM id.
+        :return: The element or None if not found.
+        """
+        condition = _automation.CreatePropertyCondition(
+            UIA.UIA_AutomationIdPropertyId, dom_id
+        )
+        return root.FindFirst(UIA.TreeScope_Descendants, condition)


### PR DESCRIPTION
## Description
This PR introduces Windows UI Automation (UIA) support to the `core-aam` test suite and adds initial test coverage for several ARIA roles.

### Key Changes
* **`UiaWrapper` Implementation:** Added `core-aam/aamtests/support/uia_wrapper.py` which uses `comtypes` to interface directly with `UIAutomationCore.dll`. It provides mappings for UIA constants and methods to retrieve control types, localized control types, properties, and landmark types.
* **UIA Fixture:** Registered the new `uia` accessibility API fixture in `fixtures_a11y_api.py`.
* **Role Tests:** Added `test_uia` assertions for all ARIA roles currently listed:

This lays the essential groundwork for expanding UIA test coverage in WPT.