### PR TITLE
script: Ensure newly slotted/unslotted nodes have a full restyle / relayout

### DIFF
--- a/shadow-dom/slot-with-slottable-slot-in-display-none-subtree-crash.html
+++ b/shadow-dom/slot-with-slottable-slot-in-display-none-subtree-crash.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45794">
+<script>
+    onload = () => {
+        var shadowRoot = shadowHost.attachShadow({mode: "open"});
+        iframe.srcdoc = "A";
+        slot.style.color = "pink";
+        document.body.clientHeight;
+        shadowRoot.appendChild(noneDiv);
+    };
+</script>
+
+<div id="noneDiv" style="display: none;">
+    <slot style="display: none;" name="innerSlot">
+</div>
+
+<h3 id="shadowHost">
+    <slot id="slot" slot="innerSlot">
+        <iframe id="iframe">
+    </slot>
+</h3>


### PR DESCRIPTION
When slotting and unslotting slottables in a slot, ensure that they get
a full restyle and layout during the next layout. This fixes an issue
where the tree can have unstyled parents with styled children, which
violates Stylo invariants -- leading to a panic.

In addition, this exposes *another* issue where we were clearing the
*assinged slot* of slottables that had already been re-assigned. Slots
are processed in order during slot re-assignment. If the new slot for a
slottable that moves from one slot to another is is handled first during
this process, by the time we reach the second slot (the one the
slottable moved from), we shouldn't clear the slottable's *assigned slot*.
The new guard here ensures that this doesn't happen, preventing panics
exposed by the first fix in this PR.

Special thanks to Frédéric Wang Nélar and Oriol Brufau for help
minimizing this test case.

Testing: A new WPT test is added. Unfortunately this test cannot reproduce
the crash consistently. In addition a few other WPT tests start to pass.
Fixes: #<!-- nolink -->45794.

Reviewed in servo/servo#45834