### PR TITLE
script: Only call `CSSRuleList::append_lazy_dom_rule` when appending keyframes if the rule list exists

### DIFF
--- a/css/cssom/CSSRuleList-appendRule-keyframe-001-crash.html
+++ b/css/cssom/CSSRuleList-appendRule-keyframe-001-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>CSSOM Test: Servo crash when modifying keyframe rules </title>
+<title>CSSOM Test: Servo crash when modifying keyframe rules</title>
 <link rel="help" href="https://github.com/servo/servo/issues/44990">
 <style>
   @keyframes keyframes0 {}

--- a/css/cssom/CSSRuleList-appendRule-keyframe-002-crash.html
+++ b/css/cssom/CSSRuleList-appendRule-keyframe-002-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Servo crash when modifying keyframe rules</title>
+<link rel="help" href="https://github.com/servo/servo/issues/46025">
+<style>@keyframes keyframe {}</style>
+<script>
+  let rule = document.styleSheets[0].cssRules[0];
+  rule.appendRule("1% { }")
+  rule.cssRules[1];
+</script>


### PR DESCRIPTION
The changes from #<!-- nolink -->45173 exposed a new panic where appending a keyframe
rule can lazily construct a `CSSRuleList` during the process of keyframe
append. Lazily constructing `CSSRuleList` and then immediately appending
a lazy DOM rule means that the `CSSRuleList` looks like it has one extra
CSS rule than it actually has -- leading to a later panic. This change
fixes that issue by only calling `CSSRuleList::append_lazy_dom_rule` if
the `CSSRuleList` has already been constructed.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->46025.

Reviewed in servo/servo#46031