### PR TITLE
Add GeometryUtils coverage for cssom-view

### DIFF
--- a/css/cssom-view/cssom-geometryutils-convertPointFromNode.html
+++ b/css/cssom-view/cssom-geometryutils-convertPointFromNode.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<title>CSSOM View - convertPointFromNode()</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #target {
+    position: absolute;
+    left: 20px;
+    top: 25px;
+    width: 260px;
+    height: 180px;
+    margin: 7px 11px 13px 17px;
+    border: solid;
+    border-width: 3px 5px 7px 9px;
+    padding: 2px 4px 6px 8px;
+  }
+
+  #source {
+    position: absolute;
+    left: 70px;
+    top: 55px;
+    width: 90px;
+    height: 45px;
+    margin: 10px 14px 18px 22px;
+    border: solid;
+    border-width: 1px 3px 5px 7px;
+    padding: 2px 4px 6px 8px;
+    transform: translate(12px, 9px) rotate(12deg) scale(1.15, 0.85);
+    transform-origin: 15px 20px;
+  }
+</style>
+<div id="target">
+  <div id="source"></div>
+</div>
+<script>
+const source = document.getElementById("source");
+const target = document.getElementById("target");
+const boxes = ["margin", "border", "padding", "content"];
+
+for (const fromBox of boxes) {
+  for (const toBox of boxes) {
+    test(() => {
+      const actual = target.convertPointFromNode(
+        {x: 0, y: 0},
+        source,
+        {fromBox, toBox}
+      );
+      const expected = expected_point_in_target_box(source, target, fromBox,
+                                                    toBox, "p1");
+      assert_point_approx_equals(actual, expected,
+                                 `${fromBox} origin to ${toBox} origin`);
+    }, `convertPointFromNode() maps ${fromBox} origin to ${toBox} coordinates`);
+  }
+}
+
+test(() => {
+  const point = {x: 10, y: 20};
+  const targetPoint = target.convertPointFromNode(point, source);
+  const roundTripped = source.convertPointFromNode(targetPoint, target);
+  assert_point_approx_equals(roundTripped, point,
+                             "point after round-trip conversion");
+}, "convertPointFromNode() round-trips between two elements");
+
+test(() => {
+  const actual = document.convertPointFromNode({x: 0, y: 0}, source);
+  const expected = source.getBoxQuads()[0].p1;
+  assert_point_approx_equals(actual, expected,
+                             "source border origin in document coordinates");
+}, "Document.convertPointFromNode() converts to viewport coordinates");
+</script>

--- a/css/cssom-view/cssom-geometryutils-convertQuadFromNode.html
+++ b/css/cssom-view/cssom-geometryutils-convertQuadFromNode.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<title>CSSOM View - convertQuadFromNode()</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #target {
+    position: absolute;
+    left: 15px;
+    top: 20px;
+    width: 280px;
+    height: 180px;
+    margin: 9px 13px 17px 21px;
+    border: solid;
+    border-width: 4px 6px 8px 10px;
+    padding: 3px 5px 7px 9px;
+  }
+
+  #source {
+    position: absolute;
+    left: 65px;
+    top: 50px;
+    width: 100px;
+    height: 50px;
+    margin: 12px 16px 20px 24px;
+    border: solid;
+    border-width: 2px 4px 6px 8px;
+    padding: 3px 5px 7px 9px;
+    transform: skewX(15deg) rotate(-8deg) translate(9px, 4px);
+    transform-origin: 25% 75%;
+  }
+</style>
+<div id="target">
+  <div id="source"></div>
+</div>
+<script>
+const source = document.getElementById("source");
+const target = document.getElementById("target");
+const boxes = ["margin", "border", "padding", "content"];
+
+for (const fromBox of boxes) {
+  for (const toBox of boxes) {
+    test(() => {
+      const size = box_size(source, fromBox);
+      const quad = new DOMQuad(
+        new DOMPoint(0, 0),
+        new DOMPoint(size.width, 0),
+        new DOMPoint(size.width, size.height),
+        new DOMPoint(0, size.height)
+      );
+      const actual = target.convertQuadFromNode(quad, source, {fromBox, toBox});
+      const expected = expected_quad_in_target_box(source, target, fromBox,
+                                                   toBox);
+      assert_quad_approx_equals(actual, expected,
+                                `${fromBox} quad to ${toBox} coordinates`);
+    }, `convertQuadFromNode() maps ${fromBox} quad to ${toBox} coordinates`);
+  }
+}
+
+test(() => {
+  const borderRect = local_box_rect(source, "border");
+  const quad = quad_from_rect(borderRect);
+  const converted = document.convertQuadFromNode(quad, source);
+  assert_quad_approx_equals(converted, source.getBoxQuads()[0],
+                            "source border quad in document coordinates");
+}, "Document.convertQuadFromNode() matches getBoxQuads()");
+
+test(() => {
+  const borderRect = local_box_rect(source, "border");
+  const quad = quad_from_rect(borderRect);
+  const targetQuad = target.convertQuadFromNode(quad, source);
+  const roundTripped = source.convertQuadFromNode(targetQuad, target);
+  assert_quad_approx_equals(roundTripped, quad,
+                            "quad after round-trip conversion");
+}, "convertQuadFromNode() round-trips between two elements");
+</script>

