### PR TITLE
stylo: Use f64 everywhere in animation logic

### DIFF
--- a/css/css-animations/crashtests/servo-bug-45008.html
+++ b/css/css-animations/crashtests/servo-bug-45008.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45008">
+<style>
+  div {
+      animation: 1s -2s infinite keyframes;
+  }
+  @keyframes keyframes {
+      0% { border-left-color: red; }
+  }
+</style>
+<div></div>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/392/

This avoids potential assert failures due to the precision loss of converting f64 into f32.

Testing: Adds a crashtest. Since the problem was dependent on timing, it would only fail intermittently. With the fix it should never fail.
Fixes: #<!-- nolink -->45008

Reviewed in servo/servo#45682