### PR TITLE
layout: Clear `BoxFragment` data from previous stacking context tree traversals

### DIFF
--- a/css/css-masking/clip-path/clip-path-restyle-crash.html
+++ b/css/css-masking/clip-path/clip-path-restyle-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/servo/servo/issues/46021">
+
+<style>
+    .clip {
+        clip-path: padding-box
+    }
+</style>
+
+<div id="target" class="clip">Content</div>
+
+<script>
+  document.body.scrollHeight;
+  target.classList.remove("clip");
+</script>


### PR DESCRIPTION
`Fragment`s can be preserved between layouts. This means that stale data
set during previous stacking context tree traversals will stick around
if it's not cleared. This can lead to references to non-existant clips
persisting between layouts. This change addresses that.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->46021.
Fixes: #<!-- nolink -->46026.

Reviewed in servo/servo#46028