--- a/css/cssom-view/cssom-geometryutils-convertRectFromNode.html
+++ b/css/cssom-view/cssom-geometryutils-convertRectFromNode.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<title>CSSOM View - convertRectFromNode()</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #target {
+    position: absolute;
+    left: 18px;
+    top: 22px;
+    width: 260px;
+    height: 170px;
+    margin: 8px 12px 16px 20px;
+    border: solid;
+    border-width: 5px 7px 9px 11px;
+    padding: 4px 6px 8px 10px;
+  }
+
+  #source {
+    position: absolute;
+    left: 60px;
+    top: 48px;
+    width: 96px;
+    height: 52px;
+    margin: 11px 15px 19px 23px;
+    border: solid;
+    border-width: 2px 6px 8px 10px;
+    padding: 4px 8px 10px 12px;
+    transform: translate(10px, 5px) scale(1.2, 0.9) rotate(10deg);
+    transform-origin: right bottom;
+  }
+</style>
+<div id="target">
+  <div id="source"></div>
+</div>
+<script>
+const source = document.getElementById("source");
+const target = document.getElementById("target");
+const boxes = ["margin", "border", "padding", "content"];
+
+for (const fromBox of boxes) {
+  for (const toBox of boxes) {
+    test(() => {
+      const size = box_size(source, fromBox);
+      const rect = new DOMRect(0, 0, size.width, size.height);
+      const actual = target.convertRectFromNode(rect, source, {fromBox, toBox});
+      const expected = expected_quad_in_target_box(source, target, fromBox,
+                                                   toBox);
+      assert_quad_approx_equals(actual, expected,
+                                `${fromBox} rect to ${toBox} coordinates`);
+    }, `convertRectFromNode() maps ${fromBox} rect to ${toBox} coordinates`);
+  }
+}
+
+test(() => {
+  const rect = new DOMRect(3, 4, 20, 15);
+  const rectQuad = target.convertRectFromNode(rect, source);
+  const equivalentQuad = target.convertQuadFromNode(quad_from_rect(rect),
+                                                   source);
+  assert_quad_approx_equals(rectQuad, equivalentQuad,
+                            "converted rect and equivalent quad");
+}, "convertRectFromNode() matches convertQuadFromNode() for the same rectangle");
+
+test(() => {
+  const rect = new DOMRect(5, 6, 21, 17);
+  const targetQuad = target.convertRectFromNode(rect, source);
+  const roundTripped = source.convertQuadFromNode(targetQuad, target);
+  assert_quad_approx_equals(roundTripped, quad_from_rect(rect),
+                            "rect after round-trip conversion");
+}, "convertRectFromNode() output round-trips as a DOMQuad");
+</script>

--- a/css/cssom-view/cssom-geometryutils-element-types.html
+++ b/css/cssom-view/cssom-geometryutils-element-types.html
@@ -54,6 +54,32 @@
     border: 2px solid purple;
     padding: 6px;
   }
+
+  #pseudo-host {
+    position: absolute;
+    left: 360px;
+    top: 260px;
+    padding: 12px 24px;
+    transform: rotate(-8deg);
+  }
+
+  #pseudo-host::before {
+    content: "before";
+    display: inline-block;
+    width: 48px;
+    height: 18px;
+    margin-right: 8px;
+    background: deepskyblue;
+  }
+
+  #pseudo-host::after {
+    content: "after";
+    position: absolute;
+    right: -18px;
+    top: -12px;
+    padding: 2px 6px;
+    background: red;
+  }
 </style>
 <div id="html-box"></div>
 <svg id="svg-root" viewBox="0 0 260 170">
@@ -79,6 +105,7 @@
     </msup>
   </math>
 </div>
+<button id="pseudo-host">Pseudo host</button>
 <script>
 const elementCases = [
   ["html-box", "HTML element"],
@@ -128,4 +155,22 @@ for (const [id, description] of elementCases) {
                               `${description} converted local rect`);
   }, `convertRectFromNode() maps a local ${description} rect as a DOMQuad`);
 }
+
+test(() => {
+  const host = document.getElementById("pseudo-host");
+  if (typeof host.pseudo !== "function" || !("CSSPseudoElement" in window)) {
+    return;
+  }
+
+  for (const type of ["::before", "::after"]) {
+    const pseudo = host.pseudo(type);
+    assert_true(pseudo instanceof CSSPseudoElement, `${type} pseudo`);
+    assert_equals(typeof pseudo.getBoxQuads, "function",
+                  `${type} getBoxQuads`);
+    const quad = pseudo.getBoxQuads()[0];
+    assert_true(quad instanceof DOMQuad, `${type} quad`);
+    assert_greater_than(quad.getBounds().width, 0, `${type} width`);
+    assert_greater_than(quad.getBounds().height, 0, `${type} height`);
+  }
+}, "getBoxQuads() returns quads for exposed CSSPseudoElement objects");
 </script>

