### PR TITLE
layout: Make the implementation of used `TransformStyle` more complete

### DIFF
--- a/css/css-transforms/transform-preserve3d-grouping-property-root-crash.html
+++ b/css/css-transforms/transform-preserve3d-grouping-property-root-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/42476">
+<style>
+  :root {
+      transform: translate(8%);
+      transform-style: preserve-3d;
+      clip-path: circle(90%);
+      border-right-style: double;
+  }
+</style>


### PR DESCRIPTION
Stylo was using a very incomplete method for calculating the used
`TransformStyle` for boxes, which didn't incorporate all of the grouping
properties from the specification. This change moves the functionality
into Servo (as cannot properly compute this value without
`FragmentFlags`) and makes it more complete. We still do not process the
value of `contain`, `mask-image`, and `mask-border-source` as we do not
support those values yet.

Incidentally, this also fixes a panic that we were causing in WebRender,
probably by going down a path that Gecko does not exercise.

Stylo PR: servo/stylo#388

Testing: This adds a new crashtest. Three other WPT tests start to pass.
Fixes: #<!-- nolink -->42476.

Reviewed in servo/servo#45629