### PR TITLE
Adjust fuzzy metadata for clip-border-area-border-shape-overflow.html

### DIFF
--- a/css/css-backgrounds/background-clip/clip-border-area-border-shape-overflow.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-border-shape-overflow.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#border-shape">
 <link rel="match" href="clip-border-area-border-shape-overflow-ref.html">
 <meta name="assert" content="background-clip:border-area backgrounds fill the full visible border-shape area, including overflow beyond the border box.">
-<meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-500">
+<meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-2500">
 <style>
   .test {
     display: inline-block;


### PR DESCRIPTION
Account for Safari: `maxDifference=0-1; totalPixels=0-2500`