--- a/css/cssom-view/cssom-geometryutils-element-types.html
+++ b/css/cssom-view/cssom-geometryutils-element-types.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<title>CSSOM View - GeometryUtils on HTML, SVG and MathML elements</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#svg-layout-box">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #html-box {
+    position: absolute;
+    left: 40px;
+    top: 35px;
+    width: 90px;
+    height: 50px;
+    border: 5px solid black;
+    padding: 8px;
+    transform: rotate(17deg) scale(1.1, 0.8);
+    transform-origin: 12px 18px;
+    background: gold;
+  }
+
+  #svg-root {
+    position: absolute;
+    left: 220px;
+    top: 35px;
+    width: 260px;
+    height: 170px;
+    overflow: visible;
+    transform: rotate(-11deg);
+    transform-origin: 30px 40px;
+    border: 3px solid gray;
+  }
+
+  #svg-rect {
+    transform-box: fill-box;
+    transform-origin: center;
+    transform: rotate(18deg);
+  }
+
+  #math-wrap {
+    position: absolute;
+    left: 60px;
+    top: 280px;
+    transform: rotate(12deg) scale(1.2);
+    transform-origin: left top;
+  }
+
+  #math-root {
+    font-size: 32px;
+    border: 2px solid purple;
+    padding: 6px;
+  }
+</style>
+<div id="html-box"></div>
+<svg id="svg-root" viewBox="0 0 260 170">
+  <g id="svg-group" transform="translate(25 20) rotate(10)">
+    <rect id="svg-rect" x="10" y="15" width="90" height="45"
+          fill="lime"></rect>
+    <circle id="svg-circle" cx="160" cy="65" r="30" fill="tomato"></circle>
+    <text id="svg-text" x="15" y="135" font-size="24">svg text</text>
+  </g>
+</svg>
+<div id="math-wrap">
+  <math id="math-root" xmlns="http://www.w3.org/1998/Math/MathML">
+    <msup>
+      <mrow>
+        <mo>(</mo>
+        <mfrac id="math-frac">
+          <mrow><mn>1</mn><mo>+</mo><mn>2</mn></mrow>
+          <mn>3</mn>
+        </mfrac>
+        <mo>)</mo>
+      </mrow>
+      <mn>4</mn>
+    </msup>
+  </math>
+</div>
+<script>
+const elementCases = [
+  ["html-box", "HTML element"],
+  ["svg-root", "outer SVG element"],
+  ["svg-group", "SVG group element"],
+  ["svg-rect", "SVG rect element"],
+  ["svg-circle", "SVG circle element"],
+  ["svg-text", "SVG text element"],
+  ["math-root", "MathML root element"],
+  ["math-frac", "MathML fraction element"],
+];
+
+for (const [id, description] of elementCases) {
+  test(() => {
+    const element = document.getElementById(id);
+    assert_quad_bounds_match_bounding_rect(
+      element,
+      {box: "border"},
+      `${description} border quad bounds`
+    );
+  }, `getBoxQuads() bounds match getBoundingClientRect() for ${description}`);
+
+  test(() => {
+    const element = document.getElementById(id);
+    const localQuad = element.getBoxQuads({relativeTo: element})[0];
+    const convertedQuad = document.convertQuadFromNode(localQuad, element);
+    assert_quad_approx_equals(convertedQuad, element.getBoxQuads()[0],
+                              `${description} converted local quad`);
+  }, `convertQuadFromNode() maps a local ${description} quad to the viewport`);
+
+  test(() => {
+    const element = document.getElementById(id);
+    const localPoint = element.getBoxQuads({relativeTo: element})[0].p1;
+    const convertedPoint = document.convertPointFromNode(localPoint, element);
+    assert_point_approx_equals(convertedPoint, element.getBoxQuads()[0].p1,
+                               `${description} converted local p1`);
+  }, `convertPointFromNode() maps a local ${description} point to the viewport`);
+
+  test(() => {
+    const element = document.getElementById(id);
+    const localBounds = element.getBoxQuads({relativeTo: element})[0]
+      .getBounds();
+    const convertedRect = document.convertRectFromNode(localBounds, element);
+    const convertedQuad = document.convertQuadFromNode(quad_from_rect(localBounds),
+                                                       element);
+    assert_quad_approx_equals(convertedRect, convertedQuad,
+                              `${description} converted local rect`);
+  }, `convertRectFromNode() maps a local ${description} rect as a DOMQuad`);
+}
+</script>

