### PR TITLE
Add a test to document behavior of `selecting an image source` when src or srcset are missing from img but exist on source.

### DIFF
--- a/html/semantics/embedded-content/the-img-element/srcset/common.js
+++ b/html/semantics/embedded-content/the-img-element/srcset/common.js
@@ -2,6 +2,10 @@ setup({explicit_done:true});
 
 function check(img) {
   var name = format_value(img.getAttribute('srcset'));
+  if (img.parentElement?.localName === 'picture') {
+    var sources = img.parentElement?.querySelectorAll('source')
+    name += Array.from(sources).map(source => ' source[srcset=' + format_value(source.getAttribute('srcset')) + ']');
+  }
   if (img.hasAttribute('sizes')) {
     name += ' sizes=' + format_value(img.getAttribute('sizes'));
   }

--- a/html/semantics/embedded-content/the-img-element/srcset/select-an-image-source.html
+++ b/html/semantics/embedded-content/the-img-element/srcset/select-an-image-source.html
@@ -18,3 +18,8 @@
 <img srcset='data:,a 1x, data:,b 1w' sizes='1px' data-expect='data:,a'>
 <img srcset='data:,a 1w, data:,b 2x' sizes='0.5px' data-expect='data:,a'>
 <img srcset='data:,a 2x, data:,b 1w' sizes='0.5px' data-expect='data:,a'>
+<!-- picture source srcset -->
+<picture>
+    <source srcset="data:,a 1x, data:,b 1x" />
+    <img data-expect='data:,a'>
+</picture>


### PR DESCRIPTION
Browsers have supported omitting src and srcset on the img element for years, as long as srcset is set on a valid source element. The [`responsive-image-select-print.html` test](https://github.com/web-platform-tests/wpt/blob/5b9051943bd631d20f1f1681778d655cbfbeceb8/html/semantics/embedded-content/the-img-element/responsive-image-select-print.html#L19) even relies on this behavior.

There are no existing test for the `<picture>` `<source>` element in `select-an-image-source.html`, but I feel this is the proper place to test [`selecting an image source`](https://html.spec.whatwg.org/multipage/images.html#selecting-an-image-source).

Ref https://github.com/whatwg/html/issues/11313

@zcorpan @foolip 