### PR TITLE
[scroll-animations] Update the test of insets for the default ViewTimeline

### DIFF
--- a/scroll-animations/view-timelines/view-timeline-snapport.html
+++ b/scroll-animations/view-timelines/view-timeline-snapport.html
@@ -41,9 +41,9 @@
 
     // 0%
     await runAndWaitForFrameUpdate(() => {
-      container.scrollTop = 600;
+      container.scrollTop = 640;
     });
-    assert_percents_equal(anim.currentTime, -12.5);
+    assert_percents_equal(anim.currentTime, 0);
 
     // 50%
     await runAndWaitForFrameUpdate(() => {
@@ -53,7 +53,7 @@
 
     // 100%
     await runAndWaitForFrameUpdate(() => {
-      container.scrollTop = 1000;
+      container.scrollTop = 960;
     });
     assert_percents_equal(anim.currentTime, 100);
   }, 'Default ViewTimeline is affected by scroll-padding');


### PR DESCRIPTION
Tweak the offset at the 0% and 100% for `scroll-padding`.

Per spec, the default value is `auto`. However, the test expects the default view timeline is not affected by scroll-padding. This doesn't match the spec. It also impacts the interop 2026, and so before we make any decision in the spec issue, we have to follow the current spec.

The related spec issue: https://github.com/w3c/csswg-drafts/issues/11644.
