### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=316356

### DIFF
--- a/content-security-policy/object-src/object-src-url-allowed-img-src-none.html
+++ b/content-security-policy/object-src/object-src-url-allowed-img-src-none.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <!--
+      Content-Security-Policy:
+        object-src 'self';
+        img-src 'none';
+        script-src 'self' 'unsafe-inline';
+        report-uri /reporting/resources/report.py?op=put&reportID={{$id}}
+    -->
+</head>
+
+<body>
+    <object type="image/png" data="/content-security-policy/support/pass.png"></object>
+    <!--
+      Per CSP3 section 6.1.9, object-src is the only directive that governs
+      object and embed elements, even when loading image content. img-src
+      must not be applied to object elements.
+    -->
+    <script src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+
+</html>

--- a/content-security-policy/object-src/object-src-url-allowed-img-src-none.html.sub.headers
+++ b/content-security-policy/object-src/object-src-url-allowed-img-src-none.html.sub.headers
@@ -1,0 +1,2 @@
+Set-Cookie: object-src-url-allowed-img-src-none={{$id:uuid()}}; Path=/content-security-policy/object-src/
+Content-Security-Policy: object-src 'self'; img-src 'none'; script-src 'self' 'unsafe-inline'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html
+++ b/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <!--
+      Content-Security-Policy:
+        object-src 'self';
+        img-src 'none';
+        script-src 'self' 'unsafe-inline';
+        report-uri /reporting/resources/report.py?op=put&reportID={{$id}}
+    -->
+</head>
+
+<body>
+    <embed height="40" width="40" type="image/png"
+           src="/content-security-policy/support/pass.png"></embed>
+    <!--
+      Per CSP3 section 6.1.9, object-src is the only directive that governs
+      object and embed elements, even when loading image content. img-src
+      must not be applied to embed elements.
+    -->
+    <script src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+
+</html>

--- a/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html.sub.headers
+++ b/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html.sub.headers
@@ -1,0 +1,2 @@
+Set-Cookie: object-src-url-embed-allowed-img-src-none={{$id:uuid()}}; Path=/content-security-policy/object-src/
+Content-Security-Policy: object-src 'self'; img-src 'none'; script-src 'self' 'unsafe-inline'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION
WebKit export from bug: [<object> elements loading images are incorrectly blocked by img-src CSP directive ](https://bugs.webkit.org/show_bug.cgi?id=316356)