### PR TITLE
layout: Adjust corner radii for inset box shadows

### DIFF
--- a/css/css-backgrounds/box-shadow-radius-002-ref.html
+++ b/css/css-backgrounds/box-shadow-radius-002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Reference: Box Shadow Border Radius (Inset)</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<style>
+body {
+  margin: 0;
+}
+#target {
+  width: 100px;
+  height: 100px;
+  border: 50px solid;
+  margin: 50px;
+  border-radius: 75px;
+}
+</style>
+<div id="target"></div>

--- a/css/css-backgrounds/box-shadow-radius-002.html
+++ b/css/css-backgrounds/box-shadow-radius-002.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Box Shadow Border Radius (Inset)</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#shadow-shape">
+<link rel="help" href="https://github.com/servo/servo/issues/45614">
+<link rel="match" href="box-shadow-radius-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-120; totalPixels=0-1500">
+
+<style>
+body {
+  margin: 0;
+}
+#target {
+  width: 200px;
+  height: 200px;
+  border: 50px solid transparent;
+  box-shadow: inset 0 0 0 50px;
+  border-radius: 125px;
+}
+</style>
+<div id="target"></div>


### PR DESCRIPTION
Inset box shadows refer to the padding box, not the border box. However, the value from `border-radius` needs to apply to the border box.

Therefore, we need to adjust the `border-radius` by the border sizes before applying it to the inset box shadow.

Testing: Adding new test
Fixes: #<!-- nolink -->45614

Reviewed in servo/servo#45620