### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318066

### DIFF
--- a/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2.html
+++ b/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<title>Test SVGIntegerOptionalInteger animation with invalid value: String value in by attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+  <defs>
+    <filter id="effect">
+      <feConvolveMatrix id="matrix" order="3 3" kernelMatrix="0 0 0 0 1 0 0 0 0">
+        <animate attributeName="order" begin="0s" dur="4s" by="A B" />
+      </feConvolveMatrix>
+    </filter>
+  </defs>
+  <rect x="10" y="10" width="80" height="80" fill="blue" filter="url(#effect)" />
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const matrix = document.getElementById("matrix")
+
+    window.addEventListener('load', t.step_func(() => {
+        // Pause before seeking so the timeline can't advance past 2s.
+        svg.pauseAnimations();
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(matrix.orderX.baseVal, 3);
+          assert_equals(matrix.orderY.baseVal, 3);
+          assert_equals(matrix.orderX.animVal, matrix.orderX.baseVal);
+          assert_equals(matrix.orderY.animVal, matrix.orderY.baseVal);
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgnumber-animation-invalid-value-2.html
+++ b/svg/animations/svgnumber-animation-invalid-value-2.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGNumber animation with invalid values: String value in by attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <defs>
+        <filter id="effect">
+            <feComposite id="composite" in="SourceGraphic" in2="SourceAlpha" operator="arithmetic" k1="1">
+                <animate attributeName="k1" begin="0s" dur="4s" by="ERROR" />
+            </feComposite>
+        </filter>
+    </defs>
+    <rect id="rect" x="0" y="0" width="100" height="100" fill="green" filter="url(#effect)" />
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const composite = document.getElementById("composite");
+
+    window.addEventListener('load', t.step_func(() => {
+        // Pause before seeking so the timeline can't advance past 2s.
+        svg.pauseAnimations();
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(composite.k1.baseVal, 1);
+          assert_equals(composite.k1.animVal, composite.k1.baseVal);
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgnumber-to-animation-valid-value-1.html
+++ b/svg/animations/svgnumber-to-animation-valid-value-1.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<title>Test SVGNumber to-animation with a valid value still animates.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <defs>
+        <filter id="effect">
+            <feComposite id="composite" in="SourceGraphic" in2="SourceAlpha" operator="arithmetic" k1="1">
+                <animate attributeName="k1" begin="0s" dur="4s" to="3" />
+            </feComposite>
+        </filter>
+    </defs>
+    <rect id="rect" x="0" y="0" width="100" height="100" fill="green" filter="url(#effect)" />
+</svg>
+
+<script>
+
+// A to-animation has an empty 'from'; the start value comes from the base value at
+// runtime. This guards against the empty-'from' path incorrectly rejecting the animation.
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const composite = document.getElementById("composite");
+
+    window.addEventListener('load', t.step_func(() => {
+        // Pause before seeking so the timeline can't advance past 2s, which keeps the
+        // sampled value exact.
+        svg.pauseAnimations();
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(composite.k1.baseVal, 1);
+          // Linear interpolation from base (1) to 'to' (3) at the mid-point.
+          assert_equals(composite.k1.animVal, 2);
+        }));
+    }));
+  });
+
+</script>

--- a/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2.html
+++ b/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<title>Test SVGNumberOptionalNumber animation with invalid values: String value in by attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <defs>
+        <filter>
+            <feGaussianBlur id="blur" stdDeviation="5 5">
+                <animate attributeName="stdDeviation" begin="0s" dur="4s" by="A Z" />
+            </feGaussianBlur>
+        </filter>
+    </defs>
+    <rect x="50" y="50" width="100" height="100" fill="green" filter="url(#filter)"></rect>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const feGaussianBlur = document.getElementById("blur");
+
+    window.addEventListener('load', t.step_func(() => {
+        // Pause before seeking so the timeline can't advance past 2s.
+        svg.pauseAnimations();
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(feGaussianBlur.stdDeviationX.baseVal, 5);
+          assert_equals(feGaussianBlur.stdDeviationY.baseVal, 5);
+          assert_equals(feGaussianBlur.stdDeviationX.animVal, feGaussianBlur.stdDeviationX.baseVal);
+          assert_equals(feGaussianBlur.stdDeviationY.animVal, feGaussianBlur.stdDeviationY.baseVal);
+        }));
+    }));
+  });
+</script>

--- a/svg/animations/svgpath-animation-invalid-value-2.html
+++ b/svg/animations/svgpath-animation-invalid-value-2.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<title>Test SVGPath animation with invalid values: Malformed path in to attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/animated-path-helpers.js"></script>
+
+<svg id="svg">
+  <path id="path" d="M 40 40 L 60 40 L 60 60 L 40 60 z" fill="green">
+    <animate attributeName="d" from="M 0 0 L 10 0 L 10 10 z" to="ERROR" begin="0s" dur="4s" fill="freeze" />
+  </path>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const path = document.getElementById("path");
+
+    window.addEventListener('load', t.step_func(() => {
+        // Pause before seeking so the timeline can't advance past 2s.
+        svg.pauseAnimations();
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_animated_path_equals(path,
+                               "M 40 40 L 60 40 L 60 60 L 40 60 z");
+        }));
+    }));
+  });
+
+</script>


### PR DESCRIPTION
WebKit export from bug: [SVG SMIL number, integer-optional-integer, number-optional-number and path animations should not apply when from/to/by values fail to parse](https://bugs.webkit.org/show_bug.cgi?id=318066)