### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=317779

### DIFF
--- a/css/css-ui/outline-offset-inset-001-ref.html
+++ b/css/css-ui/outline-offset-inset-001-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<style>
+  div {
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+    background: lightblue;
+    outline-style: solid;
+    margin: 20px;
+  }
+  .w3  { outline-width: 3px;  outline-offset: -3px; }
+  .w8  { outline-width: 8px;  outline-offset: -8px; }
+  .w12 { outline-width: 12px; outline-offset: -12px; }
+</style>
+<div class="w3"></div>
+<div class="w8"></div>
+<div class="w12"></div>

--- a/css/css-ui/outline-offset-inset-001.html
+++ b/css/css-ui/outline-offset-inset-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<link rel="match" href="outline-offset-inset-001-ref.html">
+<meta name="assert" content="outline-offset: inset renders the same as a negative outline-offset for various outline widths">
+<style>
+  div {
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+    background: lightblue;
+    outline-style: solid;
+    outline-offset: inset;
+    margin: 20px;
+  }
+  .w3  { outline-width: 3px; }
+  .w8  { outline-width: 8px; }
+  .w12 { outline-width: 12px; }
+</style>
+<div class="w3"></div>
+<div class="w8"></div>
+<div class="w12"></div>

--- a/css/css-ui/outline-offset-inset-002-ref.html
+++ b/css/css-ui/outline-offset-inset-002-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    background: lightblue;
+    border-radius: 20px;
+    outline: 6px solid blue;
+    outline-offset: -6px;
+  }
+</style>
+<div></div>

--- a/css/css-ui/outline-offset-inset-002.html
+++ b/css/css-ui/outline-offset-inset-002.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<link rel="match" href="outline-offset-inset-002-ref.html">
+<meta name="assert" content="outline-offset: inset renders the same as a negative outline-offset on an element with border-radius">
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    background: lightblue;
+    border-radius: 20px;
+    outline: 6px solid blue;
+    outline-offset: inset;
+  }
+</style>
+<div></div>

--- a/css/css-ui/outline-offset-inset-003-ref.html
+++ b/css/css-ui/outline-offset-inset-003-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<style>
+  div {
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+    background: lightblue;
+    outline-width: 6px;
+    outline-offset: -6px;
+    margin: 20px;
+  }
+  .solid  { outline-style: solid; }
+  .dashed { outline-style: dashed; }
+  .dotted { outline-style: dotted; }
+  .double { outline-style: double; }
+</style>
+<div class="solid"></div>
+<div class="dashed"></div>
+<div class="dotted"></div>
+<div class="double"></div>

--- a/css/css-ui/outline-offset-inset-003.html
+++ b/css/css-ui/outline-offset-inset-003.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<link rel="match" href="outline-offset-inset-003-ref.html">
+<meta name="assert" content="outline-offset: inset renders the same as a negative outline-offset for various outline styles">
+<style>
+  div {
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+    background: lightblue;
+    outline-width: 6px;
+    outline-offset: inset;
+    margin: 20px;
+  }
+  .solid  { outline-style: solid; }
+  .dashed { outline-style: dashed; }
+  .dotted { outline-style: dotted; }
+  .double { outline-style: double; }
+</style>
+<div class="solid"></div>
+<div class="dashed"></div>
+<div class="dotted"></div>
+<div class="double"></div>

--- a/css/css-ui/outline-offset-inset-004-ref.html
+++ b/css/css-ui/outline-offset-inset-004-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<style>
+  div {
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+    background: lightblue;
+    outline: 5px solid blue;
+    outline-offset: -5px;
+    margin: 20px;
+  }
+</style>
+<div></div>
+<div style="zoom: 2"></div>

--- a/css/css-ui/outline-offset-inset-004.html
+++ b/css/css-ui/outline-offset-inset-004.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<link rel="match" href="outline-offset-inset-004-ref.html">
+<meta name="assert" content="outline-offset: inset renders the same as a negative outline-offset when CSS zoom is applied">
+<style>
+  div {
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+    background: lightblue;
+    outline: 5px solid blue;
+    outline-offset: inset;
+    margin: 20px;
+  }
+</style>
+<div></div>
+<div style="zoom: 2"></div>

--- a/css/css-ui/outline-offset-inset-005.html
+++ b/css/css-ui/outline-offset-inset-005.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="outline-offset: inset keeps the outline produced by outline-style: auto fully within the border box, so it can be completely hidden by an opaque overlay the same size as the box">
+<style>
+  .wrapper {
+    position: relative;
+    width: 100px;
+    height: 100px;
+  }
+  .box {
+    position: absolute;
+    inset: 0;
+    background: green;
+    outline-style: auto;
+    outline-offset: inset;
+  }
+  .cover {
+    position: absolute;
+    inset: 0;
+    background: green;
+  }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="wrapper">
+  <div class="box"></div>
+  <div class="cover"></div>
+</div>

--- a/css/css-ui/outline-offset-inset-006-notref.html
+++ b/css/css-ui/outline-offset-inset-006-notref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    background: lightblue;
+    outline-style: auto;
+  }
+</style>
+<div></div>

--- a/css/css-ui/outline-offset-inset-006.html
+++ b/css/css-ui/outline-offset-inset-006.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#outline-offset">
+<link rel="mismatch" href="outline-offset-inset-006-notref.html">
+<meta name="assert" content="outline-offset: inset changes the rendering of outline-style: auto compared to the default outline-offset">
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    background: lightblue;
+    outline-style: auto;
+    outline-offset: inset;
+  }
+</style>
+<div></div>

--- a/css/css-ui/parsing/outline-offset-computed.html
+++ b/css/css-ui/parsing/outline-offset-computed.html
@@ -22,6 +22,7 @@ test_computed_value("outline-offset", "10px");
 test_computed_value("outline-offset", "0.5em", "20px");
 test_computed_value("outline-offset", "calc(10px + 0.5em)", "30px");
 test_computed_value("outline-offset", "calc(10px - 0.5em)", "-10px");
+test_computed_value("outline-offset", "inset");
 
 test(() => {
   target.style['outline-offset'] = '10px';

--- a/css/css-ui/parsing/outline-offset-invalid.html
+++ b/css/css-ui/parsing/outline-offset-invalid.html
@@ -15,6 +15,8 @@
 test_invalid_value("outline-offset", "auto");
 test_invalid_value("outline-offset", "1%");
 test_invalid_value("outline-offset", "2px 3px");
+test_invalid_value("outline-offset", "inset 3px");
+test_invalid_value("outline-offset", "3px inset");
 </script>
 </body>
 </html>

--- a/css/css-ui/parsing/outline-offset-valid.html
+++ b/css/css-ui/parsing/outline-offset-valid.html
@@ -16,6 +16,7 @@ test_valid_value("outline-offset", "0", "0px");
 test_valid_value("outline-offset", "1px");
 test_valid_value("outline-offset", "2em");
 test_valid_value("outline-offset", "calc(3rem + 4vw)");
+test_valid_value("outline-offset", "inset");
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [\[css-ui\] Add `outline-offset: inset`](https://bugs.webkit.org/show_bug.cgi?id=317779)