### PR TITLE
layout: Properly account for nested PBM of ancestor inline boxes for floats inside inline boxes

### DIFF
--- a/css/CSS2/floats/float-in-inline-001.html
+++ b/css/CSS2/floats/float-in-inline-001.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS Test: Float inside inline box</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#floats">
+<link rel="help" href="https://github.com/servo/servo/issues/46350">
+<meta name="assert" content="The float should be placed correctly even if it's inside
+    an inline box with padding, border and margin.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="position: absolute; z-index: -1; width: 200px; height: 200px; background: red"></div>
+
+<span style="padding: 30px; border: 30px solid transparent; margin: 40px">
+  <span style="float: left; background: green; width: 200px; height: 200px"></span>
+</span>

--- a/css/CSS2/floats/float-in-inline-002.html
+++ b/css/CSS2/floats/float-in-inline-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test: Float inside inline box</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#floats">
+<link rel="help" href="https://github.com/servo/servo/issues/46350">
+<meta name="assert" content="The float should be placed correctly even if it's inside
+    an inline box which is inside another inline box with padding, border and margin.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="position: absolute; z-index: -1; width: 200px; height: 200px; background: red"></div>
+
+<span style="padding: 30px; border: 30px solid transparent; margin: 40px">
+  <span>
+    <span style="float: left; background: green; width: 200px; height: 200px"></span>
+  </span>
+</span>


### PR DESCRIPTION
When laying out a float inside an inline formatting context, we still don't know the inline-axis padding/border/margin of its inline box ancestors. Therefore, it gets a tentative position, which needs to be adjusted later.

The problem was that, when ending an inline box, we were only adjusting the floats that are direct children. We were also adjusting the position in the block axis, despite that the tentative position was already including the padding/border/margin in this axis.

So now we propagate floats, so that all inline wrappers can adjust them, and they are only adjusted in the inline axis.

Testing: Adding 2 tests
Fixes: #<!-- nolink -->46350

Reviewed in servo/servo#46407