### PR TITLE
stylo: Make `iterate_by()` increment the iteration state for infinite animations

### DIFF
--- a/css/css-animations/animation-iteration-event-001.html
+++ b/css/css-animations/animation-iteration-event-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>CSS Animations Test: animation events - animationiteration</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration">
+<link rel="help" href="https://github.com/servo/servo/issues/45992">
+
+<style>
+@keyframes anim {}
+:root { animation: 1s -4s 7 anim paused }
+</style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async () => {
+  let elapsedTimes = [];
+  let element = document.documentElement;
+
+  element.style.animationPlayState = "running";
+
+  await new Promise((resolve) => {
+    let listener = e => {
+      elapsedTimes.push(e.elapsedTime);
+    };
+    element.addEventListener("animationiteration", listener);
+    element.addEventListener("animationend", () => {
+      element.removeEventListener("animationiteration", listener);
+      resolve();
+    }, { once: true });
+  });
+
+  assert_array_equals(elapsedTimes, [5, 6]);
+}, "Got the expected elapsedTime in the correct order");
+</script>

--- a/css/css-animations/animation-iteration-event-002.html
+++ b/css/css-animations/animation-iteration-event-002.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>CSS Animations Test: animation events - animationiteration</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration">
+<link rel="help" href="https://github.com/servo/servo/issues/45989">
+
+<style>
+@keyframes anim1 {}
+@keyframes anim2 {}
+:root { animation: 1s -4s 8 anim1 paused, 1s -4s infinite anim2 paused }
+</style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async () => {
+  let finiteElapsedTimes = [];
+  let infiniteElapsedTimes = [];
+  let element = document.documentElement;
+
+  element.style.animationPlayState = "running";
+
+  await new Promise((resolve, reject) => {
+    let listener = e => {
+      // Use requestAnimationFrame as a workaround for Servo delaying animationend.
+      requestAnimationFrame(() => {
+        if (e.animationName === "anim1") {
+          finiteElapsedTimes.push(e.elapsedTime);
+        } else if (e.animationName === "anim2") {
+          infiniteElapsedTimes.push(e.elapsedTime);
+        } else {
+          reject("Unexpected animationName");
+        }
+      });
+    };
+    element.addEventListener("animationiteration", listener);
+    element.addEventListener("animationend", () => {
+      element.removeEventListener("animationiteration", listener);
+      resolve();
+    }, { once: true });
+  });
+
+  assert_array_equals(finiteElapsedTimes, infiniteElapsedTimes);
+}, "By the time the finite animation ends, the infinite one had identical elapsedTime");
+</script>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/401/

Testing: Adding a new test for this which passes, and another one for #<!-- nolink -->45992 which fails.
Fixes: #<!-- nolink -->45989

Reviewed in servo/servo#45990