### PR TITLE
script: Remove duplicated incorrect version of `FormControl::is_listed()`

### DIFF
--- a/html/semantics/forms/the-label-element/move-label-into-form-and-then-move-form-into-ancestor-crash.html
+++ b/html/semantics/forms/the-label-element/move-label-into-form-and-then-move-form-into-ancestor-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45947">
+<select id="select" form="form">
+  <input form="form">
+  <data id="labelParent">
+      <label id="label" form="form"></label>
+  </data>
+  <form id="form"></form>
+</select>
+
+<script>
+    let newElement = document.createElement("div");
+    form.prepend(newElement);
+    newElement.appendChild(label);
+    select.prepend(form);
+</script>


### PR DESCRIPTION
There were two versions of this check: `FormControl::is_listed()` and
`HTMLElement::is_element_listed()`. The latter was incomplete and
incorrect. Both were used inconsistently. This led to non-specification
aligned behavior when moving form-associated elements in the page,
ultimately leading to a panic. This change fixes that issue by making
`FormControl::is_listed()` rely on `HTMLElement::is_element_listed()`,
matching the specification more closely.

Testing: This change adds a WPT crash test, though the crash only reproduces inconsistently.
Fixes: #<!-- nolink -->45947.

Reviewed in servo/servo#46094