### PR TITLE
script: Ignore non-activatable `<area>` elements when clicking a image

### DIFF
--- a/html/semantics/links/links-created-by-a-and-area-elements/area-without-href-activation-crash.html
+++ b/html/semantics/links/links-created-by-a-and-area-elements/area-without-href-activation-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/46336">
+    <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+</head>
+<body onload="image.click()">
+<img id="image" usemap="#map">
+    <map name="map">
+        <area id="foo" shape="circle" coords="1,0,509,4,0,81,0,0">


### PR DESCRIPTION
Testing: This change adds a crash test
Fixes https://github.com/servo/servo/issues/46336
Reviewed in servo/servo#46341