### PR TITLE
layout: Apply reference frame clips via stacking contexts

### DIFF
--- a/css/css-transforms/transform-2d-clip-and-filter-crash.html
+++ b/css/css-transforms/transform-2d-clip-and-filter-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<link rel="help" href="https://github.com/servo/servo/issues/45732">
+<script src="/common/rendering-utils.js"></script>
+<style>
+  html, body { overflow-x: clip; }
+  meter {
+      transform: rotate(-45deg);
+      filter: grayscale(1);
+      padding-top: 100vh;
+  }
+</style>
+<meter></meter>
+<script>
+  waitForAtLeastOneFrame().then(() => {
+    document.documentElement.classList.remove("test-wait");
+  });
+</script>
+</html>


### PR DESCRIPTION
Although the WebRender display list API allows assigning a clip from
outside a reference frame to display list items inside that reference
frame, the current version of WebRender we have panics when this
happens. The alternative is to surround all the display list items
inside the reference frame with a stacking context that has the clip
assigned. This is the approach that Gecko takes and it fixes a panic we
see frequently when fuzzing.

Testing: This change adds a new WPT crash test and causes one WPT test to start passing.
Fixes: #<!-- nolink -->45732.

Reviewed in servo/servo#45951