### PR TITLE
script: Do not clone nodes into a live document for SVG's `<use>`

### DIFF
--- a/svg/linking/scripted/use-iframe-crash.html
+++ b/svg/linking/scripted/use-iframe-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46250" />
+
+<svg>
+  <foreignObject>
+    <iframe id="iframe"></iframe>
+  </foreignObject>
+  <use href="#iframe">
+</svg>


### PR DESCRIPTION
Cloning nodes into a live document fires their connection steps, which
can do things like load `<iframe>` contents. This is not good. Instead
of doing this, clone the entire SVG tree into a `DocumentFragment` so
that all nodes are essentially inert. This prevents infinite recursion
when combining `<use>` with `<iframe>` as `<iframe>` attachment steps
trigger synchronous layouts, which in turn trigger SVG cloning and
rasterization again.

This change also avoids cloning a node for `<use>` when it already exits
inside the same `<svg>` element as that would create duplicate ids.

Testing: This change adds a WPT crash test. 
Fixes: #<!-- nolink -->46250.

Reviewed in servo/servo#46261