### PR TITLE
[digital-credentials] Test get() from an opaque origin

### DIFF
--- a/digital-credentials/get-opaque-origin-combinations.https.html
+++ b/digital-credentials/get-opaque-origin-combinations.https.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Digital Credentials: get() and opaque origins across framing combinations
+</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    const SUPPORT = "/digital-credentials/support/";
+
+    // Inline reporter for the srcdoc / data: / blob: cases, which can neither load an
+    // external page nor carry an id in a URL. Mirrors support/dc-report-get.js: it calls
+    // get() and posts { origin, secure, result } to the top-level test so even deeply
+    // nested / opaque frames can report back.
+    const reportDoc = (
+      id,
+    ) => `<!DOCTYPE html><meta charset=utf-8><body></body><script>
+(async () => {
+  const report = { id: ${JSON.stringify(id)}, origin: String(self.origin), secure: self.isSecureContext, result: "resolved" };
+  try {
+    if (!(navigator.credentials && navigator.credentials.get)) throw new TypeError("navigator.credentials.get is unavailable");
+    await navigator.credentials.get({ digital: { requests: [] } });
+  } catch (error) { report.result = error.name; }
+  (window.top || window.parent).postMessage(report, "*");
+})();
+<\/script>`;
+
+    function awaitReport(id) {
+      return new Promise((resolve) => {
+        addEventListener("message", function handler(event) {
+          if (event.data && event.data.id === id) {
+            removeEventListener("message", handler);
+            resolve(event.data);
+          }
+        });
+      });
+    }
+
+    function runInFrame(id, configure) {
+      const frame = document.createElement("iframe");
+      frame.allow = "digital-credentials-get";
+      configure(frame, id);
+      document.body.appendChild(frame);
+      return awaitReport(id).finally(() => {
+        if (frame.src.startsWith("blob:")) URL.revokeObjectURL(frame.src);
+      });
+    }
+
+    // Opaque calling document -> the opaque-origin guard fires -> SecurityError.
+    const OPAQUE = [
+      [
+        "sandboxed iframe",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.src = SUPPORT + "dc-report-get.html?id=" + id;
+        },
+      ],
+      [
+        "sandboxed srcdoc iframe",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.srcdoc = reportDoc(id);
+        },
+      ],
+      [
+        "iframe whose document has a Content-Security-Policy: sandbox header",
+        (frame, id) => {
+          frame.src = SUPPORT + "dc-report-get-csp-sandbox.html?id=" + id;
+        },
+      ],
+      [
+        "plain iframe nested inside a sandboxed iframe (2 levels)",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.src = SUPPORT + "dc-nest.html?id=" + id + "&depth=0";
+        },
+      ],
+      [
+        "plain iframes nested two deep inside a sandboxed iframe (3 levels)",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.src = SUPPORT + "dc-nest.html?id=" + id + "&depth=1";
+        },
+      ],
+      [
+        "allow-same-origin iframe nested inside a sandboxed iframe",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts";
+          frame.srcdoc = `<!DOCTYPE html><body><script>
+            const inner = document.createElement("iframe");
+            inner.sandbox = "allow-scripts allow-same-origin";
+            inner.allow = "digital-credentials-get";
+            inner.src = ${JSON.stringify(SUPPORT + "dc-report-get.html?id=" + id)};
+            document.body.appendChild(inner);
+          <\/script>`;
+        },
+      ],
+    ];
+    OPAQUE.forEach(([label, configure], index) => {
+      promise_test(
+        async () => {
+          const report = await runInFrame("opaque-" + index, configure);
+          assert_equals(report.origin, "null", "expected an opaque origin");
+          assert_equals(
+            report.result,
+            "SecurityError",
+            "an opaque origin must reject with SecurityError",
+          );
+        },
+        "get() from an opaque origin (" +
+          label +
+          ") rejects with SecurityError",
+      );
+    });
+
+    // Non-opaque calling document -> the opaque-origin guard must NOT fire.
+    const NON_OPAQUE = [
+      [
+        "sandboxed iframe with allow-same-origin",
+        (frame, id) => {
+          frame.sandbox = "allow-scripts allow-same-origin";
+          frame.src = SUPPORT + "dc-report-get.html?id=" + id;
+        },
+      ],
+      [
+        "srcdoc iframe without sandbox (inherits the parent origin)",
+        (frame, id) => {
+          frame.srcdoc = reportDoc(id);
+        },
+      ],
+      [
+        "blob: iframe (inherits the creator origin)",
+        (frame, id) => {
+          frame.src = URL.createObjectURL(
+            new Blob([reportDoc(id)], { type: "text/html" }),
+          );
+        },
+      ],
+    ];
+    NON_OPAQUE.forEach(([label, configure], index) => {
+      promise_test(
+        async () => {
+          const report = await runInFrame("nonopaque-" + index, configure);
+          assert_not_equals(
+            report.origin,
+            "null",
+            "expected a normal (non-opaque) origin",
+          );
+          assert_not_equals(
+            report.result,
+            "SecurityError",
+            "a non-opaque origin must not be rejected by the opaque-origin check",
+          );
+        },
+        "get() from a non-opaque origin (" +
+          label +
+          ") is not rejected as opaque",
+      );
+    });
+
+    promise_test(async () => {
+      const report = await runInFrame("data", (frame, id) => {
+        frame.src = "data:text/html," + encodeURIComponent(reportDoc(id));
+      });
+      assert_false(report.secure, "a data: document is not a secure context");
+      assert_equals(
+        report.result,
+        "TypeError",
+        "the API is unavailable, so it is a TypeError, not a SecurityError",
+      );
+    }, "get() in a data: iframe is unavailable (not a secure context) and never reaches the opaque-origin check");
+
+    promise_test(async () => {
+      const report = await runInFrame("blob-in-sandbox", (frame, id) => {
+        frame.sandbox = "allow-scripts";
+        frame.src = SUPPORT + "dc-report-get-blob-in-sandbox.html?id=" + id;
+      });
+      assert_equals(
+        report.origin,
+        "null",
+        "the blob inherits the opaque creator origin",
+      );
+      assert_false(
+        report.secure,
+        "a blob: document created in an opaque frame is not a secure context",
+      );
+      assert_equals(
+        report.result,
+        "TypeError",
+        "the API is unavailable, so it is a TypeError, not a SecurityError",
+      );
+    }, "get() in a blob: iframe created inside a sandboxed frame inherits the opaque origin and is unavailable");
+  </script>
+</body>

