### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318306

### DIFF
--- a/css/css-view-transitions/dynamic-stylesheet-animations-timing-function.html
+++ b/css/css-view-transitions/dynamic-stylesheet-animations-timing-function.html
@@ -59,7 +59,7 @@ promise_test(async t => {
     "The default timing function"
   );
 
-  assert_equals(
+  assert_matrix_equals(
     getComputedStyle(document.documentElement,
       "::view-transition-group(target)").transform,
     getComputedStyle(ref).transform,


### PR DESCRIPTION
WebKit export from bug: [View transition transform test fails due to float vs double blending precision](https://bugs.webkit.org/show_bug.cgi?id=318306)