### PR TITLE
Fix WebGPU texture usage in JPEG XL decode test

### DIFF
--- a/jpegxl/canvas-decode-paths-webgpu.https.html
+++ b/jpegxl/canvas-decode-paths-webgpu.https.html
@@ -52,7 +52,7 @@ async function sampleCenterPixelWithWebGPU(image) {
   const texture = device.createTexture({
     size: {width, height, depthOrArrayLayers: 1},
     format: 'rgba8unorm',
-    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
   });
 
   device.queue.copyExternalImageToTexture(


### PR DESCRIPTION
`copyExternalImageToTexture` requires `GPUTextureUsage.RENDER_ATTACHMENT` per the [spec](https://www.w3.org/TR/webgpu/#dom-gpuqueue-copyexternalimagetotexture).

It fails on Chrome without the flag, but Firefox does not validate it.