### PR TITLE
HTML: img width/height when not rendered are density-corrected

### DIFF
--- a/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html
+++ b/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html
@@ -59,8 +59,7 @@ img {
 <img src="resources/cat.jpg" width="10" height="10"
      title="raster image with width/height attributes"
      data-natural-width="320" data-natural-height="240"
-     data-width="10" data-height="10"
-     data-not-rendered-width="10" data-not-rendered-height="10">
+     data-width="10" data-height="10">
 <!-- Use "size-comes-from-broken-image-icon" attribute to opt out of checking
      img.width and img.height, because they come from the UA-dependent
      size of the broken image icon: -->
@@ -71,8 +70,7 @@ img {
 <img src="non-existent.jpg" width="10" height="10"
      title="non existent image with width/height attributes, no natural dimensions"
      data-natural-width="0" data-natural-height="0"
-     data-width="10" data-height="10"
-     data-not-rendered-width="10" data-not-rendered-height="10">
+     data-width="10" data-height="10">
 
 <!-- First group of SVG images: no viewBox, with a missing (or edge-casey, i.e.
      negative or percent-valued) value for the width and/or height attr on the
@@ -84,19 +82,18 @@ img {
 <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
      width="40" height="10"
      data-width="40" data-height="10"
-     data-not-rendered-width="40" data-not-rendered-height="10"
      title="SVG image with width/height attrs, no natural dimensions"
      data-density="none"
      data-natural-width="300" data-natural-height="150">
 <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
      width="40"
-     data-width="40" data-not-rendered-width="40"
+     data-width="40"
      title="SVG image with width attr, no natural dimensions"
      data-density="none"
      data-natural-width="300" data-natural-height="150">
 <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
      height="10"
-     data-height="10" data-not-rendered-height="10"
+     data-height="10"
      title="SVG image with height attr, no natural dimensions"
      data-density="none"
      data-natural-width="300" data-natural-height="150">
@@ -327,12 +324,6 @@ function cloneTemplateWithDensity(density) {
     // Scale our 'data-natural-{width,height}' expectations by the density,
     // but only for dimensions that are density-corrected (i.e., derived from
     // the image's own intrinsic dimensions, not from the default object size).
-    // Also:
-    // * Preserve the original 'data-natural-{width,height}' as the
-    // 'data-not-rendered-{width,height}' expectation (if we don't already have
-    // one) since browsers don't do density-correction on .width and .height when
-    // the image is not being rendered, as discussed in
-    // https://github.com/whatwg/html/issues/11287#issuecomment-2923467541
     for (let name in img.dataset) {
       if (name.startsWith("natural")) {
         let origExpectation = img.dataset[name];
@@ -343,15 +334,6 @@ function cloneTemplateWithDensity(density) {
         // Scale our img.natural{Width,Height} expectation:
         if (shouldScale) {
           img.dataset[name] = origExpectation / density;
-        }
-
-        // Construct a string for "data-not-rendered-{width,height}" for
-        // whichever axis we're currently handling, and stash the
-        // origExpectation in there if we don't already have some expectation
-        // set there:
-        let notRenderedName = name.replace("natural", "notRendered");
-        if (!(notRenderedName in img.dataset)) {
-          img.dataset[notRenderedName] = origExpectation;
         }
       }
     }
@@ -405,9 +387,7 @@ onload = function() {
     test(function() {
       // Now test what we get when the img is not rendered.
       // * naturalWidth and naturalHeight shouldn't change.
-      // * width and height should generally match naturalWidth and
-      // naturalHeight. (Exceptions are indicated via the
-      // 'data-not-rendered-{width/height} attributes).
+      // * width and height should match naturalWidth and naturalHeight.
       this.add_cleanup(function() {
         img.style.display = "";
       });
@@ -420,14 +400,9 @@ onload = function() {
       assert_equals(img.naturalHeight, expectedNaturalHeight,
                     'naturalHeight when not rendered');
 
-      const expectedNotRenderedWidth = 'notRenderedWidth' in img.dataset ?
-            parseFloat(img.dataset.notRenderedWidth) : expectedNaturalWidth;
-      const expectedNotRenderedHeight = 'notRenderedHeight' in img.dataset ?
-            parseFloat(img.dataset.notRenderedHeight) : expectedNaturalHeight;
-
-      assert_equals(img.width, expectedNotRenderedWidth,
+      assert_equals(img.width, expectedNaturalWidth,
                     'width when not rendered');
-      assert_equals(img.height, expectedNotRenderedHeight,
+      assert_equals(img.height, expectedNaturalHeight,
                     'height when not rendered');
     }, `${img.title} (when not rendered)`);
   });

--- a/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html
+++ b/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html
@@ -45,10 +45,12 @@ img {
      "data-{width,height}" attributes (as distinguished from
      data-natural-{width,height}).
      * The "data-not-rendered-{width,height}" attributes are the same thing,
-     but for when the img is not being rendered. These are needed because the
-     rendered and not-rendered values can differ: e.g. a rendered img can be
-     stretched by its containing block, whereas a not-rendered img with a
-     width/height content attribute reports that attribute's value.
+     but for when the img is not being rendered. These and "data-{width,height}"
+     both default to "data-natural-{width,height}", so an expectation that only
+     applies while rendered, such as an img stretched by its containing block, is
+     encoded by specifying "data-{width,height}" and leaving
+     "data-not-rendered-{width,height}" out. A width/height content attribute is
+     reported either way, so those cases specify the same value twice.
      * The "data-density" attribute indicates which natural dimensions are
      SVG-intrinsic (and thus should be density-corrected): "both" (default for
      raster), "width", "height", or "none". Default dimensions (300x150) and

--- a/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html
+++ b/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html
@@ -44,6 +44,11 @@ img {
      not correct, we provide the actual expected value in the
      "data-{width,height}" attributes (as distinguished from
      data-natural-{width,height}).
+     * The "data-not-rendered-{width,height}" attributes are the same thing,
+     but for when the img is not being rendered. These are needed because the
+     rendered and not-rendered values can differ: e.g. a rendered img can be
+     stretched by its containing block, whereas a not-rendered img with a
+     width/height content attribute reports that attribute's value.
      * The "data-density" attribute indicates which natural dimensions are
      SVG-intrinsic (and thus should be density-corrected): "both" (default for
      raster), "width", "height", or "none". Default dimensions (300x150) and
@@ -59,7 +64,8 @@ img {
 <img src="resources/cat.jpg" width="10" height="10"
      title="raster image with width/height attributes"
      data-natural-width="320" data-natural-height="240"
-     data-width="10" data-height="10">
+     data-width="10" data-height="10"
+     data-not-rendered-width="10" data-not-rendered-height="10">
 <!-- Use "size-comes-from-broken-image-icon" attribute to opt out of checking
      img.width and img.height, because they come from the UA-dependent
      size of the broken image icon: -->
@@ -70,7 +76,8 @@ img {
 <img src="non-existent.jpg" width="10" height="10"
      title="non existent image with width/height attributes, no natural dimensions"
      data-natural-width="0" data-natural-height="0"
-     data-width="10" data-height="10">
+     data-width="10" data-height="10"
+     data-not-rendered-width="10" data-not-rendered-height="10">
 
 <!-- First group of SVG images: no viewBox, with a missing (or edge-casey, i.e.
      negative or percent-valued) value for the width and/or height attr on the
@@ -82,18 +89,19 @@ img {
 <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
      width="40" height="10"
      data-width="40" data-height="10"
+     data-not-rendered-width="40" data-not-rendered-height="10"
      title="SVG image with width/height attrs, no natural dimensions"
      data-density="none"
      data-natural-width="300" data-natural-height="150">
 <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
      width="40"
-     data-width="40"
+     data-width="40" data-not-rendered-width="40"
      title="SVG image with width attr, no natural dimensions"
      data-density="none"
      data-natural-width="300" data-natural-height="150">
 <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
      height="10"
-     data-height="10"
+     data-height="10" data-not-rendered-height="10"
      title="SVG image with height attr, no natural dimensions"
      data-density="none"
      data-natural-width="300" data-natural-height="150">
@@ -387,7 +395,10 @@ onload = function() {
     test(function() {
       // Now test what we get when the img is not rendered.
       // * naturalWidth and naturalHeight shouldn't change.
-      // * width and height should match naturalWidth and naturalHeight.
+      // * width and height should generally match naturalWidth and
+      // naturalHeight, except that the width and height content attributes
+      // (if present and parseable) take precedence, per axis. Those cases are
+      // indicated via the 'data-not-rendered-{width,height}' attributes.
       this.add_cleanup(function() {
         img.style.display = "";
       });
@@ -400,9 +411,14 @@ onload = function() {
       assert_equals(img.naturalHeight, expectedNaturalHeight,
                     'naturalHeight when not rendered');
 
-      assert_equals(img.width, expectedNaturalWidth,
+      const expectedNotRenderedWidth = 'notRenderedWidth' in img.dataset ?
+            parseFloat(img.dataset.notRenderedWidth) : expectedNaturalWidth;
+      const expectedNotRenderedHeight = 'notRenderedHeight' in img.dataset ?
+            parseFloat(img.dataset.notRenderedHeight) : expectedNaturalHeight;
+
+      assert_equals(img.width, expectedNotRenderedWidth,
                     'width when not rendered');
-      assert_equals(img.height, expectedNaturalHeight,
+      assert_equals(img.height, expectedNotRenderedHeight,
                     'height when not rendered');
     }, `${img.title} (when not rendered)`);
   });

--- a/html/semantics/embedded-content/the-img-element/width-height-attribute-parsing.html
+++ b/html/semantics/embedded-content/the-img-element/width-height-attribute-parsing.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLImageElement width and height parse the dimension attributes when not being rendered</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-width">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-negative-integers">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- The img elements are never rendered, so width and height consult the width
+     and height content attributes, falling back to the density-corrected
+     natural width and height. -->
+<div id="container" style="display: none"></div>
+<div id="log"></div>
+<script>
+const container = document.getElementById("container");
+
+const SRC = "/images/blue-100x100.png";
+const NATURAL = 100;
+
+// The width and height content attributes are parsed with the rules for parsing
+// non-negative integers, which skip leading whitespace, ignore a leading plus
+// sign, and ignore trailing garbage. A value that is not a non-negative integer
+// is ignored in favor of the natural dimensions.
+const attributeValues = [
+  { value: "10", expected: 10 },
+  { value: "0", expected: 0 },
+  { value: "010", expected: 10 },
+  { value: "+10", expected: 10 },
+  { value: " 10 ", expected: 10 },
+  { value: "\n10", expected: 10 },
+  { value: "10px", expected: 10 },
+  { value: "50%", expected: 50 },
+  { value: "1.9", expected: 1 },
+  { value: "2147483647", expected: 2147483647 },
+  { value: "-10", expected: NATURAL },
+  { value: "", expected: NATURAL },
+  { value: "abc", expected: NATURAL },
+];
+
+function insert(attrs) {
+  const img = document.createElement("img");
+  for (const [name, value] of Object.entries(attrs)) {
+    img.setAttribute(name, value);
+  }
+
+  const loaded = new Promise(resolve => {
+    img.addEventListener("load", resolve, { once: true });
+    img.addEventListener("error", resolve, { once: true });
+  });
+
+  container.appendChild(img);
+  return { img, loaded };
+}
+
+for (const { value, expected } of attributeValues) {
+  promise_test(async t => {
+    const { img, loaded } = insert({ src: SRC, width: value, height: value });
+    t.add_cleanup(() => img.remove());
+    await loaded;
+
+    assert_array_equals([img.width, img.height], [expected, expected],
+                        "width and height");
+    assert_array_equals([img.naturalWidth, img.naturalHeight], [NATURAL, NATURAL],
+                        "naturalWidth and naturalHeight");
+  }, `width and height attribute value ${JSON.stringify(value)}`);
+}
+
+promise_test(async t => {
+  const { img, loaded } = insert({ srcset: `${SRC} 2x`, width: "abc" });
+  t.add_cleanup(() => img.remove());
+  await loaded;
+
+  assert_array_equals([img.width, img.height], [50, 50], "width and height");
+  assert_array_equals([img.naturalWidth, img.naturalHeight], [50, 50],
+                      "naturalWidth and naturalHeight");
+}, "unparseable width attribute falls back to the density-corrected natural width");
+</script>

--- a/html/semantics/forms/the-input-element/image-width-height.html
+++ b/html/semantics/forms/the-input-element/image-width-height.html
@@ -3,6 +3,7 @@
 <title>HTMLInputElement width and height for the Image Button state</title>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#dom-input-width">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
@@ -14,11 +15,26 @@ input {
 }
 </style>
 <div id="container"></div>
+<div id="hiddenContainer" style="display: none"></div>
 <div id="log"></div>
 <script>
+const container = document.getElementById("container");
+const hiddenContainer = document.getElementById("hiddenContainer");
+
 const SRC = "/images/blue-100x100.png";
 const NATURAL = 100;
 
+// SVG images whose natural dimensions are not a width and a height. Applying the
+// default sizing algorithm with a default object size of 300x150 is expected to
+// fill in whatever is missing.
+const SVG_NEITHER = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>";
+const SVG_RATIO = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 200'></svg>";
+const SVG_WIDTH = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='60'></svg>";
+const SVG_HEIGHT = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='60'></svg>";
+
+// "rendered" is optional and left out where the rendered size is not something
+// this test means to pin down, i.e., where it depends on how CSS sizes a
+// replaced element that has a natural aspect ratio but no natural dimensions.
 const cases = [
   {
     title: "no width/height attributes",
@@ -62,34 +78,136 @@ const cases = [
     rendered: [0, 0],
     notRendered: [0, 0],
   },
+  {
+    title: "SVG image with neither a natural width nor a natural height",
+    attrs: { type: "image", src: SVG_NEITHER },
+    rendered: [300, 150],
+    notRendered: [300, 150],
+  },
+  {
+    title: "SVG image with a natural aspect ratio only",
+    attrs: { type: "image", src: SVG_RATIO },
+    notRendered: [300, 100],
+  },
+  {
+    title: "SVG image with a natural aspect ratio only, and a width attribute",
+    attrs: { type: "image", src: SVG_RATIO, width: "30" },
+    rendered: [30, 10],
+    notRendered: [30, 100],
+  },
+  {
+    title: "SVG image with a natural width only",
+    attrs: { type: "image", src: SVG_WIDTH },
+    rendered: [60, 150],
+    notRendered: [60, 150],
+  },
+  {
+    title: "SVG image with a natural height only",
+    attrs: { type: "image", src: SVG_HEIGHT },
+    rendered: [300, 60],
+    notRendered: [300, 60],
+  },
 ];
+
+// The width and height content attributes are parsed with the rules for parsing
+// non-negative integers, which skip leading whitespace, ignore a leading plus
+// sign, and ignore trailing garbage. A value that is not a non-negative integer
+// is ignored in favor of the natural dimensions.
+//
+// Only the value when not being rendered is checked, as when the input is being
+// rendered these attributes are instead mapped to the width and height CSS
+// properties, which uses different parsing rules.
+const attributeValues = [
+  { value: "10", expected: 10 },
+  { value: "0", expected: 0 },
+  { value: "010", expected: 10 },
+  { value: "+10", expected: 10 },
+  { value: " 10 ", expected: 10 },
+  { value: "\n10", expected: 10 },
+  { value: "10px", expected: 10 },
+  { value: "50%", expected: 50 },
+  { value: "1.9", expected: 1 },
+  { value: "2147483647", expected: 2147483647 },
+  { value: "-10", expected: NATURAL },
+  { value: "", expected: NATURAL },
+  { value: "abc", expected: NATURAL },
+];
+
+function insert(attrs, parent) {
+  const input = document.createElement("input");
+  for (const [name, value] of Object.entries(attrs)) {
+    input.setAttribute(name, value);
+  }
+
+  const willLoad = attrs.type === "image" && "src" in attrs;
+  const loaded = willLoad ? new Promise(resolve => {
+    input.addEventListener("load", resolve, { once: true });
+    input.addEventListener("error", resolve, { once: true });
+  }) : Promise.resolve();
+
+  parent.appendChild(input);
+  return { input, loaded };
+}
 
 for (const testCase of cases) {
   promise_test(async t => {
-    const input = document.createElement("input");
-    for (const [name, value] of Object.entries(testCase.attrs)) {
-      input.setAttribute(name, value);
-    }
-
-    const willLoad = testCase.attrs.type === "image" && "src" in testCase.attrs;
-    const loaded = willLoad ? new Promise(resolve => {
-      input.addEventListener("load", resolve, { once: true });
-      input.addEventListener("error", resolve, { once: true });
-    }) : Promise.resolve();
-
-    container.appendChild(input);
+    const { input, loaded } = insert(testCase.attrs, container);
     t.add_cleanup(() => input.remove());
     await loaded;
 
-    assert_array_equals([input.width, input.height], testCase.rendered,
-                        "width and height when rendered");
+    if (testCase.rendered) {
+      assert_array_equals([input.width, input.height], testCase.rendered,
+                          "width and height when rendered");
+    }
 
     input.style.display = "none";
-    input.getBoundingClientRect(); // Flush layout.
     assert_array_equals([input.width, input.height], testCase.notRendered,
                         "width and height when not rendered");
   }, testCase.title);
 }
+
+for (const { value, expected } of attributeValues) {
+  promise_test(async t => {
+    const { input, loaded } =
+        insert({ type: "image", src: SRC, width: value, height: value }, container);
+    t.add_cleanup(() => input.remove());
+    await loaded;
+
+    input.style.display = "none";
+    assert_array_equals([input.width, input.height], [expected, expected]);
+  }, `width and height attribute value ${JSON.stringify(value)} when not rendered`);
+}
+
+promise_test(async t => {
+  // Preload, so that the image below is available from the cache.
+  await new Promise(resolve => {
+    const preload = new Image();
+    preload.addEventListener("load", resolve, { once: true });
+    preload.addEventListener("error", resolve, { once: true });
+    preload.src = SRC;
+  });
+
+  const { input, loaded } = insert({ type: "image", src: SRC }, hiddenContainer);
+  t.add_cleanup(() => input.remove());
+  // Give the load event a chance to fire, but do not hang the rest of this file
+  // if a user agent never loads the image for an input that is not rendered.
+  await Promise.race([loaded, new Promise(resolve => t.step_timeout(resolve, 1000))]);
+
+  assert_array_equals([input.width, input.height], [NATURAL, NATURAL]);
+}, "never rendered, no width/height attributes");
+
+test(t => {
+  // No image is needed here, as the attributes take precedence.
+  const input = document.createElement("input");
+  input.setAttribute("type", "image");
+  input.setAttribute("src", SRC);
+  input.setAttribute("width", "10");
+  input.setAttribute("height", "20");
+  hiddenContainer.appendChild(input);
+  t.add_cleanup(() => input.remove());
+
+  assert_array_equals([input.width, input.height], [10, 20]);
+}, "never rendered, with width/height attributes");
 
 test(() => {
   const input = document.createElement("input");

--- a/html/semantics/forms/the-input-element/image-width-height.html
+++ b/html/semantics/forms/the-input-element/image-width-height.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLInputElement width and height for the Image Button state</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#dom-input-width">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+input {
+  /* Avoid any UA border/padding affecting the content box we measure. */
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+</style>
+<div id="container"></div>
+<div id="log"></div>
+<script>
+const SRC = "/images/blue-100x100.png";
+const NATURAL = 100;
+
+const cases = [
+  {
+    title: "no width/height attributes",
+    attrs: { type: "image", src: SRC },
+    rendered: [NATURAL, NATURAL],
+    notRendered: [NATURAL, NATURAL],
+  },
+  {
+    title: "width and height attributes",
+    attrs: { type: "image", src: SRC, width: "10", height: "20" },
+    rendered: [10, 20],
+    notRendered: [10, 20],
+  },
+  {
+    title: "width attribute only",
+    attrs: { type: "image", src: SRC, width: "10" },
+    rendered: [10, 10],
+    notRendered: [10, NATURAL],
+  },
+  {
+    title: "height attribute only",
+    attrs: { type: "image", src: SRC, height: "20" },
+    rendered: [20, 20],
+    notRendered: [NATURAL, 20],
+  },
+  {
+    title: "unparseable width attribute",
+    attrs: { type: "image", src: SRC, width: "abc" },
+    rendered: [NATURAL, NATURAL],
+    notRendered: [NATURAL, NATURAL],
+  },
+  {
+    title: "no src, with width/height attributes",
+    attrs: { type: "image", width: "10", height: "20" },
+    rendered: [10, 20],
+    notRendered: [10, 20],
+  },
+  {
+    title: "not in the Image Button state",
+    attrs: { type: "text", src: SRC, width: "10", height: "20" },
+    rendered: [0, 0],
+    notRendered: [0, 0],
+  },
+];
+
+for (const testCase of cases) {
+  promise_test(async t => {
+    const input = document.createElement("input");
+    for (const [name, value] of Object.entries(testCase.attrs)) {
+      input.setAttribute(name, value);
+    }
+
+    const willLoad = testCase.attrs.type === "image" && "src" in testCase.attrs;
+    const loaded = willLoad ? new Promise(resolve => {
+      input.addEventListener("load", resolve, { once: true });
+      input.addEventListener("error", resolve, { once: true });
+    }) : Promise.resolve();
+
+    container.appendChild(input);
+    t.add_cleanup(() => input.remove());
+    await loaded;
+
+    assert_array_equals([input.width, input.height], testCase.rendered,
+                        "width and height when rendered");
+
+    input.style.display = "none";
+    input.getBoundingClientRect(); // Flush layout.
+    assert_array_equals([input.width, input.height], testCase.notRendered,
+                        "width and height when not rendered");
+  }, testCase.title);
+}
+
+test(() => {
+  const input = document.createElement("input");
+  input.setAttribute("type", "image");
+  input.setAttribute("width", "10");
+  input.setAttribute("height", "20");
+  assert_array_equals([input.width, input.height], [10, 20]);
+}, "detached input, with width/height attributes");
+
+test(() => {
+  const input = document.createElement("input");
+  input.setAttribute("type", "image");
+  assert_array_equals([input.width, input.height], [0, 0]);
+}, "detached input, no attributes and no image");
+</script>

--- a/html/semantics/forms/the-input-element/image-width-height.html
+++ b/html/semantics/forms/the-input-element/image-width-height.html
@@ -32,9 +32,10 @@ const SVG_RATIO = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' vi
 const SVG_WIDTH = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='60'></svg>";
 const SVG_HEIGHT = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='60'></svg>";
 
-// "rendered" is optional and left out where the rendered size is not something
-// this test means to pin down, i.e., where it depends on how CSS sizes a
-// replaced element that has a natural aspect ratio but no natural dimensions.
+// "cases" test how the rendered size, the width/height content attributes, and
+// the image's natural dimensions combine, and "rendered" is optional there.
+// "attributeValues" test how a single attribute value is parsed; the img element
+// has the same list in the-img-element/width-height-attribute-parsing.html.
 const cases = [
   {
     title: "no width/height attributes",
@@ -87,6 +88,7 @@ const cases = [
   {
     title: "SVG image with a natural aspect ratio only",
     attrs: { type: "image", src: SVG_RATIO },
+    // Omitting check for "rendered", which will fill the containing block.
     notRendered: [300, 100],
   },
   {
@@ -109,11 +111,6 @@ const cases = [
   },
 ];
 
-// The width and height content attributes are parsed with the rules for parsing
-// non-negative integers, which skip leading whitespace, ignore a leading plus
-// sign, and ignore trailing garbage. A value that is not a non-negative integer
-// is ignored in favor of the natural dimensions.
-//
 // Only the value when not being rendered is checked, as when the input is being
 // rendered these attributes are instead mapped to the width and height CSS
 // properties, which uses different parsing rules.
@@ -191,7 +188,7 @@ promise_test(async t => {
   t.add_cleanup(() => input.remove());
   // Give the load event a chance to fire, but do not hang the rest of this file
   // if a user agent never loads the image for an input that is not rendered.
-  await Promise.race([loaded, new Promise(resolve => t.step_timeout(resolve, 1000))]);
+  await Promise.race([loaded, new Promise(resolve => t.step_timeout(resolve, 5000))]);
 
   assert_array_equals([input.width, input.height], [NATURAL, NATURAL]);
 }, "never rendered, no width/height attributes");


### PR DESCRIPTION
An available img that is not being rendered reports its density-corrected natural width and height (matching naturalWidth/naturalHeight), per the current specification; the width/height content attributes and rendered size do not apply.