### PR TITLE
layout: Clear laid out fragments of descendants when `content` is replaced

### DIFF
--- a/css/css-content/element-replacement-dynamic-002.html
+++ b/css/css-content/element-replacement-dynamic-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>The content CSS attribute can replace an element's contents dynamically</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property">
+<meta name="assert" content="
+  Descendants of an element that is replaced because of the content property
+  shouldn't be laid out. Therefore, the resolved height in getComputedStyle
+  should be the computed value (`auto`), not the used amount of pixels from
+  the previous layout.
+">
+
+<div id="wrapper">
+  <div style="display: flow-root">
+    <div id="target">Text</div>
+  </div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+<script>
+test(function() {
+  // Force layout
+  document.body.offsetWidth;
+
+  wrapper.style.content = "linear-gradient(blue)";
+  assert_equals(getComputedStyle(target).height, "auto");
+}, "getComputedStyle().height after ancestor becomes replaced");
+</script>

--- a/css/css-content/element-replacement-gradient-scale-root-crash.html
+++ b/css/css-content/element-replacement-gradient-scale-root-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46023">
+
+<style>
+html { scale: 1; }
+div { display: flow-root; }
+</style>
+<div><img id="img"></div>
+<script>
+onload = _ => {
+  document.documentElement.style.cssText = "content: linear-gradient(blue); scale: 0";
+  img.height;
+}
+</script>


### PR DESCRIPTION
A dynamic change of the `content` property can turn a non-replaced element into replaced. In that case, it's possible that the contents were laid out previously, and now they will be skipped.

The problem was that we were still caching the results from the previous layout in some cases. Thus, script queries like `getComputedStyle` could return the wrong value, or Servo could crash.

Testing: Adding a crashtest and a testharness one
Fixes: #<!-- nolink -->46023

Reviewed in servo/servo#46314