### PR TITLE
Cover a few fragment parsing edge cases

### DIFF
--- a/custom-elements/registries/Element-innerHTML.html
+++ b/custom-elements/registries/Element-innerHTML.html
@@ -165,6 +165,25 @@ test((test) => {
     class ScopedNewElement extends HTMLElement { };
     registry.define('new-element', ScopedNewElement);
 
+    const template = document.createElement('template', {customElementRegistry: registry});
+    assert_equals(template.customElementRegistry, registry);
+
+    template.innerHTML = '<new-element><new-element></new-element></new-element>';
+    const outer_element = template.content.querySelector('new-element');
+    const inner_element = outer_element.querySelector('new-element');
+    assert_equals(outer_element.customElementRegistry, registry);
+    assert_true(outer_element instanceof ScopedNewElement);
+    assert_false(outer_element instanceof WrongNewElement);
+    assert_equals(inner_element.customElementRegistry, registry);
+    assert_true(inner_element instanceof ScopedNewElement);
+    assert_false(inner_element instanceof WrongNewElement);
+}, 'innerHTML on a template with a scoped registry should use the scoped registry of the template');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+    class ScopedNewElement extends HTMLElement { };
+    registry.define('new-element', ScopedNewElement);
+
     const div = document.createElement('div', {customElementRegistry: registry});
     assert_equals(div.customElementRegistry, registry);
 

--- a/custom-elements/registries/Element-innerHTML.html
+++ b/custom-elements/registries/Element-innerHTML.html
@@ -171,13 +171,10 @@ test((test) => {
     template.innerHTML = '<new-element><new-element></new-element></new-element>';
     const outer_element = template.content.querySelector('new-element');
     const inner_element = outer_element.querySelector('new-element');
-    assert_equals(outer_element.customElementRegistry, registry);
-    assert_true(outer_element instanceof ScopedNewElement);
-    assert_false(outer_element instanceof WrongNewElement);
-    assert_equals(inner_element.customElementRegistry, registry);
-    assert_true(inner_element instanceof ScopedNewElement);
-    assert_false(inner_element instanceof WrongNewElement);
-}, 'innerHTML on a template with a scoped registry should use the scoped registry of the template');
+    document.body.append(outer_element);
+    assert_equals(outer_element.customElementRegistry, document.customElementRegistry);
+    assert_equals(inner_element.customElementRegistry, document.customElementRegistry);
+}, 'innerHTML on a template with a scoped registry should use the scoped registry of the document');
 
 test((test) => {
     const registry = new CustomElementRegistry;

--- a/domparsing/innerhtml-08.html
+++ b/domparsing/innerhtml-08.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>innerHTML on html element</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/11023">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  const html = document.createElement('html');
+  html.innerHTML = '<head></head><body></body><!-- comment -->';
+  assert_equals(html.childNodes.length, 3);
+  assert_equals(html.childNodes[0].nodeName, 'HEAD');
+  assert_equals(html.childNodes[1].nodeName, 'BODY');
+  assert_equals(html.childNodes[2].nodeType, Node.COMMENT_NODE);
+  assert_equals(html.childNodes[2].data, ' comment ');
+}, "innerHTML on html element with trailing comment")
+
+test(function() {
+  const html = document.createElement('html');
+  html.innerHTML = '<body></body><!-- comment -->';
+  assert_equals(html.childNodes.length, 3);
+  assert_equals(html.childNodes[0].nodeName, 'HEAD');
+  assert_equals(html.childNodes[1].nodeName, 'BODY');
+  assert_equals(html.childNodes[2].nodeType, Node.COMMENT_NODE);
+  assert_equals(html.childNodes[2].data, ' comment ');
+}, "innerHTML on html element with trailing comment (no explicit head)")
+</script>

--- a/shadow-dom/declarative/declarative-shadow-dom-opt-in.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-opt-in.html
@@ -147,6 +147,32 @@ async_test((t) => {
   client.send();
 }, 'XMLHttpRequest document.open() does not enable declarative shadow DOM when it is previously disabled');
 
+async_test((t) => {
+  let client = new XMLHttpRequest();
+  client.addEventListener('load', t.step_func_done(() => {
+    assert_true(client.status == 200 && client.responseXML != null);
+    const doc = client.responseXML;
+    assert_dsd(doc.body, false);
+    const cloned = doc.cloneNode(true);
+    cloned.open();
+    cloned.write(content);
+    cloned.close();
+    assert_dsd(cloned.body, false);
+    t.done();
+  }));
+  client.open("GET", `data:text/html,${content}`);
+  client.responseType = 'document';
+  client.send();
+}, 'XMLHttpRequest cloned document document.open() does not enable declarative shadow DOM when it is previously disabled');
+
+test(() => {
+  const doc = Document.parseHTMLUnsafe('');
+  doc.open();
+  doc.write(content);
+  doc.close();
+  assert_dsd(doc.body, true);
+}, 'document.open() of a document created with parseHTMLUnsafe keeps declarative shadow DOM opt-in');
+
 test(() => {
   const div = document.createElement('div');
   div.insertAdjacentHTML('afterbegin',content);

--- a/shadow-dom/declarative/declarative-shadow-dom-opt-in.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-opt-in.html
@@ -130,6 +130,23 @@ async_test((t) => {
   client.send();
 }, 'XMLHttpRequest - not supported');
 
+async_test((t) => {
+  let client = new XMLHttpRequest();
+  client.addEventListener('load', t.step_func_done(() => {
+    assert_true(client.status == 200 && client.responseXML != null);
+    const doc = client.responseXML;
+    assert_dsd(doc.body, false);
+    doc.open();
+    doc.write(content);
+    doc.close();
+    assert_dsd(doc.body, false);
+    t.done();
+  }));
+  client.open("GET", `data:text/html,${content}`);
+  client.responseType = 'document';
+  client.send();
+}, 'XMLHttpRequest document.open() does not enable declarative shadow DOM when it is previously disabled');
+
 test(() => {
   const div = document.createElement('div');
   div.insertAdjacentHTML('afterbegin',content);


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/12624
- A few test cases of the "allow declarative shadow roots" opt-in (survives clones and document.open)
- "after body" parsing mode when fragment-parsing
- Custom element registry is taken from the template in `template.innerHTML`