### PR TITLE
Enable WebExtension tests support in wptrunner for Chrome.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -329,18 +329,17 @@ class ChromeBrowser(WebDriverBrowser):
         """ Required to store `require_webdriver_bidi` in browser settings."""
         settings = super().settings(test)
         self._is_extension_test = (
-            (test.testdriver_features is not None
-             and "extensions" in test.testdriver_features)
-            or (test.path is not None and "web-extensions/" in test.path))
+            (test.testdriver_features is not None and
+             "extensions" in test.testdriver_features) or
+            (test.path is not None and "web-extensions/" in test.path))
         self._require_webdriver_bidi = (
             (test.testdriver_features is not None and
-             ("bidi" in test.testdriver_features
-              or "extensions" in test.testdriver_features))
-            or self._is_extension_test)
+             ("bidi" in test.testdriver_features or
+              "extensions" in test.testdriver_features)) or
+            self._is_extension_test)
 
         return {
-            **settings,
-            "require_webdriver_bidi": self._require_webdriver_bidi,
+            **settings, "require_webdriver_bidi": self._require_webdriver_bidi,
             "is_extension_test": self._is_extension_test
         }
 

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -319,7 +319,9 @@ class ChromeBrowser(WebDriverBrowser):
 
     def executor_browser(self):
         browser_cls, browser_kwargs = super().executor_browser()
-        return browser_cls, {**browser_kwargs, "leak_check": self._leak_check}
+        return browser_cls, {**browser_kwargs,
+                             "leak_check": self._leak_check,
+                             "is_extension_test": self._is_extension_test}
 
     @property
     def require_webdriver_bidi(self) -> Optional[bool]:

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -273,6 +273,7 @@ class ChromeBrowser(WebDriverBrowser):
         self._leak_check = leak_check
         self._actual_port = None
         self._require_webdriver_bidi: Optional[bool] = None
+        self._is_extension_test: Optional[bool] = None
 
     def restart_on_test_type_change(self, new_test_type: str, old_test_type: str) -> bool:
         # Restart the test runner when switch from/to wdspec or aamtest tests.
@@ -327,16 +328,20 @@ class ChromeBrowser(WebDriverBrowser):
     def settings(self, test: Test) -> BrowserSettings:
         """ Required to store `require_webdriver_bidi` in browser settings."""
         settings = super().settings(test)
+        self._is_extension_test = (
+            (test.testdriver_features is not None
+             and "extensions" in test.testdriver_features)
+            or (test.path is not None and "web-extensions/" in test.path))
         self._require_webdriver_bidi = (
-            test.testdriver_features is not None and (
-                'bidi' in test.testdriver_features or
-                'extensions' in test.testdriver_features
-            )
-        )
+            (test.testdriver_features is not None and
+             ("bidi" in test.testdriver_features
+              or "extensions" in test.testdriver_features))
+            or self._is_extension_test)
 
         return {
             **settings,
-            "require_webdriver_bidi": self._require_webdriver_bidi
+            "require_webdriver_bidi": self._require_webdriver_bidi,
+            "is_extension_test": self._is_extension_test
         }
 
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -1,12 +1,13 @@
 # mypy: allow-untyped-defs
 
 import collections
+import copy
 import json
 import os
 import re
 import time
 import uuid
