### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=310888

### DIFF
--- a/css/css-anchor-position/anchor-scroll-fixedpos-nested-001.html
+++ b/css/css-anchor-position/anchor-scroll-fixedpos-nested-001.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>Fixed-positioned element nested in anchor-scroll-adjusted container doesn't double-compensate for viewport scroll</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift">
+<link rel="match" href="reference/anchor-scroll-fixedpos-nested-001-ref.html">
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  anchor-name: --a1;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 250px;
+  top: 250px;
+  anchor-name: --a2;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  position-anchor: --a2;
+  position-area: bottom right;
+  background: aqua;
+}
+
+#f3 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+  margin-top: 100px;
+  background: aqua;
+}
+</style>
+
+<div id="anchor1"></div>
+<div id="anchor2"></div>
+<div id="f1">
+  <div id="wrapper">
+    <div id="f2"></div>
+    <div id="f3"></div>
+  </div>
+</div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+</script>

--- a/css/css-anchor-position/anchor-scroll-fixedpos-nested-002.html
+++ b/css/css-anchor-position/anchor-scroll-fixedpos-nested-002.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<title>Fixed-positioned element nested in anchor-scroll-adjusted container doesn't double-compensate for scroll container scroll</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift">
+<link rel="match" href="reference/anchor-scroll-fixedpos-nested-002-ref.html">
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#scroller {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+  outline: 1px solid black;
+}
+
+#scroller-content {
+  position: relative;
+  width: 400px;
+  height: 400px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 75px;
+  top: 100px;
+  anchor-name: --a1;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 175px;
+  top: 100px;
+  anchor-name: --a2;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  position-anchor: --a2;
+  position-area: bottom right;
+  background: aqua;
+}
+</style>
+
+<div id="scroller">
+  <div id="scroller-content">
+    <div id="anchor1"></div>
+    <div id="anchor2"></div>
+  </div>
+</div>
+<div id="f1">
+  <div id="wrapper">
+    <div id="f2"></div>
+  </div>
+</div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+let scroller = document.getElementById('scroller');
+scroller.scrollLeft = 25;
+scroller.scrollTop = 50;
+</script>

--- a/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-001-ref.html
+++ b/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-001-ref.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 250px;
+  top: 250px;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  left: 200px;
+  top: 200px;
+  background: aqua;
+}
+
+#f3 {
+  position: fixed;
+  left: 100px;
+  top: 200px;
+  background: aqua;
+}
+</style>
+
+<div id="anchor1"></div>
+<div id="anchor2"></div>
+<div id="f1"></div>
+<div id="f2"></div>
+<div id="f3"></div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+</script>

--- a/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-002-ref.html
+++ b/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-002-ref.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#scroller {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+  outline: 1px solid black;
+}
+
+#scroller-content {
+  position: relative;
+  width: 400px;
+  height: 400px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 75px;
+  top: 100px;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 175px;
+  top: 100px;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  left: 150px;
+  top: 150px;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  left: 250px;
+  top: 150px;
+  background: aqua;
+}
+</style>
+
+<div id="scroller">
+  <div id="scroller-content">
+    <div id="anchor1"></div>
+    <div id="anchor2"></div>
+  </div>
+</div>
+<div id="f1"></div>
+<div id="f2"></div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+let scroller = document.getElementById('scroller');
+scroller.scrollLeft = 25;
+scroller.scrollTop = 50;
+</script>


### PR DESCRIPTION
WebKit export from bug: [CSS anchor positioning: nested anchor-positioned elements lose their position when scrolling](https://bugs.webkit.org/show_bug.cgi?id=310888)