### PR TITLE
Fix crash in CSSNumericValue.parse() with unsupported functions

### DIFF
--- a/css/css-typed-om/stylevalue-subclasses/numeric-objects/parse.tentative.html
+++ b/css/css-typed-om/stylevalue-subclasses/numeric-objects/parse.tentative.html
@@ -103,4 +103,9 @@ test(() => {
   assert_style_value_equals('calc(min(1) * min(2) * min(3))', expected.toString());
 }, 'Parsing product of multiple min() is successful');
 
+test(() => {
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse("calc(1 / sign(10em - 10rem))"));
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse("calc(sign(10em - 10rem))"));
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse("calc(sign(10rem - 1px) / 0)"));
+}, 'Parsing division with unsupported sign() function throws a SyntaxError instead of crashing');
 </script>


### PR DESCRIPTION
When division expressions (like 1 / sign(10em)) or division by zero were parsed, the calculation tree simplified them to kInvert nodes. Since kInvert is a unary operator, attempting to access its second operand in the binary operators loop of CalcToNumericValue caused an out-of-bounds crash.

This CL:
- Handles IsInvert() explicitly in CalcToNumericValue().
- Checks that sub-expressions evaluate to valid CSSNumericValues before using them in CalcToNumericValue().

Fixed: 519575719
Change-Id: Iaeded40940a2fcb1e32bc23c33a6bfa733bfba21
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7940553
Reviewed-by: Rune Lillesveen <futhark@chromium.org>
Commit-Queue: Daniil Sakhapov <sakhapov@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1648915}

---

No semantic changes from the original (just whitespace to get the patch to apply).