### PR TITLE
[wptrunner] Restart browser during wdspec tests if it stops being alive

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -771,10 +771,20 @@ class PytestExecutor(TestExecutor):
             "webdriver": {"binary": self.webdriver_binary, "args": self.webdriver_args},
         }
 
-        return pytestrunner.run(path,
-                                self.server_config,
-                                session_config,
-                                timeout=timeout)
+        harness_result, subtest_results = pytestrunner.run(path,
+                                                           self.server_config,
+                                                           session_config,
+                                                           timeout=timeout)
+
+        # pytest catches exceptions raised by individual test items (e.g. from a
+        # WebDriver connection that died mid-run) and reports them as ordinary
+        # subtest failures, so the harness-level result on its own doesn't tell
+        # us whether the browser is actually still alive.
+        if harness_result[0] != "CRASH" and not self.protocol.is_alive():
+            self.logger.info("Browser not responding, setting status to CRASH")
+            harness_result = ("CRASH", harness_result[1])
+
+        return harness_result, subtest_results
 
 
 class PytestRun(TimedRunner):

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -5,7 +5,6 @@ import hashlib
 import io
 import json
 import os
-import socket
 import struct
 import sys
 import threading
@@ -741,11 +740,14 @@ class PytestExecutor(TestExecutor):
         pass
 
     def do_test(self, test):
-        timeout = test.timeout * self.timeout_multiplier + self.extra_timeout
+        timeout = test.timeout * self.timeout_multiplier
 
-        success, data = PytestRun(self.do_pytest,
+        success, data = PytestRun(self.logger,
+                                  self.do_pytest,
+                                  self.protocol,
                                   test.abs_path,
-                                  timeout).run()
+                                  timeout,
+                                  self.extra_timeout).run()
 
         if success:
             return self.convert_result(test, data)
@@ -775,41 +777,27 @@ class PytestExecutor(TestExecutor):
                                 timeout=timeout)
 
 
-class PytestRun:
-    def __init__(self, func, path, timeout):
-        self.func = func
-        self.result = (None, None)
+class PytestRun(TimedRunner):
+    def __init__(self, logger, func, protocol, path, timeout, extra_timeout):
+        super().__init__(logger, func, protocol, path, timeout, extra_timeout)
         self.path = path
-        self.timeout = timeout
-        self.result_flag = threading.Event()
 
-    def run(self):
-        """Runs function in a thread and interrupts it if it exceeds the
-        given timeout.  Returns (True, (Result, [SubtestResult ...])) in
-        case of success, or (False, (status, extra information)) in the
-        event of failure.
-        """
+    def set_timeout(self):
+        pass  # No session-level timeout to set for pytest-based (wdspec) tests.
 
-        executor = threading.Thread(target=self._run)
-        executor.start()
-
-        self.result_flag.wait(self.timeout)
-        if self.result[1] is None:
-            self.result = False, ("EXTERNAL-TIMEOUT", None)
-
-        return self.result
-
-    def _run(self):
+    def run_func(self):
         try:
-            self.result = True, self.func(self.path, self.timeout)
-        except (socket.timeout, OSError):
-            self.result = False, ("CRASH", None)
+            self.result = True, self.func(self.path, self.timeout + self.extra_timeout)
         except Exception as e:
