### PR TITLE
script: Implement getPublicKey operations of Ed448 and X448

### DIFF
--- a/WebCryptoAPI/getPublicKey.tentative.https.any.js
+++ b/WebCryptoAPI/getPublicKey.tentative.https.any.js
@@ -24,6 +24,12 @@ const algorithms = [
         publicKeyUsages: ["verify"]
     },
     {
+        name: "Ed448",
+        generateKeyParams: { name: "Ed448" },
+        usages: ["sign", "verify"],
+        publicKeyUsages: ["verify"]
+    },
+    {
         name: "RSA-OAEP",
         generateKeyParams: {
             name: "RSA-OAEP",
@@ -59,6 +65,12 @@ const algorithms = [
     {
         name: "X25519",
         generateKeyParams: { name: "X25519" },
+        usages: ["deriveKey", "deriveBits"],
+        publicKeyUsages: []
+    },
+    {
+        name: "X448",
+        generateKeyParams: { name: "X448" },
         usages: ["deriveKey", "deriveBits"],
         publicKeyUsages: []
     },


### PR DESCRIPTION
This patch implements the getPublicKey operations of Ed448 and X448 in our WebCrypto API implementation. New test cases are added to `tests/wpt/tests/WebCryptoAPI/getPublicKey.tentative.https.any.js` for testing `SubtleCrypto.getPublicKey()` method on input Ed448 and X448 private keys.

Specification:
<https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-supports>

Testing: Pass new WPT subtests in `getPublicKey.tentative.https.any.js`
Part-of: #<!-- nolink -->46140

Reviewed in servo/servo#46402