### PR TITLE
Get the browser PID for Safari in AAM tests via safari:processID

### DIFF
--- a/core-aam/aamtests/support/fixtures_a11y_api.py
+++ b/core-aam/aamtests/support/fixtures_a11y_api.py
@@ -8,6 +8,8 @@ def pid_from(capabilities):
         return capabilities["goog:processID"], "chrome"
     if capabilities["browserName"] == "firefox":
         return capabilities["moz:processID"], "firefox"
+    if "safari:processID" in capabilities:
+        return capabilities["safari:processID"], capabilities["browserName"]
     return 0, capabilities["browserName"]
 
 


### PR DESCRIPTION
`safaridriver` now reports the PID of the Safari instance it's driving as `safari:processID`, so use that in `pid_from`. Without this, the test will use the frontmost Safari, which is often not right, and will cause tests to fail or otherwise act unexpectedly.