### PR TITLE
fonts: Simplify logic around `@font-face` descriptors

### DIFF
--- a/css/css-fonts/variations/font-descriptor-range-reversed-002-ref.html
+++ b/css/css-fonts/variations/font-descriptor-range-reversed-002-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Reference</title>
+
+<style>
+@font-face {
+  font-family: TestWeight;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-weight: 400 300;
+}
+@font-face {
+  font-family: TestStyle;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-style: oblique 40deg 30deg;
+}
+@font-face {
+  font-family: TestStretch;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-stretch: 130% 120%;
+}
+</style>
+
+<p style="font-family: TestWeight; font-weight: 250;">A</p>
+<p style="font-family: TestStyle; font-style: oblique 25deg;">A</p>
+<p style="font-family: TestStretch; font-stretch: 115%;">A</p>
+
+<script>
+document.fonts.ready.then(function() {
+  document.documentElement.className = "";
+});
+</script>

--- a/css/css-fonts/variations/font-descriptor-range-reversed-002.html
+++ b/css/css-fonts/variations/font-descriptor-range-reversed-002.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: Matching @font-face font-weight, font-style, and font-stretch descriptors with reversed ranges</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-prop-desc">
+<link rel="match" href="font-descriptor-range-reversed-002-ref.html">
+
+<!-- Using csstest-weights-{100,900}-kerned.ttf just as two convenient
+     different fonts here with different "A" glyphs -->
+
+<style>
+@font-face {
+  font-family: TestWeight;
+  src: url(resources/csstest-weights-900-kerned.ttf);
+  font-weight: 310 400;
+}
+@font-face {
+  font-family: TestWeight;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-weight: 400 300;
+}
+@font-face {
+  font-family: TestStyle;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-style: oblique 40deg 30deg;
+}
+@font-face {
+  font-family: TestStyle;
+  src: url(resources/csstest-weights-900-kerned.ttf);
+  font-style: oblique 31deg 40deg;
+}
+@font-face {
+  font-family: TestStretch;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-stretch: 130% 120%;
+}
+@font-face {
+  font-family: TestStretch;
+  src: url(resources/csstest-weights-900-kerned.ttf);
+  font-stretch: 121% 130%;
+}
+</style>
+
+<!-- Matches `font-weight: 300 200;` -->
+<p style="font-family: TestWeight; font-weight: 250;">A</p>
+
+<!-- Matches `font-style: oblique 30deg 20deg;` -->
+<p style="font-family: TestStyle; font-style: oblique 25deg;">A</p>
+
+<!-- Matches `font-style: oblique 120% 110%;` -->
+<p style="font-family: TestStretch; font-stretch: 115%;">A</p>
+
+<script>
+document.fonts.ready.then(function() {
+  document.documentElement.className = "";
+});
+</script>


### PR DESCRIPTION
This changes `CSSFontFaceDescriptors` to use:
- `ComputedFontWeightRange` instead of a pair of `FontWeight`
- `ComputedFontStretchRange` instead of a pair of `FontStretch`
- Stylo's `ComputedFontStyleDescriptor` instead of a similar copy of that

This way we can simply use the `compute()` method of `FontWeightRange`, `FontStretchRange` and `FontFaceStyle` to compute the above. The behavior should be mostly the same, but:
 - Now the ranges will be sorted, if they were in the wrong order
 - Degrees in `font-style` will be clamped within the [-90deg, 90deg] range

Bumps Stylo to https://github.com/servo/stylo/pull/399

Testing: Adding a test for ranges in the wrong order
Reviewed in servo/servo#45821