### PR TITLE
Fix three bugs breaking the set_virtual_wallet_behavior action

### DIFF
--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -350,6 +350,10 @@ class BidiDigitalCredentialsSetVirtualWalletBehaviorAction:
         self.logger = logger
         self.protocol = protocol
 
+    async def __call__(self, payload):
+        context = get_browsing_context_id(payload["context"])
+        return await self.execute(context, payload)
+
     async def execute(self, context: str, payload: Mapping[str, Any]) -> Any:
         action = payload["action"]
         protocol = payload.get("protocol")

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -985,7 +985,10 @@ class WebDriverBidiDigitalCredentialsProtocolPart(DigitalCredentialsProtocolPart
         if response is not None:
             params["response"] = response
 
-        return await self.webdriver.bidi_session.send_command("digitalCredentials.setVirtualWalletBehavior", params)
+        # send_command returns an awaitable resolving to the response future,
+        # which must itself be awaited to get the command result.
+        return await (await self.webdriver.bidi_session.send_command(
+            "digitalCredentials.setVirtualWalletBehavior", params))
 
 
 class WebDriverStorageProtocolPart(StorageProtocolPart):

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -656,7 +656,10 @@
     };
 
     window.test_driver_internal.set_virtual_wallet_behavior = function(action, protocol=null, response=null, context=null) {
-        return create_context_action("set_virtual_wallet_behavior", context, {action, protocol, response});
+        return create_action("set_virtual_wallet_behavior", {
+            // Default to the current window.
+            context: context ?? window,
+            action, protocol, response});
     };
 
     window.test_driver_internal.create_virtual_sensor = function(sensor_type, sensor_params={}, context=null) {


### PR DESCRIPTION
The digital-credentials/webdriver/ tests have been failing every subtest in CI since they landed, due to three stacked bugs in the wptrunner plumbing for the set_virtual_wallet_behavior action:

1. BidiDigitalCredentialsSetVirtualWalletBehaviorAction defined execute() but no __call__ (and does not inherit a base class that provides one), so invoking the action raised "'...Action' object is not callable".

2. The testdriver-extra.js bridge marshalled the context through create_context_action(), which omits the context key entirely for the test window (KeyError: 'context') and otherwise passes a wptrunner window id rather than something resolvable to a BiDi browsing context. Pass the WindowProxy like the other BiDi actions do, which BiDi serializes to the browsing context.

3. The protocol part awaited BiDi send_command() only once, returning the pending response future instead of the command result. The unserializable future meant the action response never reached testdriver, so tests timed out instead of seeing the command's result or error.

With these fixed, the tests now fail fast with the real underlying error on current Chrome ("Unknown command
'digitalCredentials.setVirtualWalletBehavior'"): the browser-side BiDi command is not implemented yet (tracked in
https://issues.chromium.org/issues/470685266), and the tests should start passing when it ships.