### PR TITLE
Add test for border radius being sliced in half by fragmentation

### DIFF
--- a/css/css-break/box-decoration-break-slice-border-radius-ref.html
+++ b/css/css-break/box-decoration-break-slice-border-radius-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  body {
+    margin-left: 100px;
+    line-height: 3em;
+  }
+  .breakable {
+    border: 2px solid black;
+    background: linear-gradient(to right, pink, lightblue);
+    border-radius: 50%;
+    padding: 6px;
+  }
+  .long, .short {
+    display: inline-block;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+  .long {
+    width: 100px;
+  }
+  .short {
+    width: 50px;
+  }
+  .cover {
+    position: absolute;
+    background-color: white;
+    width: 300px;
+    height: 1lh;
+  }
+</style>
+Unbroken span for reference:<br>
+<span class="breakable" id="reference">
+  <span class="long"></span><span class="short"></span>
+</span><br>
+The span, broken into two pieces that could conceivably be put back together in a seamless fashion:<br>
+<span class="breakable">
+  <span class="long"></span><span class="cover"></span><span class="short"></span>
+</span><br>
+
+<span class="breakable" style="margin-left:-108px">
+  <span class="long"></span><span class="cover" style="transform: translateX(-300px)"></span><span class="short"></span>
+</span>
+

--- a/css/css-break/box-decoration-break-slice-border-radius.html
+++ b/css/css-break/box-decoration-break-slice-border-radius.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>box-decoration-break:slice should be able to slice a border radius in half.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="match" href="box-decoration-break-slice-border-radius-ref.html">
+<meta name="assert" content="box-decoration-break:slice should be able to slice a border radius in half.">
+<style>
+  body {
+    margin-left: 100px;
+    line-height: 3em;
+  }
+  .breakable {
+    border: 2px solid black;
+    background: linear-gradient(to right, pink, lightblue);
+    border-radius: 50%;
+    padding: 6px;
+  }
+  .long, .short {
+    display: inline-block;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+  .long {
+    width: 100px;
+  }
+  .short {
+    width: 50px;
+  }
+</style>
+Unbroken span for reference:<br>
+<span class="breakable">
+  <span class="long"></span><span class="short"></span>
+</span><br>
+The span, broken into two pieces that could conceivably be put back together in a seamless fashion:<br>
+<span class="breakable">
+  <span class="long"></span><br>
+  <span class="short"></span>
+</span>


### PR DESCRIPTION
This currently passes in Firefox, but not in Chromium / WebKit.
I think that there is no test for this yet.

Reference Rendering / Rendering in Firefox:
<img width="900" height="287" alt="image" src="https://github.com/user-attachments/assets/09a16be1-d839-47d8-b633-6a5cdfb5b628" />

Rendering in Chromium:
<img width="784" height="300" alt="image" src="https://github.com/user-attachments/assets/c9f62369-a32a-4d68-9ff1-de831e67eb89" />

Rendering in WebKit:
<img width="919" height="291" alt="image" src="https://github.com/user-attachments/assets/7832456c-b4df-43bf-861c-ca0f15a954b0" />

Notice how Chromium and WebKit resolve the 50% `border-radius` relative to the fragment's size, when really the box's border/ background should've been drawn as if the box was unbroken and then sliced to pieces.

The whitespace towards the left isn't suuper necessary, but I thought I'd include it to make sure that the second fragment does not extend in that direction at all. (without it, it's kinda close to the edge)
The background gradient is just there for more visual clarity as to what is happening.