### PR TITLE
script: Run insert validations steps separately when inserting from the parser

### DIFF
--- a/dom/ranges/Range-insertNode-multiple-document-children-crash.html
+++ b/dom/ranges/Range-insertNode-multiple-document-children-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/20218">
+</head>
+
+<script>
+    onload = () => {
+      document.open();
+      try {
+          document.createRange().insertNode(document.createElement("a"));
+          document.createRange().insertNode(document.createElement("a"));
+      } finally {
+          document.close();
+      }
+    };
+</script>


### PR DESCRIPTION
When inserting from the parser, the specification doesn't say to call
`insertBefore()` (as we were doing) which combines the validation and
insertion steps. Instead it requires that we run validation as a
separate, earlier, step and abort the insertion when it isn't possible. This
change makes the parser more closely follow the specification in this way.

Testing: This change adds a new WPT crash test and fixes two other crashing WPT tests.
Fixes: #<!-- nolink -->20218.

Reviewed in servo/servo#45765