--- a/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html
+++ b/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Digital Credentials: a top-level sandboxed page with allow-same-origin is not
+  treated as opaque
+</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // Served with `Content-Security-Policy: sandbox allow-scripts allow-same-origin`
+    // (see the .headers file): the page is sandboxed for hardening but keeps its real
+    // origin, so it is NOT opaque and the opaque-origin check does not fire. The call
+    // then fails later for an unrelated reason (no requests) — which is what proves it
+    // was not rejected as opaque.
+    promise_test((t) => {
+      return promise_rejects_js(
+        t,
+        TypeError,
+        navigator.credentials.get({ digital: { requests: [] } }),
+      );
+    }, "get() from a top-level sandboxed page with allow-same-origin is not rejected as opaque");
+  </script>
+</body>

--- a/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html.headers
+++ b/digital-credentials/get-opaque-origin-top-level-allow-same-origin.https.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts allow-same-origin

--- a/digital-credentials/get-opaque-origin-top-level.https.html
+++ b/digital-credentials/get-opaque-origin-top-level.https.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Digital Credentials: get() from a top-level opaque origin rejects with
+  SecurityError
+</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // This document is served with `Content-Security-Policy: sandbox allow-scripts`
+    // (see the accompanying .headers file): the top-level document has an opaque
+    // origin while remaining a secure context. Permissions Policy still grants the
+    // feature to a top-level document (it matches its own 'self'), so the
+    // opaque-origin check is the only thing that can reject the request.
+    promise_test(async (t) => {
+      await promise_rejects_dom(
+        t,
+        "SecurityError",
+        navigator.credentials.get({ digital: { requests: [] } }),
+      );
+    }, "navigator.credentials.get() from a top-level opaque origin rejects with SecurityError");
+  </script>
+</body>