-            message = getattr(e, "message", "")
-            if message:
-                message += "\n"
-            message += traceback.format_exc()
-            self.result = False, ("INTERNAL-ERROR", message)
+            if self.protocol.is_alive():
+                message = getattr(e, "message", "")
+                if message:
+                    message += "\n"
+                message += traceback.format_exc()
+                self.result = False, ("INTERNAL-ERROR", message)
+            else:
+                self.logger.info("Browser not responding, setting status to CRASH")
+                self.result = False, ("CRASH", None)
         finally:
             self.result_flag.set()
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -373,6 +373,10 @@ RunnerManagerState = Union[BeforeInitState,
 
 
 class TestRunnerManager(threading.Thread):
+    # Statuses that indicate the runner/browser may be in a broken state and
+    # should be restarted before the next test.
+    RESTART_STATUSES = frozenset({"CRASH", "EXTERNAL-TIMEOUT", "INTERNAL-ERROR"})
+
     def __init__(self, suite_name, index, test_queue,
                  test_implementations, stop_flag, retry_index=0, rerun=1,
                  pause_after_test=False, pause_on_unexpected=False,
@@ -872,8 +876,15 @@ class TestRunnerManager(threading.Thread):
                              stack=file_result.stack,
                              subsuite=self.state.test_group.subsuite)
 
+        browser_died = False
+        if (file_result.status not in self.RESTART_STATUSES and
+                not self.browser.is_alive()):
+            self.logger.warning("Browser is no longer running; forcing a restart")
+            browser_died = True
+
         restart_before_next = (self.retry_index > 0 or test.restart_after or
-                               file_result.status in ("CRASH", "EXTERNAL-TIMEOUT", "INTERNAL-ERROR") or
+                               file_result.status in self.RESTART_STATUSES or
+                               browser_died or
                                ((subtest_unexpected or is_unexpected) and
                                 self.restart_on_unexpected))
         force_stop = test.test_type == "wdspec" and file_result.status == "EXTERNAL-TIMEOUT"

--- a/tools/wptrunner/wptrunner/tests/test_executors.py
+++ b/tools/wptrunner/wptrunner/tests/test_executors.py
@@ -1,6 +1,10 @@
 # mypy: allow-untyped-defs
 
+import socket
+import time
+
 import pytest
+from mozlog.structuredlog import StructuredLogger
 
 from ..executors import base
 
@@ -15,3 +19,73 @@ from ..executors import base
     ([[1], [6, 7], [8]], 5, {1})])
 def test_get_pages_valid(ranges_value, total_pages, expected):
     assert base.get_pages(ranges_value, total_pages) == expected
+
+
+class FakeProtocol:
+    def __init__(self, alive=True):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+def test_pytestrun_run_func_success():
+    def do_pytest(path, timeout):
+        return ("OK", None), []
+
+    runner = base.PytestRun(StructuredLogger("test"), do_pytest, FakeProtocol(),
+                            "/some/test.py", 10, 5)
+    runner.run_func()
+    assert runner.result == (True, (("OK", None), []))
+
+
+def test_pytestrun_run_func_socket_timeout_with_alive_browser_reports_internal_error():
+    def do_pytest(path, timeout):
+        raise socket.timeout()
+
+    runner = base.PytestRun(StructuredLogger("test"), do_pytest, FakeProtocol(alive=True),
+                            "/some/test.py", 10, 5)
+    runner.run_func()
+    success, (status, message) = runner.result
+    assert not success
+    assert status == "INTERNAL-ERROR"
+
+
+def test_pytestrun_run_func_exception_with_alive_browser_reports_internal_error():
+    def do_pytest(path, timeout):
+        raise ValueError("boom")
+
+    runner = base.PytestRun(StructuredLogger("test"), do_pytest, FakeProtocol(alive=True),
+                            "/some/test.py", 10, 5)
+    runner.run_func()
+    success, (status, message) = runner.result
+    assert not success
+    assert status == "INTERNAL-ERROR"
+    assert "boom" in message
+
+
+def test_pytestrun_run_func_exception_with_dead_browser_reports_crash():
+    def do_pytest(path, timeout):
+        raise ValueError("boom")
+
+    runner = base.PytestRun(StructuredLogger("test"), do_pytest, FakeProtocol(alive=False),
+                            "/some/test.py", 10, 5)
+    runner.run_func()
+    assert runner.result == (False, ("CRASH", None))
+
+
+def test_pytestrun_set_timeout_is_noop():
+    runner = base.PytestRun(StructuredLogger("test"), lambda path, timeout: None,
+                            FakeProtocol(), "/some/test.py", 10, 5)
+    assert runner.set_timeout() is None
+
+
+def test_pytestrun_run_reports_crash_when_browser_dies_during_hang():
+    def do_pytest(path, timeout):
+        time.sleep(0.5)
+
+    runner = base.PytestRun(StructuredLogger("test"), do_pytest, FakeProtocol(alive=False),
+                            "/some/test.py", 0.05, 0.025)
+    success, (status, message) = runner.run()
+    assert not success
+    assert status == "CRASH"

