### PR TITLE
Add MathML-AAM tests infrastructure and comprehensive mapping tests for mathml elements

### DIFF
--- a/core-aam/aamtests/support/atspi_wrapper.py
+++ b/core-aam/aamtests/support/atspi_wrapper.py
@@ -68,19 +68,19 @@ class AtspiWrapper(ApiWrapper[Atspi.Accessible]):
         :returns: An interface object returned by corresponding Accessible API.
         """
         interface_map = {
-            # NOTE: Please add new ATK/ATSPI interfaces and their corresponding 
+            # NOTE: Please add new ATK/ATSPI interfaces and their corresponding
             # Accessible API functions here as needed for testing.
             "AtkTable": Atspi.Accessible.get_table_iface,
             "AtkTableCell": Atspi.Accessible.get_table_cell,
         }
-        
+
         if interface_name not in interface_map:
             raise ValueError(
                 f"Unknown or unsupported interface: '{interface_name}'. "
                 f"If this is a valid interface, please register it in the "
                 f"`interface_map` inside `atspi_wrapper.py`."
             )
-            
+
         get_interface_fn = interface_map[interface_name]
         return get_interface_fn(node)
 

--- a/core-aam/aamtests/support/atspi_wrapper.py
+++ b/core-aam/aamtests/support/atspi_wrapper.py
@@ -62,6 +62,28 @@ class AtspiWrapper(ApiWrapper[Atspi.Accessible]):
 
         return relations_dict
 
+    def get_interface(self, node, interface_name):
+        """ Retrieves an interface object based on the provided name.
+
+        :returns: An interface object returned by corresponding Accessible API.
+        """
+        interface_map = {
+            # NOTE: Please add new ATK/ATSPI interfaces and their corresponding 
+            # Accessible API functions here as needed for testing.
+            "AtkTable": Atspi.Accessible.get_table_iface,
+            "AtkTableCell": Atspi.Accessible.get_table_cell,
+        }
+        
+        if interface_name not in interface_map:
+            raise ValueError(
+                f"Unknown or unsupported interface: '{interface_name}'. "
+                f"If this is a valid interface, please register it in the "
+                f"`interface_map` inside `atspi_wrapper.py`."
+            )
+            
+        get_interface_fn = interface_map[interface_name]
+        return get_interface_fn(node)
+
     def get_state_list_helper(self, node: Atspi.Accessible) -> List[str]:
         """
         :returns: A list of states for this Atspi.Accessible.

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -3,7 +3,7 @@ import pytest
 
 TEST_DATA_ATTRIBUTES = {
     "annotation": {
-        "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='TeX' style='display: inline-block;'>\\text{{two}}</annotation></semantics></math>",
+        "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='TeX' style='display: inline-block;'>\\text{two}</annotation></semantics></math>",
     },
     "annotation-xml": {
         "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='MathML-Presentation' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
@@ -55,7 +55,7 @@ TEST_DATA_ATTRIBUTES = {
         "html": "<math><mrow id='test'><mn>1</mn><mo>+</mo><mn>1</mn></mrow></math>",
     },
     "ms": {
-        "html": "<math><ms id='test'>string</ms></math>",
+        "html": """<math><ms id="test">"string"</ms></math>""",
     },
     "mspace": {
         "html": "<math><mspace id='test' width='2em'/></math>"

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -1,0 +1,103 @@
+# MathML AAM Reference: https://w3c.github.io/mathml-aam/#mathml-element-mappings
+import pytest
+
+TEST_DATA_ATTRIBUTES = {
+    "mfrac": {
+        "html": "<math><mfrac id='test'><mn id='num'>1</mn><mn id='den'>2</mn></mfrac></math>",
+        "tag": "mfrac",
+        "ax_attrs": {"AXMathFractionNumerator": "num", "AXMathFractionDenominator": "den"}
+    },
+    "mover": {
+        "html": "<math><mover id='test'><mi id='base'>a</mi><mo id='over'>˙</mo></mover></math>",
+        "tag": "mover",
+        "ax_attrs": {"AXMathBase": "base", "AXMathOver": "over"}
+    },
+    "mroot": {
+        "html": "<math><mroot id='test'><mi id='rad'>x</mi><mn id='idx'>3</mn></mroot></math>",
+        "tag": "mroot",
+        "ax_attrs": {"AXMathRootRadicand": "rad", "AXMathRootIndex": "idx"}
+    },
+    "msqrt": {
+        "html": "<math><msqrt id='test'><mi id='rad1'>x</mi></msqrt></math>",
+        "tag": "msqrt",
+        "ax_attrs": {"AXMathRootRadicand": "rad1"}
+    },
+    "msub": {
+        "html": "<math><msub id='test'><mi id='base'>x</mi><mn id='sub'>1</mn></msub></math>",
+        "tag": "msub",
+        "ax_attrs": {"AXMathBase": "base", "AXMathSubscript": "sub"}
+    },
+    "msubsup": {
+        "html": "<math><msubsup id='test'><mi id='base'>x</mi><mn id='sub'>1</mn><mn id='sup'>2</mn></msubsup></math>",
+        "tag": "msubsup",
+        "ax_attrs": {"AXMathBase": "base", "AXMathSubscript": "sub", "AXMathSuperscript": "sup"}
+    },
+    "msup": {
+        "html": "<math><msup id='test'><mi id='base'>x</mi><mn id='sup'>2</mn></msup></math>",
+        "tag": "msup",
+        "ax_attrs": {"AXMathBase": "base", "AXMathSuperscript": "sup"}
+    },
+    "mtable": {
+        "html": "<math><mtable id='test'><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>",
+        "tag": "mtable",
+        "interface": "AtkTable"
+    },
+    "mtd": {
+        "html": "<math><mtable><mtr><mtd id='test'><mn>1</mn></mtd></mtr></mtable></math>",
+        "tag": "mtd",
+        "interface": "AtkTableCell"
+    },
+    "munder": {
+        "html": "<math><munder id='test'><mi id='base'>x</mi><mo id='under'>_</mo></munder></math>",
+        "tag": "munder",
+        "ax_attrs": {"AXMathBase": "base", "AXMathUnder": "under"}
+    },
+    "munderover": {
+        "html": "<math><munderover id='test'><mi id='base'>x</mi><mo id='under'>_</mo><mo id='over'>˙</mo></munderover></math>",
+        "tag": "munderover",
+        "ax_attrs": {"AXMathBase": "base", "AXMathUnder": "under", "AXMathOver": "over"}
+    },
+    "mn": {
+        "html": "<math><mn id='test'>2</mn></math>",
+        "tag": "mn",
+    }
+}
+
+@pytest.mark.parametrize("element_name", TEST_DATA_ATTRIBUTES.keys())
+def test_atspi(atspi, session, inline, element_name):
+    data = TEST_DATA_ATTRIBUTES[element_name]
+    session.url = inline(data["html"])
+    node = atspi.find_node("test", session.url)
+
+    if "tag" in data and data["tag"]:
+        obj_attrs = atspi.Accessible.get_attributes(node)
+        assert "tag" in obj_attrs, f"<{element_name}> object attributes missing 'tag' key. Found: {obj_attrs}"
+        assert obj_attrs["tag"] == data["tag"], f"Expected tag '{data['tag']}', got '{obj_attrs['tag']}'"
+
+    if "interface" in data:
+        if data["interface"] == "AtkTable":
+            table_iface = atspi.Accessible.get_table_iface(node)
+            assert table_iface is not None, "mtable node must implement AtkTable interface"
+        elif data["interface"] == "AtkTableCell":
+            cell_iface = atspi.Accessible.get_table_cell(node)
+            assert cell_iface is not None, "mtd node must implement AtkTableCell interface"
+
+
+AX_ATTR_CASES = [name for name, d in TEST_DATA_ATTRIBUTES.items() if "ax_attrs" in d]
+
+@pytest.mark.parametrize("element_name", AX_ATTR_CASES)
+def test_axapi(axapi, session, inline, element_name):
+    data = TEST_DATA_ATTRIBUTES[element_name]
+    session.url = inline(data["html"])
+    node = axapi.find_node("test", session.url)
+
+    expected_relationships = data["ax_attrs"]
+    
+    for ax_attr_key, expected_dom_id in expected_relationships.items():
+        attr_res = axapi.AXUIElementCopyAttributeValue(node, ax_attr_key, None)
+        target_node = attr_res[1] if (attr_res and len(attr_res) > 1) else None
+        
+        assert target_node is not None, f"Relationship attribute '{ax_attr_key}' on <{element_name}> returned None."
+        
+        actual_dom_id = axapi.AXUIElementCopyAttributeValue(target_node, "AXDOMIdentifier", None)[1]
+        assert actual_dom_id == expected_dom_id, f"Pointer '{ax_attr_key}' expected to target id '{expected_dom_id}', but got '{actual_dom_id}'"

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -123,12 +123,8 @@ def test_atspi(atspi, session, inline, element_name):
     interface_name = atspi_config.get("interface")
 
     if interface_name:
-        if interface_name == "AtkTable":
-            table_iface = atspi.Accessible.get_table_iface(node)
-            assert table_iface is not None, f"{element_name} node must implement AtkTable interface"
-        elif interface_name == "AtkTableCell":
-            cell_iface = atspi.Accessible.get_table_cell(node)
-            assert cell_iface is not None, f"{element_name} node must implement AtkTableCell interface"
+        obj = atspi.get_interface(node, interface_name)
+        assert obj is not None, f"{element_name} node must implement {interface_name} interface"
 
 
 AX_ATTR_CASES = [name for name, d in TEST_DATA_ATTRIBUTES.items() if "axapi" in d]

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -69,7 +69,7 @@ def test_atspi(atspi, session, inline, element_name):
     session.url = inline(data["html"])
     node = atspi.find_node("test", session.url)
 
-    if "tag" in data and data["tag"]:
+    if "tag" in data:
         obj_attrs = atspi.Accessible.get_attributes(node)
         assert "tag" in obj_attrs, f"<{element_name}> object attributes missing 'tag' key. Found: {obj_attrs}"
         assert obj_attrs["tag"] == data["tag"], f"Expected tag '{data['tag']}', got '{obj_attrs['tag']}'"

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -4,136 +4,108 @@ import pytest
 TEST_DATA_ATTRIBUTES = {
     "annotation": {
         "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='TeX' style='display: inline-block;'>\\text{{two}}</annotation></semantics></math>",
-        "tag": "annotation"
     },
     "annotation-xml": {
         "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='MathML-Presentation' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
-        "tag": "annotation-xml"
     },
     "maction": {
         "html": "<math><maction id='test' actiontype='toggle'><mn>1</mn><mn>2</mn></maction></math>",
-        "tag": "maction"
     },
     "math": {
         "html": "<math id='test'><mn>1</mn></math>",
-        "tag": "math"
     },
     "merror": {
         "html": "<math><merror id='test'><mtext>Divide by zero</mtext></merror></math>",
-        "tag": "merror"
     },
     "mfrac": {
         "html": "<math><mfrac id='test'><mn id='num'>1</mn><mn id='den'>2</mn></mfrac></math>",
-        "tag": "mfrac",
-        "ax_attrs": {"AXMathFractionNumerator": "num", "AXMathFractionDenominator": "den"}
+        "axapi": {"AXMathFractionNumerator": "num", "AXMathFractionDenominator": "den"}
     },
     "mi": {
         "html": "<math><mi id='test'>x</mi></math>",
-        "tag": "mi"
     },
     # mmultiscripts object reference tested in mathml-aam/aamtests/attribute/mmultiscripts.py
     "mmultiscripts": {
         "html": "<math><mmultiscripts id='test'><mi id='base'>X</mi><mn id='sub'>1</mn><mn id='sup'>2</mn><mprescripts/><mn id='presub'>3</mn><mn id='presup'>4</mn></mmultiscripts></math>",
-        "tag": "mmultiscripts"
     },
     "mn": {
         "html": "<math><mn id='test'>2</mn></math>",
-        "tag": "mn"
     },
     "mo": {
         "html": "<math><mo id='test'>+</mo></math>",
-        "tag": "mo"
     },
     "mover": {
         "html": "<math><mover id='test'><mi id='base'>a</mi><mo id='over'>˙</mo></mover></math>",
-        "tag": "mover",
-        "ax_attrs": {"AXMathBase": "base", "AXMathOver": "over"}
+        "axapi": {"AXMathBase": "base", "AXMathOver": "over"}
     },
     "mpadded": {
         "html": "<math><mpadded id='test' width='+10px'><mn>1</mn></mpadded></math>",
-        "tag": "mpadded"
     },
     "mphantom": {
         "html": "<math><mphantom style='visibility: visible;' id='test'><mn>1</mn></mphantom></math>",
-        "tag": "mphantom"
     },
     "mprescripts": {
         "html": "<math><mmultiscripts><mi>X</mi><mn>1</mn><mn>2</mn><mprescripts id='test'/><mn>3</mn><mn>4</mn></mmultiscripts></math>"
     },
     "mroot": {
         "html": "<math><mroot id='test'><mi id='rad'>x</mi><mn id='idx'>3</mn></mroot></math>",
-        "tag": "mroot",
-        "ax_attrs": {"AXMathRootRadicand": "rad", "AXMathRootIndex": "idx"}
+        "axapi": {"AXMathRootRadicand": "rad", "AXMathRootIndex": "idx"}
     },
     "mrow": {
         "html": "<math><mrow id='test'><mn>1</mn><mo>+</mo><mn>1</mn></mrow></math>",
-        "tag": "mrow"
     },
     "ms": {
         "html": "<math><ms id='test'>string</ms></math>",
-        "tag": "ms"
     },
     "mspace": {
         "html": "<math><mspace id='test' width='2em'/></math>"
     },
     "msqrt": {
         "html": "<math><msqrt id='test'><mi id='rad1'>x</mi></msqrt></math>",
-        "tag": "msqrt",
-        "ax_attrs": {"AXMathRootRadicand": "rad1"}
+        "axapi": {"AXMathRootRadicand": "rad1"}
     },
     "mstyle": {
         "html": "<math><mstyle id='test' mathcolor='blue'><mn>1</mn></mstyle></math>",
-        "tag": "mstyle"
     },
     "msub": {
         "html": "<math><msub id='test'><mi id='base'>x</mi><mn id='sub'>1</mn></msub></math>",
-        "tag": "msub",
-        "ax_attrs": {"AXMathBase": "base", "AXMathSubscript": "sub"}
+        "axapi": {"AXMathBase": "base", "AXMathSubscript": "sub"}
     },
     "msubsup": {
         "html": "<math><msubsup id='test'><mi id='base'>x</mi><mn id='sub'>1</mn><mn id='sup'>2</mn></msubsup></math>",
-        "tag": "msubsup",
-        "ax_attrs": {"AXMathBase": "base", "AXMathSubscript": "sub", "AXMathSuperscript": "sup"}
+        "axapi": {"AXMathBase": "base", "AXMathSubscript": "sub", "AXMathSuperscript": "sup"}
     },
     "msup": {
         "html": "<math><msup id='test'><mi id='base'>x</mi><mn id='sup'>2</mn></msup></math>",
-        "tag": "msup",
-        "ax_attrs": {"AXMathBase": "base", "AXMathSuperscript": "sup"}
+        "axapi": {"AXMathBase": "base", "AXMathSuperscript": "sup"}
     },
     "mtable": {
         "html": "<math><mtable id='test'><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>",
-        "tag": "mtable",
-        "interface": "AtkTable"
+        "atspi": {"interface": "AtkTable"}
     },
     "mtd": {
         "html": "<math><mtable><mtr><mtd id='test'><mn>1</mn></mtd></mtr></mtable></math>",
-        "tag": "mtd",
-        "interface": "AtkTableCell"
+        "atspi": {"interface": "AtkTableCell"}
     },
     "mtext": {
         "html": "<math><mtext id='test'>hello</mtext></math>",
-        "tag": "mtext"
     },
     "mtr": {
         "html": "<math><mtable><mtr id='test'><mtd><mn>1</mn></mtd></mtr></mtable></math>",
-        "tag": "mtr"
     },
     "munder": {
         "html": "<math><munder id='test'><mi id='base'>x</mi><mo id='under'>_</mo></munder></math>",
-        "tag": "munder",
-        "ax_attrs": {"AXMathBase": "base", "AXMathUnder": "under"}
+        "axapi": {"AXMathBase": "base", "AXMathUnder": "under"}
     },
     "munderover": {
         "html": "<math><munderover id='test'><mi id='base'>x</mi><mo id='under'>_</mo><mo id='over'>˙</mo></munderover></math>",
-        "tag": "munderover",
-        "ax_attrs": {"AXMathBase": "base", "AXMathUnder": "under", "AXMathOver": "over"}
+        "axapi": {"AXMathBase": "base", "AXMathUnder": "under", "AXMathOver": "over"}
     },
     "none": {
         "html": "<math><mmultiscripts><mi>X</mi><mn>1</mn><none id='test'/></mmultiscripts></math>"
     },
     "semantics": {
         "html": "<math><semantics id='test'><mn>5</mn><annotation encoding='TeX'>5</annotation></semantics></math>",
-        "tag": "semantics"
     }
 }
 
@@ -143,21 +115,23 @@ def test_atspi(atspi, session, inline, element_name):
     session.url = inline(data["html"])
     node = atspi.find_node("test", session.url)
 
-    if "tag" in data:
-        obj_attrs = atspi.Accessible.get_attributes(node)
-        assert "tag" in obj_attrs, f"<{element_name}> object attributes missing 'tag' key. Found: {obj_attrs}"
-        assert obj_attrs["tag"] == data["tag"], f"Expected tag '{data['tag']}', got '{obj_attrs['tag']}'"
+    obj_attrs = atspi.Accessible.get_attributes(node)
+    assert "tag" in obj_attrs, f"<{element_name}> object attributes missing 'tag' key. Found: {obj_attrs}"
+    assert obj_attrs["tag"] == element_name, f"Expected tag '{element_name}', got '{obj_attrs['tag']}'"
 
-    if "interface" in data:
-        if data["interface"] == "AtkTable":
+    atspi_config = data.get("atspi", {})
+    interface_name = atspi_config.get("interface")
+
+    if interface_name:
+        if interface_name == "AtkTable":
             table_iface = atspi.Accessible.get_table_iface(node)
-            assert table_iface is not None, "mtable node must implement AtkTable interface"
-        elif data["interface"] == "AtkTableCell":
+            assert table_iface is not None, f"{element_name} node must implement AtkTable interface"
+        elif interface_name == "AtkTableCell":
             cell_iface = atspi.Accessible.get_table_cell(node)
-            assert cell_iface is not None, "mtd node must implement AtkTableCell interface"
+            assert cell_iface is not None, f"{element_name} node must implement AtkTableCell interface"
 
 
-AX_ATTR_CASES = [name for name, d in TEST_DATA_ATTRIBUTES.items() if "ax_attrs" in d]
+AX_ATTR_CASES = [name for name, d in TEST_DATA_ATTRIBUTES.items() if "axapi" in d]
 
 @pytest.mark.parametrize("element_name", AX_ATTR_CASES)
 def test_axapi(axapi, session, inline, element_name):
@@ -165,7 +139,7 @@ def test_axapi(axapi, session, inline, element_name):
     session.url = inline(data["html"])
     node = axapi.find_node("test", session.url)
 
-    expected_relationships = data["ax_attrs"]
+    expected_relationships = data["axapi"]
     
     for ax_attr_key, expected_dom_id in expected_relationships.items():
         attr_res = axapi.AXUIElementCopyAttributeValue(node, ax_attr_key, None)

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -3,10 +3,10 @@ import pytest
 
 TEST_DATA_ATTRIBUTES = {
     "annotation": {
-        "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='TeX' style='display: inline-block;'>\\text{two}</annotation></semantics></math>",
+        "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='application/x-tex' style='display: inline-block;'>\\text{two}</annotation></semantics></math>",
     },
     "annotation-xml": {
-        "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='MathML-Presentation' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
+        "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='application/mathml-content+xml' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
     },
     "maction": {
         "html": "<math><maction id='test' actiontype='toggle'><mn>1</mn><mn>2</mn></maction></math>",
@@ -105,7 +105,7 @@ TEST_DATA_ATTRIBUTES = {
         "html": "<math><mmultiscripts><mi>X</mi><mn>1</mn><none id='test'/></mmultiscripts></math>"
     },
     "semantics": {
-        "html": "<math><semantics id='test'><mn>5</mn><annotation encoding='TeX'>5</annotation></semantics></math>",
+        "html": "<math><semantics id='test'><mn>5</mn><annotation encoding='application/x-tex'>5</annotation></semantics></math>",
     }
 }
 
@@ -136,12 +136,12 @@ def test_axapi(axapi, session, inline, element_name):
     node = axapi.find_node("test", session.url)
 
     expected_relationships = data["axapi"]
-    
+
     for ax_attr_key, expected_dom_id in expected_relationships.items():
         attr_res = axapi.AXUIElementCopyAttributeValue(node, ax_attr_key, None)
         target_node = attr_res[1] if (attr_res and len(attr_res) > 1) else None
-        
+
         assert target_node is not None, f"Relationship attribute '{ax_attr_key}' on <{element_name}> returned None."
-        
+
         actual_dom_id = axapi.AXUIElementCopyAttributeValue(target_node, "AXDOMIdentifier", None)[1]
         assert actual_dom_id == expected_dom_id, f"Pointer '{ax_attr_key}' expected to target id '{expected_dom_id}', but got '{actual_dom_id}'"

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -2,6 +2,9 @@
 import pytest
 
 TEST_DATA_ATTRIBUTES = {
+    "a": {
+        "html": """<math><a href="https://kuaishou.com" id="test"><mtext>Link</mtext></a></math>""",
+    },
     "annotation": {
         "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='application/x-tex' style='display: inline-block;'>\\text{two}</annotation></semantics></math>",
     },

--- a/mathml-aam/aamtests/attribute/mathml-attributes.py
+++ b/mathml-aam/aamtests/attribute/mathml-attributes.py
@@ -2,25 +2,88 @@
 import pytest
 
 TEST_DATA_ATTRIBUTES = {
+    "annotation": {
+        "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='TeX' style='display: inline-block;'>\\text{{two}}</annotation></semantics></math>",
+        "tag": "annotation"
+    },
+    "annotation-xml": {
+        "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='MathML-Presentation' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
+        "tag": "annotation-xml"
+    },
+    "maction": {
+        "html": "<math><maction id='test' actiontype='toggle'><mn>1</mn><mn>2</mn></maction></math>",
+        "tag": "maction"
+    },
+    "math": {
+        "html": "<math id='test'><mn>1</mn></math>",
+        "tag": "math"
+    },
+    "merror": {
+        "html": "<math><merror id='test'><mtext>Divide by zero</mtext></merror></math>",
+        "tag": "merror"
+    },
     "mfrac": {
         "html": "<math><mfrac id='test'><mn id='num'>1</mn><mn id='den'>2</mn></mfrac></math>",
         "tag": "mfrac",
         "ax_attrs": {"AXMathFractionNumerator": "num", "AXMathFractionDenominator": "den"}
+    },
+    "mi": {
+        "html": "<math><mi id='test'>x</mi></math>",
+        "tag": "mi"
+    },
+    # mmultiscripts object reference tested in mathml-aam/aamtests/attribute/mmultiscripts.py
+    "mmultiscripts": {
+        "html": "<math><mmultiscripts id='test'><mi id='base'>X</mi><mn id='sub'>1</mn><mn id='sup'>2</mn><mprescripts/><mn id='presub'>3</mn><mn id='presup'>4</mn></mmultiscripts></math>",
+        "tag": "mmultiscripts"
+    },
+    "mn": {
+        "html": "<math><mn id='test'>2</mn></math>",
+        "tag": "mn"
+    },
+    "mo": {
+        "html": "<math><mo id='test'>+</mo></math>",
+        "tag": "mo"
     },
     "mover": {
         "html": "<math><mover id='test'><mi id='base'>a</mi><mo id='over'>˙</mo></mover></math>",
         "tag": "mover",
         "ax_attrs": {"AXMathBase": "base", "AXMathOver": "over"}
     },
+    "mpadded": {
+        "html": "<math><mpadded id='test' width='+10px'><mn>1</mn></mpadded></math>",
+        "tag": "mpadded"
+    },
+    "mphantom": {
+        "html": "<math><mphantom style='visibility: visible;' id='test'><mn>1</mn></mphantom></math>",
+        "tag": "mphantom"
+    },
+    "mprescripts": {
+        "html": "<math><mmultiscripts><mi>X</mi><mn>1</mn><mn>2</mn><mprescripts id='test'/><mn>3</mn><mn>4</mn></mmultiscripts></math>"
+    },
     "mroot": {
         "html": "<math><mroot id='test'><mi id='rad'>x</mi><mn id='idx'>3</mn></mroot></math>",
         "tag": "mroot",
         "ax_attrs": {"AXMathRootRadicand": "rad", "AXMathRootIndex": "idx"}
     },
+    "mrow": {
+        "html": "<math><mrow id='test'><mn>1</mn><mo>+</mo><mn>1</mn></mrow></math>",
+        "tag": "mrow"
+    },
+    "ms": {
+        "html": "<math><ms id='test'>string</ms></math>",
+        "tag": "ms"
+    },
+    "mspace": {
+        "html": "<math><mspace id='test' width='2em'/></math>"
+    },
     "msqrt": {
         "html": "<math><msqrt id='test'><mi id='rad1'>x</mi></msqrt></math>",
         "tag": "msqrt",
         "ax_attrs": {"AXMathRootRadicand": "rad1"}
+    },
+    "mstyle": {
+        "html": "<math><mstyle id='test' mathcolor='blue'><mn>1</mn></mstyle></math>",
+        "tag": "mstyle"
     },
     "msub": {
         "html": "<math><msub id='test'><mi id='base'>x</mi><mn id='sub'>1</mn></msub></math>",
@@ -47,6 +110,14 @@ TEST_DATA_ATTRIBUTES = {
         "tag": "mtd",
         "interface": "AtkTableCell"
     },
+    "mtext": {
+        "html": "<math><mtext id='test'>hello</mtext></math>",
+        "tag": "mtext"
+    },
+    "mtr": {
+        "html": "<math><mtable><mtr id='test'><mtd><mn>1</mn></mtd></mtr></mtable></math>",
+        "tag": "mtr"
+    },
     "munder": {
         "html": "<math><munder id='test'><mi id='base'>x</mi><mo id='under'>_</mo></munder></math>",
         "tag": "munder",
@@ -57,9 +128,12 @@ TEST_DATA_ATTRIBUTES = {
         "tag": "munderover",
         "ax_attrs": {"AXMathBase": "base", "AXMathUnder": "under", "AXMathOver": "over"}
     },
-    "mn": {
-        "html": "<math><mn id='test'>2</mn></math>",
-        "tag": "mn",
+    "none": {
+        "html": "<math><mmultiscripts><mi>X</mi><mn>1</mn><none id='test'/></mmultiscripts></math>"
+    },
+    "semantics": {
+        "html": "<math><semantics id='test'><mn>5</mn><annotation encoding='TeX'>5</annotation></semantics></math>",
+        "tag": "semantics"
     }
 }
 

--- a/mathml-aam/aamtests/attribute/mmultiscripts.py
+++ b/mathml-aam/aamtests/attribute/mmultiscripts.py
@@ -69,11 +69,3 @@ def test_ia2(ia2, session, inline):
 
     node = ia2.find_node("test", session.url)
     assert ia2.get_msaa_role(node) == "ROLE_SYSTEM_GROUPING"
-
-
-# def test_uia(uia, session, inline):
-#     session.url = inline(TEST_HTML)
-#     node = uia.find_node("test", session.url)
-#
-#     # Spec:
-#     # Control Type: Group (TBD)

--- a/mathml-aam/aamtests/attribute/mmultiscripts.py
+++ b/mathml-aam/aamtests/attribute/mmultiscripts.py
@@ -13,19 +13,6 @@ TEST_HTML = (
     "</math>"
 )
 
-def test_atspi(atspi, session, inline):
-    session.url = inline(TEST_HTML)
-
-    # Spec:
-    # Role: ATK_ROLE_SECTION
-    # Object Attribute: tag:mmultiscripts
-
-    node = atspi.find_node("test", session.url)
-    assert atspi.Accessible.get_role(node) == atspi.Role.SECTION
-
-    obj_attrs = atspi.Accessible.get_attributes(node)
-    assert obj_attrs.get("tag") == "mmultiscripts"
-
 
 def test_axapi(axapi, session, inline):
     session.url = inline(TEST_HTML)
@@ -59,13 +46,3 @@ def test_axapi(axapi, session, inline):
     assert axapi.AXUIElementCopyAttributeValue(presub_node, "AXDOMIdentifier", None)[1] == "presub"
     assert axapi.AXUIElementCopyAttributeValue(presup_node, "AXDOMIdentifier", None)[1] == "presup"
 
-
-def test_ia2(ia2, session, inline):
-    session.url = inline(TEST_HTML)
-
-    # Spec:
-    # Role: TBD
-    # Role: TBD
-
-    node = ia2.find_node("test", session.url)
-    assert ia2.get_msaa_role(node) == "ROLE_SYSTEM_GROUPING"

--- a/mathml-aam/aamtests/attribute/mmultiscripts.py
+++ b/mathml-aam/aamtests/attribute/mmultiscripts.py
@@ -1,0 +1,79 @@
+# Testing: https://w3c.github.io/mathml-aam/#mmultiscripts
+
+TEST_HTML = (
+    "<math>"
+    "  <mmultiscripts id='test'>"
+    "    <mi id='base'>X</mi>"
+    "    <mn id='sub'>1</mn>"
+    "    <mn id='sup'>2</mn>"
+    "    <mprescripts/>"
+    "    <mn id='presub'>3</mn>"
+    "    <mn id='presup'>4</mn>"
+    "  </mmultiscripts>"
+    "</math>"
+)
+
+def test_atspi(atspi, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Role: ATK_ROLE_SECTION
+    # Object Attribute: tag:mmultiscripts
+
+    node = atspi.find_node("test", session.url)
+    assert atspi.Accessible.get_role(node) == atspi.Role.SECTION
+    
+    obj_attrs = atspi.Accessible.get_attributes(node)
+    assert obj_attrs.get("tag") == "mmultiscripts"
+
+
+def test_axapi(axapi, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # AXRole: NSAccessibilityGroupRole
+    # AXSubrole: AXMathMultiscript
+    # AXAttributes: AXMathPostscripts, AXMathPrescripts
+
+    node = axapi.find_node("test", session.url)
+    
+    role = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)[1]
+    assert role == "AXGroup"
+    
+    subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
+    assert subrole == "AXMathMultiscript"
+
+    postscripts = axapi.AXUIElementCopyAttributeValue(node, "AXMathPostscripts", None)[1]
+    post_pair = postscripts[0]
+    
+    sub_node = post_pair.get("AXMathSubscript")
+    sup_node = post_pair.get("AXMathSuperscript")
+    assert axapi.AXUIElementCopyAttributeValue(sub_node, "AXDOMIdentifier", None)[1] == "sub"
+    assert axapi.AXUIElementCopyAttributeValue(sup_node, "AXDOMIdentifier", None)[1] == "sup"
+
+    prescripts = axapi.AXUIElementCopyAttributeValue(node, "AXMathPrescripts", None)[1]
+    pre_pair = prescripts[0]
+    
+    presub_node = pre_pair.get("AXMathSubscript")
+    presup_node = pre_pair.get("AXMathSuperscript")
+    assert axapi.AXUIElementCopyAttributeValue(presub_node, "AXDOMIdentifier", None)[1] == "presub"
+    assert axapi.AXUIElementCopyAttributeValue(presup_node, "AXDOMIdentifier", None)[1] == "presup"
+
+
+def test_ia2(ia2, session, inline):
+    session.url = inline(TEST_HTML)
+
+    # Spec:
+    # Role: ROLE_SYSTEM_GROUPING (MSAA)
+    # Role: IA2_ROLE_UNKNOWN
+
+    node = ia2.find_node("test", session.url)
+    assert ia2.get_msaa_role(node) == "ROLE_SYSTEM_GROUPING"
+
+
+# def test_uia(uia, session, inline):
+#     session.url = inline(TEST_HTML)
+#     node = uia.find_node("test", session.url)
+#
+#     # Spec:
+#     # Control Type: Group (TBD)

--- a/mathml-aam/aamtests/attribute/mmultiscripts.py
+++ b/mathml-aam/aamtests/attribute/mmultiscripts.py
@@ -22,7 +22,7 @@ def test_atspi(atspi, session, inline):
 
     node = atspi.find_node("test", session.url)
     assert atspi.Accessible.get_role(node) == atspi.Role.SECTION
-    
+
     obj_attrs = atspi.Accessible.get_attributes(node)
     assert obj_attrs.get("tag") == "mmultiscripts"
 
@@ -36,16 +36,16 @@ def test_axapi(axapi, session, inline):
     # AXAttributes: AXMathPostscripts, AXMathPrescripts
 
     node = axapi.find_node("test", session.url)
-    
+
     role = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)[1]
     assert role == "AXGroup"
-    
+
     subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
     assert subrole == "AXMathMultiscript"
 
     postscripts = axapi.AXUIElementCopyAttributeValue(node, "AXMathPostscripts", None)[1]
     post_pair = postscripts[0]
-    
+
     sub_node = post_pair.get("AXMathSubscript")
     sup_node = post_pair.get("AXMathSuperscript")
     assert axapi.AXUIElementCopyAttributeValue(sub_node, "AXDOMIdentifier", None)[1] == "sub"
@@ -53,7 +53,7 @@ def test_axapi(axapi, session, inline):
 
     prescripts = axapi.AXUIElementCopyAttributeValue(node, "AXMathPrescripts", None)[1]
     pre_pair = prescripts[0]
-    
+
     presub_node = pre_pair.get("AXMathSubscript")
     presup_node = pre_pair.get("AXMathSuperscript")
     assert axapi.AXUIElementCopyAttributeValue(presub_node, "AXDOMIdentifier", None)[1] == "presub"

--- a/mathml-aam/aamtests/attribute/mmultiscripts.py
+++ b/mathml-aam/aamtests/attribute/mmultiscripts.py
@@ -64,8 +64,8 @@ def test_ia2(ia2, session, inline):
     session.url = inline(TEST_HTML)
 
     # Spec:
-    # Role: ROLE_SYSTEM_GROUPING (MSAA)
-    # Role: IA2_ROLE_UNKNOWN
+    # Role: TBD
+    # Role: TBD
 
     node = ia2.find_node("test", session.url)
     assert ia2.get_msaa_role(node) == "ROLE_SYSTEM_GROUPING"

--- a/mathml-aam/aamtests/conftest.py
+++ b/mathml-aam/aamtests/conftest.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+# Add webdriver to the Python path so we can import the fixtures
+webdriver_tests_path = Path(__file__).parent.parent.parent / "webdriver"
+sys.path.insert(0, str(webdriver_tests_path))
+
+pytest_plugins = (
+    "tests.support.fixtures",
+    "tests.support.classic.fixtures",
+    "core-aam.aamtests.support.fixtures_a11y_api",
+)

--- a/mathml-aam/aamtests/role/link.py
+++ b/mathml-aam/aamtests/role/link.py
@@ -1,0 +1,47 @@
+import pytest
+
+TEST_CASES = {
+    "mathml-link": '<math><a href="https://baidu.com" id="test"><mtext>Link</mtext></a></math>',
+    "mathml-link-withou-href": '<math><a id="test"><mtext>Link</mtext></a></math>',
+}
+
+@pytest.mark.parametrize("test_id, test_html", TEST_CASES.items(), ids=TEST_CASES.keys())
+class TestMathMLALink:
+
+    def test_atspi(self, atspi, session, inline, test_id, test_html):
+        session.url = inline(test_html)
+        
+        node = atspi.find_node("test", session.url)
+        has_href = "href" in test_html
+        if has_href:
+            assert atspi.Accessible.get_role(node) == atspi.Role.LINK
+            hyperlink = atspi.Accessible.get_hyperlink(node)
+            assert hyperlink is not None, "hyperlink interface should be present for link role"
+            link = hyperlink.get_uri(0)
+            assert link == "https://baidu.com/"
+        else:
+            assert atspi.Accessible.get_role(node) == atspi.Role.SECTION
+
+    def test_axapi(self, axapi, session, inline, test_id, test_html):
+        session.url = inline(test_html)
+        node = axapi.find_node("test", session.url)
+
+        role = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)[1]
+        
+        if test_id == "mathml-link":
+            assert role == "AXLink"
+        else:
+            assert role != "AXLink"
+
+    def test_ia2(self, ia2, session, inline, test_id, test_html):
+        session.url = inline(test_html)
+        node = ia2.find_node("test", session.url)
+
+        if test_id == "mathml-link":
+            assert ia2.get_role(node) == "ROLE_SYSTEM_LINK"
+            assert ia2.get_hyperlink_interface(node) is not None
+            msaa_state = ia2.get_msaa_state_list(node)
+            assert "LINKED" in msaa_state
+        else:
+            assert ia2.get_role(node) != "ROLE_SYSTEM_LINK"
+            assert ia2.get_hyperlink_interface(node) is None

--- a/mathml-aam/aamtests/role/link.py
+++ b/mathml-aam/aamtests/role/link.py
@@ -47,17 +47,18 @@ class TestMathMLALink:
 
         role = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)[1]
         
+        subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
+
         if test_id == "mathml-link":
             assert role == "AXLink"
+            assert subrole == "AXMathRow"
             
         elif test_id == "mathml-link-with-onclick":
             assert role == "AXLink"
+            assert subrole == "AXMathRow"
             
         elif test_id == "mathml-link-without-href":
             assert role == "AXGroup"
-            subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
-            assert subrole == "AXMathRow"
-            
         else:
             raise ValueError(f"Unreachable code: missing AXAPI assertions for {test_id}")
 

--- a/mathml-aam/aamtests/role/link.py
+++ b/mathml-aam/aamtests/role/link.py
@@ -61,26 +61,3 @@ class TestMathMLALink:
             assert role == "AXGroup"
         else:
             raise ValueError(f"Unreachable code: missing AXAPI assertions for {test_id}")
-
-    def test_ia2(self, ia2, session, inline, test_id, test_html):
-        session.url = inline(test_html)
-        node = ia2.find_node("test", session.url)
-
-        if test_id == "mathml-link":
-            assert ia2.get_role(node) == "ROLE_SYSTEM_LINK"
-            assert ia2.get_hyperlink_interface(node) is not None
-            msaa_state = ia2.get_msaa_state_list(node)
-            assert "LINKED" in msaa_state
-
-        elif test_id == "mathml-link-with-onclick":
-            assert ia2.get_role(node) == "ROLE_SYSTEM_LINK"
-
-        elif test_id == "mathml-link-without-href":
-            # Note: We use IA2_ROLE_SECTION here as a fallback because the strict
-            # mapping for an href-less mathml:a element is TBD in the IA2 section of MathML-AAM.
-            # See: https://w3c.github.io/mathml-aam/#el-a
-            assert ia2.get_role(node) == "IA2_ROLE_SECTION"
-            assert ia2.get_hyperlink_interface(node) is None
-
-        else:
-            raise ValueError(f"Unreachable code: missing IA2 assertions for {test_id}")

--- a/mathml-aam/aamtests/role/link.py
+++ b/mathml-aam/aamtests/role/link.py
@@ -2,7 +2,7 @@ import pytest
 
 TEST_CASES = {
     "mathml-link": '<math><a href="https://baidu.com" id="test"><mtext>Link</mtext></a></math>',
-    "mathml-link-withou-href": '<math><a id="test"><mtext>Link</mtext></a></math>',
+    "mathml-link-without-href": '<math><a id="test"><mtext>Link</mtext></a></math>',
 }
 
 @pytest.mark.parametrize("test_id, test_html", TEST_CASES.items(), ids=TEST_CASES.keys())

--- a/mathml-aam/aamtests/role/link.py
+++ b/mathml-aam/aamtests/role/link.py
@@ -21,7 +21,7 @@ class TestMathMLALink:
     def test_atspi(self, atspi, session, inline, test_id, test_html):
         session.url = inline(test_html)
         node = atspi.find_node("test", session.url)
-        
+
         obj_attrs = atspi.Accessible.get_attributes(node)
         assert obj_attrs.get("tag") == "a"
 
@@ -30,14 +30,14 @@ class TestMathMLALink:
             hyperlink = atspi.Accessible.get_hyperlink(node)
             assert hyperlink is not None, "hyperlink interface should be present for link role"
             assert hyperlink.get_uri(0) == "https://baidu.com/"
-            
+
         elif test_id == "mathml-link-with-onclick":
             role = atspi.Accessible.get_role(node)
             assert role == atspi.Role.LINK
-            
+
         elif test_id == "mathml-link-without-href":
             assert atspi.Accessible.get_role(node) == atspi.Role.SECTION
-            
+
         else:
             raise ValueError(f"Unreachable code: missing ATSPI assertions for {test_id}")
 
@@ -46,17 +46,17 @@ class TestMathMLALink:
         node = axapi.find_node("test", session.url)
 
         role = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)[1]
-        
+
         subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
 
         if test_id == "mathml-link":
             assert role == "AXLink"
             assert subrole == "AXMathRow"
-            
+
         elif test_id == "mathml-link-with-onclick":
             assert role == "AXLink"
             assert subrole == "AXMathRow"
-            
+
         elif test_id == "mathml-link-without-href":
             assert role == "AXGroup"
         else:
@@ -71,16 +71,16 @@ class TestMathMLALink:
             assert ia2.get_hyperlink_interface(node) is not None
             msaa_state = ia2.get_msaa_state_list(node)
             assert "LINKED" in msaa_state
-            
+
         elif test_id == "mathml-link-with-onclick":
             assert ia2.get_role(node) == "ROLE_SYSTEM_LINK"
-            
+
         elif test_id == "mathml-link-without-href":
-            # Note: We use IA2_ROLE_SECTION here as a fallback because the strict 
+            # Note: We use IA2_ROLE_SECTION here as a fallback because the strict
             # mapping for an href-less mathml:a element is TBD in the IA2 section of MathML-AAM.
             # See: https://w3c.github.io/mathml-aam/#el-a
             assert ia2.get_role(node) == "IA2_ROLE_SECTION"
             assert ia2.get_hyperlink_interface(node) is None
-            
+
         else:
             raise ValueError(f"Unreachable code: missing IA2 assertions for {test_id}")

--- a/mathml-aam/aamtests/role/link.py
+++ b/mathml-aam/aamtests/role/link.py
@@ -1,8 +1,18 @@
 import pytest
 
+# Testing: https://w3c.github.io/mathml-aam/#ma-element
 TEST_CASES = {
-    "mathml-link": '<math><a href="https://baidu.com" id="test"><mtext>Link</mtext></a></math>',
-    "mathml-link-without-href": '<math><a id="test"><mtext>Link</mtext></a></math>',
+    "mathml-link": (
+        '<math><a href="https://baidu.com" id="test"><mtext>Link</mtext></a></math>'
+    ),
+    "mathml-link-without-href": (
+        '<math><a id="test"><mtext>Link</mtext></a></math>'
+    ),
+    # Browser heuristic behavior: treats 'a' as a Link if it has mouse event listeners
+    # Spec issue: https://github.com/w3c/mathml-aam/issues/39
+    "mathml-link-with-onclick": (
+        '<math><a id="test" onclick="void(0)"><mtext>Link</mtext></a></math>'
+    ),
 }
 
 @pytest.mark.parametrize("test_id, test_html", TEST_CASES.items(), ids=TEST_CASES.keys())
@@ -10,17 +20,26 @@ class TestMathMLALink:
 
     def test_atspi(self, atspi, session, inline, test_id, test_html):
         session.url = inline(test_html)
-        
         node = atspi.find_node("test", session.url)
-        has_href = "href" in test_html
-        if has_href:
+        
+        obj_attrs = atspi.Accessible.get_attributes(node)
+        assert obj_attrs.get("tag") == "a"
+
+        if test_id == "mathml-link":
             assert atspi.Accessible.get_role(node) == atspi.Role.LINK
             hyperlink = atspi.Accessible.get_hyperlink(node)
             assert hyperlink is not None, "hyperlink interface should be present for link role"
-            link = hyperlink.get_uri(0)
-            assert link == "https://baidu.com/"
-        else:
+            assert hyperlink.get_uri(0) == "https://baidu.com/"
+            
+        elif test_id == "mathml-link-with-onclick":
+            role = atspi.Accessible.get_role(node)
+            assert role == atspi.Role.LINK
+            
+        elif test_id == "mathml-link-without-href":
             assert atspi.Accessible.get_role(node) == atspi.Role.SECTION
+            
+        else:
+            raise ValueError(f"Unreachable code: missing ATSPI assertions for {test_id}")
 
     def test_axapi(self, axapi, session, inline, test_id, test_html):
         session.url = inline(test_html)
@@ -30,8 +49,17 @@ class TestMathMLALink:
         
         if test_id == "mathml-link":
             assert role == "AXLink"
+            
+        elif test_id == "mathml-link-with-onclick":
+            assert role == "AXLink"
+            
+        elif test_id == "mathml-link-without-href":
+            assert role == "AXGroup"
+            subrole = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)[1]
+            assert subrole == "AXMathRow"
+            
         else:
-            assert role != "AXLink"
+            raise ValueError(f"Unreachable code: missing AXAPI assertions for {test_id}")
 
     def test_ia2(self, ia2, session, inline, test_id, test_html):
         session.url = inline(test_html)
@@ -42,6 +70,16 @@ class TestMathMLALink:
             assert ia2.get_hyperlink_interface(node) is not None
             msaa_state = ia2.get_msaa_state_list(node)
             assert "LINKED" in msaa_state
-        else:
-            assert ia2.get_role(node) != "ROLE_SYSTEM_LINK"
+            
+        elif test_id == "mathml-link-with-onclick":
+            assert ia2.get_role(node) == "ROLE_SYSTEM_LINK"
+            
+        elif test_id == "mathml-link-without-href":
+            # Note: We use IA2_ROLE_SECTION here as a fallback because the strict 
+            # mapping for an href-less mathml:a element is TBD in the IA2 section of MathML-AAM.
+            # See: https://w3c.github.io/mathml-aam/#el-a
+            assert ia2.get_role(node) == "IA2_ROLE_SECTION"
             assert ia2.get_hyperlink_interface(node) is None
+            
+        else:
+            raise ValueError(f"Unreachable code: missing IA2 assertions for {test_id}")

--- a/mathml-aam/aamtests/role/mathml-role.py
+++ b/mathml-aam/aamtests/role/mathml-role.py
@@ -5,13 +5,13 @@ import pytest
 # See https://github.com/w3c/mathml-aam/issues/41
 TEST_DATA = {
     "annotation": {
-        "html": "<math><annotation id='test'>XML</annotation></math>",
+        "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='application/x-tex' style='display: inline-block;'>\\text{two}</annotation></semantics></math>",
         "atspi_role": "ROLE_STATIC",
         "axapi_role": "NSAccessibilityGroupRole",
         "axapi_subrole": "AXMathText" # Not mapped, match chrome
     },
     "annotation-xml": {
-        "html": "<math><annotation-xml id='test'>XML</annotation-xml></math>",
+        "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='application/mathml-content+xml' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
         "atspi_role": "ROLE_SECTION",
         "axapi_role": "NSAccessibilityGroupRole",
         "axapi_subrole": "AXMathRow" # Not mapped, match chrome
@@ -85,7 +85,7 @@ TEST_DATA = {
     "mprescripts": {
         "html": "<math><mmultiscripts><mi>X</mi><mprescripts id='test'/></mmultiscripts></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole", # Not mapped, match chrome 
+        "axapi_role": "NSAccessibilityGroupRole", # Not mapped, match chrome
         "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     },
     "mroot": {
@@ -195,7 +195,7 @@ TEST_DATA = {
 @pytest.mark.parametrize("element_name", TEST_DATA.keys())
 def test_atspi(atspi, session, inline, element_name):
     data = TEST_DATA[element_name]
-    
+
     session.url = inline(data["html"])
     node = atspi.find_node("test", session.url)
 
@@ -224,5 +224,5 @@ def test_axapi(axapi, session, inline, element_name):
 
     subrole_result = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)
     actual_subrole = subrole_result[1] if (subrole_result and len(subrole_result) > 1) else None
-  
+
     assert actual_subrole == data["axapi_subrole"], f"AXSubrole mismatch for <{element_name}>. Expected '{data['axapi_subrole']}', got '{actual_subrole}'"

--- a/mathml-aam/aamtests/role/mathml-role.py
+++ b/mathml-aam/aamtests/role/mathml-role.py
@@ -1,192 +1,194 @@
 import pytest
 
 # Testing MathML Core AAM Mappings: https://w3c.github.io/mathml-aam/#mathml-element-mappings
+# FIXME: For role that is not mapped, TBD and nil, we match the chrome behavior for now
+# See https://github.com/w3c/mathml-aam/issues/41
 TEST_DATA = {
     "annotation": {
         "html": "<math><annotation id='test'>XML</annotation></math>",
-        "atk_role": "ATK_ROLE_STATIC",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathText" # Not mapped, match chrome
+        "atspi_role": "ROLE_STATIC",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathText" # Not mapped, match chrome
     },
     "annotation-xml": {
         "html": "<math><annotation-xml id='test'>XML</annotation-xml></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     },
     "maction": {
         "html": "<math><maction id='test' actiontype='toggle'><mi>A</mi></maction></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     },
     "math": {
         "html": "<math id='test'><mi>x</mi></math>",
-        "atk_role": "ATK_ROLE_MATH",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXDocumentMath"
+        "atspi_role": "ROLE_MATH",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXDocumentMath"
     },
     "merror": {
         "html": "<math><merror id='test'><mtext>error</mtext></merror></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow"
     },
     "mfrac": {
         "html": "<math><mfrac id='test'><mi>a</mi><mi>b</mi></mfrac></math>",
-        "atk_role": "ATK_ROLE_MATH_FRACTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathFraction"
+        "atspi_role": "ROLE_MATH_FRACTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathFraction"
     },
     "mi": {
         "html": "<math><mi id='test'>x</mi></math>",
-        "atk_role": "ATK_ROLE_STATIC",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathIdentifier"
+        "atspi_role": "ROLE_STATIC",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathIdentifier"
     },
     "mmultiscripts": {
         "html": "<math><mmultiscripts id='test'><mi>X</mi></mmultiscripts></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathMultiscript"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathMultiscript"
     },
     "mn": {
         "html": "<math><mn id='test'>2</mn></math>",
-        "atk_role": "ATK_ROLE_STATIC",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathNumber"
+        "atspi_role": "ROLE_STATIC",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathNumber"
     },
     "mo": {
         "html": "<math><mo id='test'>+</mo></math>",
-        "atk_role": "ATK_ROLE_STATIC",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathOperator"
+        "atspi_role": "ROLE_STATIC",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathOperator"
     },
     "mover": {
         "html": "<math><mover id='test'><mi>a</mi><mo>˙</mo></mover></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathUnderOver"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathUnderOver"
     },
     "mpadded": {
         "html": "<math><mpadded id='test'><mi>x</mi></mpadded></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     },
     "mphantom": {
         "html": "<math><mphantom style='visibility: visible;' id='test'><mi>x</mi></mphantom></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow"
     },
     "mprescripts": {
         "html": "<math><mmultiscripts><mi>X</mi><mprescripts id='test'/></mmultiscripts></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole", # Not mapped, match chrome 
-        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole", # Not mapped, match chrome 
+        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     },
     "mroot": {
         "html": "<math><mroot id='test'><mi>x</mi><mn>3</mn></mroot></math>",
-        "atk_role": "ATK_ROLE_MATH_ROOT",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRoot"
+        "atspi_role": "ROLE_MATH_ROOT",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRoot"
     },
     "mrow": {
         "html": "<math><mrow id='test'><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow"
     },
     "ms": {
         "html": "<math><ms id='test'>string</ms></math>",
-        "atk_role": "ATK_ROLE_STATIC",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": None # nil
+        "atspi_role": "ROLE_STATIC",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": None # nil
     },
     "mspace": {
         "html": "<math><mspace id='test' width='1em'/></math>",
-        "atk_role": "ATK_ROLE_SECTION", # Not mapped, match chrome
-        "ax_role": "NSAccessibilityGroupRole",  # Not mapped, match chrome
-        "ax_subrole": "AXEmptyGroup" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION", # Not mapped, match chrome
+        "axapi_role": "NSAccessibilityGroupRole",  # Not mapped, match chrome
+        "axapi_subrole": "AXEmptyGroup" # Not mapped, match chrome
     },
     "msqrt": {
         "html": "<math><msqrt id='test'><mi>x</mi></msqrt></math>",
-        "atk_role": "ATK_ROLE_MATH_ROOT",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathSquareRoot"
+        "atspi_role": "ROLE_MATH_ROOT",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathSquareRoot"
     },
     "mstyle": {
         "html": "<math><mstyle id='test' mathcolor='red'><mi>x</mi></mstyle></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow"
     },
     "msub": {
         "html": "<math><msub id='test'><mi>x</mi><mn>1</mn></msub></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathSubscriptSuperscript"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathSubscriptSuperscript"
     },
     "msubsup": {
         "html": "<math><msubsup id='test'><mi>x</mi><mn>1</mn><mn>2</mn></msubsup></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathSubscriptSuperscript"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathSubscriptSuperscript"
     },
     "msup": {
         "html": "<math><msup id='test'><mi>x</mi><mn>2</mn></msup></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathSubscriptSuperscript"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathSubscriptSuperscript"
     },
     "mtable": {
         "html": "<math><mtable id='test'><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>",
-        "atk_role": "ATK_ROLE_TABLE",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathTable"
+        "atspi_role": "ROLE_TABLE",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathTable"
     },
     "mtd": {
         "html": "<math><mtable><mtr><mtd id='test'><mn>1</mn></mtd></mtr></mtable></math>",
-        "atk_role": "ATK_ROLE_TABLE_CELL",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathTableCell"
+        "atspi_role": "ROLE_TABLE_CELL",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathTableCell"
     },
     "mtext": {
         "html": "<math><mtext id='test'>text</mtext></math>",
-        "atk_role": "ATK_ROLE_STATIC",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathText"
+        "atspi_role": "ROLE_STATIC",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathText"
     },
     "mtr": {
         "html": "<math><mtable><mtr id='test'><mtd><mn>1</mn></mtd></mtr></mtable></math>",
-        "atk_role": "ATK_ROLE_TABLE_ROW",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathTableRow"
+        "atspi_role": "ROLE_TABLE_ROW",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathTableRow"
     },
     "munder": {
         "html": "<math><munder id='test'><mi>x</mi><mo>_</mo></munder></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathUnderOver"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathUnderOver"
     },
     "munderover": {
         "html": "<math><munderover id='test'><mi>x</mi><mo>_</mo><mo>˙</mo></munderover></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathUnderOver"
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathUnderOver"
     },
     "none": {
         "html": "<math><mmultiscripts><mi>X</mi><none id='test'/></mmultiscripts></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole", # Not mapped, match chrome
-        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole", # Not mapped, match chrome
+        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     },
     "semantics": {
         "html": "<math><semantics id='test'><mi>x</mi></semantics></math>",
-        "atk_role": "ATK_ROLE_SECTION",
-        "ax_role": "NSAccessibilityGroupRole",
-        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION",
+        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
     }
 }
 
@@ -199,7 +201,7 @@ def test_atspi(atspi, session, inline, element_name):
 
     actual_role = atspi.Accessible.get_role(node)
 
-    role_attr_name = data["atk_role"].replace("ATK_ROLE_", "")
+    role_attr_name = data["atspi_role"].replace("ROLE_", "")
     expected_role = getattr(atspi.Role, role_attr_name)
 
     assert actual_role == expected_role, f"Expected {expected_role}, but got {actual_role}"
@@ -212,15 +214,15 @@ def test_axapi(axapi, session, inline, element_name):
     session.url = inline(data["html"])
     node = axapi.find_node("test", session.url)
 
-    expected_role = data["ax_role"]
+    expected_role = data["axapi_role"]
     if expected_role == "NSAccessibilityGroupRole":
         expected_role = "AXGroup"
 
     role_result = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)
     actual_role = role_result[1] if (role_result and len(role_result) > 1) else None
-    assert actual_role == expected_role, f"AXRole mismatch for <{element_name}>. Expected '{data['ax_role']}', got '{actual_role}'"
+    assert actual_role == expected_role, f"AXRole mismatch for <{element_name}>. Expected '{data['axapi_role']}', got '{actual_role}'"
 
     subrole_result = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)
     actual_subrole = subrole_result[1] if (subrole_result and len(subrole_result) > 1) else None
   
-    assert actual_subrole == data["ax_subrole"], f"AXSubrole mismatch for <{element_name}>. Expected '{data['ax_subrole']}', got '{actual_subrole}'"
+    assert actual_subrole == data["axapi_subrole"], f"AXSubrole mismatch for <{element_name}>. Expected '{data['axapi_subrole']}', got '{actual_subrole}'"

--- a/mathml-aam/aamtests/role/mathml-role.py
+++ b/mathml-aam/aamtests/role/mathml-role.py
@@ -1,194 +1,197 @@
 import pytest
 
-# Testing MathML Core AAM Mappings: https://w3c.github.io/mathml-aam/#mathml-element-mappings
-# FIXME: For role that is not mapped, TBD and nil, we match the chrome behavior for now
-# See https://github.com/w3c/mathml-aam/issues/41
 TEST_DATA = {
+    "a": {
+        "html": """<math><a href="https://google.com" id="test"><mtext>Link</mtext></a></math>""",
+        "atspi_role": "ROLE_LINK",
+        "axapi_role": "AXLink",
+        "axapi_subrole": "AXMathRow"
+    },
     "annotation": {
         "html": "<math><semantics><mn>2</mn><annotation id='test' encoding='application/x-tex' style='display: inline-block;'>\\text{two}</annotation></semantics></math>",
         "atspi_role": "ROLE_STATIC",
-        "axapi_role": "NSAccessibilityGroupRole",
-        "axapi_subrole": "AXMathText" # Not mapped, match chrome
+        "axapi_role": "AXGroup",
+        "axapi_subrole": "AXMathText" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "annotation-xml": {
         "html": "<math><semantics><mn>2</mn><annotation-xml id='test' encoding='application/mathml-content+xml' style='display: inline-block;'><mtext>two</mtext></annotation-xml></semantics></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
-        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
+        "axapi_role": "AXGroup",
+        "axapi_subrole": "AXMathRow" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "maction": {
         "html": "<math><maction id='test' actiontype='toggle'><mi>A</mi></maction></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
-        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
+        "axapi_role": "AXGroup",
+        "axapi_subrole": "AXMathRow" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "math": {
         "html": "<math id='test'><mi>x</mi></math>",
         "atspi_role": "ROLE_MATH",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXDocumentMath"
     },
     "merror": {
         "html": "<math><merror id='test'><mtext>error</mtext></merror></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathRow"
     },
     "mfrac": {
         "html": "<math><mfrac id='test'><mi>a</mi><mi>b</mi></mfrac></math>",
         "atspi_role": "ROLE_MATH_FRACTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathFraction"
     },
     "mi": {
         "html": "<math><mi id='test'>x</mi></math>",
         "atspi_role": "ROLE_STATIC",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathIdentifier"
     },
     "mmultiscripts": {
         "html": "<math><mmultiscripts id='test'><mi>X</mi></mmultiscripts></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathMultiscript"
     },
     "mn": {
         "html": "<math><mn id='test'>2</mn></math>",
         "atspi_role": "ROLE_STATIC",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathNumber"
     },
     "mo": {
         "html": "<math><mo id='test'>+</mo></math>",
         "atspi_role": "ROLE_STATIC",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathOperator"
     },
     "mover": {
         "html": "<math><mover id='test'><mi>a</mi><mo>˙</mo></mover></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathUnderOver"
     },
     "mpadded": {
         "html": "<math><mpadded id='test'><mi>x</mi></mpadded></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
-        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
+        "axapi_role": "AXGroup",
+        "axapi_subrole": "AXMathRow" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "mphantom": {
         "html": "<math><mphantom style='visibility: visible;' id='test'><mi>x</mi></mphantom></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathRow"
     },
     "mprescripts": {
         "html": "<math><mmultiscripts><mi>X</mi><mprescripts id='test'/></mmultiscripts></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole", # Not mapped, match chrome
-        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
+        "axapi_role": "AXGroup", # FIXME: https://github.com/w3c/mathml-aam/issues/41
+        "axapi_subrole": "AXEmptyGroup" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "mroot": {
         "html": "<math><mroot id='test'><mi>x</mi><mn>3</mn></mroot></math>",
         "atspi_role": "ROLE_MATH_ROOT",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathRoot"
     },
     "mrow": {
         "html": "<math><mrow id='test'><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathRow"
     },
     "ms": {
         "html": """<math><ms id="test">"string"</ms></math>""",
         "atspi_role": "ROLE_STATIC",
-        "axapi_role": "NSAccessibilityGroupRole",
-        "axapi_subrole": None # nil
+        "axapi_role": "AXGroup",
+        "axapi_subrole": "AXMathText" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "mspace": {
         "html": "<math><mspace id='test' width='1em'/></math>",
-        "atspi_role": "ROLE_SECTION", # Not mapped, match chrome
-        "axapi_role": "NSAccessibilityGroupRole",  # Not mapped, match chrome
-        "axapi_subrole": "AXEmptyGroup" # Not mapped, match chrome
+        "atspi_role": "ROLE_SECTION", # FIXME: https://github.com/w3c/mathml-aam/issues/41
+        "axapi_role": "AXGroup", # FIXME: https://github.com/w3c/mathml-aam/issues/41
+        "axapi_subrole": "AXEmptyGroup" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "msqrt": {
         "html": "<math><msqrt id='test'><mi>x</mi></msqrt></math>",
         "atspi_role": "ROLE_MATH_ROOT",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathSquareRoot"
     },
     "mstyle": {
         "html": "<math><mstyle id='test' mathcolor='red'><mi>x</mi></mstyle></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathRow"
     },
     "msub": {
         "html": "<math><msub id='test'><mi>x</mi><mn>1</mn></msub></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathSubscriptSuperscript"
     },
     "msubsup": {
         "html": "<math><msubsup id='test'><mi>x</mi><mn>1</mn><mn>2</mn></msubsup></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathSubscriptSuperscript"
     },
     "msup": {
         "html": "<math><msup id='test'><mi>x</mi><mn>2</mn></msup></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathSubscriptSuperscript"
     },
     "mtable": {
         "html": "<math><mtable id='test'><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>",
         "atspi_role": "ROLE_TABLE",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathTable"
     },
     "mtd": {
         "html": "<math><mtable><mtr><mtd id='test'><mn>1</mn></mtd></mtr></mtable></math>",
         "atspi_role": "ROLE_TABLE_CELL",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathTableCell"
     },
     "mtext": {
         "html": "<math><mtext id='test'>text</mtext></math>",
         "atspi_role": "ROLE_STATIC",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathText"
     },
     "mtr": {
         "html": "<math><mtable><mtr id='test'><mtd><mn>1</mn></mtd></mtr></mtable></math>",
         "atspi_role": "ROLE_TABLE_ROW",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathTableRow"
     },
     "munder": {
         "html": "<math><munder id='test'><mi>x</mi><mo>_</mo></munder></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathUnderOver"
     },
     "munderover": {
         "html": "<math><munderover id='test'><mi>x</mi><mo>_</mo><mo>˙</mo></munderover></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
+        "axapi_role": "AXGroup",
         "axapi_subrole": "AXMathUnderOver"
     },
     "none": {
         "html": "<math><mmultiscripts><mi>X</mi><none id='test'/></mmultiscripts></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole", # Not mapped, match chrome
-        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
+        "axapi_role": "AXGroup", # FIXME: https://github.com/w3c/mathml-aam/issues/41
+        "axapi_subrole": "AXEmptyGroup" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     },
     "semantics": {
         "html": "<math><semantics id='test'><mi>x</mi></semantics></math>",
         "atspi_role": "ROLE_SECTION",
-        "axapi_role": "NSAccessibilityGroupRole",
-        "axapi_subrole": "AXMathRow" # Not mapped, match chrome
+        "axapi_role": "AXGroup",
+        "axapi_subrole": "AXMathRow" # FIXME: https://github.com/w3c/mathml-aam/issues/41
     }
 }
 
@@ -215,8 +218,6 @@ def test_axapi(axapi, session, inline, element_name):
     node = axapi.find_node("test", session.url)
 
     expected_role = data["axapi_role"]
-    if expected_role == "NSAccessibilityGroupRole":
-        expected_role = "AXGroup"
 
     role_result = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)
     actual_role = role_result[1] if (role_result and len(role_result) > 1) else None

--- a/mathml-aam/aamtests/role/mathml-role.py
+++ b/mathml-aam/aamtests/role/mathml-role.py
@@ -1,0 +1,226 @@
+import pytest
+
+# Testing MathML Core AAM Mappings: https://w3c.github.io/mathml-aam/#mathml-element-mappings
+TEST_DATA = {
+    "annotation": {
+        "html": "<math><annotation id='test'>XML</annotation></math>",
+        "atk_role": "ATK_ROLE_STATIC",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathText" # Not mapped, match chrome
+    },
+    "annotation-xml": {
+        "html": "<math><annotation-xml id='test'>XML</annotation-xml></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+    },
+    "maction": {
+        "html": "<math><maction id='test' actiontype='toggle'><mi>A</mi></maction></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+    },
+    "math": {
+        "html": "<math id='test'><mi>x</mi></math>",
+        "atk_role": "ATK_ROLE_MATH",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXDocumentMath"
+    },
+    "merror": {
+        "html": "<math><merror id='test'><mtext>error</mtext></merror></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow"
+    },
+    "mfrac": {
+        "html": "<math><mfrac id='test'><mi>a</mi><mi>b</mi></mfrac></math>",
+        "atk_role": "ATK_ROLE_MATH_FRACTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathFraction"
+    },
+    "mi": {
+        "html": "<math><mi id='test'>x</mi></math>",
+        "atk_role": "ATK_ROLE_STATIC",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathIdentifier"
+    },
+    "mmultiscripts": {
+        "html": "<math><mmultiscripts id='test'><mi>X</mi></mmultiscripts></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathMultiscript"
+    },
+    "mn": {
+        "html": "<math><mn id='test'>2</mn></math>",
+        "atk_role": "ATK_ROLE_STATIC",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathNumber"
+    },
+    "mo": {
+        "html": "<math><mo id='test'>+</mo></math>",
+        "atk_role": "ATK_ROLE_STATIC",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathOperator"
+    },
+    "mover": {
+        "html": "<math><mover id='test'><mi>a</mi><mo>˙</mo></mover></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathUnderOver"
+    },
+    "mpadded": {
+        "html": "<math><mpadded id='test'><mi>x</mi></mpadded></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+    },
+    "mphantom": {
+        "html": "<math><mphantom style='visibility: visible;' id='test'><mi>x</mi></mphantom></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow"
+    },
+    "mprescripts": {
+        "html": "<math><mmultiscripts><mi>X</mi><mprescripts id='test'/></mmultiscripts></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole", # Not mapped, match chrome 
+        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+    },
+    "mroot": {
+        "html": "<math><mroot id='test'><mi>x</mi><mn>3</mn></mroot></math>",
+        "atk_role": "ATK_ROLE_MATH_ROOT",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRoot"
+    },
+    "mrow": {
+        "html": "<math><mrow id='test'><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow"
+    },
+    "ms": {
+        "html": "<math><ms id='test'>string</ms></math>",
+        "atk_role": "ATK_ROLE_STATIC",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": None # nil
+    },
+    "mspace": {
+        "html": "<math><mspace id='test' width='1em'/></math>",
+        "atk_role": "ATK_ROLE_SECTION", # Not mapped, match chrome
+        "ax_role": "NSAccessibilityGroupRole",  # Not mapped, match chrome
+        "ax_subrole": "AXEmptyGroup" # Not mapped, match chrome
+    },
+    "msqrt": {
+        "html": "<math><msqrt id='test'><mi>x</mi></msqrt></math>",
+        "atk_role": "ATK_ROLE_MATH_ROOT",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathSquareRoot"
+    },
+    "mstyle": {
+        "html": "<math><mstyle id='test' mathcolor='red'><mi>x</mi></mstyle></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow"
+    },
+    "msub": {
+        "html": "<math><msub id='test'><mi>x</mi><mn>1</mn></msub></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathSubscriptSuperscript"
+    },
+    "msubsup": {
+        "html": "<math><msubsup id='test'><mi>x</mi><mn>1</mn><mn>2</mn></msubsup></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathSubscriptSuperscript"
+    },
+    "msup": {
+        "html": "<math><msup id='test'><mi>x</mi><mn>2</mn></msup></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathSubscriptSuperscript"
+    },
+    "mtable": {
+        "html": "<math><mtable id='test'><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>",
+        "atk_role": "ATK_ROLE_TABLE",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathTable"
+    },
+    "mtd": {
+        "html": "<math><mtable><mtr><mtd id='test'><mn>1</mn></mtd></mtr></mtable></math>",
+        "atk_role": "ATK_ROLE_TABLE_CELL",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathTableCell"
+    },
+    "mtext": {
+        "html": "<math><mtext id='test'>text</mtext></math>",
+        "atk_role": "ATK_ROLE_STATIC",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathText"
+    },
+    "mtr": {
+        "html": "<math><mtable><mtr id='test'><mtd><mn>1</mn></mtd></mtr></mtable></math>",
+        "atk_role": "ATK_ROLE_TABLE_ROW",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathTableRow"
+    },
+    "munder": {
+        "html": "<math><munder id='test'><mi>x</mi><mo>_</mo></munder></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathUnderOver"
+    },
+    "munderover": {
+        "html": "<math><munderover id='test'><mi>x</mi><mo>_</mo><mo>˙</mo></munderover></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathUnderOver"
+    },
+    "none": {
+        "html": "<math><mmultiscripts><mi>X</mi><none id='test'/></mmultiscripts></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole", # Not mapped, match chrome
+        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+    },
+    "semantics": {
+        "html": "<math><semantics id='test'><mi>x</mi></semantics></math>",
+        "atk_role": "ATK_ROLE_SECTION",
+        "ax_role": "NSAccessibilityGroupRole",
+        "ax_subrole": "AXMathRow" # Not mapped, match chrome
+    }
+}
+
+@pytest.mark.parametrize("element_name", TEST_DATA.keys())
+def test_atspi(atspi, session, inline, element_name):
+    data = TEST_DATA[element_name]
+    
+    session.url = inline(data["html"])
+    node = atspi.find_node("test", session.url)
+
+    actual_role = atspi.Accessible.get_role(node)
+
+    role_attr_name = data["atk_role"].replace("ATK_ROLE_", "")
+    expected_role = getattr(atspi.Role, role_attr_name)
+
+    assert actual_role == expected_role, f"Expected {expected_role}, but got {actual_role}"
+
+
+@pytest.mark.parametrize("element_name", TEST_DATA.keys())
+def test_axapi(axapi, session, inline, element_name):
+    data = TEST_DATA[element_name]
+
+    session.url = inline(data["html"])
+    node = axapi.find_node("test", session.url)
+
+    expected_role = data["ax_role"]
+    if expected_role == "NSAccessibilityGroupRole":
+        expected_role = "AXGroup"
+
+    role_result = axapi.AXUIElementCopyAttributeValue(node, "AXRole", None)
+    actual_role = role_result[1] if (role_result and len(role_result) > 1) else None
+    assert actual_role == expected_role, f"AXRole mismatch for <{element_name}>. Expected '{data['ax_role']}', got '{actual_role}'"
+
+    subrole_result = axapi.AXUIElementCopyAttributeValue(node, "AXSubrole", None)
+    actual_subrole = subrole_result[1] if (subrole_result and len(subrole_result) > 1) else None
+  
+    assert actual_subrole == data["ax_subrole"], f"AXSubrole mismatch for <{element_name}>. Expected '{data['ax_subrole']}', got '{actual_subrole}'"

--- a/mathml-aam/aamtests/role/mathml-role.py
+++ b/mathml-aam/aamtests/role/mathml-role.py
@@ -101,7 +101,7 @@ TEST_DATA = {
         "axapi_subrole": "AXMathRow"
     },
     "ms": {
-        "html": "<math><ms id='test'>string</ms></math>",
+        "html": """<math><ms id="test">"string"</ms></math>""",
         "atspi_role": "ROLE_STATIC",
         "axapi_role": "NSAccessibilityGroupRole",
         "axapi_subrole": None # nil


### PR DESCRIPTION
Introduces the testing infrastructure for MathML Accessibility API Mappings (MathML-AAM) and implements verification for 31 MathML elements.

Add a seperate role mapping test for link, it's not standardized yet.