### PR TITLE
HTML Processing Instruction test fixes

### DIFF
--- a/html/syntax/parsing/resources/processing-instructions.dat
+++ b/html/syntax/parsing/resources/processing-instructions.dat
@@ -75,36 +75,39 @@
 |     <?hey ?there?>
 
 #data
-<body><?hey\tthere=1?>
+<body><?hey	there=1?>
 #document
 | <html>
 |   <head>
 |   <body>
-|     <?hey there=1?>
+|     <?hey	there=1?>
 
 #data
-<body><?hey\nthere=1?>
+<body><?hey
+there=1?>
 #document
 | <html>
 |   <head>
 |   <body>
-|     <?hey there=1?>
+|     <?hey
+there=1?>
 
 #data
-<body><?hey\rthere=1?>
+<body><?heythere=1?>
 #document
 | <html>
 |   <head>
 |   <body>
-|     <?hey there=1?>
+|     <?hey
+there=1?>
 
 #data
-<body><?hey\fthere=1?>
+<body><?heythere=1?>
 #document
 | <html>
 |   <head>
 |   <body>
-|     <?hey there=1?>
+|     <?heythere=1?>
 
 #data
 <body><?something ? >

--- a/html/syntax/parsing/resources/processing-instructions.dat
+++ b/html/syntax/parsing/resources/processing-instructions.dat
@@ -80,7 +80,7 @@
 | <html>
 |   <head>
 |   <body>
-|     <?hey	there=1?>
+|     <?hey there=1?>
 
 #data
 <body><?hey
@@ -89,8 +89,7 @@ there=1?>
 | <html>
 |   <head>
 |   <body>
-|     <?hey
-there=1?>
+|     <?hey there=1?>
 
 #data
 <body><?heythere=1?>
@@ -98,8 +97,7 @@ there=1?>
 | <html>
 |   <head>
 |   <body>
-|     <?hey
-there=1?>
+|     <?hey there=1?>
 
 #data
 <body><?heythere=1?>
@@ -107,7 +105,7 @@ there=1?>
 | <html>
 |   <head>
 |   <body>
-|     <?heythere=1?>
+|     <?hey there=1?>
 
 #data
 <body><?something ? >
@@ -599,7 +597,7 @@ there=1?>
 |     <!-- ?99-problems -->
 
 #data
-<body><?\u0665-star>
+<body><?٥-star>
 #document
 | <html>
 |   <head>
@@ -639,7 +637,7 @@ there=1?>
 |     <!-- ?-100 -->
 
 #data
-<body><?\u00B7middle-dot>
+<body><?·middle-dot>
 #document
 | <html>
 |   <head>
@@ -647,7 +645,7 @@ there=1?>
 |     <!-- ?·middle-dot -->
 
 #data
-<body><?\u0375greek-numeral>
+<body><?͵greek-numeral>
 #document
 | <html>
 |   <head>
@@ -655,7 +653,7 @@ there=1?>
 |     <!-- ?͵greek-numeral -->
 
 #data
-<body><?\u0301accent-start>
+<body><?́accent-start>
 #document
 | <html>
 |   <head>
@@ -775,7 +773,7 @@ there=1?>
 |     <!-- ?lit$$4x -->
 
 #data
-<body><?\uD83D\uDE80-launch>
+<body><?🚀-launch>
 #document
 | <html>
 |   <head>
@@ -783,7 +781,7 @@ there=1?>
 |     <!-- ?🚀-launch -->
 
 #data
-<body><?error-\u26A0\uFE0F>
+<body><?error-⚠️>
 #document
 | <html>
 |   <head>
@@ -791,7 +789,7 @@ there=1?>
 |     <!-- ?error-⚠️ -->
 
 #data
-<body><?fire-\uD83D\uDD25>
+<body><?fire-🔥>
 #document
 | <html>
 |   <head>
@@ -799,7 +797,7 @@ there=1?>
 |     <!-- ?fire-🔥 -->
 
 #data
-<body><?v1-\u2705>
+<body><?v1-✅>
 #document
 | <html>
 |   <head>

--- a/html/syntax/parsing/resources/tests1.dat
+++ b/html/syntax/parsing/resources/tests1.dat
@@ -568,6 +568,7 @@ Line1<br>Line2<br>Line3<br>Line4
 #new-errors
 (1:2) unexpected-question-mark-instead-of-tag-name
 #document
+| <!-- ?# -->
 | <html>
 |   <head>
 |   <body>
@@ -606,7 +607,7 @@ Line1<br>Line2<br>Line3<br>Line4
 #new-errors
 (1:2) unexpected-question-mark-instead-of-tag-name
 #document
-| <?COMMENT ??>
+| <?COMMENT?>
 | <html>
 |   <head>
 |   <body>
@@ -645,7 +646,7 @@ Line1<br>Line2<br>Line3<br>Line4
 #new-errors
 (1:2) unexpected-question-mark-instead-of-tag-name
 #document
-| <?COM--MENT ??>
+| <?COM--MENT?>
 | <html>
 |   <head>
 |   <body>


### PR DESCRIPTION
I'm working on processing instruction support for the WordPress HTML API based on recent spec updates. There seem to be some problems in the current tests:

**Use raw whitespace characters in PI target-terminator fixtures**

Some tests used escapes in the test input (`\t` instead of horizontal tab character). This contradicts the data format:

https://github.com/web-platform-tests/wpt/blob/eccc506bb2988311d0f3a0dbea4046e444386740/html/syntax/parsing/resources/README.md?plain=1#L16-L19

See also this test cases where `\n` serializes as `\n`:

https://github.com/web-platform-tests/wpt/blob/eccc506bb2988311d0f3a0dbea4046e444386740/html/syntax/parsing/resources/html5test-com.dat#L59-L68

**Use literal non-ASCII characters in PI invalid-target fixtures**

Same as above, the test inputs should not use escape sequences.

**Update tests1.dat PI expectations to match the current spec**

This file seemed to be outdated with the latest version of the spec. It also includes stale errors or missing new errors, but I did left these untouched.

---

I noticed some inconsistencies in the PI tree data format as specified and as written in the test files. I'll file a separate PR for those issues.