### PR TITLE
layout: Normalize the input to euclid's rotation function when creating reference frames

### DIFF
--- a/css/css-transforms/rotate-3d-parameters-noramlized.html
+++ b/css/css-transforms/rotate-3d-parameters-noramlized.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <title>CSS Transforms: User agents should properly normalize parameters to 3D `rotate`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#interpolation-of-transform-functions">
+  <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com" />
+  <link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+  <style type="text/css">
+  .rotated {
+      background-color: green;
+      rotate: 2 0 0 180deg;
+      height: 100px;
+      width: 100px;
+  }
+  </style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div class="rotated"></div>
+ </body>
+</html>

--- a/css/filter-effects/filter-clip-overflow-crash.html
+++ b/css/filter-effects/filter-clip-overflow-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/36870">
+<style>
+  #outer {
+    overflow-x: clip;
+  }
+  #inner {
+    display: inline-block;
+    rotate: 672 1 4096 180deg;
+    overflow-x: clip;
+    filter: contrast(0%);
+  }
+</style>
+<div id="outer">
+  <div id="inner">
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  </div>
+</div>


### PR DESCRIPTION
The rotation values we get from Stylo are unnormalized, yet euclid
expects them to be[^1]. This change enusures that before we give the
rotation values to euclid we normalize them. Lucikly, Stylo already has
normalization functionality available so we can reuse it.

[^1]:  https://github.com/servo/euclid/blob/main/src/rotation.rs#L276

Testing: This change adds a new crashtest.
Fixes: #<!-- nolink -->36870

Reviewed in servo/servo#45634