--- a/tools/wptrunner/wptrunner/tests/test_executors.py
+++ b/tools/wptrunner/wptrunner/tests/test_executors.py
@@ -89,3 +89,61 @@ def test_pytestrun_run_reports_crash_when_browser_dies_during_hang():
     success, (status, message) = runner.run()
     assert not success
     assert status == "CRASH"
+
+
+class FakeBrowser:
+    host = "127.0.0.1"
+    port = 4444
+    env: dict[str, str] = {}
+    pac = None
+
+
+def make_pytest_executor(monkeypatch, protocol_alive, pytest_result):
+    executor = base.PytestExecutor(StructuredLogger("test"), FakeBrowser(), server_config=None,
+                                   webdriver_binary="webdriver", webdriver_args=[],
+                                   target_platform="linux")
+    executor.setup(None)
+    monkeypatch.setattr(executor.protocol, "is_alive", lambda: protocol_alive)
+    monkeypatch.setattr(base.pytestrunner, "run", lambda *args, **kwargs: pytest_result)
+    return executor
+
+
+def test_do_pytest_reports_crash_when_browser_dead_despite_ok_result(monkeypatch):
+    executor = make_pytest_executor(monkeypatch, protocol_alive=False,
+                                    pytest_result=(("OK", None), []))
+
+    harness_result, subtest_results = executor.do_pytest("/some/test.py", 10)
+
+    assert harness_result == ("CRASH", None)
+    assert subtest_results == []
+
+
+def test_do_pytest_reports_crash_when_browser_dead_despite_error_result(monkeypatch):
+    # A non-OK, non-CRASH pytest result (e.g. a collection error) is just as
+    # uninformative about browser liveness as an OK one.
+    executor = make_pytest_executor(monkeypatch, protocol_alive=False,
+                                    pytest_result=(("ERROR", "boom"), []))
+
+    harness_result, subtest_results = executor.do_pytest("/some/test.py", 10)
+
+    assert harness_result == ("CRASH", "boom")
+
+
+def test_do_pytest_keeps_result_when_browser_alive(monkeypatch):
+    executor = make_pytest_executor(monkeypatch, protocol_alive=True,
+                                    pytest_result=(("OK", None), []))
+
+    harness_result, subtest_results = executor.do_pytest("/some/test.py", 10)
+
+    assert harness_result == ("OK", None)
+
+
+def test_do_pytest_skips_is_alive_probe_when_already_crash(monkeypatch):
+    executor = make_pytest_executor(monkeypatch, protocol_alive=True,
+                                    pytest_result=(("CRASH", "boom"), []))
+    monkeypatch.setattr(executor.protocol, "is_alive",
+                        lambda: (_ for _ in ()).throw(AssertionError("should not be called")))
+
+    harness_result, subtest_results = executor.do_pytest("/some/test.py", 10)
+
+    assert harness_result == ("CRASH", "boom")

