### PR TITLE
layout: Do not create widgets for elements with the `content` property

### DIFF
--- a/css/css-content/element-replacement-gradient-details-crash.html
+++ b/css/css-content/element-replacement-gradient-details-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46196" />
+<style>
+  details { content: linear-gradient(blue, red); }
+  summary { display: inline-table; }
+</style>
+<details open=""><summary>


### PR DESCRIPTION
Widgets are created for replaced elements, but these should not be
created for replaced elements created due to the application of the
`content` property on normal elements. These kind of elements have their
entire contents replaced. Creating a widget here can cause an unexpected
shape of the `FragmentTree` because anonymous boxes in Servo currently
have `display: inline`.

Testing: This change includes a new WPT crash test.
Fixes: #<!-- nolink -->46196.

Reviewed in servo/servo#46249