### PR TITLE
wpt: Add missing message type to autoplay permission query.

### DIFF
--- a/permissions-policy/resources/permissions-policy-autoplay.html
+++ b/permissions-policy/resources/permissions-policy-autoplay.html
@@ -5,7 +5,7 @@
 
 window.addEventListener('load', () => {
   isAutoplayAllowed().then((result) => {
-    window.parent.postMessage({ enabled: result }, '*');
+    window.parent.postMessage({ enabled: result, type: 'availability-result' }, '*');
   });
 }, { once: true });
 </script>


### PR DESCRIPTION
The missing field is present in every other similar permissions check file in https://github.com/servo/servo/tree/main/tests/wpt/tests/permissions-policy/resources . The tests are all timing out consistently in every browser as a result: https://wpt.fyi/results/html/semantics/embedded-content/media-elements?label=master&label=experimental&aligned

Testing: Several media subtests stop timing out.
Reviewed in servo/servo#45962