### PR TITLE
[line-clamp] Ignore open boxes for the line height of displaced lines

### DIFF
--- a/css/css-overflow/line-clamp/block-ellipsis-036.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-036.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: block-ellipsis strut</title>
+<link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Preserved tabs are properly taken into account when clamping. In particular, if the last line before clamp is also the last line of the line-clamp container, and it ends in a tab that doesn't cause it to overflow, then that shouldn't cause it to have an ellipsis.">
+<style>
+.parent {
+  height: 100px;
+  width: 100px;
+  background: red;
+}
+.clamp {
+  font: 25px/25px Ahem;
+  line-clamp: 3;
+  width: 100px;
+  color: transparent;
+  background: linear-gradient(green, green) 0 0 / 100px 100px no-repeat, red;
+}
+.big {
+  font: 50px/50px Ahem;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="parent">
+  <div class="clamp">
+    XXXX
+    <span class="big">
+      XX
+      XXX
+      X
+    </span>
+  </div>
+</div>

--- a/css/css-overflow/line-clamp/block-ellipsis-quirk-002.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-quirk-002.html
@@ -1,0 +1,44 @@
+<!-- doctype intentionally missing -->
+<meta charset="utf-8">
+<title>CSS Overflow: block-ellipsis and the blocks ignore line-height quirk</title>
+<link rel="author" title="Andreu Botella" href="mailto:abotella@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="In quirks mode, the 'blocks ignore line-height quirk' makes inlines not have a strut. When the line-clamp ellipsis displaces a line's entire contents, it is considered to have a strut for the root inline box, which is not removed by this quirk. There are no struts for other open inline boxes.">
+<style>
+p {
+  /* Making sure the margin collapsing quirk doesn't apply:
+   * https://html.spec.whatwg.org/multipage/rendering.html#margin-collapsing-quirks */
+  margin-block: 1em;
+}
+
+#parent {
+  height: 100px;
+  width: 100px;
+  background-color: red;
+}
+#container {
+  width: 100px;
+  background: linear-gradient(green, green) 0 0 / 100px 100px no-repeat, red;
+  font: 25px/25px Ahem;
+  color: transparent;
+  line-clamp: 3;
+}
+.large {
+  font: 50px/50px Ahem;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="parent">
+  <div id="container">
+    XXXX
+    <span class="large">
+      XX
+      XXXX
+      X
+    </span>
+  </div>
+</div>


### PR DESCRIPTION
If the `line-clamp` ellipsis must be inserted into a line box such that inserting it will cause the line to overflow, and there are no possible previous breakpoints; the line's contents must be entirely displaced by the ellipsis. When this happens, the line behaves as if it contained only the ellipsis (which has a line-height of zero), plus a strut corresponding to the root inline box.

Our implementation of fully displacing a line so far was to simply rewind the line to the beginning when line breaking, resulting in an empty `InlineItemResults`; the ellipsis would then be inserted in the `LogicalLineBuilder`. This made it so inline boxes that would open on the displaced line were obviously not counted for the line height, but open boxes from previous lines were still counted.

Additionally, since in quirks mode there are no struts, and the only thing that gives a line height is text, this behavior caused fully displaced lines to have no metrics, because the ellipsis does not grow the line. We had previously tentatively fixed this in https://crrev.com/c/7694492 by giving those lines zero metrics, but in https://github.com/w3c/csswg-drafts/issues/13708 the CSSWG resolved that these lines should contain a strut instead.

This behavior where there's a strut for the root inline box, but not for any other inline boxes, ends up being the same as for list items in quirks mode. Therefore, this patch reuses this behavior for fully displaced lines due to the `line-clamp` ellipsis.

One catch is that this can cause the cached box states in `InlineChildLayoutContext` to be wrong for subsequent lines. This is not an issue in quirks mode, since the next lines will always be quirks mode; but not here where there can be multiple (hidden) lines after the ellipsis. To fix this, we detect this and rebuild the box states in `InlineLayoutAlgorithm::PrepareBoxStates`.

This patch also removes the fix we added in
https://crrev.com/c/7694492 to not end up with lines with empty metrics, since it should not be needed anymore.

Bug: 40336192, 499008229
Change-Id: I16de3623f96e95650127b7a13f866c43d71de6ce
Change-Id: Ib74f6c7393d1268290d18204b68e7e72ff31b6de
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7922428
Reviewed-by: Koji Ishii <kojii@chromium.org>
Commit-Queue: Andreu Botella <abotella@igalia.com>
Cr-Commit-Position: refs/heads/main@{#1646630}

---

Manual export of https://crrev.com/c/7922428 and https://crrev.com/c/7956940. `block-ellipsis-quirk-002.html` is a file add, not rename, because the test should be forked (https://github.com/web-platform-tests/wpt/pull/60574#pullrequestreview-4483706048).