### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=317512

### DIFF
--- a/css/css-masking/clip-path/clip-path-nested-clippath-zoom.html
+++ b/css/css-masking/clip-path/clip-path-nested-clippath-zoom.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>CSS Masking: nested clip-path (clip-path on a clipPath) honors zoom</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="reference/green-100x100.html">
+<style>
+#target {
+    top: 4px;
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    clip-path: url(#outer);
+    zoom: 2;
+}
+</style>
+</head>
+<body>
+<svg width="0" height="0">
+  <clipPath id="outer" clipPathUnits="userSpaceOnUse" clip-path="url(#inner)">
+    <rect x="0" y="0" width="100" height="50"/>
+    <rect x="0" y="50" width="100" height="50"/>
+  </clipPath>
+  <clipPath id="inner" clipPathUnits="userSpaceOnUse">
+    <rect x="0" y="0" width="50" height="50"/>
+  </clipPath>
+</svg>
+<div id="target"></div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Nested clip-path (clip-path on a clipPath) ignores zoom](https://bugs.webkit.org/show_bug.cgi?id=317512)