### PR TITLE
Fix WebIDL/JSON serialization type conversion in Digital Credentials tests

### DIFF
--- a/digital-credentials/create.tentative.https.html
+++ b/digital-credentials/create.tentative.https.html
@@ -229,9 +229,9 @@
 
   promise_test(async (t) => {
     const throwingValues = [
-      BigInt(123),
+      { val: BigInt(123) },
       (() => { const o = {}; o.self = o; return o; })(),
-      Symbol("foo")
+      { toJSON() { throw new TypeError("toJSON throws"); } }
     ];
 
     for (const badValue of throwingValues) {
@@ -267,7 +267,7 @@
         requests: [
           {
             protocol: "unknown-protocol",
-            data: BigInt(1), // malformed/non-serializable
+            data: { val: BigInt(1) }, // malformed/non-serializable
           },
           {
             protocol: "openid4vci",

--- a/digital-credentials/get.https.html
+++ b/digital-credentials/get.https.html
@@ -236,9 +236,9 @@
 
 promise_test(async t => {
   const throwingValues = [
-    BigInt(123),
+    { val: BigInt(123) },
     (() => { const o = {}; o.self = o; return o; })(),
-    Symbol("foo")
+    { toJSON() { throw new TypeError("toJSON throws"); } }
   ];
 
   for (const badValue of throwingValues) {
@@ -270,7 +270,7 @@ promise_test(async (t) => {
       requests: [
         {
           protocol: "unknown-protocol",
-          data: BigInt(1), // malformed/non-serializable
+          data: { val: BigInt(1) }, // malformed/non-serializable
         },
       ],
       signal,
@@ -286,9 +286,9 @@ promise_test(async (t) => {
     const options = {
       digital: {
         requests: [
-          { protocol: "bogus-1", data: BigInt(1) },
-          { protocol: "bogus-2", data: BigInt(2) },
-          { protocol: "bogus-3", data: BigInt(3) },
+          { protocol: "bogus-1", data: { val: BigInt(1) } },
+          { protocol: "bogus-2", data: { val: BigInt(2) } },
+          { protocol: "bogus-3", data: { val: BigInt(3) } },
         ],
       },
     };
@@ -308,8 +308,8 @@ promise_test(async (t) => {
       protocol: [], // disable defaults
       requests: [
         openidReq,
-        { protocol: "bogus-1", data: BigInt(1) },
-        { protocol: "bogus-2", data: BigInt(2) },
+        { protocol: "bogus-1", data: { val: BigInt(1) } },
+        { protocol: "bogus-2", data: { val: BigInt(2) } },
         mdocReq,
       ],
       signal,
@@ -331,10 +331,10 @@ promise_test(async (t) => {
     const options = makeGetOptions({
       protocol: [], // disable automatic protocol requests
       requests: [
-        { protocol: "bogus-1", data: BigInt(1) },
+        { protocol: "bogus-1", data: { val: BigInt(1) } },
         openidReq,
         mdocReq,
-        { protocol: "bogus-2", data: BigInt(2) },
+        { protocol: "bogus-2", data: { val: BigInt(2) } },
       ],
       signal,
     });

--- a/digital-credentials/user-activation-create.tentative.https.html
+++ b/digital-credentials/user-activation-create.tentative.https.html
@@ -27,7 +27,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
-    const options = makeCreateOptions({ data: BigInt(1) });
+    const options = makeCreateOptions({ data: { val: BigInt(1) } });
     await promise_rejects_dom(
       t,
       "NotAllowedError",

--- a/digital-credentials/user-activation-get.https.html
+++ b/digital-credentials/user-activation-get.https.html
@@ -27,7 +27,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
-    const options = makeGetOptions({ data: BigInt(1) });
+    const options = makeGetOptions({ data: { val: BigInt(1) } });
     await promise_rejects_dom(
       t,
       "NotAllowedError",


### PR DESCRIPTION
### Description
WebIDL specifies `required object data` for the request dictionary members in `DigitalCredentialGetRequest` and `DigitalCredentialCreateRequest`. Passing primitive values (such as `BigInt(1)` or `Symbol("foo")`) causes the tests to fail early at the WebIDL type conversion boundary with a `TypeError`.

This PR updates the tests to pass non-serializable objects (e.g., `{ val: BigInt(1) }` or objects with a throwing `toJSON` function) instead of primitives. This allows them to pass the WebIDL object type check and correctly verify that the user agent's JSON serialization/processing phase throws the expected `TypeError`.

### Affected Files
* [get.https.html](file:///usr/local/google/home/mamir/spec-work/wpt/digital-credentials/get.https.html)
* [create.tentative.https.html](file:///usr/local/google/home/mamir/spec-work/wpt/digital-credentials/create.tentative.https.html)
* [user-activation-get.https.html](file:///usr/local/google/home/mamir/spec-work/wpt/digital-credentials/user-activation-get.https.html)
* [user-activation-create.tentative.https.html](file:///usr/local/google/home/mamir/spec-work/wpt/digital-credentials/user-activation-create.tentative.https.html)