### PR TITLE
script: Make script-blocking stylesheets be an ordered set

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-error-handler-triggers-abort-crash.html
+++ b/html/semantics/document-metadata/the-link-element/link-error-handler-triggers-abort-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/42854">
+<link id="link" rel="stylesheet" onerror="window.stop(); location.href='about:blank'">
+<script>
+  link.href = "about:blank";
+</script>


### PR DESCRIPTION
The specification says that script-blocking stylesheets should be stored
in an ordered set. Previously these were represented as a simple count,
which leads to issues when following the specification:

 - A stylesheet has a load error.
 - The error handler is called. In the error handler, `window.stop()`
   is called which sets the count to 0.
 - The subsequent decrement of the script-blocking stylesheets will try
   to subtract 1 from 0.

This problem is solved by simply following the specification more
closely. If the list of blocking stylesheets is stored as a set,
removing a stylesheet from the set becomes idempotent.

Testing: This change adds a new WPT crash test.
Fixes #<!-- nolink -->42854
Supersedes and closes #<!-- nolink -->42855.

Reviewed in servo/servo#46054