### PR TITLE
layout: Pass `DescendantHasBoxDamage` to children of isolating formatting contexts to prevent stale layout data

### DIFF
--- a/css/css-transforms/crashtests/uninvertible-root-transform-query.html
+++ b/css/css-transforms/crashtests/uninvertible-root-transform-query.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46023">
+<style>
+html { rotate: z 360deg; }
+span { display: inline-flex; }
+.class0 { content: radial-gradient(blue); scale: 0; }
+</style>
+<script>
+  onload = _ => {
+    document.scrollingElement.className = "class0";
+    img.height;
+  }
+</script>
+<span><img id="img"></span>


### PR DESCRIPTION
This change avoids a panic when apply an uninvertible transform to root node.

When an ancestor needs a box tree relayout, elements that isolate damage for fragment tree layout blocked the propagation of box damage to their children. I found that the `isolate_incoming_damage` function left `damage_for_children` empty, causing the entire rebuild procedure skipping these child nodes.

In this specific test case, the children (span tag) never received `RebuildAncestor` and their `unset_all_boxes()` was never called. So, after the box tree was rebuilt, the children's DOM nodes still held stale spatial tree node IDs from the old tree. Layout queries on those elements would then panic with index out of bounds when indexing this stale IDs.

Fix this by inserting `DescendantHasBoxDamage` into `damage_for_children` in this situation. Make sure descendants clean up their boxes before the box tree is rebuilt.

Testing: Add test `tests/wpt/tests/css/css-transforms/crashtests/uninvertible-root-transform-query.html` to cover this change.
Fixes: #<!-- nolink -->46023
Reviewed in servo/servo#46055