### PR TITLE
script: Fix crash when input type changes during activation

### DIFF
--- a/html/semantics/forms/the-input-element/input-type-change-during-activation-crash.html
+++ b/html/semantics/forms/the-input-element/input-type-change-during-activation-crash.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
-<title>Input type changes during activation events should not crashs"</title>
+<meta charset="utf-8">
+<title>Input type changes during activation events should not crash</title>
 <body>
 <script>
-test(() => {
-  const input = document.createElement("input");
-  input.type = "checkbox";
-  document.body.append(input);
+"use strict";
 
-  input.addEventListener("input", () => {
-    input.type = "text";
-  });
+const input = document.createElement("input");
+input.type = "checkbox";
+document.body.append(input);
 
-  input.click();
+input.addEventListener("input", () => {
+  input.type = "text";
+});
 
-  assert_equals(input.type, "text");
-}, "Changging checkbox input type from an input event listener should not crashs");
+input.click();
 </script>

--- a/html/semantics/forms/the-input-element/input-type-change-during-activation-crash.html
+++ b/html/semantics/forms/the-input-element/input-type-change-during-activation-crash.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<title>Input type changes during activation events</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<title>Input type changes during activation events should not crashs"</title>
 <body>
 <script>
 test(() => {

--- a/html/semantics/forms/the-input-element/input-type-change-during-activation.html
+++ b/html/semantics/forms/the-input-element/input-type-change-during-activation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Input type changes during activation events</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+test(() => {
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  document.body.append(input);
+
+  input.addEventListener("input", () => {
+    input.type = "text";
+  });
+
+  input.click();
+
+  assert_equals(input.type, "text");
+}, "Changging checkbox input type from an input event listener should not crashs");
+</script>


### PR DESCRIPTION
Fix crash when input type changes during activation

Testing: added input-type-change-during-activation.html test

Fixes: #<!-- nolink -->45585

Reviewed in servo/servo#45619