### PR TITLE
Fix indeterminate progress rendering

### DIFF
--- a/html/semantics/forms/the-progress-element/progress-indeterminate-rendering-full-notref.html
+++ b/html/semantics/forms/the-progress-element/progress-indeterminate-rendering-full-notref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>Indeterminate progress rendering full-value notref</title>
+<progress value="1"></progress>

--- a/html/semantics/forms/the-progress-element/progress-indeterminate-rendering-notref.html
+++ b/html/semantics/forms/the-progress-element/progress-indeterminate-rendering-notref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>Indeterminate progress rendering notref</title>
+<progress value="0"></progress>

--- a/html/semantics/forms/the-progress-element/progress-indeterminate-rendering.html
+++ b/html/semantics/forms/the-progress-element/progress-indeterminate-rendering.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>Indeterminate progress rendering</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-progress-element">
+<link rel="mismatch" href="progress-indeterminate-rendering-notref.html">
+<link rel="mismatch" href="progress-indeterminate-rendering-full-notref.html">
+<meta name="assert" content="An indeterminate progress element renders differently from determinate zero-value and full-value progress elements.">
+<progress></progress>


### PR DESCRIPTION
Indeterminate `<progress>` elements currently render the same as `<progress value="0">`, because the internal progress bar width is computed from `value / max` and a missing `value` is interpreted as zero for the `value` IDL attribute.

Use the presence of the `value` content attribute to distinguish indeterminate progress elements in the current UA shadow tree rendering, while preserving the existing `Value() / Max()` path for determinate progress elements. Indeterminate progress elements render as a centered segment so they do not look like either zero progress or completed progress.

Testing: Added a WPT mismatch reftest covering that indeterminate `<progress>` renders differently from both `<progress value="0">` and `<progress value="1">`.

Fixes: #<!-- nolink -->35829
Reviewed in servo/servo#46367