### PR TITLE
Navigation Timing - destination based TAO

### DIFF
--- a/navigation-timing/redirect-tao.tentative.html
+++ b/navigation-timing/redirect-tao.tentative.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigation Timing: redirect timing exposure for cross-origin redirect chains based on Timing-Allow-Origin and the destination origin</title>
+<link rel="author" title="Yoav Weiss" href="mailto:yoav@yoav.ws">
+<link rel="help" href="https://github.com/whatwg/fetch/pull/1931">
+<link rel="help" href="https://github.com/whatwg/html/pull/12513">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/redirect-tao-helper.js"></script>
+<body>
+<script>
+const dest = DESTINATION_ORIGIN;
+
+promise_test(async () => {
+  const entry = await navigation_entry_after_redirects([dest]);
+  assert_redirect_timing_exposed(entry, 1);
+}, "Exposed when a cross-origin redirect opts in to the destination origin");
+
+promise_test(async () => {
+  const entry = await navigation_entry_after_redirects(["*"]);
+  assert_redirect_timing_exposed(entry, 1);
+}, "Exposed when a cross-origin redirect opts in with a wildcard");
+
+promise_test(async () => {
+  const entry = await navigation_entry_after_redirects([dest, dest]);
+  assert_redirect_timing_exposed(entry, 2);
+}, "Exposed when every redirect in the chain opts in to the destination origin");
+
+promise_test(async () => {
+  const entry = await navigation_entry_after_redirects([
+    "https://not-the-destination.example",
+  ]);
+  assert_redirect_timing_hidden(entry);
+}, "Hidden when the redirect opts in to a non-destination origin");
+
+promise_test(async () => {
+  // First hop sends no Timing-Allow-Origin header; second hop opts in. Every
+  // redirect in the chain must opt in for redirect timing to be exposed.
+  const entry = await navigation_entry_after_redirects([null, dest]);
+  assert_redirect_timing_hidden(entry);
+}, "Hidden when only part of the chain opts in to the destination origin");
+
+promise_test(async () => {
+  const entry = await navigation_entry_after_redirects([dest],
+      {referrerPolicy: "no-referrer"});
+  assert_redirect_timing_hidden(entry);
+}, "Hidden for a no-referrer navigation even when the redirect opts in");
+</script>
+</body>

--- a/navigation-timing/resources/redirect-tao-helper.js
+++ b/navigation-timing/resources/redirect-tao-helper.js
@@ -1,0 +1,71 @@
+// Helpers for navigation redirect-timing TAO tests.
+//
+// These build a cross-origin server-side redirect chain (served from the "www"
+// subdomain, which is cross-origin to the test page) that finally lands back on
+// the test page's own origin -- the navigation's "destination origin". Each hop
+// is handled by resources/redirect-tao.py, which optionally emits a
+// Timing-Allow-Origin header.
+//
+// See:
+//   https://github.com/whatwg/fetch/pull/1931
+//   https://github.com/whatwg/html/pull/12513
+
+// The navigation's destination origin (where the chain lands).
+const DESTINATION_ORIGIN = location.origin;
+
+// The final, non-redirect document the chain resolves to (same-origin with the
+// test page, so its navigation timing entry is readable).
+const FINAL_URL =
+    make_absolute_url({path: "/navigation-timing/resources/blank-page-green.html"});
+
+// Builds a redirect-chain URL from `hops`, an array with one entry per redirect.
+// Each entry is the value to send in that redirect's Timing-Allow-Origin header,
+// or null to send no header (i.e. that hop does not opt in).
+function redirect_chain_url(hops) {
+  let url = FINAL_URL;
+  // Build from the last hop backwards, so each redirect points at the next one.
+  for (let i = hops.length - 1; i >= 0; i--) {
+    const tao = hops[i] === null ? "" : "tao=" + encodeURIComponent(hops[i]) + "&";
+    url = make_absolute_url({
+      subdomain: "www",
+      path: "/navigation-timing/resources/redirect-tao.py",
+      query: tao + "location=" + encodeURIComponent(url),
+    });
+  }
+  return url;
+}
+
+// Navigates an iframe through the redirect chain described by `hops` and resolves
+// with the iframe's PerformanceNavigationTiming entry. `referrerPolicy` is an
+// optional referrer policy to apply to the iframe (e.g. "no-referrer").
+function navigation_entry_after_redirects(hops, {referrerPolicy} = {}) {
+  return new Promise(resolve => {
+    const frame = document.createElement("iframe");
+    frame.style.cssText = "width: 250px; height: 250px;";
+    if (referrerPolicy) {
+      frame.referrerPolicy = referrerPolicy;
+    }
+    frame.onload = () => {
+      resolve(frame.contentWindow.performance.getEntriesByType("navigation")[0]);
+    };
+    frame.src = redirect_chain_url(hops);
+    document.body.appendChild(frame);
+  });
+}
+
+// Asserts that redirect timing is exposed, with `expectedCount` redirects.
+function assert_redirect_timing_exposed(entry, expectedCount) {
+  assert_equals(entry.type, "navigate", "navigation type");
+  assert_equals(entry.redirectCount, expectedCount, "redirectCount");
+  assert_greater_than(entry.redirectStart, 0, "redirectStart is exposed");
+  assert_greater_than_equal(entry.redirectEnd, entry.redirectStart,
+      "redirectEnd is greater than or equal to redirectStart");
+}
+
+// Asserts that redirect timing is fully hidden (zeroed out).
+function assert_redirect_timing_hidden(entry) {
+  assert_equals(entry.type, "navigate", "navigation type");
+  assert_equals(entry.redirectCount, 0, "redirectCount is hidden");
+  assert_equals(entry.redirectStart, 0, "redirectStart is hidden");
+  assert_equals(entry.redirectEnd, 0, "redirectEnd is hidden");
+}

--- a/navigation-timing/resources/redirect-tao.py
+++ b/navigation-timing/resources/redirect-tao.py
@@ -1,0 +1,22 @@
+def main(request, response):
+    """Redirect handler that optionally sets a Timing-Allow-Origin header.
+
+    Query parameters:
+      status   - The status code to use for the redirection. Defaults to 302.
+      location - The (percent-encoded) resource to redirect to.
+      tao      - The value to send in the Timing-Allow-Origin response header. If
+                 absent, no Timing-Allow-Origin header is sent (i.e. the redirect
+                 does not opt in).
+    """
+    status = 302
+    if b"status" in request.GET:
+        try:
+            status = int(request.GET.first(b"status"))
+        except ValueError:
+            pass
+
+    response.status = status
+    location = request.GET.first(b"location")
+    response.headers.set(b"Location", location)
+    if b"tao" in request.GET:
+        response.headers.set(b"Timing-Allow-Origin", request.GET.first(b"tao"))


### PR DESCRIPTION
https://github.com/whatwg/fetch/pull/1931 adds a mechanism to opt-in Navigations to expose their timings while taking the destination navigation origin into account.

This PR implements the relevant tests