### PR TITLE
layout: add support for box-decoration-break

### DIFF
--- a/css/CSS2/linebox/split-inline-borders-ref.html
+++ b/css/CSS2/linebox/split-inline-borders-ref.html
@@ -7,7 +7,6 @@
     padding: 10px;
     margin: 10px;
     line-height: 200px;
-    box-decoration-break: clone;
   }
   div {
     border: solid cyan;
@@ -15,6 +14,6 @@
     width: 200px;
   }
 </style>
-<span>inline before split</span>
+<span style="border-inline-end: none; padding-inline-end: 0; margin-inline-end: 0;">inline before split</span>
 <div>There should be no magenta around this.</div>
-<span>inline after split</span>
+<span style="border-inline-start: none; padding-inline-start: 0; margin-inline-start: 0;">inline after split</span>

--- a/css/CSS2/linebox/split-inline-borders.html
+++ b/css/CSS2/linebox/split-inline-borders.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>box-decoration-break: clone should not insert decorations around a block-level box that has split the inline.</title>
+<title>Block-level boxes that split the inline should not be wrapped in that inline's borders</title>
 <link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
-<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
 <link rel="help" href="https://www.w3.org/Style/css2-updates/css2/visuren.html#:~:text=When%20an%20inline%20box%20contains%20an%20in-flow%20block-level%20box">
-<link rel="match" href="box-decoration-break-clone-split-inline-ref.html">
-<meta name="assert" content="box-decoration-break: clone should not insert decorations around an in-flow block-level box that has split the inline.">
+<link rel="match" href="split-inline-borders-ref.html">
+<meta name="assert" content="Block-level boxes that split the inline should not be wrapped in that inline's borders.">
 <style>
   span {
     border: 10px solid magenta;
     padding: 10px;
     margin: 10px;
     line-height: 200px;
-    box-decoration-break: clone;
   }
   div {
     border: solid cyan;

--- a/css/css-break/box-decoration-break-clone-split-inline-ref.html
+++ b/css/css-break/box-decoration-break-clone-split-inline-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  span {
+    border-inline: 25px solid magenta;
+    box-decoration-break: clone;
+  }
+  div {
+    border: solid cyan;
+    width: 200px;
+  }
+</style>
+<span>inline before split</span>
+<div>There should be no magenta around this.</div>
+<span>inline after split</span>

--- a/css/css-break/box-decoration-break-clone-split-inline.html
+++ b/css/css-break/box-decoration-break-clone-split-inline.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>box-decoration-break: clone should not insert decorations around a block-level box that has split the inline.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="help" href="https://www.w3.org/Style/css2-updates/css2/visuren.html#:~:text=When%20an%20inline%20box%20contains%20an%20in-flow%20block-level%20box">
+<link rel="match" href="box-decoration-break-clone-split-inline-ref.html">
+<meta name="assert" content="box-decoration-break: clone should not insert decorations around an in-flow block-level box that has split the inline.">
+<style>
+  span {
+    border-inline: 25px solid magenta;
+    box-decoration-break: clone;
+  }
+  div {
+    border: solid cyan;
+    width: 200px;
+  }
+</style>
+<span>
+  inline before split
+  <div>There should be no magenta around this.</div>
+  inline after split
+</span>


### PR DESCRIPTION
This adds initial handling for the `box-decoration-break` CSS property.
The implementation thus far only does line breaks, but in the future this will need to insert paddings/borders/margins when bidi-reordering causes a box to be split as well.

Corresponding stylo PR is at https://github.com/servo/stylo/pull/386

Testing: We now pass some css-break tests. I've also added some new tests for related behavior.

Reviewed in servo/servo#45492