### PR TITLE
Don't set test fail status in web-extensions-helper.js.

### DIFF
--- a/resources/web-extensions-helper.js
+++ b/resources/web-extensions-helper.js
@@ -27,10 +27,6 @@ globalThis.runTestsWithWebExtension = function(extensionPath) {
 
     test.done();
 
-    if (!data.result) {
-      test.set_status(test.FAIL);
-    }
-
     if (data.remainingTests) {
       return;
     }


### PR DESCRIPTION
web-extension-helper.js was overriding the test status to just `test.FAIL`, leaving out the test message. This causes a test failure to look like: `FAIL message: Undefined.UNDEFINED` since the message and stack are `undefined`.

`test.set_status(status, message, stack);` is already being handled by testharness.js in the `step()` method (see line 2878) so we can just rely on that.