### PR TITLE
script: Do not trigger restyles on light tree children not in the flat tree

### DIFF
--- a/shadow-dom/shadow-host-child-restyle-crash.html
+++ b/shadow-dom/shadow-host-child-restyle-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46149">
+<script>
+function main() {
+  option.dir = "rtl";
+  window.pageYOffset;
+  dialog.close();
+  window.pageYOffset;
+  host.attachShadow({mode: "open"});
+}
+</script>
+
+<body onload="main()">
+<dialog id="dialog" open="">
+    <select>
+        <option id="option" style="display: contents">
+            <div id="host">
+        </option>
+    </select>
+</dialog>


### PR DESCRIPTION
A light child may not be in the flat tree if its parent node is a shadow
host with an attached shadow DOM or if its parent is a `<slot>` element
with a slotted node (fallback slot content). In that case,
`parent_in_flat_tree` should not return a node as the node itself is not
actually in the flat tree.

This change makes it so that the return value of `parent_in_flat_tree`
can distinguish that case from the success case and also from the case
that the input `Node` is the root node.

This prevents the script thread from recording a restyle on a node
that is not in the flat tree when it's style changes. This was causing
Stylo to look at this node and try to restyle it.

Testing: This change adds a WPT crash test.
Fixes:  #<!-- nolink -->46149.
Fixes: #<!-- nolink -->46024.

Reviewed in servo/servo#46188