### PR TITLE
Fix sharedWorker "Blob URLs should not resolve relative to document base URL" test.

### DIFF
--- a/workers/shared-worker-from-blob-url.window.js
+++ b/workers/shared-worker-from-blob-url.window.js
@@ -60,12 +60,14 @@ try {
   new Request("./file.js");
   constructedRequest = true;
 } catch (e) {}
-self.postMessage(constructedRequest);
+self.onconnect = e => {
+  e.source.postMessage(constructedRequest);
+};
 `;
   const blob = new Blob([blob_contents]);
   const url = URL.createObjectURL(blob);
 
   const worker = new SharedWorker(url);
-  const reply = await message_from_port(worker);
+  const reply = await message_from_port(worker.port);
   assert_equals(reply, run_result, "Should not be able to resolve request with relative file path in blob");
 }, 'Blob URLs should not resolve relative to document base URL.');


### PR DESCRIPTION


I am working on sharedworker for Servo and I noticed `Blob URLs should not resolve relative to document base URL.` [test](https://wpt.fyi/results/workers/shared-worker-from-blob-url.window.html?label=master&label=experimental&product=chrome&product=servo&product=firefox&product=safari&aligned&q=shared-worker-from-blob-url.window.html) is failing  for all browsers.

The last subtest copied the dedicated-worker pattern but did not adapt it for `SharedWorker`.

Why it is wrong:

1. `SharedWorkerGlobalScope` has no `postMessage()`. The spec interface only has `name`, `close()`, and `onconnect`; no `postMessage` method. Dedicated workers have `postMessage`, shared workers do not. See the spec WebIDL: `DedicatedWorkerGlobalScope` includes `postMessage`, while `SharedWorkerGlobalScope` only has `onconnect`. ([html.spec.whatwg.org](https://html.spec.whatwg.org/multipage/workers.html))

2. SharedWorker messages go through `worker.port`.

Servo introduce it in https://github.com/servo/servo/pull/38033/changes#diff-7ea77e4e81237f6f657bbf71e5b297d8ab93d8a0e8fe97db1fb38c56c998d700