### PR TITLE
Remove fake UI flag for digital credentials API tests

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -123,8 +123,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     # This is needed until https://github.com/web-platform-tests/wpt/pull/40709
     # is merged.
     chrome_options["args"].append("--enable-features=FedCmWithoutWellKnownEnforcement")
-    # Use a fake UI for digital identity to allow testing it.
-    chrome_options["args"].append("--use-fake-ui-for-digital-identity")
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.
     chrome_options["args"].append("--short-reporting-delay")
     # Point all .test domains to localhost for Chrome


### PR DESCRIPTION
This flag was used to force all DC API requests to auto-resolve within 1 ms, which made it not possible to test "concurrent-requests" for example.

More context is in: https://crrev.com/c/8026070