### PR TITLE
Add fuzzy metadata to border-image-repeat-round.html

### DIFF
--- a/css/css-backgrounds/border-image-repeat-round.html
+++ b/css/css-backgrounds/border-image-repeat-round.html
@@ -6,7 +6,8 @@
     <link rel="help" href="http://www.w3.org/TR/css3-background/#border-images">
     <link rel="match" href="reference/border-image-repeat-round-ref.html">
     <meta name="assert" content="diamonds in corners should be red, and other diamonds should be orange, it should be 4 orange diamonds on each side.">
-    <style type="text/css">
+    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-1500">
+    <style>
         .container {
             border: double red 1em;
             border-image: url("support/border.png") 27 round;


### PR DESCRIPTION
Took the max of Chrome & Safari. Did not take in account Firefox since they removed the metadata.