### PR TITLE
align="middle"/"center" should map to middle-with-baseline values

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html
@@ -30,6 +30,17 @@ const kInitialValues = {
   "float": "none",
 };
 
+const kVerticalAlignKeywords = [
+  "baseline",
+  "sub",
+  "super",
+  "text-top",
+  "text-bottom",
+  "middle",
+  "top",
+  "bottom",
+];
+
 let replaced = document.getElementById("replaced");
 let nonReplaced = document.getElementById("non-replaced");
 let t = async_test("align attribute mapping");
@@ -47,10 +58,9 @@ onload = t.step_func_done(function() {
             assert_equals(actual, expected, `align=${attributeValue} should map to ${property}: ${expected}`);
           } else {
             assert_equals(property, "vertical-align");
-            assert_in_array(
-              actual,
-              ["-moz-middle-with-baseline", "-webkit-baseline-middle"],
-              `align=${attributeValue} should map to a browser-specific middle-with-baseline value`
+            assert_false(
+              kVerticalAlignKeywords.includes(actual),
+             `align=${attributeValue} should map to a special vertical-align value`
             );
           }
         }

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html
@@ -11,11 +11,9 @@ const kMapping = {
 
   "top": ["vertical-align", "top"],
 
-  // This one requires a magic value (`-moz-middle-with-baseline` on Gecko,
+  // These two require a magic value (`-moz-middle-with-baseline` on Gecko,
   // `-webkit-baseline-middle` on WebKit-based browsers).
   "middle": ["vertical-align", undefined],
-  // These are inconsistent across browsers. WebKit maps it to "middle", Gecko
-  // to the aforementioned value.
   "center": ["vertical-align", undefined],
 
   "baseline": ["vertical-align", "baseline"],
@@ -49,7 +47,11 @@ onload = t.step_func_done(function() {
             assert_equals(actual, expected, `align=${attributeValue} should map to ${property}: ${expected}`);
           } else {
             assert_equals(property, "vertical-align");
-            assert_not_equals(actual, "baseline", `align=${attributeValue} should map a vertical-align value`);
+            assert_in_array(
+              actual,
+              ["-moz-middle-with-baseline", "-webkit-baseline-middle"],
+              `align=${attributeValue} should map to a browser-specific middle-with-baseline value`
+            );
           }
         }
       }, `align=${attributeValue} on ${element == replaced ? "replaced" : "non-replaced"} elements`);


### PR DESCRIPTION
Per the specification [1], when an embed, iframe, img, or object element, or an input element whose type attribute is in the Image Button state, has an align attribute whose value is an ASCII case-insensitive match for the string "center" or the string "middle", the user agent is expected to act as if the element's 'vertical-align' property was set to a value that aligns the vertical middle of the element with the parent element's baseline.

[1] https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images