### PR TITLE
script: More resiliently handle out of order removal / access of `TreeOrderedIndexMap`

### DIFF
--- a/html/semantics/forms/the-button-element/button-form-refers-to-elements-with-duplicate-ids-crash.html
+++ b/html/semantics/forms/the-button-element/button-form-refers-to-elements-with-duplicate-ids-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45792">
+
+<button form="duplicate"></button>
+<div id="container">
+  <span id="duplicate"></span>
+  <span id="duplicate"></span>
+</div>
+<script>
+  container.remove();
+</script>


### PR DESCRIPTION
Sometimes script will multiple items from the tree, call JavaScript
code, and finally remove some of those removed-from-tree item's `id`s
from the `TreeOrderedIndexMap`. When this happens and a map entry is in
unresolved state, it will try to re-resolve entries accessed during
script execution. During re-resolution we were trying to remove newly
empty entries from the map (regardless of their count), meaning that
when removed-from-tree but not removed-from-map entries have their ids
removed, the map would be in an unexpected state.

This change removes the cleanup code, relying on script to always call
one remove for any addition in order to clean up old entries. This
prevents going into an unreachable code section because a map entry is
always expected when a remove happens.

In short, the previous implementation had a self-healing approach that
could put the `TreeOrderedIndexMap` in an unexpected state, so this
change removes that self-healing code. This shouldn't be an issue as
long as every addition comes with a removal. The failure mode is that
the map has too many entries, which isn't an error, just a little messy.
Some kinds of misuse are already guarded with assertions (the code that
was tripped by this bug).

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->45792.

Reviewed in servo/servo#45799