### PR TITLE
Test link rel=compression-dictionary header as early hints

### DIFF
--- a/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html
@@ -49,7 +49,7 @@ compression_dictionary_promise_test(async (t) => {
       getRemoteHostUrl(`${kRegisterDictionaryPath}?save_header=${dict_token}`);
   addLinkRelCompressionDictionaryElement(url, 'anonymous');
   const headers = await waitUntilPreviousRequestHeaders(
-      t, dict_token, /*check_remote=*/ true);
+      t, dict_token, {check_remote: true});
   assert_true(headers !== undefined, 'Headers should be available');
   assert_equals(headers['sec-fetch-mode'], 'cors');
 

--- a/fetch/compression-dictionary/dictionary-fetch-with-link-header-in-early-hints.tentative.https.h2.html
+++ b/fetch/compression-dictionary/dictionary-fetch-with-link-header-in-early-hints.tentative.https.h2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/common/utils.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+<script>
+  const dict_token = token();
+  const url = new URL(
+      `${kRegisterDictionaryHttp2Path}?save_header=${dict_token}`, location.href);
+  navigateToTestWithCompressionDictionaryEarlyHints("resources/dictionary-fetch-with-link-header-in-early-hints.tentative.https.h2.html", url.href);
+</script>

--- a/fetch/compression-dictionary/resources/compression-dictionary-util.sub.js
+++ b/fetch/compression-dictionary/resources/compression-dictionary-util.sub.js
@@ -96,8 +96,9 @@ async function waitUntilAvailableDictionaryHeader(test, {
 
 // Checks the HTTP request headers which was sent to the server with `token`
 // to register a dictionary.
-async function checkPreviousRequestHeaders(token, check_remote = false) {
-  let url = `./resources/register-dictionary.py?get_previous_header=${token}`;
+async function checkPreviousRequestHeaders(token, options = {}) {
+  const { check_remote = false, use_http2 = false } = options;
+  let url = `${use_http2 ? kRegisterDictionaryHttp2Path : kRegisterDictionaryPath}?get_previous_header=${token}`;
   if (check_remote) {
     url = getRemoteHostUrl(url);
   }
@@ -108,12 +109,12 @@ async function checkPreviousRequestHeaders(token, check_remote = false) {
 // `token` to register a dictionary is available, and returns the header. If the
 // header is not available after the specified number of retries, returns
 // `undefined`.
-async function waitUntilPreviousRequestHeaders(
-    test, token, check_remote = false) {
+async function waitUntilPreviousRequestHeaders(test, token, options = {}) {
+  const { check_remote = false, use_http2 = false } = options;
   for (let retry_count = 0; retry_count <= kCheckPreviousRequestHeadersMaxRetry;
        retry_count++) {
     const header =
-        (await checkPreviousRequestHeaders(token, check_remote))['headers'];
+        (await checkPreviousRequestHeaders(token, {check_remote, use_http2}))['headers'];
     if (header) {
       return header;
     }
@@ -155,4 +156,12 @@ async function registerAltDictionaryAndWait(t) {
   assert_equals(
       await waitUntilAvailableDictionaryHeader(t, {use_alt_path: true}),
       kDefaultDictionaryHashBase64);
+}
+
+function navigateToTestWithCompressionDictionaryEarlyHints(test_url, dictionary_url) {
+  const params = new URLSearchParams();
+  params.set("test_url", test_url);
+  params.set("dictionary_url", dictionary_url);
+  const url = `${RESOURCES_PATH}/early-hint-for-compression-dictionary-test-loader.h2.py?${params.toString()}`;
+  window.location.replace(new URL(url, window.location));
 }

--- a/fetch/compression-dictionary/resources/dictionary-fetch-with-link-header-in-early-hints.tentative.https.h2.html
+++ b/fetch/compression-dictionary/resources/dictionary-fetch-with-link-header-in-early-hints.tentative.https.h2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<!-- resources/early-hint-for-compression-dictionary-test-loader.h2.py loads
+     this file but it really uses links relative to the parent directory. -->
+<base href="../">
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+compression_dictionary_promise_test(async (t) => {
+  const searchParams = new URLSearchParams(location.search);
+  const dictionary_url = searchParams.get("dictionary_url");
+  const dict_token = (new URL(dictionary_url)).searchParams.get("save_header");
+  const headers = await waitUntilPreviousRequestHeaders(t, dict_token, {use_http2: true});
+  assert_true(headers !== undefined, 'Headers should be available');
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed.
+  const data_url = `${kCompressedDataHttp2Path}?content_encoding=dcb`;
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Fetch dictionary using link header in early hint');
+
+</script>
+</body>

--- a/fetch/compression-dictionary/resources/early-hint-for-compression-dictionary-test-loader.h2.py
+++ b/fetch/compression-dictionary/resources/early-hint-for-compression-dictionary-test-loader.h2.py
@@ -1,0 +1,32 @@
+import os
+import time
+
+def _remove_relative_resources_prefix(path):
+    if path.startswith("resources/"):
+        return path[len("resources/"):]
+    return path
+
+def handle_headers(frame, request, response):
+    # Send a 103 response.
+    dictionary_url = request.GET.first(b"dictionary_url").decode()
+    link_header_value = "<{}>; rel=\"compression-dictionary\"".format(dictionary_url).encode()
+    early_hints = [
+        (b":status", b"103"),
+        (b"link", link_header_value),
+    ]
+    response.writer.write_raw_header_frame(headers=early_hints,
+                                           end_headers=True)
+
+    # Delay before sending the 200 response.
+    time.sleep(0.2)
+    response.status = 200
+    response.headers[b"content-type"] = "text/html"
+    response.write_status_headers()
+
+def main(request, response):
+    test_path = _remove_relative_resources_prefix(
+        request.GET[b"test_url"].decode("utf-8"))
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    file_path = os.path.join(current_dir, test_path)
+    test_content = open(file_path, "r").read()
+    response.writer.write_data(item=test_content, last=True)


### PR DESCRIPTION
 Spec PR: https://github.com/whatwg/html/pull/11620
    
This is currently only implemented in Firefox but not covered by any test:
https://searchfox.org/firefox-main/rev/5e465cbe324a291bb69aa85c5c4231e052cabe9a/netwerk/protocol/http/EarlyHintsService.cpp#106
