### PR TITLE
WebRTC: Fix broken setRemoteDescription(invalidOffer) rollback test

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
@@ -328,14 +328,20 @@ if (rest) {
     const timeoutPromise = new Promise(
     (resolve, reject) => t.step_timeout(reject, 1000));
     try {
-      await Promise.any(statePromise, timeoutPromise);
+      await Promise.race([statePromise, timeoutPromise]);
     } catch (error) {
       assert_unreached('State should have changed');
     }
     assert_equals(pc1.signalingState, 'stable');
     assert_equals(pc1.pendingLocalDescription, null);
     assert_equals(pc1.pendingRemoteDescription, null);
-    await promise_rejects_dom(t, 'RTCError', p);
+    try {
+      await p;
+      assert_unreached('setRemoteDescription with invalid SDP should reject');
+    } catch (err) {
+      assert_true(err instanceof RTCError, 'Expect err to be instance of RTCError');
+      assert_equals(err.name, 'OperationError');
+    }
   }, 'setRemoteDescription(invalidOffer) from have-local-offer does not undo rollback');
 
   promise_test(async t => {


### PR DESCRIPTION
The test had two bugs that mean it never actually ran the check it's supposed to. All browsers were failing but for the wrong reason.

**Bug 1:** Promise.any(statePromise, timeoutPromise) is called with two positional args. Promise.any wants an iterable, so this throws TypeError immediately and the catch fires assert_unreached on every run. This was the error every browser was seeing. Promise.any is also the wrong choice here, it only resolves on the first fulfilled promise, so the rejection-only timeoutPromise can't break the wait anyway. Switched to Promise.race([statePromise, timeoutPromise]).

**Bug 2:** promise_rejects_dom(t, 'RTCError', p) compared against 'RTCError' as a DOMException name, but per spec and webrtc/RTCError.html, RTCError.name === 'OperationError'. The helper also doesn't accept non-DOMException constructors, so it can't enforce instanceof RTCError on the side. Replaced with an explicit try/catch matching the sibling test at lines 148-166 in the same file.

With these fixes the test passes in Firefox. Chrome now fails at assert_unreached('State should have changed'), which is the real bug. Chrome doesn't do the implicit rollback on setRemoteDescription with invalid SDP from have-local-offer. That's the gap this test was meant to catch, and it was previously hidden behind the TypeError.