### PR TITLE
Implement accessibility property support via CDP for Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -15,6 +15,7 @@ from .base import strip_server
 from .executorwebdriver import (
     WebDriverBaseProtocolPart,
     WebDriverCrashtestExecutor,
+    WebDriverAccessibilityProtocolPart,
     WebDriverFedCMProtocolPart,
     WebDriverPrintRefTestExecutor,
     WebDriverProtocol,
@@ -191,6 +192,94 @@ class ChromeDriverFedCMProtocolPart(WebDriverFedCMProtocolPart):
                                                    f"{self.parent.vendor_prefix}/fedcm/confirmidplogin")
 
 
+class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
+    def setup(self):
+        super().setup()
+        self._nodes_by_id = {}
+
+    def after_connect(self):
+        super().after_connect()
+        self.parent.cdp.execute_cdp_command("Accessibility.enable")
+
+    def teardown(self):
+        try:
+            self.parent.cdp.execute_cdp_command("Accessibility.disable")
+        except error.WebDriverException:
+            pass
+
+    def get_computed_label(self, element):
+        node = self._get_ax_node_for_element(element)
+        return self._serialize_node(node).get("label", "") if node else ""
+
+    def get_computed_role(self, element):
+        node = self._get_ax_node_for_element(element)
+        return self._serialize_node(node).get("role", "") if node else ""
+
+    def get_accessibility_properties_for_element(self, element):
+        node = self._get_ax_node_for_element(element)
+        return self._serialize_node(node) if node else {}
+
+    def get_accessibility_properties_for_accessibility_node(self, id):
+        node = self._get_ax_node_by_backend_id(id)
+        return self._serialize_node(node) if node else {}
+
+    def _get_ax_node_for_element(self, element):
+        # Parse the ID, then hand it off to the shared helper
+        parsed_ids = self._extract_chromedriver_ids(element.id)
+
+        if parsed_ids and parsed_ids.get("element"):
+            return self._get_ax_node_by_backend_id(parsed_ids["element"])
+
+        return None
+
+    def _get_ax_node_by_backend_id(self, backend_node_id):
+        """Shared CDP call to fetch an accessibility node by its backend ID."""
+        ax_tree = self.parent.cdp.execute_cdp_command(
+            "Accessibility.getPartialAXTree",
+            {
+                "backendNodeId": int(backend_node_id),
+                "fetchRelatives": False,
+            }
+        )
+        nodes = ax_tree.get("nodes", [])
+        return nodes[0] if nodes else None
+
+    @staticmethod
+    def _extract_chromedriver_ids(element_id_string):
+        """
+        Extracts Frame, Document, and Element IDs from a ChromeDriver id.
+        Expected format: f.[hash].d.[hash].e.[id]
+        """
+        pattern = r"^f\.(?P<frame>[^.]+)\.d\.(?P<document>[^.]+)\.e\.(?P<element>.+)$"
+        match = re.match(pattern, element_id_string)
+
+        return match.groupdict() if match else None
+
+    @staticmethod
+    def _serialize_node(node):
+        rv = {
+            "accessibilityId": node["nodeId"],
+            "children": node.get("childIds", []),
+        }
+
+        if "parentId" in node:
+            rv["parent"] = node["parentId"]
+
+        # Parse native fields
+        if "role" in node:
+            rv["role"] = node["role"].get("value")
+        if "name" in node:
+            rv["label"] = node["name"].get("value")
+        if "value" in node:
+            rv["value"] = node["value"].get("value")
+        if "description" in node:
+            rv["description"] = node["description"].get("value")
+
+        for prop in node.get("properties", []):
+            rv[prop["name"]] = prop["value"].get("value")
+
+        return rv
+
 class ChromeDriverDevToolsProtocolPart(ProtocolPart):
     """A low-level API for sending Chrome DevTools Protocol [0] commands directly to the browser.
 
@@ -244,6 +333,7 @@ class ChromeDriverTracingProtocolPart(ProtocolPart):
 
 class ChromeDriverProtocol(WebDriverProtocol):
     implements = [
+        ChromeDriverAccessibilityProtocolPart,
         ChromeDriverBaseProtocolPart,
         ChromeDriverDevToolsProtocolPart,
         ChromeDriverFedCMProtocolPart,
@@ -269,6 +359,7 @@ class ChromeDriverProtocol(WebDriverProtocol):
 
 class ChromeDriverBidiProtocol(WebDriverBidiProtocol):
     implements = [
+        ChromeDriverAccessibilityProtocolPart,
         ChromeDriverBaseProtocolPart,
         ChromeDriverDevToolsProtocolPart,
         ChromeDriverFedCMProtocolPart,

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -198,7 +198,6 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
     def setup(self):
         super().setup()
         self._nodes_by_id = {}
-        self.full_ax_tree: MutableMapping[str, AXNode] = {}
 
     def teardown(self):
         try:
@@ -207,34 +206,25 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
             pass
 
     def get_accessibility_properties_for_element(self, element):
-        # Wipe cached tree on new call
-        self.full_ax_tree = {}
-
         node = self._get_ax_node_for_element(element)
         return self._serialize_node(node) if node else {}
 
     def get_accessibility_properties_for_accessibility_node(self, id):
-        # Wipe cached tree on new call to avoid stale properties
-        self.full_ax_tree = {}
-
         node = self._find_ax_node_by_ax_node_id(id)
         return self._serialize_node(node) if node else {}
 
-    def _set_full_ax_tree(self) -> None:
+    def _get_full_ax_tree(self) -> Mapping[str, AXNode]:
         self.parent.cdp.execute_cdp_command("Accessibility.enable")
         node_array = self.parent.cdp.execute_cdp_command(
             "Accessibility.getFullAXTree",
             {}
         ).get("nodes", [])
 
-        self.full_ax_tree = {node["nodeId"]: node for node in node_array}
+        return {node["nodeId"]: node for node in node_array}
 
     def _find_ax_node_by_ax_node_id(self, ax_node_id: str) -> Optional[AXNode]:
-        node: Optional[AXNode] = self.full_ax_tree.get(ax_node_id, None)
-
-        if not node:
-            self._set_full_ax_tree()
-            node = self.full_ax_tree.get(ax_node_id, None)
+        full_ax_tree = self._get_full_ax_tree()
+        node = full_ax_tree.get(ax_node_id, None)
 
         return node
 
@@ -261,7 +251,7 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
 
     def _serialize_node(self, node: AXNode) -> Mapping[str, Any]:
         # TODO: Define an approach to handle ignored items as this is different
-        # browsers by browser and might make testing the Tree harder.
+        # browsers by browser and might make testing the subtree harder.
 
         rv: dict[str,Any] = {
             "accessibilityId": node["nodeId"],
@@ -281,8 +271,14 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
         if "description" in node:
             rv["description"] = node["description"].get("value")
 
+        # We only support a subset of properties for now outside of the native fields.
+        allowed_properties = {'checked', 'pressed', 'level',
+                              'multiline', 'orientation', 'required',
+                              'roledescription', 'selected'}
+
         for prop in node.get("properties", []):
-            rv[prop["name"]] = prop["value"].get("value")
+            if prop["name"] in allowed_properties:
+                rv[prop["name"]] = prop["value"].get("value")
 
         return rv
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -196,10 +196,7 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
     def setup(self):
         super().setup()
         self._nodes_by_id = {}
-
-    def after_connect(self):
-        super().after_connect()
-        self.parent.cdp.execute_cdp_command("Accessibility.enable")
+        self.full_ax_tree = {}
 
     def teardown(self):
         try:
@@ -207,32 +204,48 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
         except error.WebDriverException:
             pass
 
-    def get_computed_label(self, element):
-        node = self._get_ax_node_for_element(element)
-        return self._serialize_node(node).get("label", "") if node else ""
-
-    def get_computed_role(self, element):
-        node = self._get_ax_node_for_element(element)
-        return self._serialize_node(node).get("role", "") if node else ""
-
     def get_accessibility_properties_for_element(self, element):
+        # Wipe cached tree on new call
+        self.full_ax_tree = {}
+
         node = self._get_ax_node_for_element(element)
         return self._serialize_node(node) if node else {}
 
     def get_accessibility_properties_for_accessibility_node(self, id):
-        node = self._get_ax_node_by_backend_id(id)
+        # Wipe cached tree on new call to avoid stale properties
+        self.full_ax_tree = {}
+
+        node = self._find_ax_node_by_ax_node_id(id)
         return self._serialize_node(node) if node else {}
+
+    def _set_full_ax_tree(self):
+        self.parent.cdp.execute_cdp_command("Accessibility.enable")
+        node_array =  self.parent.cdp.execute_cdp_command(
+            "Accessibility.getFullAXTree",
+            {}
+        ).get("nodes", [])
+
+        self.full_ax_tree = {node["nodeId"]: node for node in node_array}
+
+    def _find_ax_node_by_ax_node_id(self, ax_node_id: str ) -> any:    
+        node = self.full_ax_tree.get(ax_node_id, None)
+
+        if not node:
+            self._set_full_ax_tree()
+            node = self.full_ax_tree.get(ax_node_id, None)
+
+        return node
 
     def _get_ax_node_for_element(self, element):
         # Parse the ID, then hand it off to the shared helper
         parsed_ids = self._extract_chromedriver_ids(element.id)
 
         if parsed_ids and parsed_ids.get("element"):
-            return self._get_ax_node_by_backend_id(parsed_ids["element"])
+            return self._get_ax_node_by_backend_node_id(parsed_ids["element"])
 
         return None
 
-    def _get_ax_node_by_backend_id(self, backend_node_id):
+    def _get_ax_node_by_backend_node_id(self, backend_node_id):
         """Shared CDP call to fetch an accessibility node by its backend ID."""
         ax_tree = self.parent.cdp.execute_cdp_command(
             "Accessibility.getPartialAXTree",
@@ -244,19 +257,10 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
         nodes = ax_tree.get("nodes", [])
         return nodes[0] if nodes else None
 
-    @staticmethod
-    def _extract_chromedriver_ids(element_id_string):
-        """
-        Extracts Frame, Document, and Element IDs from a ChromeDriver id.
-        Expected format: f.[hash].d.[hash].e.[id]
-        """
-        pattern = r"^f\.(?P<frame>[^.]+)\.d\.(?P<document>[^.]+)\.e\.(?P<element>.+)$"
-        match = re.match(pattern, element_id_string)
+    def _serialize_node(self, node):
+        if node.get("ignored", False) and len(node.get("childIds", [])) == 1:
+           node = self._find_ax_node_by_ax_node_id(node.get("childIds", [])[0])
 
-        return match.groupdict() if match else None
-
-    @staticmethod
-    def _serialize_node(node):
         rv = {
             "accessibilityId": node["nodeId"],
             "children": node.get("childIds", []),
@@ -279,6 +283,17 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
             rv[prop["name"]] = prop["value"].get("value")
 
         return rv
+
+    @staticmethod
+    def _extract_chromedriver_ids(element_id_string):
+        """
+        Extracts Frame, Document, and Element IDs from a ChromeDriver id.
+        Expected format: f.[hash].d.[hash].e.[id]
+        """
+        pattern = r"^f\.(?P<frame>[^.]+)\.d\.(?P<document>[^.]+)\.e\.(?P<element>.+)$"
+        match = re.match(pattern, element_id_string)
+
+        return match.groupdict() if match else None
 
 class ChromeDriverDevToolsProtocolPart(ProtocolPart):
     """A low-level API for sending Chrome DevTools Protocol [0] commands directly to the browser.

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -29,6 +29,8 @@ from .protocol import LeakProtocolPart, ProtocolPart
 
 here = os.path.dirname(__file__)
 
