### PR TITLE
geometry: Limit the size of `MaxRect` sent to WebRender

### DIFF
--- a/css/filter-effects/filter-clip-overflow-crash.html
+++ b/css/filter-effects/filter-clip-overflow-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/36870">
+<style>
+  #outer {
+    overflow-x: clip;
+  }
+  #inner {
+    display: inline-block;
+    rotate: 672 1 4096 180deg;
+    overflow-x: clip;
+    filter: contrast(0%);
+  }
+</style>
+<div id="outer">
+  <div id="inner">
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  </div>
+</div>


### PR DESCRIPTION
In the WebRender code the maximum coordinate allowed is set to 1e9 * 2.
In Servo we were sending coordinates in the range `f32::MIN / 2.0` to
`f32::MAX` which is outside that range. This change limits the maximum
coordinates we send to WebRender when creating a `MaxRect`.

Testing: This change adds a crash test.
Fixes: #<!-- nolink -->36870

Reviewed in servo/servo#45622