### PR TITLE
Streams: fix `ReadableStream.from` tests returning non-objects from `return()`

### DIFF
--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -434,6 +434,7 @@ promise_test(async t => {
     throw: t.unreached_func('throw() should not be called'),
     async return() {
       returnCalls += 1;
+      return { done: true };
     },
     [Symbol.asyncIterator]: () => iterable
   };
@@ -605,6 +606,7 @@ promise_test(async () => {
     },
     async return() {
       returnCalls++;
+      return { done: true };
     },
     [Symbol.asyncIterator]: () => iterable
   };

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -591,7 +591,7 @@ promise_test(async () => {
 
 }, `ReadableStream.from: reader.read() inside next()`);
 
-promise_test(async () => {
+promise_test(async t => {
 
   let nextCalls = 0;
   let returnCalls = 0;
@@ -600,7 +600,7 @@ promise_test(async () => {
   const iterable = {
     async next() {
       nextCalls++;
-      await reader.cancel();
+      await reader.cancel().catch(t.unreached_func('cancel() should not reject'));
       return { value: 'something else', done: false };
     },
     async return() {
@@ -619,6 +619,7 @@ promise_test(async () => {
   assert_equals(returnCalls, 1, 'return() should be called once');
 
   await reader.closed;
+  await flushAsyncEvents(); // wait for next() to settle
 
 }, `ReadableStream.from: reader.cancel() inside next()`);
 

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -601,7 +601,6 @@ promise_test(async () => {
     async next() {
       nextCalls++;
       await reader.cancel();
-      assert_equals(returnCalls, 1, 'return() should be called once');
       return { value: 'something else', done: false };
     },
     async return() {
@@ -617,6 +616,7 @@ promise_test(async () => {
   const read = await reader.read();
   assert_object_equals(read, { value: undefined, done: true }, 'first read should be done');
   assert_equals(nextCalls, 1, 'next() should be called once');
+  assert_equals(returnCalls, 1, 'return() should be called once');
 
   await reader.closed;
 

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -424,7 +424,6 @@ promise_test(async t => {
 promise_test(async t => {
 
   let nextCalls = 0;
-  let returnCalls = 0;
 
   const iterable = {
     async next() {
@@ -432,10 +431,7 @@ promise_test(async t => {
       return { value: undefined, done: true };
     },
     throw: t.unreached_func('throw() should not be called'),
-    async return() {
-      returnCalls += 1;
-      return { done: true };
-    },
+    return: t.unreached_func('return() should not be called'),
     [Symbol.asyncIterator]: () => iterable
   };
 
@@ -447,7 +443,6 @@ promise_test(async t => {
   assert_equals(nextCalls, 1, 'next() should be called once');
 
   await reader.closed;
-  assert_equals(returnCalls, 0, 'return() should not be called');
 
 }, `ReadableStream.from: return() is not called when iterator completes normally`);
 


### PR DESCRIPTION
Some tests for `ReadableStream.from()` created async iterable objects with a `return()` method that implicitly returned `undefined` instead of an object, even though these tests weren't really meant to be testing this non-object behavior.

I've updated the offending tests as followed:
* `reader.cancel() inside next()`:
  * `return()` now returns `{ done: true }`, so `reader.cancel()` will fulfill.
  * `next()` now asserts that `reader.cancel()` actually fulfills. An extra `flushAsyncEvents()` at the end of the test gives it enough time to reach this assertion, since `reader.closed` fulfills immediately at the start of `cancel()`.
* `return() is not called when iterator completes normally`
  * `return()` is now just a `t.unreached_func`.