+AXNode = Mapping[str, Any]
+
 def _update_capabilities_if_extension_test(
     browser: Any, capabilities: Optional[MutableMapping[str, Any]]
 ) -> Optional[MutableMapping[str, Any]]:
@@ -196,7 +198,7 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
     def setup(self):
         super().setup()
         self._nodes_by_id = {}
-        self.full_ax_tree = {}
+        self.full_ax_tree: MutableMapping[str, AXNode] = {}
 
     def teardown(self):
         try:
@@ -218,17 +220,17 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
         node = self._find_ax_node_by_ax_node_id(id)
         return self._serialize_node(node) if node else {}
 
-    def _set_full_ax_tree(self):
+    def _set_full_ax_tree(self) -> None:
         self.parent.cdp.execute_cdp_command("Accessibility.enable")
-        node_array =  self.parent.cdp.execute_cdp_command(
+        node_array = self.parent.cdp.execute_cdp_command(
             "Accessibility.getFullAXTree",
             {}
         ).get("nodes", [])
 
         self.full_ax_tree = {node["nodeId"]: node for node in node_array}
 
-    def _find_ax_node_by_ax_node_id(self, ax_node_id: str ) -> any:    
-        node = self.full_ax_tree.get(ax_node_id, None)
+    def _find_ax_node_by_ax_node_id(self, ax_node_id: str) -> Optional[AXNode]:
+        node: Optional[AXNode] = self.full_ax_tree.get(ax_node_id, None)
 
         if not node:
             self._set_full_ax_tree()
@@ -236,7 +238,7 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
 
         return node
 
-    def _get_ax_node_for_element(self, element):
+    def _get_ax_node_for_element(self, element: Any) -> Optional[AXNode]:
         # Parse the ID, then hand it off to the shared helper
         parsed_ids = self._extract_chromedriver_ids(element.id)
 
@@ -245,7 +247,7 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
 
         return None
 
-    def _get_ax_node_by_backend_node_id(self, backend_node_id):
+    def _get_ax_node_by_backend_node_id(self, backend_node_id: str) -> Optional[AXNode]:
         """Shared CDP call to fetch an accessibility node by its backend ID."""
         ax_tree = self.parent.cdp.execute_cdp_command(
             "Accessibility.getPartialAXTree",
@@ -254,14 +256,14 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
                 "fetchRelatives": False,
             }
         )
