### PR TITLE
Add test for processing of type attribute with <link rel=compression-dictionary>

### DIFF
--- a/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- rel=compression-dictionary does not have a default type, so it should
+     always fetch the link when the type is omitted. When the type is specified
+     the same is true if "UA does support the given MIME type for the given link
+     relationship" and "even if that is not a valid MIME type string". Details
+     don't seem to be specified but this test assumes UAs support any type for
+     rel=compression-dictionary. -->
+<link rel="help" href="https://html.spec.whatwg.org/#processing-the-type-attribute">
+<link rel="help" href="https://github.com/whatwg/html/pull/11620">
+<link id="defaultType" rel="compression-dictionary" href="./resources/register-dictionary.py?defaultType"> <!-- type attribute omitted -->
+<link id="emptyType" rel="compression-dictionary" href="./resources/register-dictionary.py?emptyType" type="">
+<link id="invalidType" rel="compression-dictionary" href="./resources/register-dictionary.py?invalidType" type="invalid|type">
+<link id="unsupportedType" rel="compression-dictionary" href="./resources/register-dictionary.py?unsupportedType" type="not/supported">
+<link id="cssType" rel="compression-dictionary" href="./resources/register-dictionary.py?cssType" type="text/css">
+<link id="htmlType" rel="compression-dictionary" href="./resources/register-dictionary.py?htmlType" type="text/html">
+<link id="javascriptType" rel="compression-dictionary" href="./resources/register-dictionary.py?javascriptType" type="text/javascript">
+<body>
+  <script>
+    let fetchedDictionaries = [];
+    const observer = new PerformanceObserver((list) => {
+      list.getEntries().forEach(entry => {
+        const url = new URL(entry.name);
+        if (url.pathname == "/fetch/compression-dictionary/resources/register-dictionary.py") {
+          fetchedDictionaries.push(url.search);
+        }
+      });
+    });
+    observer.observe({ type: "resource", buffered: true});
+
+    compression_dictionary_promise_test(async t => {
+      // Initially fetched dictionaries.
+      let expectedEntries = [
+        "?cssType",
+        "?defaultType",
+        "?emptyType",
+        "?htmlType",
+        "?invalidType",
+        "?javascriptType",
+        "?unsupportedType",
+      ];
+      await t.step_wait(_ => fetchedDictionaries.length >= expectedEntries.length, "<link> with omitted type attribute should trigger fetch", 5000);
+      assert_array_equals(fetchedDictionaries.toSorted(), expectedEntries, "dictionary fetched for <link> with omitted type attribute.");
+    }, "<link rel=compression-dictionary> are fetched independently of the type.");
+  </script>
+</body>

--- a/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https.html
+++ b/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https.html
@@ -31,7 +31,7 @@
         }
       });
     });
-    observer.observe({ type: "resource", buffered: true});
+    observer.observe({ type: "resource", buffered: true });
 
     compression_dictionary_promise_test(async t => {
       // Initially fetched dictionaries.
@@ -44,8 +44,12 @@
         "?javascriptType",
         "?unsupportedType",
       ];
-      await t.step_wait(_ => fetchedDictionaries.length >= expectedEntries.length, "<link> with omitted type attribute should trigger fetch", 5000);
-      assert_array_equals(fetchedDictionaries.toSorted(), expectedEntries, "dictionary fetched for <link> with omitted type attribute.");
+      await t.step_wait(_ => fetchedDictionaries.length >= expectedEntries.length, "All <link rel=compression-dictionary> elements should trigger dictionary fetches regardless of their type attribute", 5000);
+      assert_array_equals(fetchedDictionaries.toSorted(), expectedEntries, "All <link rel=compression-dictionary> elements should trigger dictionary fetches regardless of their type attribute.");
+
+      fetchedDictionaries = [];
+      await new Promise(resolve => step_timeout(resolve, 1000));
+      assert_equals(fetchedDictionaries.length, 0, "no more dictionary fetched.");
     }, "<link rel=compression-dictionary> are fetched independently of the type.");
   </script>
 </body>


### PR DESCRIPTION
rel=compression-dictionary does not have a default type, so it should always fetch the link when the type is omitted. When the type is specified the same is true if "UA does support the given MIME type for the given link relationship" and "even if that is not a valid MIME type string". Details don't seem to be specified but this test assumes UAs support any type for rel=compression-dictionary, which is what Chromium, Firefox and WebKit do.

http://github.com/whatwg/html/pull/11620
https://html.spec.whatwg.org/#processing-the-type-attribute