### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=311817

### DIFF
--- a/svg/animations/svglengthlist-animation-invalid-value-2.html
+++ b/svg/animations/svglengthlist-animation-invalid-value-2.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGLengthList animation with invalid values: String value in length list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <text id="text" x="50 70 90 110" y="50">ABCD
+        <animate attributeName="x" begin="0s" dur="4s" from="50 70 90 A" to="60 90 120 50" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+  const svg = document.getElementById("svg");
+  const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(
+            Array.from(text.x.baseVal).map(v => v.value),
+            [50, 70, 90, 110]
+          );
+          assert_array_equals(
+            Array.from(text.x.animVal).map(v => v.value),
+            Array.from(text.x.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svglengthlist-animation-invalid-value-3.html
+++ b/svg/animations/svglengthlist-animation-invalid-value-3.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGLengthList animation with invalid values: String value in length list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <text id="text" x="50 70 90 110" y="50">ABCD
+        <animate attributeName="x" begin="0s" dur="4s" from="50 70 90 110" to="60 90 120 X" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+  const svg = document.getElementById("svg");
+  const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(
+            Array.from(text.x.baseVal).map(v => v.value),
+            [50, 70, 90, 110]
+          );
+          assert_array_equals(
+            Array.from(text.x.animVal).map(v => v.value),
+            Array.from(text.x.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgnumberlist-animation-invalid-value-2.html
+++ b/svg/animations/svgnumberlist-animation-invalid-value-2.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGNumberList animation with invalid values: String value in from list attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <text id="text" x="40 60 80 100" y="60" rotate="15 20 30 40" fill="green">ABCD
+        <animate attributeName="rotate" from="0 0 0 A" to="45 90 135 40" begin="0s" dur="4s" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(
+            Array.from(text.rotate.baseVal).map(v => v.value),
+            [15, 20, 30, 40]
+          );
+          assert_array_equals(
+            Array.from(text.rotate.animVal).map(v => v.value),
+            Array.from(text.rotate.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgnumberlist-animation-invalid-value-3.html
+++ b/svg/animations/svgnumberlist-animation-invalid-value-3.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGNumberList animation with invalid values: String value in from list attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <text id="text" x="40 60 80 100" y="60" rotate="15 20 30 40" fill="green">ABCD
+        <animate attributeName="rotate" from="0 0 0 0" to="45 90 135 A" begin="0s" dur="4s" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(
+            Array.from(text.rotate.baseVal).map(v => v.value),
+            [15, 20, 30, 40]
+          );
+          assert_array_equals(
+            Array.from(text.rotate.animVal).map(v => v.value),
+            Array.from(text.rotate.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgpointlist-animation-invalid-value-2.html
+++ b/svg/animations/svgpointlist-animation-invalid-value-2.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<title>Test SVGPointList animation with invalid values: String value in point list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <polygon id="poly" points="0,0 200,0 200,200 0,200" fill="green">
+        <animate attributeName="points" begin="0s" dur="4s" from="0,0 200,0 200,200 A,C" to="0,0 100,0 100,100 B,D" />
+    </polygon>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const poly = document.getElementById("poly");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(
+            Array.from(poly.points).map(v => v.x),
+            [0, 200, 200, 0]
+          );
+          assert_array_equals(
+            Array.from(poly.points).map(v => v.y),
+            [0, 0, 200, 200]
+          );
+
+          assert_array_equals(
+            Array.from(poly.animatedPoints).map(v => v.x),
+            Array.from(poly.points).map(v => v.x)
+          );
+          assert_array_equals(
+            Array.from(poly.animatedPoints).map(v => v.y),
+            Array.from(poly.points).map(v => v.y)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgpointlist-animation-invalid-value-3.html
+++ b/svg/animations/svgpointlist-animation-invalid-value-3.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<title>Test SVGPointList animation with invalid values: String value in point list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <polygon id="poly" points="0,0 200,0 200,200 0,200" fill="green">
+        <animate attributeName="points" begin="0s" dur="4s" from="0,0 200,0 200,200 0,0" to="0,0 100,0 100,100 B,D" />
+    </polygon>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const poly = document.getElementById("poly");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(
+            Array.from(poly.points).map(v => v.x),
+            [0, 200, 200, 0]
+          );
+          assert_array_equals(
+            Array.from(poly.points).map(v => v.y),
+            [0, 0, 200, 200]
+          );
+
+          assert_array_equals(
+            Array.from(poly.animatedPoints).map(v => v.x),
+            Array.from(poly.points).map(v => v.x)
+          );
+          assert_array_equals(
+            Array.from(poly.animatedPoints).map(v => v.y),
+            Array.from(poly.points).map(v => v.y)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgtransformlist-animation-invalid-value-1.html
+++ b/svg/animations/svgtransformlist-animation-invalid-value-1.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGTransformList animation with invalid values: String value in transform list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/svg/resources/svg-transform-equals.js"></script>
+
+<svg id="svg">
+    <text id="text" transform="scale(2, 1)" y="50">ABCD
+        <animateTransform attributeName="transform" begin="0s" dur="14s" from="scale(2, 2), a" to="scale(3, 3), b" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+  const svg = document.getElementById("svg");
+  const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          const expected = svg.createSVGTransform();
+          expected.setScale(2, 1);
+          assert_svg_transform_equals(text.transform.animVal.getItem(0), expected);
+          assert_array_equals(
+            Array.from(text.transform.animVal).map(v => v.value),
+            Array.from(text.transform.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgtransformlist-animation-invalid-value-2.html
+++ b/svg/animations/svgtransformlist-animation-invalid-value-2.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGTransformList animation with invalid values: String value in transform list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/svg/resources/svg-transform-equals.js"></script>
+
+<svg id="svg">
+    <text id="text" transform="scale(2, 1)" y="50">ABCD
+        <animateTransform attributeName="transform" begin="0s" dur="14s" from="scale(2, 2), a" to="scale(3, 3)" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+  const svg = document.getElementById("svg");
+  const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          const expected = svg.createSVGTransform();
+          expected.setScale(2, 1);
+          assert_svg_transform_equals(text.transform.animVal.getItem(0), expected);
+          assert_array_equals(
+            Array.from(text.transform.animVal).map(v => v.value),
+            Array.from(text.transform.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgtransformlist-animation-invalid-value-3.html
+++ b/svg/animations/svgtransformlist-animation-invalid-value-3.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGTransformList animation with invalid values: String value in transform list values for from and to attributes.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromAttribute">
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/svg/resources/svg-transform-equals.js"></script>
+
+<svg id="svg">
+    <text id="text" transform="scale(2, 1)" y="50">ABCD
+        <animateTransform attributeName="transform" begin="0s" dur="14s" from="scale(2, 2)" to="scale(3, 3), b" />
+    </text>
+</svg>
+
+<script>
+
+async_test(t => {
+  const svg = document.getElementById("svg");
+  const text = document.getElementById("text");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          const expected = svg.createSVGTransform();
+          expected.setScale(2, 1);
+          assert_svg_transform_equals(text.transform.animVal.getItem(0), expected);
+          assert_array_equals(
+            Array.from(text.transform.animVal).map(v => v.value),
+            Array.from(text.transform.baseVal).map(v => v.value)
+          );
+        }));
+    }));
+  });
+
+</script>


### PR DESCRIPTION
From the SMIL animation spec [1]:
 "If any values (i.e., the argument-values for from, to, by or values attributes) are not legal, the animation will have no effect (see also Handling Syntax Errors)."
Added tests for this.
    
 [1] https://www.w3.org/TR/smil-animation/

