### PR TITLE
script: Do not crash with delete command when cursor is at start of the editing host

### DIFF
--- a/editing/crashtests/delete-before-first-child-of-editing-host.html
+++ b/editing/crashtests/delete-before-first-child-of-editing-host.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+<link rel="help" href="https://github.com/servo/servo/issues/46235" />
+<meta charset="utf-8">
+<body>
+<!-- For this test it is important that there are no text nodes in the inner div -->
+<div id="outer" contenteditable="true">
+    <div contenteditable="true"><span></span></div>
+</div>
+
+<script>
+"use strict";
+
+const span = document.querySelector('span');
+document.getElementById('outer').textContent = "Text";
+
+const range = document.createRange();
+getSelection().addRange(range);
+range.setEndBefore(span);
+
+document.execCommand("delete");
+</script>
+</body>
+</html>


### PR DESCRIPTION
It currently is not possible to distinguish between the two scenarios:

1. We select the full editing host with `selection.collapse(editingHost)`
2. We set the cursor to just before the first child of the editing host

In both cases, the start container is the editing host and the index is zero. Other browsers do not enable the delete command in the second case, but keep it enabled (and do nothing) in the first case.

For now, to avoid crashes, we mimic browser behavior for determining whether the command is enabled by traversing the indices and check if we are at the start of the editing host. Unfortunately this regresses the WPT test that checks if the full empty editing host can be deleted, but that requires the non-standard concept of anchor position type that Chromium has.

Testing: adds a new crashtest
Fixes #<!-- nolink -->46235

Reviewed in servo/servo#46265