### PR TITLE
layout: Properly set IS_BLEND_CONTAINER when creating WebRender stacking contexts

### DIFF
--- a/css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
+++ b/css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/41207">
+<style>
+  html {
+      transform: matrix3d(0,866,1,0,0,0,1,628,1,0.46,0,868,0,0,8,0.33) rotateZ(180deg);
+      -webkit-box-shadow: 1em 0em 463px;
+      mix-blend-mode: hue;
+  }
+</style>
+
+


### PR DESCRIPTION
In order to properly support `mix-blend-mode` stacking contexts that are
parents of child stacking contexts with `mix-blend-mode` in their style
need to be marked with the is `IS_BLEND_CONTAINER` StackingContextFlag.
In addition to correcting the display of `mix-blend-mode` content, this
also works around an issue where `mix-blend-mode` was causing a panic
when combined with a particular transform.

This change also works around a variety of WebRender bugs that happen when
`mix-blend-mode` is used near the root stacking context.

Testing: This change updates test results and also adds a WPT crash test.
Fixes: #<!-- nolink -->42292.

Reviewed in servo/servo#45624