### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318489

### DIFF
--- a/css/css-grid/grid-overflowing-item-below-container-is-painted-ref.html
+++ b/css/css-grid/grid-overflowing-item-below-container-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/css/css-grid/grid-overflowing-item-below-container-is-painted.html
+++ b/css/css-grid/grid-overflowing-item-below-container-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-below-container-is-painted-ref.html">
+<meta name="assert" content="A grid item in a zero-height grid container overflows its bottom edge and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 100px;
+    height: 0;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  }
+  .item {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/css/css-grid/grid-overflowing-item-in-both-axes-is-painted-ref.html
+++ b/css/css-grid/grid-overflowing-item-in-both-axes-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/css/css-grid/grid-overflowing-item-in-both-axes-is-painted.html
+++ b/css/css-grid/grid-overflowing-item-in-both-axes-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-in-both-axes-is-painted-ref.html">
+<meta name="assert" content="A grid item in a zero-width, zero-height grid container overflows both the right and bottom edges and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 0;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  }
+  .item {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted-ref.html
+++ b/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 40px;
+    top: 40px;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted.html
+++ b/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-in-nonstart-cell-is-painted-ref.html">
+<meta name="assert" content="A grid item placed in a non-start row and column of a zero-width, zero-height grid overflows both the right and bottom edges and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 0;
+    display: grid;
+    grid-template-columns: 40px 40px;
+    grid-template-rows: 40px 40px;
+  }
+  .item {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/css/css-grid/grid-overflowing-item-right-of-container-is-painted-ref.html
+++ b/css/css-grid/grid-overflowing-item-right-of-container-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/css/css-grid/grid-overflowing-item-right-of-container-is-painted.html
+++ b/css/css-grid/grid-overflowing-item-right-of-container-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-right-of-container-is-painted-ref.html">
+<meta name="assert" content="A grid item in a zero-width grid container overflows its right edge and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 100px;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  }
+  .item {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/css/css-grid/grid-overflowing-multiple-items-are-painted-ref.html
+++ b/css/css-grid/grid-overflowing-multiple-items-are-painted-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .a {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 30px;
+    background-color: green;
+  }
+  .b {
+    position: absolute;
+    left: 40px;
+    top: 40px;
+    width: 30px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="a"></div>
+<div class="b"></div>

--- a/css/css-grid/grid-overflowing-multiple-items-are-painted.html
+++ b/css/css-grid/grid-overflowing-multiple-items-are-painted.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-multiple-items-are-painted-ref.html">
+<meta name="assert" content="Multiple grid items placed in different cells of a zero-width, zero-height grid overflow different edges and must all still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 0;
+    display: grid;
+    grid-template-columns: 40px 40px;
+    grid-template-rows: 40px 40px;
+  }
+  .a {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 30px;
+    background-color: green;
+  }
+  .b {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    width: 30px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="a"></div>
+  <div class="b"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[GFC\] Visually overflowing content is not painted](https://bugs.webkit.org/show_bug.cgi?id=318489)