### PR TITLE
WebRTC: Fix typos in test titles and assertion messages

### DIFF
--- a/webrtc/RTCConfiguration-bundlePolicy.html
+++ b/webrtc/RTCConfiguration-bundlePolicy.html
@@ -170,9 +170,9 @@
     const candidatesA2 = SDPUtils.matchPrefix(sections[1], 'a=candidate:');
     assert_greater_than(candidatesA2.length, 0, 'Second audio m-line should have candidates');
     const candidatesV = SDPUtils.matchPrefix(sections[2], 'a=candidate:');
-    assert_greater_than(candidatesV.length, 0, 'First video m-lne should have candidates');
+    assert_greater_than(candidatesV.length, 0, 'First video m-line should have candidates');
     const candidatesD = SDPUtils.matchPrefix(sections[3], 'a=candidate:');
-    assert_greater_than(candidatesD.length, 0, 'First data m-line should have candiates');
+    assert_greater_than(candidatesD.length, 0, 'First data m-line should have candidates');
   }, '"max-compat" bundle policy should gather ICE candidates for each track');
 
   promise_test(async t => {
@@ -192,9 +192,9 @@
     const candidatesA1 = SDPUtils.matchPrefix(sections[0], 'a=candidate:');
     assert_greater_than(candidatesA1.length, 0, 'First audio m-line should have candidates');
     const candidatesA2 = SDPUtils.matchPrefix(sections[1], 'a=candidate:');
-    assert_equals(candidatesA2.length, 0, 'Second audio m-line shoud have no candidates');
+    assert_equals(candidatesA2.length, 0, 'Second audio m-line should have no candidates');
     const candidatesV = SDPUtils.matchPrefix(sections[2], 'a=candidate:');
-    assert_equals(candidatesV.length, 0, 'Firt video m-line should have no candidates');
+    assert_equals(candidatesV.length, 0, 'First video m-line should have no candidates');
     const candidatesD = SDPUtils.matchPrefix(sections[3], 'a=candidate:');
     assert_equals(candidatesD.length, 0, 'First data m-line should have no candidates');
   }, '"max-bundle" bundle policy should gather ICE candidates for one track');

--- a/webrtc/RTCRtpReceiver-getCapabilities.html
+++ b/webrtc/RTCRtpReceiver-getCapabilities.html
@@ -24,16 +24,16 @@
   test(() => {
     const capabilities = RTCRtpReceiver.getCapabilities('audio');
     validateRtpCapabilities(capabilities);
-  }, `RTCRtpSender.getCapabilities('audio') should return RTCRtpCapabilities dictionary`);
+  }, `RTCRtpReceiver.getCapabilities('audio') should return RTCRtpCapabilities dictionary`);
 
   test(() => {
     const capabilities = RTCRtpReceiver.getCapabilities('video');
     validateRtpCapabilities(capabilities);
-  }, `RTCRtpSender.getCapabilities('video') should return RTCRtpCapabilities dictionary`);
+  }, `RTCRtpReceiver.getCapabilities('video') should return RTCRtpCapabilities dictionary`);
 
   test(() => {
     const capabilities = RTCRtpReceiver.getCapabilities('dummy');
     assert_equals(capabilities, null);
-  }, `RTCRtpSender.getCapabilities('dummy') should return null`);
+  }, `RTCRtpReceiver.getCapabilities('dummy') should return null`);
 
  </script>


### PR DESCRIPTION
RTCRtpReceiver-getCapabilities.html: three test titles referenced `RTCRtpSender.getCapabilities(...)` even though the file tests `RTCRtpReceiver`. Looks like a leftover from copying RTCRtpSender-getCapabilities.html.

RTCConfiguration-bundlePolicy.html: four typos in assertion failure messages (`m-lne`, `candiates`, `shoud`, `Firt`). No behavior change; just makes failures readable.