### PR TITLE
script: Gracefully handle font face rule parsing errors in `FontFace`

### DIFF
--- a/css/css-fonts/font-face-array-buffer-parsing-failure-crash.html
+++ b/css/css-fonts/font-face-array-buffer-parsing-failure-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/44537">
+<script>
+new FontFace("1",new ArrayBuffer());
+</script>


### PR DESCRIPTION
This change avoids a panic when a font face rule fails to parse in the
`ArrayBuffer` creation path. The issue was that when the constructor is
passed an `ArrayBuffer`, we didn't check if the parsing previously
failed in new_inherited, and then queued the task for loading data
anyway.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->44537.

Reviewed in servo/servo#46027