### PR TITLE
Make Apple Pay payment method manifest fetches fail fast in Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -125,8 +125,17 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     chrome_options["args"].append("--enable-features=FedCmWithoutWellKnownEnforcement")
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.
     chrome_options["args"].append("--short-reporting-delay")
-    # Point all .test domains to localhost for Chrome
-    chrome_options["args"].append("--host-resolver-rules=MAP nonexistent.*.test ^NOTFOUND, MAP *.test 127.0.0.1, MAP *.test. 127.0.0.1")
+    # Point all .test domains to localhost for Chrome. Also make payment
+    # method manifest fetches for the Apple Pay method (which many
+    # payment-request tests use, as it is the only method Safari supports)
+    # fail fast and deterministically instead of hitting the live apple.com
+    # servers, whose response timing made those tests flaky.
+    chrome_options["args"].append("--host-resolver-rules="
+                                  "MAP nonexistent.*.test ^NOTFOUND, "
+                                  "MAP *.test 127.0.0.1, "
+                                  "MAP *.test. 127.0.0.1, "
+                                  "MAP apple.com ^NOTFOUND, "
+                                  "MAP *.apple.com ^NOTFOUND")
     # Enable Secure Payment Confirmation for Chrome. This is normally disabled
     # on Linux as it hasn't shipped there yet, but in WPT we enable virtual
     # authenticator devices anyway for testing and so SPC works.


### PR DESCRIPTION
Many payment-request tests include the Apple Pay payment method (https://apple.com/apple-pay), as it is the only payment method Safari supports. Chrome performs payment method manifest fetches for URL-based payment methods, so these tests caused live network requests to apple.com from test runs. The unpredictable timing of those requests made ~5 payment-request tests flaky in Chrome on wpt.fyi (varying between FAIL, TIMEOUT, NOTRUN and harness ERROR run to run), and depending on the live apple.com servers violates the expectation that tests do not rely on the external network.

Map apple.com to NOTFOUND in the --host-resolver-rules that wptrunner already passes to Chrome, so that the manifest fetch fails immediately and deterministically.

Verified locally by running the five affected tests (payment-is-showing, payment-request-show-method,
payment-request-abort-method, payment-request-canmakepayment-method and show-consume-activation) three times: results went from flaky with 60-second timeouts to byte-identical results in ~8 seconds per iteration.