### PR TITLE
Digital Credentials: Split WebDriver get() tests by protocol (openid4vp, org-iso-mdoc)

### DIFF
--- a/digital-credentials/webdriver/get-mdoc.https.html
+++ b/digital-credentials/webdriver/get-mdoc.https.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() webdriver tests for org-iso-mdoc.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeGetOptions } from "../support/helper.js";
+
+  promise_test(async (t) => {
+    const responseData = "test-response-data";
+    await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", { "value": responseData });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "org-iso-mdoc");
+    assert_equals(result.data.value, responseData);
+  }, "navigator.credentials.get() with respond mode should resolve with the specified data.");
+
+  promise_test(async (t) => {
+    const complexData = { "a": 1, "b": [2, 3], "c": { "d": 4 } };
+    await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", complexData);
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "org-iso-mdoc");
+    assert_equals(result.data.a, 1);
+    assert_array_equals(result.data.b, [2, 3]);
+    assert_equals(result.data.c.d, 4);
+  }, "navigator.credentials.get() with complex data response should resolve with structured data.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("decline");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.get(options));
+  }, "navigator.credentials.get() with decline mode should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const controller = new AbortController();
+    const options = makeGetOptions({ protocol: "org-iso-mdoc", signal: controller.signal });
+    const promise = navigator.credentials.get(options);
+
+    const reason = new Error("aborted by test");
+    controller.abort(reason);
+    await promise_rejects_exactly(t, reason, promise);
+  }, "navigator.credentials.get() with wait mode should reject with the abort reason when aborted.");
+</script>

--- a/digital-credentials/webdriver/get-openid4vp.https.html
+++ b/digital-credentials/webdriver/get-openid4vp.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Digital Credential API: get() webdriver tests.</title>
+<title>Digital Credential API: get() webdriver tests for openid4vp-v1-unsigned.</title>
 <link rel="help" href="https://wicg.github.io/digital-credentials/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -55,10 +55,8 @@
     const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned", signal: controller.signal });
     const promise = navigator.credentials.get(options);
 
-    // Give it some time to make sure it's pending.
-    await new Promise(resolve => t.step_timeout(resolve, 100));
-
-    controller.abort();
-    await promise_rejects_dom(t, "AbortError", promise);
-  }, "navigator.credentials.get() with wait mode should remain pending until aborted.");
+    const reason = new Error("aborted by test");
+    controller.abort(reason);
+    await promise_rejects_exactly(t, reason, promise);
+  }, "navigator.credentials.get() with wait mode should reject with the abort reason when aborted.");
 </script>


### PR DESCRIPTION
`webdriver/get.https.html` exercises the virtual wallet behaviors (respond/decline/wait) using the `openid4vp-v1-unsigned` protocol only. This renames it to `get-openid4vp.https.html` to make the protocol explicit, and adds a complementary `get-mdoc.https.html` covering the same behaviors with `org-iso-mdoc`, so engines that implement `org-iso-mdoc` can exercise the WebDriver virtual wallet.

This follows the existing `protocol-filtering-{openid4vp,mdoc}.https.html` naming convention in this directory. The renamed openid4vp test is unchanged.