### PR TITLE
wpt: Ensure async subtest is declared during test execution

### DIFF
--- a/css/css-conditional/container-queries/style-range-dynamic.html
+++ b/css/css-conditional/container-queries/style-range-dynamic.html
@@ -181,20 +181,20 @@ test(() => {
   ]);
 }, "After increasing container line-height");
 
-document.fonts.load("16px TallLineHeight").then(() => {
-  test(() => {
-    // Set font family to TallLineHeight; line-height is normal.
-    // lh should compute to 16px * 4 = 64px.
-    document.querySelector("div.container.lh3").style.fontFamily = "TallLineHeight";
-    expect([
-      ["rem", green],
-      ["em", green],
-      ["rlh1", green],
-      ["rlh2", green],
-      ["lh1", green],
-      ["lh2", green],
-      ["lh3", green],
-    ]);
-  }, "After changing container font-family to TallLineHeight");
-});
+promise_test(async () => {
+  await document.fonts.load("16px TallLineHeight");
+
+  // Set font family to TallLineHeight; line-height is normal.
+  // lh should compute to 16px * 4 = 64px.
+  document.querySelector("div.container.lh3").style.fontFamily = "TallLineHeight";
+  expect([
+    ["rem", green],
+    ["em", green],
+    ["rlh1", green],
+    ["rlh2", green],
+    ["lh1", green],
+    ["lh2", green],
+    ["lh3", green],
+  ]);
+}, "After changing container font-family to TallLineHeight");
 </script>


### PR DESCRIPTION
This test could have unexpected behaviour depending on when the promise resolves relative to the script execution. This change makes it deterministic.

Testing: Subtest now deterministically fails.
Reviewed in servo/servo#46122