### PR TITLE
Add tests for processing instructions in templates and head noscript

### DIFF
--- a/html/syntax/parsing/resources/processing-instructions.dat
+++ b/html/syntax/parsing/resources/processing-instructions.dat
@@ -996,3 +996,13 @@ there=1?>
 |       <?pi ?>
 |   <body>
 
+#data
+<template><?pi>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <template>
+|       content
+|         <?pi ?>
+

--- a/html/syntax/parsing/resources/processing-instructions.dat
+++ b/html/syntax/parsing/resources/processing-instructions.dat
@@ -986,3 +986,13 @@ there=1?>
 |     <title>
 |       "<?something>"
 
+#data
+<noscript><?pi>
+#script-off
+#document
+| <html>
+|   <head>
+|     <noscript>
+|       <?pi ?>
+|   <body>
+


### PR DESCRIPTION
Companion to https://github.com/whatwg/html/pull/12653.

Adds processing instruction tests for `in head noscript` and `in template` insertion modes.