### PR TITLE
Fix extension cleanup in chrome+firefox

### DIFF
--- a/resources/web-extensions-helper.js
+++ b/resources/web-extensions-helper.js
@@ -37,8 +37,8 @@ globalThis.runTestsWithWebExtension = function(extensionPath) {
 
     cleanupListeners();
     installPromise
-        .then((result) => {
-          return test_driver.uninstall_web_extension(result.extension);
+        .then((extension_id) => {
+          return test_driver.uninstall_web_extension(extension_id);
         })
         .then(() => {
           done();

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -822,7 +822,7 @@ class MarionetteWebExtensionsProtocolPart(WebExtensionsProtocolPart):
             extension_path = self.parent.test_dir + path
             extension_id = self.addons.install(extension_path, temp=True)
 
-        return {'extension': extension_id}
+        return extension_id
 
     def uninstall_web_extension(self, extension_id):
         return self.addons.uninstall(extension_id)

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -452,7 +452,7 @@ class WebDriverBidiWebExtensionsProtocolPart(WebExtensionsProtocolPart):
         extension_id = self.parent.loop.run_until_complete(
             self.webdriver.bidi_session.web_extension.install(
                 extension_data=params))
-        return {"extension": extension_id}
+        return extension_id
 
     def uninstall_web_extension(self, extension_id):
         return self.parent.loop.run_until_complete(

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -449,9 +449,10 @@ class WebDriverBidiWebExtensionsProtocolPart(WebExtensionsProtocolPart):
         else:
             params["value"] = value
 
-        return self.parent.loop.run_until_complete(
+        extension_id = self.parent.loop.run_until_complete(
             self.webdriver.bidi_session.web_extension.install(
                 extension_data=params))
+        return {"extension": extension_id}
 
     def uninstall_web_extension(self, extension_id):
         return self.parent.loop.run_until_complete(


### PR DESCRIPTION
Before this commit, chrome WPT extension tests using WebDriver BiDi failed during cleanup (uninstall_web_extension) because the runner expected a dictionary containing the extension ID, but the Python BiDi client library automatically unpacked it to a raw string. This mismatch caused an invalid argument error when calling the uninstall command. This exposed that there was a mismatch in what `test_driver.install_web_extension` is expected and what is actually to resolves to. It's expected to resolve to a string (technically `Promise<string>`). executormarionette.py resolved it to `{'extension': extension_id}` ({<string>:<string>}), whereas executorchrome.py resolved it to `extension_id` (string). `web-extensions-helper.js` expected it to be the map version.

After this commit, we align both executors to provide the extension_id as a string and web-extensions-helper.js to expect just a string to make the uninstallation behavior work for Firefox and Chrome.