--- a/css/cssom-view/cssom-geometryutils-getBoxQuads-options.html
+++ b/css/cssom-view/cssom-geometryutils-getBoxQuads-options.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<title>CSSOM View - getBoxQuads() options</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<link rel="help" href="https://hacks.mozilla.org/2014/03/introducing-the-getboxquads-api/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #target {
+    position: absolute;
+    left: 40px;
+    top: 30px;
+    width: 200px;
+    height: 160px;
+    margin: 11px 13px 17px 19px;
+    border: solid;
+    border-width: 2px 4px 6px 8px;
+    padding: 3px 5px 7px 9px;
+    box-sizing: content-box;
+    background: lightblue;
+  }
+
+  #relative {
+    position: absolute;
+    left: 20px;
+    top: 15px;
+    width: 300px;
+    height: 220px;
+    border: 10px solid gray;
+    padding: 12px;
+  }
+
+  #child {
+    position: absolute;
+    left: 50px;
+    top: 45px;
+    width: 80px;
+    height: 40px;
+    margin: 10px 14px 18px 22px;
+    border: solid;
+    border-width: 1px 3px 5px 7px;
+    padding: 2px 4px 6px 8px;
+    box-sizing: content-box;
+    background: gold;
+  }
+
+  #rtl {
+    position: absolute;
+    left: 320px;
+    top: 30px;
+    width: 60px;
+    height: 25px;
+    direction: rtl;
+    writing-mode: vertical-rl;
+    border: 4px solid black;
+    padding: 6px;
+  }
+</style>
+<div id="target"></div>
+<div id="relative">
+  <div id="child"></div>
+</div>
+<div id="rtl"></div>
+<script>
+const boxes = ["margin", "border", "padding", "content"];
+const target = document.getElementById("target");
+const relative = document.getElementById("relative");
+const child = document.getElementById("child");
+const rtl = document.getElementById("rtl");
+
+test(() => {
+  assert_geometry_utils_exist();
+}, "GeometryUtils APIs exist on Element");
+
+for (const box of boxes) {
+  test(() => {
+    const quad = target.getBoxQuads({box})[0];
+    const expected = local_box_rect(target, box);
+    const borderRect = target.getBoundingClientRect();
+    assert_point_approx_equals(quad.p1,
+                               new DOMPoint(borderRect.left + expected.x,
+                                            borderRect.top + expected.y),
+                               `${box} p1`);
+    assert_point_approx_equals(quad.p3,
+                               new DOMPoint(borderRect.left + expected.x +
+                                              expected.width,
+                                            borderRect.top + expected.y +
+                                              expected.height),
+                               `${box} p3`);
+    assert_approx_equals(quad.getBounds().width, expected.width,
+                         GEOMETRY_UTILS_EPSILON, `${box} width`);
+    assert_approx_equals(quad.getBounds().height, expected.height,
+                         GEOMETRY_UTILS_EPSILON, `${box} height`);
+  }, `getBoxQuads({box: "${box}"}) returns the requested CSS box`);
+}
+
+test(() => {
+  const defaultQuad = target.getBoxQuads()[0];
+  const borderQuad = target.getBoxQuads({box: "border"})[0];
+  assert_quad_approx_equals(defaultQuad, borderQuad,
+                            "default getBoxQuads() border box");
+}, "getBoxQuads() defaults to the border box");
+
+test(() => {
+  const quad = child.getBoxQuads({relativeTo: relative})[0];
+  const childRect = child.getBoundingClientRect();
+  const relativeRect = relative.getBoundingClientRect();
+  assert_point_approx_equals(quad.p1,
+                             new DOMPoint(childRect.left - relativeRect.left,
+                                          childRect.top - relativeRect.top),
+                             "child border p1 relative to relative border box");
+  assert_point_approx_equals(quad.p3,
+                             new DOMPoint(childRect.right - relativeRect.left,
+                                          childRect.bottom - relativeRect.top),
+                             "child border p3 relative to relative border box");
+}, "getBoxQuads({relativeTo}) uses the relative element border-box origin");
+
+test(() => {
+  const quad = child.getBoxQuads({box: "content", relativeTo: relative})[0];
+  const childRect = child.getBoundingClientRect();
+  const relativeRect = relative.getBoundingClientRect();
+  const contentRect = local_box_rect(child, "content");
+  assert_point_approx_equals(quad.p1,
+                             new DOMPoint(childRect.left - relativeRect.left +
+                                            contentRect.x,
+                                          childRect.top - relativeRect.top +
+                                            contentRect.y),
+                             "child content p1 relative to relative");
+  assert_point_approx_equals(quad.p3,
+                             new DOMPoint(childRect.left - relativeRect.left +
+                                            contentRect.x + contentRect.width,
+                                          childRect.top - relativeRect.top +
+                                            contentRect.y + contentRect.height),
+                             "child content p3 relative to relative");
+}, "getBoxQuads() combines box and relativeTo options");
+
+test(() => {
+  const quad = rtl.getBoxQuads()[0];
+  assert_true(quad.p1.x < quad.p2.x, "p1 remains the physical left corner");
+  assert_true(quad.p1.y < quad.p4.y, "p1 remains the physical top corner");
+}, "getBoxQuads() point order is physical for bidi and writing-mode");
+
+test(() => {
+  const quad = document.getBoxQuads()[0];
+  assert_point_approx_equals(quad.p1, new DOMPoint(0, 0),
+                             "document quad origin");
+  assert_approx_equals(quad.getBounds().width, document.documentElement.clientWidth,
+                       GEOMETRY_UTILS_EPSILON, "document quad width");
+  assert_approx_equals(quad.getBounds().height, document.documentElement.clientHeight,
+                       GEOMETRY_UTILS_EPSILON, "document quad height");
+}, "Document.getBoxQuads() returns the viewport quad");
+</script>

