### PR TITLE
Remove stale wai-aria folder in html/dom/elements

### DIFF
--- a/html/dom/elements/wai-aria/README.md
+++ b/html/dom/elements/wai-aria/README.md
@@ -1,1 +1,0 @@
-The test suite for WAI-ARIA is available at: <https://www.w3.org/WAI/PF/testharness/>.


### PR DESCRIPTION
The nested `html/dom/elements/wai-aria` folder contained only a README pointing to a dead W3C URL (`https://www.w3.org/WAI/PF/testharness/`) and no actual tests. The maintained WAI-ARIA tests live in the root `wai-aria/` folder, making this nested folder redundant.

Verified there are no references to `html/dom/elements/wai-aria` anywhere in the repo.

Closes web-platform-tests/interop-accessibility#218