### PR TITLE
WebKit export: Update outline-width and outline-offset to match updated computed style resolution rules

### DIFF
--- a/css/css-ui/parsing/outline-offset-computed.html
+++ b/css/css-ui/parsing/outline-offset-computed.html
@@ -22,6 +22,15 @@ test_computed_value("outline-offset", "10px");
 test_computed_value("outline-offset", "0.5em", "20px");
 test_computed_value("outline-offset", "calc(10px + 0.5em)", "30px");
 test_computed_value("outline-offset", "calc(10px - 0.5em)", "-10px");
+
+test(() => {
+  target.style['outline-offset'] = '10px';
+  target.style['outline-style'] = 'none';
+  assert_equals(getComputedStyle(target)['outline-offset'], '10px');
+  target.style['outline-style'] = 'auto';
+  assert_equals(getComputedStyle(target)['outline-offset'], '10px');
+  target.style['outline-style'] = '';
+}, 'outline-offset is independent of the value of outline-style');
 </script>
 </body>
 </html>


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=304909