--- a/css/cssom-view/cssom-geometryutils-special-cases.html
+++ b/css/cssom-view/cssom-geometryutils-special-cases.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<title>CSSOM View - GeometryUtils special cases</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<link rel="help" href="https://hacks.mozilla.org/2014/03/introducing-the-getboxquads-api/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #text-container {
+    position: absolute;
+    left: 30px;
+    top: 25px;
+    width: 95px;
+    font: 20px/1.2 monospace;
+    border: 4px solid black;
+  }
+
+  x-geometry-host {
+    position: absolute;
+    left: 250px;
+    top: 35px;
+    width: 230px;
+    height: 150px;
+    border: 5px solid gray;
+    padding: 10px;
+    transform: rotate(8deg);
+    transform-origin: left top;
+    display: block;
+  }
+
+  #slotted {
+    width: 80px;
+    height: 45px;
+    border: 3px solid black;
+    transform: translate(18px, 12px) rotate(-16deg);
+    background: gold;
+  }
+
+  iframe {
+    position: absolute;
+    left: 60px;
+    top: 260px;
+    width: 260px;
+    height: 170px;
+    border: 8px solid purple;
+    transform: rotate(9deg);
+    transform-origin: left top;
+  }
+</style>
+<div id="text-container">GeometryUtils text fragments wrap here.</div>
+<x-geometry-host>
+  <div id="slotted" slot="content"></div>
+</x-geometry-host>
+<script>
+customElements.define("x-geometry-host", class extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({mode: "open"});
+    shadow.innerHTML = `
+      <style>
+        #shadow-target {
+          position: absolute;
+          left: 95px;
+          top: 65px;
+          width: 70px;
+          height: 35px;
+          border: 4px solid blue;
+          transform: rotate(21deg) scale(1.15);
+          transform-origin: center;
+        }
+        slot {
+          position: absolute;
+          left: 20px;
+          top: 18px;
+          display: block;
+        }
+      </style>
+      <slot name="content"></slot>
+      <div id="shadow-target"></div>
+    `;
+  }
+});
+
+function load_iframe(srcdoc) {
+  const frame = document.createElement("iframe");
+  document.body.appendChild(frame);
+  const loaded = new Promise(resolve => frame.onload = resolve);
+  frame.srcdoc = srcdoc;
+  return loaded.then(() => frame);
+}
+
+test(() => {
+  const textNode = document.getElementById("text-container").firstChild;
+  const range = document.createRange();
+  range.selectNodeContents(textNode);
+  const quads = textNode.getBoxQuads();
+  const rects = range.getClientRects();
+
+  assert_greater_than(quads.length, 1, "text node produces fragments");
+  assert_equals(quads.length, rects.length,
+                "text node quads match range fragment count");
+  for (let i = 0; i < quads.length; ++i) {
+    assert_rect_approx_equals(quads[i].getBounds(), rects[i],
+                              `text fragment ${i}`);
+  }
+}, "Text.getBoxQuads() matches Range.getClientRects() fragments");
+
+test(() => {
+  const textNode = document.getElementById("text-container").firstChild;
+  const localPoint = textNode.getBoxQuads({relativeTo: textNode})[0].p1;
+  const convertedPoint = document.convertPointFromNode(localPoint, textNode);
+  assert_point_approx_equals(convertedPoint, textNode.getBoxQuads()[0].p1,
+                             "text local p1");
+}, "convertPointFromNode() converts from a Text node");
+
+test(() => {
+  const host = document.querySelector("x-geometry-host");
+  const shadowTarget = host.shadowRoot.getElementById("shadow-target");
+  assert_quad_bounds_match_bounding_rect(shadowTarget, {},
+                                         "shadow tree element bounds");
+
+  const relativeQuad = shadowTarget.getBoxQuads({relativeTo: host})[0];
+  const convertedQuad = host.convertQuadFromNode(
+    shadowTarget.getBoxQuads({relativeTo: shadowTarget})[0],
+    shadowTarget
+  );
+  assert_quad_approx_equals(relativeQuad, convertedQuad,
+                            "shadow tree element relative to host");
+}, "GeometryUtils follows shadow tree ancestry");
+
+test(() => {
+  const host = document.querySelector("x-geometry-host");
+  const slotted = document.getElementById("slotted");
+  assert_quad_bounds_match_bounding_rect(slotted, {},
+                                         "slotted light DOM element bounds");
+
+  const relativeQuad = slotted.getBoxQuads({relativeTo: host})[0];
+  const convertedQuad = host.convertQuadFromNode(
+    slotted.getBoxQuads({relativeTo: slotted})[0],
+    slotted
+  );
+  assert_quad_approx_equals(relativeQuad, convertedQuad,
+                            "slotted element relative to host");
+}, "GeometryUtils follows flat-tree slot assignment");
+
+promise_test(async () => {
+  const frame = await load_iframe(`<!DOCTYPE html>
+    <style>
+      html, body { margin: 0; }
+      #inner {
+        position: absolute;
+        left: 35px;
+        top: 28px;
+        width: 80px;
+        height: 45px;
+        border: 4px solid black;
+        padding: 6px;
+        transform: rotate(14deg) scale(1.1);
+        transform-origin: 10px 15px;
+      }
+    </style>
+    <div id="inner"></div>`);
+
+  const inner = frame.contentDocument.getElementById("inner");
+  const innerQuad = inner.getBoxQuads()[0];
+  assert_rect_approx_equals(innerQuad.getBounds(),
+                            inner.getBoundingClientRect(),
+                            "iframe-local inner bounds");
+}, "getBoxQuads() works in a same-origin iframe document");
+
+promise_test(async () => {
+  const frame = await load_iframe(`<!DOCTYPE html>
+    <style>
+      html, body { margin: 0; }
+      #inner {
+        position: absolute;
+        left: 35px;
+        top: 28px;
+        width: 80px;
+        height: 45px;
+        border: 4px solid black;
+        transform: rotate(14deg);
+      }
+    </style>
+    <div id="inner"></div>`);
+
+  const inner = frame.contentDocument.getElementById("inner");
+  const localQuad = inner.getBoxQuads({relativeTo: inner})[0];
+  const convertedQuad = document.convertQuadFromNode(localQuad, inner);
+  assert_quad_approx_equals(convertedQuad,
+                            inner.getBoxQuads({relativeTo: document})[0],
+                            "iframe element quad relative to outer document");
+}, "GeometryUtils converts same-origin iframe content to the outer document");
+</script>

