### PR TITLE
Fix processing instruction script/style expectations

### DIFF
--- a/html/syntax/parsing/resources/processing-instructions.dat
+++ b/html/syntax/parsing/resources/processing-instructions.dat
@@ -896,18 +896,18 @@
 #document
 | <html>
 |   <head>
-|   <body>
 |     <script>
 |       "<?something>"
+|   <body>
 
 #data
 <style><?something></style>
 #document
 | <html>
 |   <head>
-|   <body>
 |     <style>
 |       "<?something>"
+|   <body>
 
 #data
 <?something>


### PR DESCRIPTION
Per spec, when a document starts with `<script>` or `<style>`, parser first creates the implied `<html>` and `<head>`, then handles the token in "in head" mode. So `<script>`/`<style>` belong under `<head>`, with the implied `<body>` created afterward.

This matches current Chromium, Firefox and Safari behavior

Ref: https://github.com/web-platform-tests/wpt/pull/60828