--- a/digital-credentials/get-opaque-origin-top-level.https.html.headers
+++ b/digital-credentials/get-opaque-origin-top-level.https.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/digital-credentials/support/dc-nest.html
+++ b/digital-credentials/support/dc-nest.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script>
+  const params = new URL(location.href).searchParams;
+  const id = params.get("id");
+  const depth = parseInt(params.get("depth") || "0", 10);
+  const nextSrc =
+    depth > 0
+      ? "/digital-credentials/support/dc-nest.html?id=" +
+        encodeURIComponent(id) +
+        "&depth=" +
+        (depth - 1)
+      : "/digital-credentials/support/dc-report-get.html?id=" +
+        encodeURIComponent(id);
+  const frame = document.createElement("iframe");
+  frame.allow = "digital-credentials-get";
+  frame.src = nextSrc;
+  document.body.appendChild(frame);
+</script>

--- a/digital-credentials/support/dc-report-get-blob-in-sandbox.html
+++ b/digital-credentials/support/dc-report-get-blob-in-sandbox.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script>
+  // Creates a blob: child from this (sandboxed, opaque) context; the blob inherits the opaque origin.
+  const id = new URL(location.href).searchParams.get("id");
+  const inner = `<!doctype html><meta charset=utf-8><body><script>
+(async () => {
+  const report = { id: ${JSON.stringify("__ID__")}, origin: String(self.origin), secure: self.isSecureContext, result: "resolved" };
+  try {
+    if (!(navigator.credentials && navigator.credentials.get)) throw new TypeError("navigator.credentials.get is unavailable");
+    await navigator.credentials.get({ digital: { requests: [] } });
+  } catch (error) { report.result = error.name; }
+  (window.top || window.parent).postMessage(report, "*");
+})();
+<\/script>`.replace("__ID__", id);
+  const frame = document.createElement("iframe");
+  frame.allow = "digital-credentials-get";
+  frame.src = URL.createObjectURL(new Blob([inner], { type: "text/html" }));
+  document.body.appendChild(frame);
+</script>

--- a/digital-credentials/support/dc-report-get-csp-sandbox.html
+++ b/digital-credentials/support/dc-report-get-csp-sandbox.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script src="dc-report-get.js"></script>

--- a/digital-credentials/support/dc-report-get-csp-sandbox.html.headers
+++ b/digital-credentials/support/dc-report-get-csp-sandbox.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/digital-credentials/support/dc-report-get.html
+++ b/digital-credentials/support/dc-report-get.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script src="dc-report-get.js"></script>

--- a/digital-credentials/support/dc-report-get.js
+++ b/digital-credentials/support/dc-report-get.js
@@ -1,0 +1,20 @@
+// Used by the served (src=) cases. The srcdoc/data:/blob: cases in
+// get-opaque-origin-combinations.https.html inline the same logic because they can
+// neither load an external page nor carry an id in a URL.
+(async () => {
+  const id = new URL(location.href).searchParams.get("id");
+  const report = {
+    id,
+    origin: String(self.origin),
+    secure: self.isSecureContext,
+    result: "resolved",
+  };
+  try {
+    if (!(navigator.credentials && navigator.credentials.get))
+      throw new TypeError("navigator.credentials.get is unavailable");
+    await navigator.credentials.get({ digital: { requests: [] } });
+  } catch (error) {
+    report.result = error.name;
+  }
+  (window.top || window.parent).postMessage(report, "*");
+})();


### PR DESCRIPTION
Adds a test that `navigator.credentials.get({ digital })` from a document with an opaque origin (a sandboxed iframe without `allow-same-origin`) is rejected, with a non-opaque `allow-same-origin` frame as a control to show the check keys on origin opacity rather than the sandbox attribute.

Marked tentative because it asserts `SecurityError`. The current spec text in w3c-fedid/digital-credentials#535 and Chromium's implementation currently use `NotAllowedError`, so the opaque assertion is expected to fail on other engines until they align.

WebKit implementation: https://bugs.webkit.org/show_bug.cgi?id=318947