-from typing import Mapping, MutableMapping
+from typing import Any, Mapping, MutableMapping, Optional
 
 from webdriver import error
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -39,7 +39,10 @@ def _update_capabilities_if_extension_test(
             capabilities = copy.deepcopy(capabilities)
         chrome_options = capabilities.setdefault("goog:chromeOptions", {})
         args = chrome_options.setdefault("args", [])
-        add_arg = lambda arg: args.append(arg) if arg not in args else None
+
+        def add_arg(arg: str) -> None:
+            if arg not in args:
+                args.append(arg)
         # Enabled `browser` JS namespace on <test_name>.<api>.html test page.
         add_arg("--extension-browser-namespace-on-webpages")
         # Enables `chrome.test` JS API (and by extension `browser.test`) on <test_name>.<api>.html test page.

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -27,6 +27,27 @@ from .protocol import LeakProtocolPart, ProtocolPart
 
 here = os.path.dirname(__file__)
 
+def _update_capabilities_if_extension_test(
+    browser: Any, capabilities: Optional[MutableMapping[str, Any]]
+) -> Optional[MutableMapping[str, Any]]:
+    """Updates ChromeDriver capabilities if the browser is running an extension test."""
+    if getattr(browser, "is_extension_test", False):
+        if capabilities is None:
+            capabilities = {}
+        else:
+            capabilities = copy.deepcopy(capabilities)
+        chrome_options = capabilities.setdefault("goog:chromeOptions", {})
+        args = chrome_options.setdefault("args", [])
+        add_arg = lambda arg: args.append(arg) if arg not in args else None
+        # Enabled `browser` JS namespace on <test_name>.<api>.html test page.
+        add_arg("--extension-browser-namespace-on-webpages")
+        # Enables `chrome.test` JS API (and by extension `browser.test`) on <test_name>.<api>.html test page.
+        add_arg("--extension-test-api-on-web-pages")
+        # Modifies the `chrome.test` JS API to behave per the `browser.test` API proposal:
+        # https://github.com/w3c/webextensions/blob/main/proposals/browser_test_api.md
+        add_arg("--extension-test-api-standardized-behavior")
+
+    return capabilities
 
 class ChromeDriverBaseProtocolPart(WebDriverBaseProtocolPart):
     def create_window(self, type="tab", **kwargs):
@@ -237,6 +258,8 @@ class ChromeDriverProtocol(WebDriverProtocol):
         self.implements = list(ChromeDriverProtocol.implements)
         if getattr(browser, "leak_check", False):
             self.implements.append(ChromeDriverLeakProtocolPart)
+        capabilities = _update_capabilities_if_extension_test(
+            browser, capabilities)
         super().__init__(executor, browser, capabilities, **kwargs)
 
 
@@ -259,6 +282,8 @@ class ChromeDriverBidiProtocol(WebDriverBidiProtocol):
         self.implements = list(ChromeDriverBidiProtocol.implements)
         if getattr(browser, "leak_check", False):
             self.implements.append(ChromeDriverLeakProtocolPart)
+        capabilities = _update_capabilities_if_extension_test(
+            browser, capabilities)
         super().__init__(executor, browser, capabilities, **kwargs)
 
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -449,10 +449,14 @@ class WebDriverBidiWebExtensionsProtocolPart(WebExtensionsProtocolPart):
         else:
             params["value"] = value
 
-        return self.webdriver.loop.run_until_complete(self.webdriver.bidi_session.web_extension.install(params))
+        return self.parent.loop.run_until_complete(
+            self.webdriver.bidi_session.web_extension.install(
+                extension_data=params))
 
     def uninstall_web_extension(self, extension_id):
-        return self.webdriver.loop.run_until_complete(self.webdriver.bidi_session.web_extension.uninstall(extension_id))
+        return self.parent.loop.run_until_complete(
+            self.webdriver.bidi_session.web_extension.uninstall(
+                extension=extension_id))
 
     def _resolve_path(self, path):
         if self.parent.test_path is not None:


### PR DESCRIPTION
Before this change, wptrunner did not support running WebExtension tests for Chrome. It didn't have the ability to detect extension tests and apply necessary Chrome flags (like enabling the extension test API on webpages). 

Additionally, the WebDriver BiDi extension installation/uninstallation implementation in wptrunner was incorrect. `self.webdriver` refers to the `Session` object instead of the `WebDriverBidiProtocol` object, which contains the `loop()` method. Also `install()` and `uninstall()` methods [expect keyword arguments](https://source.chromium.org/chromium/chromium/src/+/main:third_party/wpt_tools/wpt/tools/webdriver/webdriver/bidi/modules/web_extension.py;l=11,21;drc=aa6d692165ec004179933677be7bccbd0b454435), not positional arguments.

After this change, wptrunner should be able to run WebExtension tests. It detects them based on path and applies Chrome flags that enable the `(chrome|browser).test` JS API. The WebDriver BiDi implementation is also updated to use the expected keyword parameters and `WebDriverBidiProtocol` loop.

Context: crbug.com/493946943