### PR TITLE
[digital-credentials] concurrent-requests: park the first request with a "wait" wallet

### DIFF
--- a/digital-credentials/concurrent-requests.https.html
+++ b/digital-credentials/concurrent-requests.https.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body></body>
@@ -12,6 +12,10 @@
   import { makeGetOptions } from "./support/helper.js";
 
   promise_test(async (t) => {
+    // Park the first request ("wait") so the second hits the concurrency guard.
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+
     const abortController = new AbortController();
     const firstOptions = makeGetOptions({ signal: abortController.signal });
     const secondOptions = makeGetOptions();


### PR DESCRIPTION
The concurrent-requests test issues two `navigator.credentials.get()` calls, expecting the second to be rejected with `NotAllowedError` by the concurrency guard while the first is still pending. Without a virtual wallet, the first request fails before it can stay pending, so the guard never runs and the second request fails with the wrong error.

Set a `"wait"` virtual wallet behavior via `test_driver.set_virtual_wallet_behavior` so the first request parks and stays pending, letting the guard reject the second. `testdriver.js` is loaded with `?feature=bidi` to match the other digital-credentials tests that drive the virtual wallet (`webdriver/create`, `webdriver/get-mdoc`, `webdriver/get-openid4vp`).
