### PR TITLE
script: Retarget `elementFromPoint` and `elementsFromPoint` using retargeting algorithm

### DIFF
--- a/css/cssom-view/elementFromPoint-ua-shadowroot-crash.html
+++ b/css/cssom-view/elementFromPoint-ua-shadowroot-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45170">
+<style>
+  #container {scale: 1000; }
+  :read-only { width: max-content; }
+</style>
+<div id="container">
+  <input id="user"></input>
+</div>
+<script>
+  container.replaceChild(document.elementFromPoint(0, 0), user);
+</script>
+


### PR DESCRIPTION
Browsers still, in practice, disagree about what `elementsFromPoint` and
`elementFromPoint` should return, but there is a CSSWG resolution that we
can follow from last month: https://github.com/w3c/csswg-drafts/issues/556

This change implements the resolution and also fixes a panic that was
resulting from returning an element within a UA shadow tree.

Testing: This change includes a new crash test. A decent number of tests
start to pass, a group of `<select>` element tests that were failing now fail
in a different way (a WebDriver `CRASH` which doesn't indicate a real crash,
but an unexpected state). The only new failure is `negativeMargins.html`,
where it seems that not filtering every non-`Element` as before is revealing
some issues with hit testing/layout.
Fixes: #<!-- nolink -->45170.
Fixes: #<!-- nolink -->40973.
Fixes: #<!-- nolink -->44302.

Reviewed in servo/servo#45612