### PR TITLE
[dom] Update NodeIterator-removal.html comment and add coverage for step 2

### DIFF
--- a/dom/traversal/NodeIterator-removal.html
+++ b/dom/traversal/NodeIterator-removal.html
@@ -43,12 +43,9 @@ for (var i = 0; i < testNodes.length; i++) {
 
           var idx = iters.length - 1;
 
-          // "If the node is root or is not an inclusive ancestor of the
-          // referenceNode attribute value, terminate these steps."
-          //
-          // We also have to rule out the case where node is an ancestor of
-          // root, which is implicitly handled by the spec since such a node
-          // was not part of the iterator collection to start with.
+          // "If toBeRemovedNode is not an inclusive ancestor of nodeIterator's
+          // reference, or toBeRemovedNode is an inclusive ancestor of
+          // nodeIterator's root, then return."
           if (isInclusiveAncestor(node, root)
               || !isInclusiveAncestor(node, iter.referenceNode)) {
             continue;
@@ -97,4 +94,85 @@ for (var i = 0; i < testNodes.length; i++) {
 }
 
 testDiv.style.display = "none";
+
+// Targeted coverage for the pre-remove step that fires when
+// pointerBeforeReferenceNode is true and the iterator's reference is inside
+// the subtree being removed. The parametric loop above only drives iterators
+// forward with nextNode(), so pointerBeforeReferenceNode is true only when
+// referenceNode === root — a case the algorithm's first step now always
+// short-circuits. To reach the "find next within root" branch we have to back
+// the iterator up with previousNode() first.
+
+const buildScratchTree = (structure) => {
+  // structure is a string like "root[a[a1],b[b1],c]"; returns an object whose
+  // keys are the named elements.
+  const nodes = {};
+  let i = 0;
+  const parse = (parent) => {
+    let name = "";
+    while (i < structure.length && /[A-Za-z0-9]/.test(structure[i])) {
+      name += structure[i++];
+    }
+    const el = document.createElement(name);
+    nodes[name] = el;
+    if (parent) parent.appendChild(el);
+    if (structure[i] === "[") {
+      i++;
+      while (structure[i] !== "]") {
+        parse(el);
+        if (structure[i] === ",") i++;
+      }
+      i++;
+    }
+    return el;
+  };
+  const root = parse(null);
+  document.body.appendChild(root);
+  return { root, nodes };
+};
+
+test((t) => {
+  // Tree: root[a[a1], b[b1], c]
+  const { root, nodes } = buildScratchTree("root[a[a1],b[b1],c]");
+  t.add_cleanup(() => root.remove());
+
+  const iter = document.createNodeIterator(root);
+  for (let i = 0; i < 5; i++) iter.nextNode();
+  assert_equals(iter.referenceNode, nodes.b1, "advanced reference");
+  assert_false(iter.pointerBeforeReferenceNode, "advanced pointer");
+  iter.previousNode();
+  assert_equals(iter.referenceNode, nodes.b1, "backed-up reference");
+  assert_true(iter.pointerBeforeReferenceNode, "backed-up pointer");
+
+  nodes.b.remove();
+
+  // pre-remove step 2: next-within-root exists, so reference jumps to it and
+  // pointer stays true.
+  assert_equals(iter.referenceNode, nodes.c, "post-removal reference");
+  assert_true(iter.pointerBeforeReferenceNode, "post-removal pointer");
+}, "Removing an inclusive ancestor of reference, pointer before reference is true, "
+   + "with a following node within root");
+
+test((t) => {
+  // Tree: root[a[a1], b[b1]] — no node after b within root.
+  const { root, nodes } = buildScratchTree("root[a[a1],b[b1]]");
+  t.add_cleanup(() => root.remove());
+
+  const iter = document.createNodeIterator(root);
+  for (let i = 0; i < 5; i++) iter.nextNode();
+  assert_equals(iter.referenceNode, nodes.b1, "advanced reference");
+  assert_false(iter.pointerBeforeReferenceNode, "advanced pointer");
+  iter.previousNode();
+  assert_equals(iter.referenceNode, nodes.b1, "backed-up reference");
+  assert_true(iter.pointerBeforeReferenceNode, "backed-up pointer");
+
+  nodes.b.remove();
+
+  // pre-remove step 2: no next-within-root, so pointer flips to false and
+  // step 3 moves reference to the last inclusive descendant of b's previous
+  // sibling.
+  assert_equals(iter.referenceNode, nodes.a1, "post-removal reference");
+  assert_false(iter.pointerBeforeReferenceNode, "post-removal pointer");
+}, "Removing an inclusive ancestor of reference, pointer before reference is true, "
+   + "with no following node within root");
 </script>


### PR DESCRIPTION
Two changes to `dom/traversal/NodeIterator-removal.html`:

**1. Fix a misleading comment.** It claimed the *"node is an ancestor of root"* case was implicitly handled by the spec because such a node was not in the iterator's collection. That is incorrect: the [`NodeIterator` pre-remove steps](https://dom.spec.whatwg.org/#nodeiterator-pre-removing-steps) run for every iterator in the document, regardless of whether the removed node is in the iterator's collection. The existing assertion (`isInclusiveAncestor(node, root)`) is correct; the comment now quotes the spec's first early-return clause directly. Companion to whatwg/dom#1477.

**2. Add coverage for the previously-unexercised step-2 branch.** The parametric loop above only drives iterators forward with `nextNode()`, so `pointerBeforeReferenceNode` is true only when `referenceNode === root` — a case the first step now always short-circuits. The two new tests back the iterator up with `previousNode()` first, exercising both sub-branches of step 2:

| Test | Scenario | Spec outcome |
| ---- | -------- | ------------ |
| 1 | `root[a[a1], b[b1], c]`, remove `b`, with reference at `b1` and pointer before | `c` exists as next-within-root → ref becomes `c`, pointer stays `true` |
| 2 | `root[a[a1], b[b1]]`, remove `b`, with reference at `b1` and pointer before | No next-within-root → pointer flips to `false`, ref becomes `a1` (last descendant of `b`'s previous sibling) |

### Engine results

| Engine | Test 1 | Test 2 |
| ------ | ------ | ------ |
| Firefox | ✅ | ✅ |
| Chrome  | ✅ | ❌ — leaves ref at the detached `b1` |
| Safari  | ✅ | ❌ — leaves ref at the detached `b1` |

Test 2 exposes a real interop divergence. The spec (matching Firefox) places the iterator at a sensible in-tree position so iteration can continue. Chrome and Safari leave the reference pointing at the now-detached `b1`, from which neither `nextNode()` nor `previousNode()` can find anything in the iterator's collection.

Filing this as a regression-tracking signal rather than blocking on engine fixes.

See whatwg/dom#907 for background.