### PR TITLE
[Payment-request] Replace basic-card with JIT-installable payment handlers

### DIFF
--- a/payment-request/payment-request-abort-method.https.html
+++ b/payment-request/payment-request-abort-method.https.html
@@ -14,7 +14,14 @@ setup({
   allow_uncaught_exception: true,
   explicit_timeout: true,
 });
-const basicCard = Object.freeze({ supportedMethods: "basic-card" });
+const wptPay1 = Object.freeze({
+  supportedMethods:
+    window.location.origin + "/payment-request/resources/wpt-pay-1.json",
+});
+const wptPay2 = Object.freeze({
+  supportedMethods:
+    window.location.origin + "/payment-request/resources/wpt-pay-2.json",
+});
 const applePay = Object.freeze({
   supportedMethods: "https://apple.com/apple-pay",
   data: {
@@ -25,7 +32,7 @@ const applePay = Object.freeze({
     supportedNetworks: ["visa"],
   },
 });
-const defaultMethods = Object.freeze([basicCard, applePay]);
+const defaultMethods = Object.freeze([wptPay1, wptPay2, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "Total",

--- a/payment-request/payment-request-canmakepayment-method.https.html
+++ b/payment-request/payment-request-canmakepayment-method.https.html
@@ -8,7 +8,14 @@
 <script src='/resources/testdriver-vendor.js'></script>
 <script>
 "use strict";
-const basicCard = Object.freeze({ supportedMethods: "basic-card" });
+const wptPay1 = Object.freeze({
+  supportedMethods:
+    window.location.origin + "/payment-request/resources/wpt-pay-1.json",
+});
+const wptPay2 = Object.freeze({
+  supportedMethods:
+    window.location.origin + "/payment-request/resources/wpt-pay-2.json",
+});
 const applePay = Object.freeze({
   supportedMethods: "https://apple.com/apple-pay",
   data: {
@@ -19,7 +26,7 @@ const applePay = Object.freeze({
     supportedNetworks: ["visa"],
   }
 });
-const defaultMethods = Object.freeze([basicCard, applePay]);
+const defaultMethods = Object.freeze([wptPay1, wptPay2, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "Total",

--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -19,10 +19,15 @@
         supportedNetworks: ["visa"],
       },
     });
-    const validMethod = Object.freeze({
-      supportedMethods: "basic-card",
+    const wptPay1 = Object.freeze({
+      supportedMethods:
+        window.location.origin + "/payment-request/resources/wpt-pay-1.json",
     });
-    const validMethods = Object.freeze([validMethod, applePay]);
+    const wptPay2 = Object.freeze({
+      supportedMethods:
+        window.location.origin + "/payment-request/resources/wpt-pay-2.json",
+    });
+    const validMethods = Object.freeze([wptPay1, wptPay2, applePay]);
 
     const validDetails = Object.freeze({
       total: {

--- a/payment-request/resources/wpt-pay-1.json
+++ b/payment-request/resources/wpt-pay-1.json
@@ -1,0 +1,15 @@
+{
+  "default_applications": ["wpt-pay-1.json"],
+  "name": "WPT Pay 1",
+  "icons": [
+    {
+      "src": "/images/rgrg-256x256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    }
+  ],
+  "serviceworker": {
+    "src": "wpt-pay-app-1.js",
+    "scope": "wpt-pay-1/"
+  }
+}

--- a/payment-request/resources/wpt-pay-1.json.headers
+++ b/payment-request/resources/wpt-pay-1.json.headers
@@ -1,0 +1,1 @@
+Link: </payment-request/resources/wpt-pay-1.json>; rel="payment-method-manifest"

--- a/payment-request/resources/wpt-pay-2.json
+++ b/payment-request/resources/wpt-pay-2.json
@@ -1,0 +1,15 @@
+{
+  "default_applications": ["wpt-pay-2.json"],
+  "name": "WPT Pay 2",
+  "icons": [
+    {
+      "src": "/images/rgrg-256x256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    }
+  ],
+  "serviceworker": {
+    "src": "wpt-pay-app-2.js",
+    "scope": "wpt-pay-2/"
+  }
+}

--- a/payment-request/resources/wpt-pay-2.json.headers
+++ b/payment-request/resources/wpt-pay-2.json.headers
@@ -1,0 +1,1 @@
+Link: </payment-request/resources/wpt-pay-2.json>; rel="payment-method-manifest"

--- a/payment-request/resources/wpt-pay-app-1.js
+++ b/payment-request/resources/wpt-pay-app-1.js
@@ -1,0 +1,2 @@
+"use strict";
+importScripts("wpt-pay-app.js");

--- a/payment-request/resources/wpt-pay-app-2.js
+++ b/payment-request/resources/wpt-pay-app-2.js
@@ -1,0 +1,2 @@
+"use strict";
+importScripts("wpt-pay-app.js");

--- a/payment-request/resources/wpt-pay-app.js
+++ b/payment-request/resources/wpt-pay-app.js
@@ -1,0 +1,17 @@
+"use strict";
+// Minimal payment handler backing the wpt-pay-1.json and wpt-pay-2.json
+// payment methods, for tests that need PaymentRequest.show() to be
+// supported. Chromium-based browsers install these payment apps
+// just-in-time during show(). Two apps are needed because with only a
+// single candidate app Chromium skips the payment sheet and invokes the
+// handler directly, which makes abort() fail; with two apps the sheet
+// stays open (and show() stays pending) until the test resolves the
+// request. Chromium also requires each app to have its own service worker
+// script URL, so wpt-pay-app-1.js and wpt-pay-app-2.js are trivial
+// wrappers importing this shared implementation. The paymentrequest event
+// is deliberately left unanswered as no test using these methods completes
+// a payment.
+self.addEventListener("canmakepayment", (event) => {
+  event.respondWith(true);
+});
+self.addEventListener("paymentrequest", (event) => {});

--- a/payment-request/show-consume-activation.https.html
+++ b/payment-request/show-consume-activation.https.html
@@ -12,7 +12,14 @@
   <body>
     <script>
       const defaultMethods = [
-        { supportedMethods: "basic-card" },
+        {
+          supportedMethods:
+            window.location.origin + "/payment-request/resources/wpt-pay-1.json",
+        },
+        {
+          supportedMethods:
+            window.location.origin + "/payment-request/resources/wpt-pay-2.json",
+        },
         {
           supportedMethods: "https://apple.com/apple-pay",
           data: {

--- a/payment-request/show-method-optional-promise-rejects.https.html
+++ b/payment-request/show-method-optional-promise-rejects.https.html
@@ -21,8 +21,16 @@
     supportedMethods: "valid-but-wont-ever-match",
   });
 
-  const validMethodBasicCard = Object.freeze({
-    supportedMethods: "basic-card",
+  const wptPay1Method =
+    window.location.origin + "/payment-request/resources/wpt-pay-1.json";
+
+  const validMethodWptPay1 = Object.freeze({
+    supportedMethods: wptPay1Method,
+  });
+
+  const validMethodWptPay2 = Object.freeze({
+    supportedMethods:
+      window.location.origin + "/payment-request/resources/wpt-pay-2.json",
   });
 
   const validMethodApplePay = Object.freeze({
@@ -38,7 +46,8 @@
 
   // Methods
   const validMethods = Object.freeze([
-    validMethodBasicCard,
+    validMethodWptPay1,
+    validMethodWptPay2,
     validMethod,
     validMethodApplePay,
   ]);
@@ -131,19 +140,19 @@
 
   const modifierWithInvalidDisplayItems = Object.freeze({
     additionalDisplayItems: invalidPaymentItems,
-    supportedMethods: "basic-card",
+    supportedMethods: wptPay1Method,
     total: validTotal,
   });
 
   const modifierWithValidDisplayItems = Object.freeze({
     additionalDisplayItems: validPaymentItems,
-    supportedMethods: "basic-card",
+    supportedMethods: wptPay1Method,
     total: validTotal,
   });
 
   const modifierWithInvalidTotal = Object.freeze({
     additionalDisplayItems: validPaymentItems,
-    supportedMethods: "basic-card",
+    supportedMethods: wptPay1Method,
     total: invalidTotal,
   });
 
@@ -152,7 +161,7 @@
   Object.freeze(recursiveData);
 
   const modifierWithRecursiveData = Object.freeze({
-    supportedMethods: "basic-card",
+    supportedMethods: wptPay1Method,
     total: validTotal,
     data: recursiveData,
   });


### PR DESCRIPTION
Since basic-card support was removed from browsers, no automated
payment-request test has used a payment method that any browser other
than Safari supports (Apple Pay being the only other supported method
in the suite). As a result, every test that needs show() to actually
show a payment sheet has silently lost coverage in browsers that
support the Web-Based Payment Handler API.

Add a pair of minimal web-based payment handlers, served from the test
origin, which supporting browsers can install just-in-time during
show(). Use them (and drop the long-dead basic-card method) in the
five tests whose subtests only need show() to show a sheet and stay
pending: payment-request-abort-method,
payment-request-canmakepayment-method, show-consume-activation,
show-method-optional-promise-rejects and rejects_if_not_active.

In Chromium-based browsers this takes payment-request-abort-method,
payment-request-canmakepayment-method and show-consume-activation to
all-PASS, and converts the remaining failures in the other two from
artifacts of the missing payment method into deterministic,
genuine spec-conformance failures now that the tested code paths
actually execute: Chromium rejects show() on non-fully-active
documents with AbortError instead of InvalidStateError (see w3c
payment-request PR https://github.com/web-platform-tests/wpt/pull/58210), and rejects a bad show(detailsPromise)
update with an AbortError wrapping the conversion error instead of the
TypeError itself. All results verified identical across repeated local
runs. Safari results are unchanged on all five tests: it ignores
unsupported URL-based payment methods and the Apple Pay method is
retained.

Notes on the shape of the support files, found experimentally with
Chromium 149:
- Two payment apps are needed because with a single candidate app
  Chromium skips the payment sheet and invokes the handler directly,
  after which abort() fails with InvalidStateError.
- The two apps must come from two separate payment methods (a single
  method manifest listing two default_applications broke show()) and
  must have distinct service worker script URLs (hence the trivial
  wrapper workers importing the shared implementation).
- The Link: rel="payment-method-manifest" response header and the
  manifest icons are both required for the method to be usable.

payment-is-showing.https.html and payment-request-show-method.https.html
are deliberately left out: their subtests require a new user activation
while a payment sheet is already showing, and Chromium's sheet is
tab-modal, blocking WebDriver input to the page. They need either test
restructuring or browser-side automation support to pass in Chromium.