### PR TITLE
[css-color-5] fix `alpha()` tests with `none` in `srgb` space

### DIFF
--- a/css/css-color/parsing/alpha-color-computed.html
+++ b/css/css-color/parsing/alpha-color-computed.html
@@ -26,7 +26,8 @@ test_computed_value("color", "alpha(from red)", "rgb(255, 0, 0)");
 test_computed_value("color", "alpha(from rgba(255, 0, 0, 0.3))", "rgba(255, 0, 0, 0.3)");
 
 // None alpha.
-test_computed_value("color", "alpha(from red / none)", "rgba(255, 0, 0, 0)");
+test_computed_value("color", "alpha(from red / none)", "color(srgb 1 0 0 / none)");
+test_computed_value("color", "color-mix(in srgb, rgb(255 0 0 / 0.5), alpha(from red / none))", "rgba(255, 0, 0, 0.5)")
 
 // Alpha clamped to [0, 1].
 test_computed_value("color", "alpha(from red / 2)", "rgb(255, 0, 0)");

--- a/css/css-color/parsing/alpha-color-computed.html
+++ b/css/css-color/parsing/alpha-color-computed.html
@@ -27,7 +27,7 @@ test_computed_value("color", "alpha(from rgba(255, 0, 0, 0.3))", "rgba(255, 0, 0
 
 // None alpha.
 test_computed_value("color", "alpha(from red / none)", "color(srgb 1 0 0 / none)");
-test_computed_value("color", "color-mix(in srgb, rgb(255 0 0 / 0.5), alpha(from red / none))", "rgba(255, 0, 0, 0.5)")
+test_computed_value("color", "color-mix(in srgb, rgb(255 0 0 / 0.5), alpha(from red / none))", "color(srgb 1 0 0 / 0.5)")
 
 // Alpha clamped to [0, 1].
 test_computed_value("color", "alpha(from red / 2)", "rgb(255, 0, 0)");


### PR DESCRIPTION
See: https://drafts.csswg.org/css-color-4/#css-serialization-of-srgb

> However, the legacy color syntax with comma separators cannot represent none. If the value has at least one missing color component, the serialization form is chosen to preserve those components as the none keyword, based on the color function of the declared value:
> 
> For `rgb()` and `rgba()` values (...), the value is serialized as a `color()` function in the `srgb` color space ...