### PR TITLE
[jpegxl] Add fuzzy matching to specific tests

### DIFF
--- a/jpegxl/alpha-modular-reftest.html
+++ b/jpegxl/alpha-modular-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="alpha-modular-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-5">
 <meta name="assert" content="Alpha-bearing modular JPEG XL decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/bitdepth-10bpc-reftest.html
+++ b/jpegxl/bitdepth-10bpc-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="bitdepth-10bpc-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1280664">
 <meta name="assert" content="10-bit JPEG XL decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/bitdepth-12bpc-reftest.html
+++ b/jpegxl/bitdepth-12bpc-reftest.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="bitdepth-12bpc-reftest-ref.html">
-<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-100000">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1048576">
 <meta name="assert" content="12-bit JPEG XL decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/bitdepth-16bpc-reftest.html
+++ b/jpegxl/bitdepth-16bpc-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="bitdepth-16bpc-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-2250150">
 <meta name="assert" content="16-bit JPEG XL decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/canvas-decode-paths.html
+++ b/jpegxl/canvas-decode-paths.html
@@ -3,6 +3,7 @@
 <title>JPEG XL integration: canvas decode paths reftest</title>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="canvas-decode-paths-ref.html">
+<meta name="fuzzy" content="maxDifference=0-10; totalPixels=0-14400">
 <meta name="assert" content="Canvas decode paths should match PNG reference output for drawImage, createImageBitmap, WebGL texture upload, and rgba-float16 readback conversion.">
 
 <canvas id="output"></canvas>

--- a/jpegxl/html-video-poster.html
+++ b/jpegxl/html-video-poster.html
@@ -3,6 +3,7 @@
 <title>JPEG XL integration: video poster</title>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="html-video-poster-ref.html">
+<meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-3600">
 <meta name="assert" content="A <video> poster can render from a JPEG XL image URL.">
 <script src="/common/reftest-wait.js"></script>
 

--- a/jpegxl/icc-uncommon-profile-reftest.html
+++ b/jpegxl/icc-uncommon-profile-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="icc-uncommon-profile-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-2000">
 <meta name="assert" content="JXL with uncommon ICC profile should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/progressive-dc-observable-reftest.html
+++ b/jpegxl/progressive-dc-observable-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="progressive-dc-observable-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-3429216">
 <meta name="assert" content="Progressive JXL codestream decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/vardct-large-blocks-reftest.html
+++ b/jpegxl/vardct-large-blocks-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="vardct-large-blocks-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-257982">
 <meta name="assert" content="VarDCT larger image JXL decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 

--- a/jpegxl/vardct-small-blocks-reftest.html
+++ b/jpegxl/vardct-small-blocks-reftest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="vardct-small-blocks-reftest-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-10">
 <meta name="assert" content="VarDCT small block JXL decode should match PNG reference output.">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 


### PR DESCRIPTION
The tolerances are based on the image size for each test, and the tolerance from similar tests plus the artifacts that result by running `djxl`.

`jpegxl/cmyk-basic-conversion-reftest.html` was not changed, although it probably needs some fuzziness too. I was getting differences that were too big, which I suspect it is because of issues with color profiles on my machine.

Part of web-platform-tests/interop-jpegxl#3