### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=317983

### DIFF
--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-explicit-row.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-explicit-row.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: block-axis 'auto' margins with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
+<link rel="match" href="../reference/grid-block-axis-alignment-auto-margins-explicit-row-ref.html">
+<meta name="assert" content="Block-axis 'auto' margins center an explicitly-placed grid item within its row.">
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 100px;
+      grid-template-rows: 100px 100px;
+  }
+  #grid div {
+      margin: auto 0;          /* center within the row in the block axis */
+      width: 100px;
+  }
+  #item1 {
+      grid-row: 1 / 2;
+      height: 20px;
+      background: green;
+  }
+  #item2 {
+      grid-row: 2 / 3;
+      height: 40px;
+      background: blue;
+  }
+</style>
+<p>The test passes if the green box and the blue box are each centered vertically within their grid row.</p>
+<div id="grid">
+    <div id="item1"></div>
+    <div id="item2"></div>
+</div>

--- a/css/css-grid/alignment/grid-calc-margins-explicit-row.html
+++ b/css/css-grid/alignment/grid-calc-margins-explicit-row.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: calc() margin on a grid item with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" title="6.4 Grid Item Margins and Paddings" href="https://drafts.csswg.org/css-grid/#item-margins">
+<link rel="match" href="../reference/grid-calc-margins-explicit-row-ref.html">
+<meta name="assert" content="A percentage in a calc() margin on a grid item resolves against the inline size of its containing block (the grid area).">
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 200px;
+      grid-template-rows: 100px;
+  }
+  #item {
+      grid-row: 1 / 2;
+      width: 50px;
+      height: 50px;
+      /* margin % resolves against the grid area inline size (200px):
+         30% -> 60px, + 10px -> 70px left offset. */
+      margin-left: calc(10px + 30%);
+      background: green;
+  }
+</style>
+<p>The test passes if the left edge of the green box is 70px from the left edge of the grey grid.</p>
+<div id="grid">
+    <div id="item"></div>
+</div>

--- a/css/css-grid/reference/grid-block-axis-alignment-auto-margins-explicit-row-ref.html
+++ b/css/css-grid/reference/grid-block-axis-alignment-auto-margins-explicit-row-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: block-axis 'auto' margins with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<!-- Same layout achieved with align-items:center instead of auto margins. -->
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 100px;
+      grid-template-rows: 100px 100px;
+      align-items: center;     /* center within the row in the block axis */
+  }
+  #grid div {
+      width: 100px;
+  }
+  #item1 {
+      grid-row: 1 / 2;
+      height: 20px;
+      background: green;
+  }
+  #item2 {
+      grid-row: 2 / 3;
+      height: 40px;
+      background: blue;
+  }
+</style>
+<p>The test passes if the green box and the blue box are each centered vertically within their grid row.</p>
+<div id="grid">
+    <div id="item1"></div>
+    <div id="item2"></div>
+</div>

--- a/css/css-grid/reference/grid-calc-margins-explicit-row-ref.html
+++ b/css/css-grid/reference/grid-calc-margins-explicit-row-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: calc() margin on a grid item with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<!-- Same layout achieved with a resolved fixed margin instead of calc(). -->
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 200px;
+      grid-template-rows: 100px;
+  }
+  #item {
+      grid-row: 1 / 2;
+      width: 50px;
+      height: 50px;
+      margin-left: 70px;
+      background: green;
+  }
+</style>
+<p>The test passes if the left edge of the green box is 70px from the left edge of the grey grid.</p>
+<div id="grid">
+    <div id="item"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[GFC\] Items with auto or calc margins are not supported](https://bugs.webkit.org/show_bug.cgi?id=317983)