--- a/css/cssom-view/cssom-geometryutils-transforms.html
+++ b/css/cssom-view/cssom-geometryutils-transforms.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<title>CSSOM View - GeometryUtils with transform-like CSS properties</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/">
+<link rel="help" href="https://drafts.fxtf.org/motion-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/geometry-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+  }
+
+  #stage {
+    position: absolute;
+    left: 20px;
+    top: 20px;
+    width: 700px;
+    height: 850px;
+  }
+
+  .case {
+    position: absolute;
+    width: 90px;
+    height: 50px;
+    border: 4px solid black;
+    padding: 6px;
+    background: gold;
+    box-sizing: content-box;
+  }
+
+  #css-transform {
+    left: 40px;
+    top: 35px;
+    transform: translate(24px, 11px) rotate(23deg) scale(1.2, 0.75)
+      skewX(8deg);
+    transform-origin: 10px 35px;
+  }
+
+  #individual-transform {
+    left: 240px;
+    top: 45px;
+    translate: 18px 12px;
+    rotate: -31deg;
+    scale: 0.85 1.25;
+    transform-origin: right bottom;
+  }
+
+  #zoomed {
+    left: 450px;
+    top: 45px;
+    zoom: 1.4;
+    transform: rotate(11deg);
+  }
+
+  #perspective-parent {
+    position: absolute;
+    left: 55px;
+    top: 220px;
+    width: 180px;
+    height: 140px;
+    perspective: 260px;
+    perspective-origin: 20% 80%;
+    border: 2px solid gray;
+  }
+
+  #perspective-child {
+    left: 30px;
+    top: 35px;
+    transform: rotateY(38deg) translateZ(22px);
+    transform-origin: center center;
+  }
+
+  #preserve-3d-parent {
+    position: absolute;
+    left: 330px;
+    top: 225px;
+    width: 170px;
+    height: 130px;
+    transform-style: preserve-3d;
+    transform: rotateX(12deg) rotateY(-18deg);
+  }
+
+  #preserve-3d-child {
+    left: 25px;
+    top: 30px;
+    transform: translateZ(35px) rotateY(25deg);
+  }
+
+  #motion-path {
+    left: 70px;
+    top: 470px;
+    offset-path: path("M 0 0 L 160 70");
+    offset-distance: 60%;
+    offset-rotate: 40deg;
+  }
+
+  #scale-zero {
+    left: 350px;
+    top: 500px;
+    transform: scale(0);
+  }
+
+  #relative-target {
+    position: absolute;
+    left: 80px;
+    top: 680px;
+    width: 240px;
+    height: 130px;
+    border: 5px solid gray;
+    transform: rotate(19deg);
+    transform-origin: 20px 10px;
+  }
+
+  #relative-source {
+    left: 45px;
+    top: 35px;
+    transform: rotate(-24deg) translate(12px, 8px);
+  }
+</style>
+<div id="stage">
+  <div id="css-transform" class="case"></div>
+  <div id="individual-transform" class="case"></div>
+  <div id="zoomed" class="case"></div>
+  <div id="perspective-parent">
+    <div id="perspective-child" class="case"></div>
+  </div>
+  <div id="preserve-3d-parent">
+    <div id="preserve-3d-child" class="case"></div>
+  </div>
+  <div id="motion-path" class="case"></div>
+  <div id="scale-zero" class="case"></div>
+  <div id="relative-target">
+    <div id="relative-source" class="case"></div>
+  </div>
+</div>
+<script>
+const transformedCases = [
+  ["css-transform", "transform, transform-origin, skew, rotate and scale"],
+  ["individual-transform", "individual translate, rotate and scale"],
+  ["zoomed", "zoom with transform"],
+  ["perspective-child", "perspective and perspective-origin"],
+  ["preserve-3d-child", "transform-style: preserve-3d"],
+  ["motion-path", "offset-path, offset-distance and offset-rotate"],
+];
+
+for (const [id, description] of transformedCases) {
+  test(() => {
+    const element = document.getElementById(id);
+    assert_quad_bounds_match_bounding_rect(
+      element,
+      {box: "border"},
+      `${description} border quad bounds`
+    );
+  }, `getBoxQuads() matches getBoundingClientRect() for ${description}`);
+}
+
+test(() => {
+  const quad = document.getElementById("css-transform").getBoxQuads()[0];
+  assert_not_equals(Math.round(quad.p1.y), Math.round(quad.p2.y),
+                    "top edge is not axis-aligned");
+  assert_not_equals(Math.round(quad.p2.x), Math.round(quad.p3.x),
+                    "right edge is not axis-aligned");
+}, "getBoxQuads() preserves non-axis-aligned corners for CSS transforms");
+
+test(() => {
+  assert_true(CSS.supports("offset-path", "path(\"M 0 0 L 1 1\")"),
+              "offset-path is supported");
+  assert_true(CSS.supports("offset-rotate", "40deg"),
+              "offset-rotate is supported");
+}, "Motion path properties used by this test are supported");
+
+test(() => {
+  const bounds = document.getElementById("scale-zero").getBoxQuads()[0]
+    .getBounds();
+  assert_approx_equals(bounds.width, 0, GEOMETRY_UTILS_EPSILON,
+                       "scale(0) width");
+  assert_approx_equals(bounds.height, 0, GEOMETRY_UTILS_EPSILON,
+                       "scale(0) height");
+}, "getBoxQuads() returns a zero-size bounds for scale(0)");
+
+test(() => {
+  const source = document.getElementById("relative-source");
+  const target = document.getElementById("relative-target");
+  const relativeQuad = source.getBoxQuads({relativeTo: target})[0];
+  const convertedQuad = target.convertQuadFromNode(
+    quad_from_rect(local_box_rect(source, "border")),
+    source
+  );
+  assert_quad_approx_equals(relativeQuad, convertedQuad,
+                            "relative quad and converted quad");
+}, "getBoxQuads({relativeTo}) matches convertQuadFromNode() in a transformed subtree");
+</script>

