### PR TITLE
script: Stop treating `<label>` as a form-associated element

### DIFF
--- a/html/semantics/forms/the-label-element/move-form-associated-element-into-label-crash.html
+++ b/html/semantics/forms/the-label-element/move-form-associated-element-into-label-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46108">
+<form>
+  <select id="select">
+    <label id="label">
+<script>
+    label.outerHTML = select.outerHTML;
+</script>


### PR DESCRIPTION
`<label>` was being treated as a form-associated element, but the
spec[^1] does not list it as one. This led to it being added to
`HTMLFormElement::controls`, but not removed consistently. This change
stops treating it as a special-case form-associated element which fixes
a panic in debug builds.

[^1]: https://html.spec.whatwg.org/multipage/forms.html#form-associated-element

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->46108.

Reviewed in servo/servo#46110