### PR TITLE
layout: Clear fragments and caches under layout roots after failed layout root layout

### DIFF
--- a/css/css-position/crashtests/dynamic-fixed-in-nested-absolutes-crash.html
+++ b/css/css-position/crashtests/dynamic-fixed-in-nested-absolutes-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46109">
+<style>
+  html, #parent_abs, #child_abs { position: absolute; }
+  #fixed { position: fixed; }
+</style>
+<script>
+  onload = _ => {
+    parent_abs.appendChild(document.createElement("div"));
+    document.body.scrollHeight;
+    select.appendChild(document.createElement("div"));
+    document.body.scrollHeight;
+    fixed_child.style.width = "200px";
+  }
+</script>
+
+<select id="select">text</select>
+
+<div id="parent_abs">
+    <div id="child_abs">
+        <div id="fixed">
+            <div id="fixed_child"></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
When layout root layout fails, for instance because a new fixed position
element has started escaping the layout root, a full layout must be
done. This change ensures that partial layout results (such as new,
orphaned hoisted absolute cells) are cleared before doing that full
layout. If this doesn't happen, layout caches will be used during the
full layout and hoisted absolutes may not be hoisted properly out of the
layout root.

Testing: This change adds a WPT crashtest.
Fixes: #<!-- nolink -->46109.

Reviewed in servo/servo#46127