### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318007

### DIFF
--- a/svg/historical.html
+++ b/svg/historical.html
@@ -82,6 +82,8 @@ var removedMembers = {
     "pixelUnitToMillimeterY",
     "screenPixelToMillimeterX",
     "screenPixelToMillimeterY",
+    "setCurrentScale",
+    "setCurrentTranslate",
     "useCurrentView",
     "viewport"
   ],


### PR DESCRIPTION
WebKit export from bug: [Extend svg/historical.html removed Members list to include setCurrentScale, setCurrentTranslate](https://bugs.webkit.org/show_bug.cgi?id=318007)