### PR TITLE
constellation: Update pipeline correctly when traversing session history

### DIFF
--- a/css/cssom-view/scroll-behavior-smooth-navigation.html
+++ b/css/cssom-view/scroll-behavior-smooth-navigation.html
@@ -50,7 +50,7 @@
       window.onhashchange = function() {
         instantHistoryNavigationTest.step(function() {
           assert_equals(location.hash, "", "Shouldn't be scrolled to a fragment.");
-          assert_equals(window.scrollY, 0, "Shouldn't be scrolled back to top yet.");
+          assert_equals(window.scrollY, 0, "Should be scrolled to top.");
         });
         p.remove();
         instantHistoryNavigationTest.done();

--- a/html/browsers/history/the-history-interface/back-pushstate-back-history-state.html
+++ b/html/browsers/history/the-history-interface/back-pushstate-back-history-state.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>history.state is null after pushState+back+pushState+back</title>
+    <link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+    <link rel=help href="https://github.com/servo/servo/issues/45905">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+    promise_test(async t => {
+      history.pushState({x: 1}, "");
+
+      await new Promise(resolve => {
+        addEventListener("popstate", resolve, {once: true});
+        history.back();
+      });
+      assert_equals(history.state?.x, undefined,
+        "state is null after back from first pushState");
+
+      history.pushState({x: 2}, "");
+
+      await new Promise(resolve => {
+        addEventListener("popstate", resolve, {once: true});
+        history.back();
+      });
+      assert_equals(history.state?.x, undefined,
+        "state is null after back from second pushState");
+    }, "history.state is null after pushState+back+pushState+back");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
As titled. This fixes a bug where traverse session history does not update url correctly.
For cross-origin navigation, we don't have this problem as we end up with new pipeline.

Testing: New passing in `/css/cssom-view/scroll-behavior-smooth-navigation.html`. 
We also fix the assertion message in the test.
We add a new test `html\browsers\history\the-history-interface\back-pushstate-back-history-state.html`
to cover `history_state_id` change.

Fixes: https://github.com/servo/servo/issues/45835
Fixes: https://github.com/servo/servo/issues/45905

Reviewed in servo/servo#45847