### PR TITLE
layout: Prevent animations from producing invalid color values

### DIFF
--- a/css/css-animations/animation-transition-color-crash.html
+++ b/css/css-animations/animation-transition-color-crash.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/45945">
+    <style>
+    :root {
+        animation: keyframes 1s normal;
+        transition: border-right 1ms;
+        border: solid;
+        translate: 10px;
+    }
+    @keyframes keyframes {
+        to { border: inset; }
+    }
+    </style>
+</head>
+
+<body onload="main()">
+
+<script>
+function main() {
+    document.styleSheets[0].insertRule("nonexistent-tag {}");
+    document.body.clientHeight;
+    document.styleSheets[0].insertRule("nonexistent-tag2 {}");
+    window.scroll(1, 1);
+}
+
+document.body.clientHeight;
+</script>
+


### PR DESCRIPTION
This commits makes two changes to prevent animations from producing
invalid color values (defense in depth):

1. Update Stylo to a version that fixing an issue with interpolation of
   values in interrupted transitions that are reversing[^1].
2. Prevents the creation of WebRender color values with alpha that is
   out of range.

[^1]: https://www.w3.org/TR/css-transitions-1/#reversing

Stylo PR: servo/style#403
Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->45945

Reviewed in servo/servo#46016