### PR TITLE
Allow replaceChildren() to replace a Document's children

### DIFF
--- a/dom/nodes/ParentNode-replaceChildren.html
+++ b/dom/nodes/ParentNode-replaceChildren.html
@@ -122,6 +122,50 @@
   test_replacechildren(document.createElement('div'), 'Element');
   test_replacechildren(document.createDocumentFragment(), 'DocumentFragment');
 
+  // Document is special: replaceChildren removes the existing children (a
+  // doctype and a document element) before inserting, so the pre-insert
+  // validity checks must ignore them. See
+  // https://github.com/whatwg/dom/issues/1045.
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const el = doc.createElement("a");
+    doc.replaceChildren(el);
+    assert_array_equals(doc.childNodes, [el]);
+  }, "Document.replaceChildren() with an element, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const df = doc.createDocumentFragment();
+    const el = doc.createElement("a");
+    df.appendChild(el);
+    doc.replaceChildren(df);
+    assert_array_equals(doc.childNodes, [el]);
+  }, "Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const doctype = doc.doctype.cloneNode();
+    doc.replaceChildren(doctype);
+    assert_array_equals(doc.childNodes, [doctype]);
+  }, "Document.replaceChildren() with a doctype, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    doc.replaceChildren();
+    assert_array_equals(doc.childNodes, []);
+  }, "Document.replaceChildren() without any argument, removing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    assert_throws_dom("HierarchyRequestError",
+      () => doc.replaceChildren(doc.createElement("a"), doc.createElement("b")));
+  }, "Document.replaceChildren() with two elements throws a HierarchyRequestError.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    assert_throws_dom("HierarchyRequestError", () => doc.replaceChildren("text"));
+  }, "Document.replaceChildren() with text throws a HierarchyRequestError.");
+
   async_test(t => {
     let root = document.createElement("div");
     root.innerHTML = "<div id='a'>text<div id='b'>text2</div></div>";

--- a/dom/nodes/pre-insertion-validation-hierarchy.js
+++ b/dom/nodes/pre-insertion-validation-hierarchy.js
@@ -51,31 +51,41 @@ function preInsertionValidateHierarchy(methodName) {
   }, "If node is a DocumentFragment with multiple elements and parent is a document, then throw a HierarchyRequestError DOMException.");
 
   // Step 6, in case of DocumentFragment has multiple elements when document already has an element
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const df = doc.createDocumentFragment();
-    df.appendChild(doc.createElement("a"));
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, df));
-  }, "If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const df = doc.createDocumentFragment();
+      df.appendChild(doc.createElement("a"));
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, df));
+    }, "If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of an element
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const el = doc.createElement("a");
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, el));
-  }, "If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const el = doc.createElement("a");
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, el));
+    }, "If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of a doctype when document already has another doctype
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const doctype = doc.childNodes[0].cloneNode();
-    doc.documentElement.remove();
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, doctype));
-  }, "If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const doctype = doc.childNodes[0].cloneNode();
+      doc.documentElement.remove();
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, doctype));
+    }, "If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of a doctype when document has an element
-  if (methodName !== "prepend") {
+  if (methodName !== "prepend" && methodName !== "replaceChildren") {
     // Skip `.prepend` as this doesn't throw if `child` is an element
+    // Skip `.replaceChildren` as it removes the document's existing children first
     test(() => {
       const doc = document.implementation.createHTMLDocument("title");
       const doctype = doc.childNodes[0].cloneNode();


### PR DESCRIPTION
`replaceChildren()` removes the parent's existing children before inserting, so the "ensure pre-insert validity" checks must not count them. Previously the shared hierarchy-validation helper asserted that `replaceChildren()` on a `Document` that already has an element/doctype throws, which is wrong.

This updates the tests:

- `pre-insertion-validation-hierarchy.js`: skip the cases that depend on pre-existing children for `replaceChildren` (mirroring the existing `prepend` skip). These remain asserted for `append`, `prepend`, `insertBefore`, and `moveBefore`, which do not remove the existing children.
- `ParentNode-replaceChildren.html`: add coverage for `Document` parents — `replaceChildren()` with an element, a single-element `DocumentFragment`, a doctype, and no arguments all succeed; two elements and text still throw.

Spec change: a corresponding whatwg/dom PR generalizes the "ensure pre-insert validity" `childToExclude` into a list of children to exclude, which `replaceChildren` populates with all of the parent's children.

See https://github.com/whatwg/dom/issues/1045.