### PR TITLE
[Extension WPT] Fix `browser` namespace on web feature flag

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -44,7 +44,7 @@ def _update_capabilities_if_extension_test(
             if arg not in args:
                 args.append(arg)
         # Enabled `browser` JS namespace on <test_name>.<api>.html test page.
-        add_arg("--extension-browser-namespace-on-webpages")
+        add_arg("--enable-features=ExtensionBrowserNamespaceOnWebPages")
         # Enables `chrome.test` JS API (and by extension `browser.test`) on <test_name>.<api>.html test page.
         add_arg("--extension-test-api-on-web-pages")
         # Modifies the `chrome.test` JS API to behave per the `browser.test` API proposal:


### PR DESCRIPTION
This change corrects the flag format to enable the `browser` namespace on web pages. This then actually allows testharness components like web-extension-helper.js to access `browser.test...` (an alias to `chrome.test...`). The previous version was a raw command-line flag that didn't enable the feature.