### PR TITLE
Add support for retrieving pid for Edge 

### DIFF
--- a/core-aam/aamtests/support/fixtures_a11y_api.py
+++ b/core-aam/aamtests/support/fixtures_a11y_api.py
@@ -6,6 +6,8 @@ def pid_from(capabilities):
     # TODO: add support for getting the PID from other browsers.
     if capabilities["browserName"] == "chrome":
         return capabilities["goog:processID"], "chrome"
+    if capabilities["browserName"].lower() in ("microsoftedge", "edge"):
+        return capabilities.get("ms:processID", capabilities.get("goog:processID", 0)), "edge"
     if capabilities["browserName"] == "firefox":
         return capabilities["moz:processID"], "firefox"
     if "safari:processID" in capabilities:


### PR DESCRIPTION
a very simple commit to enablement of wai-aria WPTs on Edge(Note: to really test Edge, you need the CDP/Chrome executor I made a PR for here: https://github.com/web-platform-tests/wpt/pull/60778).