### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=317964

### DIFF
--- a/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001.html
+++ b/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid item minimum contribution when preferred size depends on size of containing block.</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#algo-single-span-items">
+<meta name="assert" content="A grid item whose preferred size depends on the size of its containing block in the relevant axis should contribute its automatic minimum size, not its min-content contribution.">
+<link rel="stylesheet" href="/css/support/grid.css">
+<style>
+.inline-grid {
+    grid-template-columns: minmax(auto, 50px);
+}
+.content {
+    width: 100px;
+    height: 25px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.inline-grid')">
+<div id="log"></div>
+
+<div class="inline-grid" data-expected-width="50">
+    <div class="item" style="width: stretch;"><div class="content"></div></div>
+</div>
+
+<div class="inline-grid" data-expected-width="50">
+    <div class="item" style="width: auto;"><div class="content"></div></div>
+</div>
+
+</body>

--- a/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001.html
+++ b/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid item minimum contribution when preferred size is fit-content.</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#algo-single-span-items">
+<meta name="assert" content="A grid item whose preferred size is fit-content neither behaves as auto nor depends on the size of its containing block in the relevant axis, so its minimum contribution is its min-content contribution, not its automatic minimum size, even when that exceeds the fixed max track sizing function.">
+<link rel="stylesheet" href="/css/support/grid.css">
+<style>
+.inline-grid {
+    grid-template-columns: minmax(auto, 50px);
+}
+.content {
+    width: 100px;
+    height: 25px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.inline-grid')">
+<div id="log"></div>
+
+<div class="inline-grid" data-expected-width="100">
+    <div class="item" style="width: fit-content;"><div class="content"></div></div>
+</div>
+
+</body>


### PR DESCRIPTION
WebKit export from bug: [\[Grid\] Grid items with stretch or fit-content preferred size have incorrect min content contributions.](https://bugs.webkit.org/show_bug.cgi?id=317964)