### PR TITLE
script: Avoid creating a `Trusted<Document>` during GC

### DIFF
--- a/html/semantics/embedded-content/media-elements/crashtests/no-blocking-loads-gc-crash.html
+++ b/html/semantics/embedded-content/media-elements/crashtests/no-blocking-loads-gc-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<link rel="help" href="https://github.com/servo/servo/issues/46207">
+<meta name="assert" content="No crash during GC tracing after a media element's load blocker is dropped during GC">
+<script src="/common/gc.js"></script>
+<script>
+function createAndDropBlockingMediaElement() {
+  const container = document.getElementById("container");
+  container.innerHTML = '<audio autoplay src="data:audio/mp3;base64,AAAA"></audio>';
+  container.innerHTML = "";
+  garbageCollect();
+}
+async function main() {
+  for (let round = 0; round < 200; round++) {
+    createAndDropBlockingMediaElement();
+    await garbageCollect();
+    await new Promise(r => setTimeout(r, 0));
+  }
+  document.documentElement.classList.remove("test-wait");
+}
+</script>
+<body onload="main()">
+<div id="container"></div>

--- a/lint.ignore
+++ b/lint.ignore
@@ -226,6 +226,7 @@ SET TIMEOUT: html/canvas/element/manual/draw-element-image/onpaint-css-animation
 SET TIMEOUT: html/canvas/element/manual/draw-element-image/requestPaint.tentative.html
 SET TIMEOUT: html/cross-origin-opener-policy/resources/fully-loaded.js
 SET TIMEOUT: html/editing/dnd/*
+SET TIMEOUT: html/semantics/embedded-content/media-elements/crashtests/no-blocking-loads-gc-crash.html
 SET TIMEOUT: html/semantics/embedded-content/media-elements/track/track-element/crashtests/*
 SET TIMEOUT: html/semantics/embedded-content/the-iframe-element/*
 SET TIMEOUT: html/semantics/embedded-content/the-img-element/*


### PR DESCRIPTION
`Document::finish_load_for_dropped_blocker`, creates a `Trusted<Document>` , which is problematic if the drop happens during (because of) an ongoing GC. If the owning `Document` is being collected in the same GC, we have a problem that can manifest as a segfault during the next GC.

Presumably we might still want to handle the dropped loadblocker somehow, but that can be investigated in a follow-up issue, after fixing the segfault, since this also unblocks adding a reproducible test for #<!-- nolink -->46155.

Testing: Adds a crashtest that reproduces the use-after-free.
Fixes: #<!-- nolink -->46207
Reviewed in servo/servo#46255