### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267129

### DIFF
--- a/css/css-backgrounds/background-clip-border-area-and-blend-mode.html
+++ b/css/css-backgrounds/background-clip-border-area-and-blend-mode.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Backgrounds and Borders: background-clip color backgrounds</title>
+    <link rel="match" href="reference/background-clip-border-area-and-blend-mode-ref.html">
+    <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background-clip">
+    <style>
+        .box {
+            margin: 20px;
+            width: 400px;
+            box-sizing: border-box;
+            border: 20px solid transparent;
+            padding: 20px;
+            font-size: 20pt;
+            font-weight: 900;
+            font-family: sans-serif;
+            text-align: center;
+        }
+
+        .single-background {
+            background-clip: border-area;
+            background-image: url('resources/green-100.png');
+            background-color: blue;
+            background-blend-mode: lighten;
+        }
+
+        .middle-background {
+            background-clip: border-area, border-box;
+            background-image: url('resources/green-100.png'), url('resources/blue-100.png');
+            background-color: lime;
+            background-blend-mode: difference, lighten;
+        }
+
+        .last-background {
+            background-clip: border-box, border-area;
+            background-image: url('resources/green-100.png'), url('resources/blue-100.png');
+            background-color: yellow;
+            background-blend-mode: difference, lighten;
+        }
+    </style>    
+</head>
+<body>
+    <div class="box single-background">Cyan border, white background</div>
+    <div class="box middle-background">Blue border, cyan background</div>
+    <div class="box last-background">Magenta border, lime background</div>
+</body>
+</html>

--- a/css/css-backgrounds/background-clip-border-area-and-blend-mode.html
+++ b/css/css-backgrounds/background-clip-border-area-and-blend-mode.html
@@ -38,7 +38,7 @@
             background-color: yellow;
             background-blend-mode: difference, lighten;
         }
-    </style>    
+    </style>
 </head>
 <body>
     <div class="box single-background">Cyan border, white background</div>

--- a/css/css-backgrounds/background-clip-text-and-blend-mode.html
+++ b/css/css-backgrounds/background-clip-text-and-blend-mode.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Backgrounds and Borders: background-clip color backgrounds</title>
+    <link rel="match" href="reference/background-clip-text-and-blend-mode-ref.html">
+    <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background-clip">
+    <style>
+        .box {
+            margin: 20px;
+            width: 400px;
+            border: 1px solid black;
+            padding: 20px;
+            font-size: 40pt;
+            font-weight: 900;
+            font-family: sans-serif;
+            text-align: center;
+            color: transparent;
+        }
+
+        .single-background {
+            background-clip: text;
+            background-image: url('resources/green-100.png');
+            background-color: blue;
+            background-blend-mode: lighten;
+        }
+
+        .middle-background {
+            background-clip: text, border-box;
+            background-image: url('resources/green-100.png'), url('resources/blue.png');
+            background-color: cyan;
+            background-blend-mode: difference, lighten;
+        }
+
+        .last-background {
+            background-clip: border-box, text;
+            background-image: url('resources/green-100.png'), url('resources/blue.png');
+            background-color: yellow;
+            background-blend-mode: difference, lighten;
+        }
+    </style>    
+</head>
+<body>
+    <div class="box single-background">Cyan text on white</div>
+    <div class="box middle-background">Blue text on cyan</div>
+    <div class="box last-background">Red text on lime</div>
+</body>
+</html>

--- a/css/css-backgrounds/background-clip-text-and-blend-mode.html
+++ b/css/css-backgrounds/background-clip-text-and-blend-mode.html
@@ -38,7 +38,7 @@
             background-color: yellow;
             background-blend-mode: difference, lighten;
         }
-    </style>    
+    </style>
 </head>
 <body>
     <div class="box single-background">Cyan text on white</div>

--- a/css/css-backgrounds/reference/background-clip-border-area-and-blend-mode-ref.html
+++ b/css/css-backgrounds/reference/background-clip-border-area-and-blend-mode-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 20px;
+            width: 400px;
+            box-sizing: border-box;
+            border: 20px solid rgb(0, 128, 255);
+            padding: 20px;
+            font-size: 20pt;
+            font-weight: 900;
+            font-family: sans-serif;
+            text-align: center;
+        }
+
+        .single-background {
+            background-color: white;
+            border-color: cyan;
+        }
+
+        .middle-background {
+            background-color: cyan;
+            border-color: blue;
+        }
+
+        .last-background {
+            background-color: lime;
+            border-color: magenta;
+        }
+    </style>    
+</head>
+<body>
+    <div class="box single-background">Cyan border, white background</div>
+    <div class="box middle-background">Blue border, cyan background</div>
+    <div class="box last-background">Magenta border, lime background</div>
+</body>
+</html>

--- a/css/css-backgrounds/reference/background-clip-border-area-and-blend-mode-ref.html
+++ b/css/css-backgrounds/reference/background-clip-border-area-and-blend-mode-ref.html
@@ -28,7 +28,7 @@
             background-color: lime;
             border-color: magenta;
         }
-    </style>    
+    </style>
 </head>
 <body>
     <div class="box single-background">Cyan border, white background</div>

--- a/css/css-backgrounds/reference/background-clip-text-and-blend-mode-ref.html
+++ b/css/css-backgrounds/reference/background-clip-text-and-blend-mode-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 20px;
+            width: 400px;
+            border: 1px solid black;
+            padding: 20px;
+            font-size: 40pt;
+            font-weight: 900;
+            font-family: sans-serif;
+            text-align: center;
+        }
+        
+        .single-background {
+            color: cyan;
+        }
+
+        .middle-background {
+            background-color: cyan;
+            color: blue;
+        }
+
+        .last-background {
+            background-color: lime;
+            color: red;
+        }
+    </style>    
+</head>
+<body>
+    <div class="box single-background">Cyan text on white</div>
+    <div class="box middle-background">Blue text on cyan</div>
+    <div class="box last-background">Red text on lime</div>
+</body>
+</html>

--- a/css/css-backgrounds/reference/background-clip-text-and-blend-mode-ref.html
+++ b/css/css-backgrounds/reference/background-clip-text-and-blend-mode-ref.html
@@ -12,7 +12,7 @@
             font-family: sans-serif;
             text-align: center;
         }
-        
+
         .single-background {
             color: cyan;
         }

--- a/css/css-backgrounds/reference/background-clip-text-and-blend-mode-ref.html
+++ b/css/css-backgrounds/reference/background-clip-text-and-blend-mode-ref.html
@@ -26,7 +26,7 @@
             background-color: lime;
             color: red;
         }
-    </style>    
+    </style>
 </head>
 <body>
     <div class="box single-background">Cyan text on white</div>


### PR DESCRIPTION
WebKit export from bug: [`background-blend-mode` not applied when a layer has `background-clip: text`](https://bugs.webkit.org/show_bug.cgi?id=267129)