### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=316976

### DIFF
--- a/urlpattern/urlpattern-empty-regexp-group.html
+++ b/urlpattern/urlpattern-empty-regexp-group.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_throws_js(TypeError, () => { new URLPattern({ pathname: '()' }); });
+}, `URLPattern rejects an empty regexp group '()' with a TypeError`);
+
+test(() => {
+  new URLPattern({ pathname: '(a)' });
+}, `URLPattern accepts a non-empty regexp group '(a)'`);
+</script>


### PR DESCRIPTION
WebKit export from bug: [URL Pattern tokenizer emits a spurious zero-length Regexp token for empty regexp groups](https://bugs.webkit.org/show_bug.cgi?id=316976)