### PR TITLE
wpt: Wait for document.fonts.ready in empty-text-baseline-001/002.html

### DIFF
--- a/css/css-display/empty-text-baseline-001.html
+++ b/css/css-display/empty-text-baseline-001.html
@@ -23,23 +23,29 @@ body {
 </style>
 <div id="container"><div id="inner">x</div><span id="span">x</span></div>
 <script>
-const expected = span.offsetTop;
+setup({ explicit_done: true });
 
-// Force an empty text node on the second line of #inner
-inner.appendChild(document.createElement("br"));
-inner.appendChild(document.createTextNode(''));
+document.fonts.ready.then(() => {
+  const expected = span.offsetTop;
 
-test(function() {
-  assert_equals(span.offsetTop, expected);
-}, "Empty second line in #inner does not generate baseline for #span");
+  // Force an empty text node on the second line of #inner
+  inner.appendChild(document.createElement("br"));
+  inner.appendChild(document.createTextNode(''));
 
-test(function() {
-  inner.style = "white-space: pre-line";
-  assert_equals(span.offsetTop, expected);
-}, "Empty second line in #inner does not generate baseline for #span with white-space: pre-line");
+  test(function() {
+    assert_equals(span.offsetTop, expected);
+  }, "Empty second line in #inner does not generate baseline for #span");
 
-test(function() {
-  inner.style = "white-space: pre";
-  assert_equals(span.offsetTop, expected);
-}, "Empty second line in #inner does not generate baseline for #span with white-space: pre");
+  test(function() {
+    inner.style = "white-space: pre-line";
+    assert_equals(span.offsetTop, expected);
+  }, "Empty second line in #inner does not generate baseline for #span with white-space: pre-line");
+
+  test(function() {
+    inner.style = "white-space: pre";
+    assert_equals(span.offsetTop, expected);
+  }, "Empty second line in #inner does not generate baseline for #span with white-space: pre");
+
+  done();
+});
 </script>

--- a/css/css-display/empty-text-baseline-002.html
+++ b/css/css-display/empty-text-baseline-002.html
@@ -44,19 +44,24 @@ body {
 <div id="ba" class="ahem with-pseudo line-height">x</div>
 <div id="ec" class="ahem with-pseudo font-size empty-concat">x</div>
 <script>
-test(function() {
-  assert_equals(fs.offsetHeight, reference.offsetHeight);
-  assert_equals(ba.offsetHeight, reference.offsetHeight);
-  assert_equals(ec.offsetHeight, reference.offsetHeight);
-}, "Empty content pseudo-element does not generate baseline");
+setup({ explicit_done: true });
 
-test(function() {
-  const divs = [fs, ba, ec];
-  for (let d of divs) {
-    d.style = "white-space: pre";
-  }
-  assert_equals(fs.offsetHeight, reference.offsetHeight);
-  assert_equals(ba.offsetHeight, reference.offsetHeight);
-  assert_equals(ec.offsetHeight, reference.offsetHeight);
-}, "Empty content pseudo-element does not generate baseline with white-space: pre");
+document.fonts.ready.then(() => {
+  test(function() {
+    assert_equals(fs.offsetHeight, reference.offsetHeight);
+    assert_equals(ba.offsetHeight, reference.offsetHeight);
+    assert_equals(ec.offsetHeight, reference.offsetHeight);
+  }, "Empty content pseudo-element does not generate baseline");
+
+  test(function() {
+    const divs = [fs, ba, ec];
+    for (let d of divs) {
+      d.style = "white-space: pre";
+    }
+    assert_equals(fs.offsetHeight, reference.offsetHeight);
+    assert_equals(ba.offsetHeight, reference.offsetHeight);
+    assert_equals(ec.offsetHeight, reference.offsetHeight);
+  }, "Empty content pseudo-element does not generate baseline with white-space: pre");
+  done();
+})
 </script>


### PR DESCRIPTION
The tests rely on the same font being used in all layout queries. However, its possible that the `Ahem` fonts loads inbetween queries, causing timing-dependent failures. This surfaces in https://github.com/servo/servo/pull/46271 because that PR changes the timing of font loads. 

When we wait for `document.fonts.ready` then the referenced PR reliably passes both tests.

cc @dshin-moz 

Reviewed in servo/servo#46344