### PR TITLE
Actually give a distinct exit code for uncaught exceptions

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -1155,7 +1155,7 @@ def _run_main(argv: List[Text]) -> None:
         raise
     except Exception:
         traceback.print_exc()
-        sys.exit(3)
+        sys.exit(getattr(os, "EX_SOFTWARE", 70))
 
 
 if __name__ == "__main__":

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -1018,7 +1018,8 @@ def main(venv: Any = None, **kwargs: Any) -> int:
 
     jobs = kwargs.get("jobs", 0)
 
-    return lint(repo_root, paths, output_format, ignore_glob, github_checks_outputter, jobs)
+    error_count = lint(repo_root, paths, output_format, ignore_glob, github_checks_outputter, jobs)
+    return 1 if error_count > 0 else 0
 
 
 # best experimental guess at a decent cut-off for using the parallel path
@@ -1149,14 +1150,12 @@ def all_paths_lints() -> Any:
 
 def _run_main(argv: List[Text]) -> None:
     try:
-        error_count = main(**vars(create_parser().parse_args(argv)))
+        sys.exit(main(**vars(create_parser().parse_args(argv))))
     except SystemExit:
         raise
     except Exception:
         traceback.print_exc()
         sys.exit(3)
-    if error_count > 0:
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -442,14 +442,50 @@ def test_main_all():
         sys.argv = orig_argv
 
 
+def test_main_returns_zero_on_clean():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint']
+        with _mock_lint('lint', return_value=0):
+            with _mock_lint('changed_files', return_value=['foo', 'bar']):
+                rv = lint_mod.main(**vars(create_parser().parse_args()))
+                assert rv == 0
+    finally:
+        sys.argv = orig_argv
 
-def test_run_main_no_errors_returns():
+
+def test_main_returns_one_on_errors():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint']
+        with _mock_lint('lint', return_value=5):
+            with _mock_lint('changed_files', return_value=['foo', 'bar']):
+                rv = lint_mod.main(**vars(create_parser().parse_args()))
+                assert rv == 1
+    finally:
+        sys.argv = orig_argv
+
+
+def test_main_json_markdown_exits_2():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint', '--json', '--markdown']
+        with pytest.raises(SystemExit) as excinfo:
+            lint_mod.main(**vars(create_parser().parse_args()))
+        assert excinfo.value.code == 2
+    finally:
+        sys.argv = orig_argv
+
+
+def test_run_main_no_errors_exits_0():
     with mock.patch.object(lint_mod, 'main', return_value=0):
-        lint_mod._run_main(['--all'])  # should not raise
+        with pytest.raises(SystemExit) as exc_info:
+            lint_mod._run_main(['--all'])
+    assert exc_info.value.code == 0
 
 
 def test_run_main_errors_exits_1():
-    with mock.patch.object(lint_mod, 'main', return_value=5):
+    with mock.patch.object(lint_mod, 'main', return_value=1):
         with pytest.raises(SystemExit) as exc_info:
             lint_mod._run_main(['--all'])
     assert exc_info.value.code == 1

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -497,11 +497,11 @@ def test_run_main_argument_error_exits_2():
     assert exc_info.value.code == 2
 
 
-def test_run_main_exception_exits_3(capsys):
+def test_run_main_exception_exits_ex_software(capsys):
     with mock.patch.object(lint_mod, 'main', side_effect=RuntimeError('simulated crash')):
         with pytest.raises(SystemExit) as exc_info:
             lint_mod._run_main(['--all'])
-    assert exc_info.value.code == 3
+    assert exc_info.value.code == getattr(os, "EX_SOFTWARE", 70)
 
     captured = capsys.readouterr()
     assert 'Traceback (most recent call last):' in captured.err

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import argparse
 import errno
 import logging
 import os
@@ -8,6 +9,7 @@ import socket
 import subprocess
 import sys
 import time
+from unittest import mock
 from urllib.request import urlopen
 from urllib.error import URLError
 
@@ -108,6 +110,40 @@ def test_load_commands():
     commands = wpt.load_commands()
     # The `wpt run` command has conditional requirements.
     assert "conditional_requirements" in commands["run"]
+
+
+def test_dispatcher_uncaught_exception_exits_70(monkeypatch, capsys):
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    def fake_import_command(prog, command, props):
+        return boom, argparse.ArgumentParser()
+
+    monkeypatch.setattr(wpt, "import_command", fake_import_command)
+
+    with pytest.raises(SystemExit) as excinfo:
+        wpt.main(argv=["files-changed"])
+    assert excinfo.value.code == getattr(os, "EX_SOFTWARE", 70)
+    err = capsys.readouterr().err
+    assert "Traceback (most recent call last):" in err
+    assert "RuntimeError: boom" in err
+
+
+def test_dispatcher_uncaught_exception_debug_invokes_pdb(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    def fake_import_command(prog, command, props):
+        return boom, argparse.ArgumentParser()
+
+    monkeypatch.setattr(wpt, "import_command", fake_import_command)
+
+    with mock.patch("pdb.post_mortem", autospec=True, spec_set=True) as mock_pm:
+        with pytest.raises(SystemExit) as excinfo:
+            wpt.main(argv=["--debug", "files-changed"])
+    # Falls through to the trailing sys.exit(0) after pdb.post_mortem returns.
+    assert excinfo.value.code == 0
+    mock_pm.assert_called_once_with()
 
 
 @pytest.mark.slow

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -6,6 +6,7 @@ import logging
 import multiprocessing
 import os
 import sys
+import traceback
 
 from tools import localpaths  # noqa: F401
 
@@ -238,7 +239,8 @@ def main(prog=None, argv=None):
                 import pdb
                 pdb.post_mortem()
             else:
-                raise
+                traceback.print_exc()
+                sys.exit(getattr(os, "EX_SOFTWARE", 70))
     sys.exit(0)
 
 


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/60431, part 2.

This changes `wpt.wpt` to exit with `os.EX_SOFTWARE` in general when exceptions are raised, with the goal of avoiding the ambiguity between a singular test failure (`wpt run`) or a singular lint error (`wpt lint`).

This also makes `wpt lint` always exit with one on a lint error so that it is unambiguous from exit code when a linter error has occurred.