### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318401

### DIFF
--- a/css/css-view-transitions/navigation/resources/abort-before-render.html
+++ b/css/css-view-transitions/navigation/resources/abort-before-render.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<head>
+  <style>
+  @view-transition {
+    navigation: auto;
+  }
+</style>
+<script id="blocker" async src="common.js?pipe=trickle(d10)" blocking="render"></script>
+<script src="/resources/testharness.js"></script>
+<script>
+const params = new URLSearchParams(location.search);
+const bc_channel = new BroadcastChannel(params.get("channel"));
+
+window.addEventListener("pagereveal", e => {
+  bc_channel.postMessage(`did reveal original page ${e.viewTransition ? "with" : "without"} transition`);
+});
+
+if (params.get("phase") !== "aborted") {
+  // While still render-blocked (before the first rendering opportunity), start a
+  // cross-document navigation and then let it be aborted: the destination responds
+  // with 204 No Content, which keeps this (the original) document. The original
+  // document must still be revealed, and no view transition should have started.
+  step_timeout(() => {
+    location.href = `?phase=aborted&channel=${bc_channel.name}&pipe=status(204)`;
+  }, 100);
+}
+</script>
+</head>
+
+<body>
+  Content
+</body>

--- a/css/css-view-transitions/navigation/reveal-after-aborted-navigation.html
+++ b/css/css-view-transitions/navigation/reveal-after-aborted-navigation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: aborted outbound navigation before reveal still reveals the original document</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#revealing-the-document">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  promise_test(async t => {
+    const result = await new Promise(resolve => {
+      const channel_name = `abort-nav-reveal-${new Date().valueOf()}`;
+      const bc = new BroadcastChannel(channel_name);
+      bc.addEventListener("message", e => resolve(e.data));
+      const popup = window.open(`resources/abort-before-render.html?channel=${channel_name}`);
+
+      t.add_cleanup(() => popup.close());
+    });
+
+    assert_equals(result, "did reveal original page without transition");
+  }, "an aborted navigation while render-blocked still reveals the original document");
+</script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Navigating away from a render-blocked document before it is revealed incorrectly reveals it and starts a cross-document view transition.](https://bugs.webkit.org/show_bug.cgi?id=318401)