--- a/tools/wptrunner/wptrunner/tests/test_testrunner.py
+++ b/tools/wptrunner/wptrunner/tests/test_testrunner.py
@@ -1,0 +1,105 @@
+# mypy: allow-untyped-defs
+
+import collections
+import types
+from unittest import mock
+
+from mozlog.structuredlog import StructuredLogger
+
+from .. import testrunner
+
+
+class FakeBrowser:
+    def __init__(self, is_alive=True, has_crash_dump=False):
+        self.browser_pid = None
+        self._is_alive = is_alive
+        self._has_crash_dump = has_crash_dump
+
+    def check_crash(self, test_id):
+        return self._has_crash_dump
+
+    def is_alive(self):
+        return self._is_alive
+
+
+class FakeTest:
+    def __init__(self, test_id="/test.html", test_type="testharness", timeout=10,
+                restart_after=False):
+        self.id = test_id
+        self.test_type = test_type
+        self.timeout = timeout
+        self.restart_after = restart_after
+
+    def disabled(self, subtest_name):
+        return False
+
+    def expected_fail_message(self, subtest_name):
+        return None
+
+
+class FakeFileResult:
+    def __init__(self, status="OK", expected="OK", known_intermittent=None):
+        self.status = status
+        self.expected = expected
+        self.known_intermittent = known_intermittent or []
+        self.extra = {}
+        self.message = None
+        self.stack = None
+
+
+class FakeTestGroup:
+    subsuite = None
+
+
+def make_manager(status="OK", browser_alive=True, has_crash_dump=False,
+                 retry_index=0, restart_after=False, restart_on_unexpected=True,
+                 test_type="testharness"):
+    manager = object.__new__(testrunner.TestRunnerManager)
+    test = FakeTest(test_type=test_type, restart_after=restart_after)
+    manager.state = testrunner.RunningState(FakeTestGroup(), test)
+    manager.timer = None
+    manager.logger = StructuredLogger("test")
+    manager.browser = FakeBrowser(is_alive=browser_alive, has_crash_dump=has_crash_dump)
+    manager.update_status_on_crash = True
+    manager.test_count = 0
+    manager.unexpected_pass_tests = collections.defaultdict(list)
+    manager.unexpected_fail_tests = collections.defaultdict(list)
+    manager.executor_implementation = types.SimpleNamespace(
+        executor_kwargs={"timeout_multiplier": 1})
+    manager.recording = mock.MagicMock()
+    manager.pause_after_test = False
+    manager.pause_on_unexpected = False
+    manager.restart_on_unexpected = restart_on_unexpected
+    manager.retry_index = retry_index
+    manager.after_test_end = mock.MagicMock()
+
+    file_result = FakeFileResult(status=status, expected="OK")
+    return manager, test, file_result
+
+
+def test_test_ended_no_restart_for_ok_result():
+    manager, test, file_result = make_manager(status="OK", browser_alive=True)
+    manager.test_ended(test, (file_result, []))
+    args, kwargs = manager.after_test_end.call_args
+    assert args[1] is False
+
+
+def test_test_ended_restarts_on_crash_status_even_if_browser_reports_alive():
+    manager, test, file_result = make_manager(status="CRASH", browser_alive=True)
+    manager.test_ended(test, (file_result, []))
+    args, kwargs = manager.after_test_end.call_args
+    assert args[1] is True
+
+
+def test_test_ended_forces_restart_when_browser_died_despite_ok_status():
+    manager, test, file_result = make_manager(status="OK", browser_alive=False)
+    manager.test_ended(test, (file_result, []))
+    args, kwargs = manager.after_test_end.call_args
+    assert args[1] is True
+
+
+def test_test_ended_skips_is_alive_probe_when_status_already_forces_restart():
+    manager, test, file_result = make_manager(status="CRASH", browser_alive=True)
+    manager.browser.is_alive = mock.MagicMock(side_effect=AssertionError("should not be called"))
+    manager.test_ended(test, (file_result, []))
+    manager.browser.is_alive.assert_not_called()


### PR DESCRIPTION
- **wptrunner: make PytestRun a TimedRunner subclass so wdspec detects a dead browser**
- **wptrunner: detect a dead browser even when pytest reports a non-CRASH result**
- **wptrunner: force a restart when the browser is confirmed dead, independent of executor status**