-        nodes = ax_tree.get("nodes", [])
+        nodes: list[AXNode] = ax_tree.get("nodes", [])
         return nodes[0] if nodes else None
 
-    def _serialize_node(self, node):
-        if node.get("ignored", False) and len(node.get("childIds", [])) == 1:
-           node = self._find_ax_node_by_ax_node_id(node.get("childIds", [])[0])
+    def _serialize_node(self, node: AXNode) -> Mapping[str, Any]:
+        # TODO: Define an approach to handle ignored items as this is different
+        # browsers by browser and might make testing the Tree harder.
 
-        rv = {
+        rv: dict[str,Any] = {
             "accessibilityId": node["nodeId"],
             "children": node.get("childIds", []),
         }
@@ -285,7 +287,7 @@ class ChromeDriverAccessibilityProtocolPart(WebDriverAccessibilityProtocolPart):
         return rv
 
     @staticmethod
-    def _extract_chromedriver_ids(element_id_string):
+    def _extract_chromedriver_ids(element_id_string: str) -> Optional[Mapping[str, str]]:
         """
         Extracts Frame, Document, and Element IDs from a ChromeDriver id.
         Expected format: f.[hash].d.[hash].e.[id]

--- a/wai-aria/scripts/aria-utils.js
+++ b/wai-aria/scripts/aria-utils.js
@@ -225,7 +225,7 @@ const AriaUtils = {
       promise_test(async t => {
         const actual = await test_driver.get_accessibility_properties_for_element(el);
         for (const key in expected) {
-          assert_equals(actual[key], expected[key], `${key}: ${el.outerHTML}`);
+          assert_equals(String(actual[key]), expected[key], `${key}: ${el.outerHTML}`);
         }
       }, testName);
     }


### PR DESCRIPTION
Introduces `ChromeDriverAccessibilityProtocolPart` to provide accessibility tree and computed property support for Chrome under `wptrunner`. This mirrors the pattern used by existing drivers (such as Marionette) and leverages the Chrome DevTools Protocol (`CDP`) `Accessibility.getPartialAXTree` command(https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#method-getPartialAXTree). It also, as a result, adds support for Edge and other Chromium browsers.

### Technical Changes

* **Protocol Implementation:** Added `ChromeDriverAccessibilityProtocolPart` (subclassing `WebDriverAccessibilityProtocolPart`) to fetch computed labels, roles, and tree structures via CDP commands `Accessibility.getPartialAXTree`.
* Changes to aria-utils.js to cast elements to a String to prevent a undefined =! "undefined" bug

### Verification

Verified locally on both **macOS** and **Windows** by running the `wai-aria` test suite to ensure properties and tree extractions map correctly across environments without regressions:

```bash
./wpt run chrome --include wai-aria --log-wptreport wai-chrome.json