--- a/css/cssom-view/resources/geometry-utils.js
+++ b/css/cssom-view/resources/geometry-utils.js
@@ -1,0 +1,148 @@
+const GEOMETRY_UTILS_EPSILON = 0.5;
+
+function assert_point_approx_equals(actual, expected, description) {
+  assert_approx_equals(actual.x, expected.x, GEOMETRY_UTILS_EPSILON,
+                       `${description} x`);
+  assert_approx_equals(actual.y, expected.y, GEOMETRY_UTILS_EPSILON,
+                       `${description} y`);
+}
+
+function assert_quad_approx_equals(actual, expected, description) {
+  for (const point of ["p1", "p2", "p3", "p4"]) {
+    assert_point_approx_equals(actual[point], expected[point],
+                               `${description} ${point}`);
+  }
+}
+
+function assert_rect_approx_equals(actual, expected, description) {
+  for (const prop of ["left", "top", "right", "bottom", "width", "height"]) {
+    assert_approx_equals(actual[prop], expected[prop], GEOMETRY_UTILS_EPSILON,
+                         `${description} ${prop}`);
+  }
+}
+
+function assert_quad_bounds_match_bounding_rect(element, options, description) {
+  const quad = element.getBoxQuads(options)[0];
+  assert_rect_approx_equals(quad.getBounds(), element.getBoundingClientRect(),
+                            description);
+}
+
+function px(value) {
+  const result = parseFloat(value);
+  return Number.isFinite(result) ? result : 0;
+}
+
+function used_box_edges(element) {
+  const style = getComputedStyle(element);
+  return {
+    marginTop: px(style.marginTop),
+    marginRight: px(style.marginRight),
+    marginBottom: px(style.marginBottom),
+    marginLeft: px(style.marginLeft),
+    borderTop: px(style.borderTopWidth),
+    borderRight: px(style.borderRightWidth),
+    borderBottom: px(style.borderBottomWidth),
+    borderLeft: px(style.borderLeftWidth),
+    paddingTop: px(style.paddingTop),
+    paddingRight: px(style.paddingRight),
+    paddingBottom: px(style.paddingBottom),
+    paddingLeft: px(style.paddingLeft),
+    borderWidth: element.offsetWidth,
+    borderHeight: element.offsetHeight,
+  };
+}
+
+function local_box_rect(element, box) {
+  const edges = used_box_edges(element);
+  const borderWidth = edges.borderWidth;
+  const borderHeight = edges.borderHeight;
+
+  if (box === "margin") {
+    return {
+      x: -edges.marginLeft,
+      y: -edges.marginTop,
+      width: borderWidth + edges.marginLeft + edges.marginRight,
+      height: borderHeight + edges.marginTop + edges.marginBottom,
+    };
+  }
+
+  if (box === "padding") {
+    return {
+      x: edges.borderLeft,
+      y: edges.borderTop,
+      width: borderWidth - edges.borderLeft - edges.borderRight,
+      height: borderHeight - edges.borderTop - edges.borderBottom,
+    };
+  }
+
+  if (box === "content") {
+    return {
+      x: edges.borderLeft + edges.paddingLeft,
+      y: edges.borderTop + edges.paddingTop,
+      width: borderWidth - edges.borderLeft - edges.borderRight -
+        edges.paddingLeft - edges.paddingRight,
+      height: borderHeight - edges.borderTop - edges.borderBottom -
+        edges.paddingTop - edges.paddingBottom,
+    };
+  }
+
+  return {x: 0, y: 0, width: borderWidth, height: borderHeight};
+}
+
+function box_size(element, box) {
+  const rect = local_box_rect(element, box);
+  return {width: rect.width, height: rect.height};
+}
+
+function box_origin(element, box) {
+  const rect = local_box_rect(element, box);
+  return new DOMPoint(rect.x, rect.y);
+}
+
+function quad_from_rect(rect) {
+  return new DOMQuad(
+    new DOMPoint(rect.x, rect.y),
+    new DOMPoint(rect.x + rect.width, rect.y),
+    new DOMPoint(rect.x + rect.width, rect.y + rect.height),
+    new DOMPoint(rect.x, rect.y + rect.height)
+  );
+}
+
+function translated_quad(quad, dx, dy) {
+  return new DOMQuad(
+    new DOMPoint(quad.p1.x + dx, quad.p1.y + dy),
+    new DOMPoint(quad.p2.x + dx, quad.p2.y + dy),
+    new DOMPoint(quad.p3.x + dx, quad.p3.y + dy),
+    new DOMPoint(quad.p4.x + dx, quad.p4.y + dy)
+  );
+}
+
+function translated_point(point, dx, dy) {
+  return new DOMPoint(point.x + dx, point.y + dy);
+}
+
+function expected_quad_in_target_box(source, target, fromBox, toBox) {
+  const targetOrigin = box_origin(target, toBox);
+  return translated_quad(
+    source.getBoxQuads({box: fromBox, relativeTo: target})[0],
+    -targetOrigin.x,
+    -targetOrigin.y
+  );
+}
+
+function expected_point_in_target_box(source, target, fromBox, toBox, pointName) {
+  const targetOrigin = box_origin(target, toBox);
+  const point = source.getBoxQuads({box: fromBox, relativeTo: target})[0][pointName];
+  return translated_point(point, -targetOrigin.x, -targetOrigin.y);
+}
+
+function assert_geometry_utils_exist() {
+  assert_equals(typeof Element.prototype.getBoxQuads, "function",
+                "Element.prototype.getBoxQuads");
+  assert_equals(typeof Element.prototype.convertQuadFromNode, "function",
+                "Element.prototype.convertQuadFromNode");
+  assert_equals(typeof Element.prototype.convertRectFromNode, "function",
+                "Element.prototype.convertRectFromNode");
+  assert_equals(typeof Element.prototype.convertPointFromNode, "function",
+                "Element.prototype.convertPointFromNode");
+}


### PR DESCRIPTION
This adds broader WPT coverage for the CSSOM View GeometryUtils interface.

Covered APIs:
- `getBoxQuads()`
- `convertPointFromNode()`
- `convertQuadFromNode()`
- `convertRectFromNode()`

Coverage includes:
- all `box` values for `getBoxQuads()`
- all `fromBox` / `toBox` combinations for conversion methods
- `relativeTo`
- `Document` and `Text` nodes
- HTML, SVG, and MathML elements
- shadow DOM and slotted content
- same-origin iframe content
- transform-affecting CSS including `transform`, individual transform properties, `zoom`, `transform-origin`, `perspective`, `perspective-origin`, `transform-style`, `offset-path`, and `offset-rotate`

The assertions avoid a large set of brittle hard-coded coordinates where possible, and instead check stable GeometryUtils invariants, consistency with `getBoundingClientRect()`, and round-trip conversion behavior.

Tested:
- `python wpt lint ...`
- Firefox Nightly 154.0a1 with:
  - `layout.css.getBoxQuads.enabled=true`
  - `layout.css.convertFromNode.enabled=true`

All added tests passed locally: 7 files, 112 testharness tests.