### PR TITLE
Create nodes in the passed document's realm

### DIFF
--- a/dom/nodes/attach-shadow-realm-after-adoption.html
+++ b/dom/nodes/attach-shadow-realm-after-adoption.html
@@ -6,22 +6,17 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <body>
+<iframe></iframe>
 <script>
 // See https://github.com/whatwg/dom/issues/977. attachShadow() creates the
 // shadow root in the realm of the host's node document, not in whatever realm
-// happens to be running the algorithm (e.g. the host's relevant realm, or the
+// happens to be running the algorithm (e.g., the host's relevant realm, or the
 // realm that owns the attachShadow() method that was invoked).
 
-const ready = (async () => {
-  const inner = await new Promise(resolve => {
-    const iframe = document.createElement("iframe");
-    iframe.onload = () => resolve(iframe.contentWindow);
-    document.body.appendChild(iframe);
-  });
-  // A custom element host defined only in the inner realm.
-  inner.customElements.define("x-host", class extends inner.HTMLElement {});
-  return inner;
-})();
+const inner = document.querySelector("iframe").contentWindow;
+
+// A custom element host defined only in the inner realm.
+inner.customElements.define("x-host", class extends inner.HTMLElement {});
 
 // Each host is created in the inner realm and adopted into the top-level
 // document, so its relevant realm (inner) differs from its node document
@@ -30,8 +25,7 @@ const ready = (async () => {
 for (const localName of ["div", "x-host"]) {
   const label = localName === "div" ? "built-in host" : "custom element host";
 
-  promise_test(async () => {
-    const inner = await ready;
+  test(() => {
     const host = inner.document.createElement(localName);
     document.body.appendChild(host); // adopts into the top-level document
     assert_equals(host.ownerDocument, document,
@@ -40,29 +34,23 @@ for (const localName of ["div", "x-host"]) {
                 "host's relevant realm remains the inner realm after adoption");
   }, `Precondition (${label}): node document and relevant realm differ after adoption`);
 
-  promise_test(async () => {
-    const inner = await ready;
+  test(() => {
     const host = inner.document.createElement(localName);
     document.body.appendChild(host);
     const shadow = host.attachShadow({ mode: "open" });
     assert_true(shadow instanceof ShadowRoot,
                 "shadow root is from the node document's (top-level) realm");
-    assert_false(shadow instanceof inner.ShadowRoot,
-                 "shadow root is not from the host's relevant (inner) realm");
   }, `attachShadow() on an adopted ${label}: shadow root uses the node document realm`);
 }
 
 // Isolate the running realm: a host that lives entirely in the top-level
 // document, but with attachShadow() invoked via the inner realm's method. The
 // shadow root must still be created in the node document (top-level) realm.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const host = document.createElement("div");
   document.body.appendChild(host);
   const shadow = inner.Element.prototype.attachShadow.call(host, { mode: "open" });
   assert_true(shadow instanceof ShadowRoot,
               "shadow root is from the node document's (top-level) realm");
-  assert_false(shadow instanceof inner.ShadowRoot,
-               "shadow root is not from the attachShadow() method's (inner) realm");
 }, "attachShadow() invoked via another realm's method uses the node document realm");
 </script>

--- a/dom/nodes/attach-shadow-realm-after-adoption.html
+++ b/dom/nodes/attach-shadow-realm-after-adoption.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>attachShadow() creates the shadow root in the host's node document realm</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-attach-a-shadow-root">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// See https://github.com/whatwg/dom/issues/977. attachShadow() creates the
+// shadow root in the realm of the host's node document, not in whatever realm
+// happens to be running the algorithm (e.g. the host's relevant realm, or the
+// realm that owns the attachShadow() method that was invoked).
+
+const ready = (async () => {
+  const inner = await new Promise(resolve => {
+    const iframe = document.createElement("iframe");
+    iframe.onload = () => resolve(iframe.contentWindow);
+    document.body.appendChild(iframe);
+  });
+  // A custom element host defined only in the inner realm.
+  inner.customElements.define("x-host", class extends inner.HTMLElement {});
+  return inner;
+})();
+
+// Each host is created in the inner realm and adopted into the top-level
+// document, so its relevant realm (inner) differs from its node document
+// (top-level). Both a built-in and a custom-element host are covered because
+// engines have been observed to treat the two cases differently.
+for (const localName of ["div", "x-host"]) {
+  const label = localName === "div" ? "built-in host" : "custom element host";
+
+  promise_test(async () => {
+    const inner = await ready;
+    const host = inner.document.createElement(localName);
+    document.body.appendChild(host); // adopts into the top-level document
+    assert_equals(host.ownerDocument, document,
+                  "host's node document is the top-level document");
+    assert_true(host instanceof inner.HTMLElement,
+                "host's relevant realm remains the inner realm after adoption");
+  }, `Precondition (${label}): node document and relevant realm differ after adoption`);
+
+  promise_test(async () => {
+    const inner = await ready;
+    const host = inner.document.createElement(localName);
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    assert_true(shadow instanceof ShadowRoot,
+                "shadow root is from the node document's (top-level) realm");
+    assert_false(shadow instanceof inner.ShadowRoot,
+                 "shadow root is not from the host's relevant (inner) realm");
+  }, `attachShadow() on an adopted ${label}: shadow root uses the node document realm`);
+}
+
+// Isolate the running realm: a host that lives entirely in the top-level
+// document, but with attachShadow() invoked via the inner realm's method. The
+// shadow root must still be created in the node document (top-level) realm.
+promise_test(async () => {
+  const inner = await ready;
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const shadow = inner.Element.prototype.attachShadow.call(host, { mode: "open" });
+  assert_true(shadow instanceof ShadowRoot,
+              "shadow root is from the node document's (top-level) realm");
+  assert_false(shadow instanceof inner.ShadowRoot,
+               "shadow root is not from the attachShadow() method's (inner) realm");
+}, "attachShadow() invoked via another realm's method uses the node document realm");
+</script>

--- a/dom/nodes/create-element-realm-after-adoption.html
+++ b/dom/nodes/create-element-realm-after-adoption.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Parsing into a node adopted into another document creates elements in that document's realm</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-element">
+<link rel=help href="https://dom.spec.whatwg.org/#create-an-element-internal">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// A node created in an inner (iframe) realm and adopted into the top-level
+// document has its relevant realm in the inner realm but its node document in
+// the top-level document. Per https://dom.spec.whatwg.org/#create-an-element-internal,
+// elements created while parsing into such a node use the realm of the node
+// document (top-level), not the realm running the algorithm (e.g. the realm of
+// the innerHTML setter).
+
+// Resolves with the inner realm's global once the iframe has loaded, and
+// registers x-baz with a distinct class in each realm.
+const ready = (async () => {
+  const inner = await new Promise(resolve => {
+    const iframe = document.createElement("iframe");
+    iframe.onload = () => resolve(iframe.contentWindow);
+    document.body.appendChild(iframe);
+  });
+  inner.customElements.define("x-baz", class extends inner.HTMLElement {});
+  customElements.define("x-baz", class extends HTMLElement {});
+  return inner;
+})();
+
+// Returns a shadow root whose host was created in the inner realm and then
+// adopted into the top-level document.
+function adoptedShadow(inner) {
+  const host = inner.document.createElement("div");
+  document.body.appendChild(host); // adopts into the top-level document
+  return host.attachShadow({ mode: "open" });
+}
+
+// The innerHTML setter belonging to a particular realm.
+function innerHTMLSetter(realm) {
+  return Object.getOwnPropertyDescriptor(realm.ShadowRoot.prototype, "innerHTML").set;
+}
+
+promise_test(async () => {
+  const inner = await ready;
+  const host = inner.document.createElement("div");
+  document.body.appendChild(host);
+  assert_equals(host.ownerDocument, document,
+                "host is adopted into the top-level document");
+  assert_true(host instanceof inner.HTMLElement,
+              "host's relevant realm remains the inner realm after adoption");
+}, "Precondition: the host's node document and relevant realm differ after adoption");
+
+promise_test(async () => {
+  const inner = await ready;
+  const shadow = adoptedShadow(inner);
+  shadow.innerHTML = "<p></p>";
+  const p = shadow.querySelector("p");
+  assert_true(p instanceof HTMLParagraphElement,
+              "<p> is from the node document's (top-level) realm");
+  assert_false(p instanceof inner.HTMLParagraphElement,
+               "<p> is not from the inner realm");
+}, "Built-in element: innerHTML creates it in the node document's realm");
+
+promise_test(async () => {
+  const inner = await ready;
+  const shadow = adoptedShadow(inner);
+  // Explicitly run the inner realm's innerHTML setter, so the algorithm runs in
+  // the inner realm while the node document stays top-level.
+  innerHTMLSetter(inner).call(shadow, "<p></p>");
+  const p = shadow.querySelector("p");
+  assert_true(p instanceof HTMLParagraphElement,
+              "<p> is from the node document's (top-level) realm");
+  assert_false(p instanceof inner.HTMLParagraphElement,
+               "<p> is not from the innerHTML setter's (inner) realm");
+}, "Built-in element: the created element's realm is independent of the setter's realm");
+
+promise_test(async () => {
+  const inner = await ready;
+  const shadow = adoptedShadow(inner);
+  shadow.innerHTML = "<x-baz></x-baz>";
+  const baz = shadow.querySelector("x-baz");
+  assert_true(baz instanceof customElements.get("x-baz"),
+              "<x-baz> uses the node document's (top-level) registry");
+  assert_false(baz instanceof inner.customElements.get("x-baz"),
+               "<x-baz> does not use the inner document's registry");
+}, "Custom element: innerHTML upgrades it using the node document's registry");
+
+promise_test(async () => {
+  const inner = await ready;
+  const shadow = adoptedShadow(inner);
+  innerHTMLSetter(inner).call(shadow, "<x-baz></x-baz>");
+  const baz = shadow.querySelector("x-baz");
+  assert_true(baz instanceof customElements.get("x-baz"),
+              "<x-baz> uses the node document's (top-level) registry");
+  assert_false(baz instanceof inner.customElements.get("x-baz"),
+               "<x-baz> does not use the inner registry via the setter's realm");
+}, "Custom element: the registry used is independent of the setter's realm");
+</script>

--- a/dom/nodes/create-element-realm-after-adoption.html
+++ b/dom/nodes/create-element-realm-after-adoption.html
@@ -7,30 +7,23 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <body>
+<iframe></iframe>
 <script>
 // A node created in an inner (iframe) realm and adopted into the top-level
 // document has its relevant realm in the inner realm but its node document in
 // the top-level document. Per https://dom.spec.whatwg.org/#create-an-element-internal,
 // elements created while parsing into such a node use the realm of the node
-// document (top-level), not the realm running the algorithm (e.g. the realm of
+// document (top-level), not the realm running the algorithm (e.g., the realm of
 // the innerHTML setter).
 
-// Resolves with the inner realm's global once the iframe has loaded, and
-// registers x-baz with a distinct class in each realm.
-const ready = (async () => {
-  const inner = await new Promise(resolve => {
-    const iframe = document.createElement("iframe");
-    iframe.onload = () => resolve(iframe.contentWindow);
-    document.body.appendChild(iframe);
-  });
-  inner.customElements.define("x-baz", class extends inner.HTMLElement {});
-  customElements.define("x-baz", class extends HTMLElement {});
-  return inner;
-})();
+// Register x-baz with a distinct class in each realm.
+const inner = document.querySelector("iframe").contentWindow;
+inner.customElements.define("x-baz", class extends inner.HTMLElement {});
+customElements.define("x-baz", class extends HTMLElement {});
 
 // Returns a shadow root whose host was created in the inner realm and then
 // adopted into the top-level document.
-function adoptedShadow(inner) {
+function adoptedShadow() {
   const host = inner.document.createElement("div");
   document.body.appendChild(host); // adopts into the top-level document
   return host.attachShadow({ mode: "open" });
@@ -41,8 +34,7 @@ function innerHTMLSetter(realm) {
   return Object.getOwnPropertyDescriptor(realm.ShadowRoot.prototype, "innerHTML").set;
 }
 
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const host = inner.document.createElement("div");
   document.body.appendChild(host);
   assert_equals(host.ownerDocument, document,
@@ -51,49 +43,37 @@ promise_test(async () => {
               "host's relevant realm remains the inner realm after adoption");
 }, "Precondition: the host's node document and relevant realm differ after adoption");
 
-promise_test(async () => {
-  const inner = await ready;
-  const shadow = adoptedShadow(inner);
+test(() => {
+  const shadow = adoptedShadow();
   shadow.innerHTML = "<p></p>";
   const p = shadow.querySelector("p");
   assert_true(p instanceof HTMLParagraphElement,
               "<p> is from the node document's (top-level) realm");
-  assert_false(p instanceof inner.HTMLParagraphElement,
-               "<p> is not from the inner realm");
 }, "Built-in element: innerHTML creates it in the node document's realm");
 
-promise_test(async () => {
-  const inner = await ready;
-  const shadow = adoptedShadow(inner);
+test(() => {
+  const shadow = adoptedShadow();
   // Explicitly run the inner realm's innerHTML setter, so the algorithm runs in
   // the inner realm while the node document stays top-level.
   innerHTMLSetter(inner).call(shadow, "<p></p>");
   const p = shadow.querySelector("p");
   assert_true(p instanceof HTMLParagraphElement,
               "<p> is from the node document's (top-level) realm");
-  assert_false(p instanceof inner.HTMLParagraphElement,
-               "<p> is not from the innerHTML setter's (inner) realm");
 }, "Built-in element: the created element's realm is independent of the setter's realm");
 
-promise_test(async () => {
-  const inner = await ready;
-  const shadow = adoptedShadow(inner);
+test(() => {
+  const shadow = adoptedShadow();
   shadow.innerHTML = "<x-baz></x-baz>";
   const baz = shadow.querySelector("x-baz");
   assert_true(baz instanceof customElements.get("x-baz"),
               "<x-baz> uses the node document's (top-level) registry");
-  assert_false(baz instanceof inner.customElements.get("x-baz"),
-               "<x-baz> does not use the inner document's registry");
 }, "Custom element: innerHTML upgrades it using the node document's registry");
 
-promise_test(async () => {
-  const inner = await ready;
-  const shadow = adoptedShadow(inner);
+test(() => {
+  const shadow = adoptedShadow();
   innerHTMLSetter(inner).call(shadow, "<x-baz></x-baz>");
   const baz = shadow.querySelector("x-baz");
   assert_true(baz instanceof customElements.get("x-baz"),
               "<x-baz> uses the node document's (top-level) registry");
-  assert_false(baz instanceof inner.customElements.get("x-baz"),
-               "<x-baz> does not use the inner registry via the setter's realm");
 }, "Custom element: the registry used is independent of the setter's realm");
 </script>

--- a/dom/nodes/node-creation-realm.html
+++ b/dom/nodes/node-creation-realm.html
@@ -6,6 +6,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <body>
+<iframe></iframe>
 <script>
 // Every node is created in its node document's relevant realm, not in whatever
 // realm is running the creation algorithm. Each subtest forces those two realms
@@ -13,19 +14,11 @@
 // with a "this" (and thus a node document) that belongs to the top-level realm.
 // The created node must be a top-level-realm object.
 
-const ready = new Promise(resolve => {
-  const iframe = document.createElement("iframe");
-  iframe.onload = () => resolve(iframe.contentWindow);
-  document.body.appendChild(iframe);
-});
+const inner = document.querySelector("iframe").contentWindow;
 
-// Asserts node is an instance of the top-level realm's interface and not the
-// inner realm's, i.e. it was created in the top-level realm.
-function assertTopRealm(inner, node, iface) {
+function assertTopRealm(node, iface) {
   assert_true(node instanceof window[iface],
               `is a top-level-realm ${iface}`);
-  assert_false(node instanceof inner[iface],
-               `is not an inner-realm ${iface}`);
 }
 
 // Document factory methods invoked cross-realm on the top-level document.
@@ -38,91 +31,81 @@ const FACTORIES = [
 ];
 
 for (const { name, iface, args } of FACTORIES) {
-  promise_test(async () => {
-    const inner = await ready;
+  test(() => {
     const method = inner.Document.prototype[name];
     const node = method.apply(document, args);
-    assertTopRealm(inner, node, iface);
+    assertTopRealm(node, iface);
   }, `Document.${name}() creates a node in the target document's realm`);
 }
 
 // createCDATASection requires an XML document.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const xml = document.implementation.createDocument(null, "root", null);
   const node = inner.Document.prototype.createCDATASection.call(xml, "x");
-  assertTopRealm(inner, node, "CDATASection");
+  assertTopRealm(node, "CDATASection");
 }, "Document.createCDATASection() creates a node in the target document's realm");
 
 // DOMImplementation.createDocumentType invoked cross-realm.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const doctype = inner.DOMImplementation.prototype.createDocumentType.call(
     document.implementation, "html", "", "");
-  assertTopRealm(inner, doctype, "DocumentType");
+  assertTopRealm(doctype, "DocumentType");
 }, "DOMImplementation.createDocumentType() creates a node in the associated document's realm");
 
 // Document base case: implementation.createDocument / createHTMLDocument create
 // the new document in the DOMImplementation's relevant realm.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const doc = inner.DOMImplementation.prototype.createDocument.call(
     document.implementation, null, "root", null);
-  assertTopRealm(inner, doc, "XMLDocument");
+  assertTopRealm(doc, "XMLDocument");
 }, "DOMImplementation.createDocument() creates the document in the target realm");
 
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const doc = inner.DOMImplementation.prototype.createHTMLDocument.call(
     document.implementation, "title");
   assert_true(doc instanceof Document, "is a top-level-realm Document");
-  assert_false(doc instanceof inner.Document, "is not an inner-realm Document");
   // Its parser-created descendants share the document's realm.
-  assertTopRealm(inner, doc.doctype, "DocumentType");
-  assertTopRealm(inner, doc.documentElement, "HTMLHtmlElement");
-  assertTopRealm(inner, doc.querySelector("title").firstChild, "Text");
+  assertTopRealm(doc.doctype, "DocumentType");
+  assertTopRealm(doc.documentElement, "HTMLHtmlElement");
+  assertTopRealm(doc.querySelector("title").firstChild, "Text");
 }, "DOMImplementation.createHTMLDocument() creates the document and its contents in the target realm");
 
 // cloneNode: the clone uses the node's node document's realm, regardless of the
 // realm whose cloneNode() is invoked.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const comment = document.createComment("x");
   const clone = inner.Node.prototype.cloneNode.call(comment);
-  assertTopRealm(inner, clone, "Comment");
+  assertTopRealm(clone, "Comment");
 }, "cloneNode() clones into the node's node document realm");
 
 // importNode: the copy uses the target document's realm (the document
 // importNode() is called on), not the realm whose method is invoked.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const source = inner.document.createComment("x");
   const copy = inner.Document.prototype.importNode.call(document, source);
-  assertTopRealm(inner, copy, "Comment");
+  assertTopRealm(copy, "Comment");
 }, "importNode() imports into the target document's realm");
 
 // Range.cloneContents() builds its DocumentFragment in the range's node document
 // realm.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const container = document.createElement("div");
   container.append(document.createComment("a"), document.createComment("b"));
   const range = document.createRange();
   range.selectNodeContents(container);
   const fragment = inner.Range.prototype.cloneContents.call(range);
-  assertTopRealm(inner, fragment, "DocumentFragment");
+  assertTopRealm(fragment, "DocumentFragment");
 }, "Range.cloneContents() builds the fragment in the range's node document realm");
 
 // innerHTML on a host adopted into the top-level document: the parsed Text and
 // Comment nodes are created in the node document's (top-level) realm. This is
 // the character/comment analogue of the element case in issue #977.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const host = inner.document.createElement("div");
   document.body.appendChild(host); // adopts into the top-level document
   const shadow = host.attachShadow({ mode: "open" });
   shadow.innerHTML = "text<!--comment-->";
-  assertTopRealm(inner, shadow.firstChild, "Text");
-  assertTopRealm(inner, shadow.lastChild, "Comment");
+  assertTopRealm(shadow.firstChild, "Text");
+  assertTopRealm(shadow.lastChild, "Comment");
 }, "innerHTML parses Text and Comment nodes in the node document's realm after adoption");
 </script>

--- a/dom/nodes/node-creation-realm.html
+++ b/dom/nodes/node-creation-realm.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node creation uses the node document's realm, not the running realm</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// Every node is created in its node document's relevant realm, not in whatever
+// realm is running the creation algorithm. Each subtest forces those two realms
+// apart by invoking a creation method that belongs to an inner (iframe) realm
+// with a "this" (and thus a node document) that belongs to the top-level realm.
+// The created node must be a top-level-realm object.
+
+const ready = new Promise(resolve => {
+  const iframe = document.createElement("iframe");
+  iframe.onload = () => resolve(iframe.contentWindow);
+  document.body.appendChild(iframe);
+});
+
+// Asserts node is an instance of the top-level realm's interface and not the
+// inner realm's, i.e. it was created in the top-level realm.
+function assertTopRealm(inner, node, iface) {
+  assert_true(node instanceof window[iface],
+              `is a top-level-realm ${iface}`);
+  assert_false(node instanceof inner[iface],
+               `is not an inner-realm ${iface}`);
+}
+
+// Document factory methods invoked cross-realm on the top-level document.
+const FACTORIES = [
+  { name: "createTextNode", iface: "Text", args: ["x"] },
+  { name: "createComment", iface: "Comment", args: ["x"] },
+  { name: "createProcessingInstruction", iface: "ProcessingInstruction", args: ["t", "d"] },
+  { name: "createDocumentFragment", iface: "DocumentFragment", args: [] },
+  { name: "createAttribute", iface: "Attr", args: ["x"] },
+];
+
+for (const { name, iface, args } of FACTORIES) {
+  promise_test(async () => {
+    const inner = await ready;
+    const method = inner.Document.prototype[name];
+    const node = method.apply(document, args);
+    assertTopRealm(inner, node, iface);
+  }, `Document.${name}() creates a node in the target document's realm`);
+}
+
+// createCDATASection requires an XML document.
+promise_test(async () => {
+  const inner = await ready;
+  const xml = document.implementation.createDocument(null, "root", null);
+  const node = inner.Document.prototype.createCDATASection.call(xml, "x");
+  assertTopRealm(inner, node, "CDATASection");
+}, "Document.createCDATASection() creates a node in the target document's realm");
+
+// DOMImplementation.createDocumentType invoked cross-realm.
+promise_test(async () => {
+  const inner = await ready;
+  const doctype = inner.DOMImplementation.prototype.createDocumentType.call(
+    document.implementation, "html", "", "");
+  assertTopRealm(inner, doctype, "DocumentType");
+}, "DOMImplementation.createDocumentType() creates a node in the associated document's realm");
+
+// Document base case: implementation.createDocument / createHTMLDocument create
+// the new document in the DOMImplementation's relevant realm.
+promise_test(async () => {
+  const inner = await ready;
+  const doc = inner.DOMImplementation.prototype.createDocument.call(
+    document.implementation, null, "root", null);
+  assertTopRealm(inner, doc, "XMLDocument");
+}, "DOMImplementation.createDocument() creates the document in the target realm");
+
+promise_test(async () => {
+  const inner = await ready;
+  const doc = inner.DOMImplementation.prototype.createHTMLDocument.call(
+    document.implementation, "title");
+  assert_true(doc instanceof Document, "is a top-level-realm Document");
+  assert_false(doc instanceof inner.Document, "is not an inner-realm Document");
+  // Its parser-created descendants share the document's realm.
+  assertTopRealm(inner, doc.doctype, "DocumentType");
+  assertTopRealm(inner, doc.documentElement, "HTMLHtmlElement");
+  assertTopRealm(inner, doc.querySelector("title").firstChild, "Text");
+}, "DOMImplementation.createHTMLDocument() creates the document and its contents in the target realm");
+
+// cloneNode: the clone uses the node's node document's realm, regardless of the
+// realm whose cloneNode() is invoked.
+promise_test(async () => {
+  const inner = await ready;
+  const comment = document.createComment("x");
+  const clone = inner.Node.prototype.cloneNode.call(comment);
+  assertTopRealm(inner, clone, "Comment");
+}, "cloneNode() clones into the node's node document realm");
+
+// importNode: the copy uses the target document's realm (the document
+// importNode() is called on), not the realm whose method is invoked.
+promise_test(async () => {
+  const inner = await ready;
+  const source = inner.document.createComment("x");
+  const copy = inner.Document.prototype.importNode.call(document, source);
+  assertTopRealm(inner, copy, "Comment");
+}, "importNode() imports into the target document's realm");
+
+// Range.cloneContents() builds its DocumentFragment in the range's node document
+// realm.
+promise_test(async () => {
+  const inner = await ready;
+  const container = document.createElement("div");
+  container.append(document.createComment("a"), document.createComment("b"));
+  const range = document.createRange();
+  range.selectNodeContents(container);
+  const fragment = inner.Range.prototype.cloneContents.call(range);
+  assertTopRealm(inner, fragment, "DocumentFragment");
+}, "Range.cloneContents() builds the fragment in the range's node document realm");
+
+// innerHTML on a host adopted into the top-level document: the parsed Text and
+// Comment nodes are created in the node document's (top-level) realm. This is
+// the character/comment analogue of the element case in issue #977.
+promise_test(async () => {
+  const inner = await ready;
+  const host = inner.document.createElement("div");
+  document.body.appendChild(host); // adopts into the top-level document
+  const shadow = host.attachShadow({ mode: "open" });
+  shadow.innerHTML = "text<!--comment-->";
+  assertTopRealm(inner, shadow.firstChild, "Text");
+  assertTopRealm(inner, shadow.lastChild, "Comment");
+}, "innerHTML parses Text and Comment nodes in the node document's realm after adoption");
+</script>

--- a/dom/nodes/node-realm-adoption-after-frame-removal.html
+++ b/dom/nodes/node-realm-adoption-after-frame-removal.html
@@ -8,10 +8,14 @@
 <script src=/resources/testharnessreport.js></script>
 <body>
 <script>
-// A never-wrapped subtree is built in an iframe, the iframe is removed, and only
-// then is the subtree adopted and inspected. The creation realm must have been
-// captured while the frame existed. Interface objects are captured before removal
-// since a detached window can no longer be queried.
+// The <p>/<b> nodes are built by the HTML parser and never touched from script
+// before the frame is removed, so no JS object is ever created for them in the
+// inner realm. This checks that the creation realm is recorded on the node when
+// it is created, rather than derived on demand from a pre-existing JS object: by
+// adoption time the inner realm is gone and can no longer be consulted.
+// Interface objects are captured before removal since a detached window can no
+// longer be queried. Each test asserts on both a direct child and a deep
+// descendant so the realm is checked throughout the parsed subtree.
 
 function freshIframe() {
   const iframe = document.createElement("iframe");
@@ -23,85 +27,62 @@ test(() => {
   const iframe = freshIframe();
   const inner = iframe.contentWindow;
   const InnerParagraph = inner.HTMLParagraphElement;
+  const InnerBold = inner.HTMLElement;
 
   const container = inner.document.createElement("div");
-  container.innerHTML = "<p></p>";
+  container.innerHTML = "<p><b>x</b></p>";
   inner.document.body.appendChild(container);
   container.remove();
   iframe.remove();
 
   document.body.appendChild(container);
   const p = container.querySelector("p");
+  const b = container.querySelector("b");
   assert_equals(p.ownerDocument, document, "adopted into the top-level document");
   assert_true(p instanceof InnerParagraph, "keeps its creation realm");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm");
 }, "Never-wrapped node keeps its creation realm: subtree detached, iframe removed, then adopted");
 
 test(() => {
   const iframe = freshIframe();
   const inner = iframe.contentWindow;
   const InnerParagraph = inner.HTMLParagraphElement;
+  const InnerBold = inner.HTMLElement;
 
   const container = inner.document.createElement("div");
-  container.innerHTML = "<p></p>";
+  container.innerHTML = "<p><b>x</b></p>";
   inner.document.body.appendChild(container);
   iframe.remove(); // removed without first detaching the subtree
 
   document.body.appendChild(container);
   const p = container.querySelector("p");
+  const b = container.querySelector("b");
   assert_equals(p.ownerDocument, document, "adopted into the top-level document");
   assert_true(p instanceof InnerParagraph, "keeps its creation realm");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm");
 }, "Never-wrapped node keeps its creation realm: iframe removed before adoption (subtree not pre-detached)");
 
-test(() => {
-  const iframe = freshIframe();
-  const inner = iframe.contentWindow;
-  const InnerBold = inner.HTMLElement;
-
-  const container = inner.document.createElement("div");
-  container.innerHTML = "<p><b>x</b></p>"; // deep descendant
-  inner.document.body.appendChild(container);
-  container.remove();
-  iframe.remove();
-
-  document.body.appendChild(container);
-  const b = container.querySelector("b");
-  assert_equals(b.ownerDocument, document, "descendant adopted into the top-level document");
-  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm");
-}, "Never-wrapped deep descendant keeps its creation realm after the iframe is removed and it is adopted");
-
-// The subtests above reach the orphan through `container`, whose wrapper is in the
-// creation realm. The subtests below reach it through the adopting document
-// instead, so the realm must be preserved independently of the access path.
+// The tests above reach the adopted nodes through `container`, whose JS object is
+// in the creation realm. The test below reaches them through the adopting
+// document instead, so the realm must be preserved independently of the access
+// path.
 
 test(() => {
   const iframe = freshIframe();
   const inner = iframe.contentWindow;
   const InnerParagraph = inner.HTMLParagraphElement;
-
-  const container = inner.document.createElement("div");
-  container.innerHTML = "<p id=frame-removal-orphan></p>";
-  inner.document.body.appendChild(container);
-  iframe.remove();
-
-  document.body.appendChild(container);
-  const p = document.getElementById("frame-removal-orphan"); // reached through the top-level document
-  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
-  assert_true(p instanceof InnerParagraph, "keeps its creation realm regardless of access path");
-}, "Orphan reached through the adopting document still reports its creation realm (frame removed before adoption)");
-
-test(() => {
-  const iframe = freshIframe();
-  const inner = iframe.contentWindow;
   const InnerBold = inner.HTMLElement;
 
   const container = inner.document.createElement("div");
-  container.innerHTML = "<section><b id=frame-removal-orphan-deep>x</b></section>";
+  container.innerHTML = "<p id=frame-removal-node><b id=frame-removal-node-deep>x</b></p>";
   inner.document.body.appendChild(container);
   iframe.remove();
 
   document.body.appendChild(container);
-  const b = document.getElementById("frame-removal-orphan-deep"); // reached through the top-level document
-  assert_equals(b.ownerDocument, document, "descendant adopted into the top-level document");
+  const p = document.getElementById("frame-removal-node"); // reached through the top-level document
+  const b = document.getElementById("frame-removal-node-deep");
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm regardless of access path");
   assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm regardless of access path");
-}, "Deep orphan reached through the adopting document still reports its creation realm (frame removed before adoption)");
+}, "Node reached through the adopting document still reports its creation realm (frame removed before adoption)");
 </script>

--- a/dom/nodes/node-realm-adoption-after-frame-removal.html
+++ b/dom/nodes/node-realm-adoption-after-frame-removal.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node's creation realm is preserved when its creating frame is removed before adoption</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// A never-wrapped subtree is built in an iframe, the iframe is removed, and only
+// then is the subtree adopted and inspected. The creation realm must have been
+// captured while the frame existed. Interface objects are captured before removal
+// since a detached window can no longer be queried.
+
+function freshIframe() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return iframe;
+}
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerParagraph = inner.HTMLParagraphElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p></p>";
+  inner.document.body.appendChild(container);
+  container.remove();
+  iframe.remove();
+
+  document.body.appendChild(container);
+  const p = container.querySelector("p");
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm");
+}, "Never-wrapped node keeps its creation realm: subtree detached, iframe removed, then adopted");
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerParagraph = inner.HTMLParagraphElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p></p>";
+  inner.document.body.appendChild(container);
+  iframe.remove(); // removed without first detaching the subtree
+
+  document.body.appendChild(container);
+  const p = container.querySelector("p");
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm");
+}, "Never-wrapped node keeps its creation realm: iframe removed before adoption (subtree not pre-detached)");
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerBold = inner.HTMLElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p><b>x</b></p>"; // deep descendant
+  inner.document.body.appendChild(container);
+  container.remove();
+  iframe.remove();
+
+  document.body.appendChild(container);
+  const b = container.querySelector("b");
+  assert_equals(b.ownerDocument, document, "descendant adopted into the top-level document");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm");
+}, "Never-wrapped deep descendant keeps its creation realm after the iframe is removed and it is adopted");
+
+// The subtests above reach the orphan through `container`, whose wrapper is in the
+// creation realm. The subtests below reach it through the adopting document
+// instead, so the realm must be preserved independently of the access path.
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerParagraph = inner.HTMLParagraphElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p id=frame-removal-orphan></p>";
+  inner.document.body.appendChild(container);
+  iframe.remove();
+
+  document.body.appendChild(container);
+  const p = document.getElementById("frame-removal-orphan"); // reached through the top-level document
+  assert_equals(p.ownerDocument, document, "adopted into the top-level document");
+  assert_true(p instanceof InnerParagraph, "keeps its creation realm regardless of access path");
+}, "Orphan reached through the adopting document still reports its creation realm (frame removed before adoption)");
+
+test(() => {
+  const iframe = freshIframe();
+  const inner = iframe.contentWindow;
+  const InnerBold = inner.HTMLElement;
+
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<section><b id=frame-removal-orphan-deep>x</b></section>";
+  inner.document.body.appendChild(container);
+  iframe.remove();
+
+  document.body.appendChild(container);
+  const b = document.getElementById("frame-removal-orphan-deep"); // reached through the top-level document
+  assert_equals(b.ownerDocument, document, "descendant adopted into the top-level document");
+  assert_true(b instanceof InnerBold, "deep descendant keeps its creation realm regardless of access path");
+}, "Deep orphan reached through the adopting document still reports its creation realm (frame removed before adoption)");
+</script>

--- a/dom/nodes/node-realm-mixed-across-adoption.html
+++ b/dom/nodes/node-realm-mixed-across-adoption.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node's realm across adoption when creation realm, node document, and adopting realm all differ</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<iframe id=a></iframe>
+<iframe id=b></iframe>
+<script>
+// A node is created in its node document's realm, not the realm of its ancestors
+// or the realm it is later adopted into. In particular an element parsed into a
+// container created in a different realm takes the container's node-document
+// realm, not the container's creation realm.
+
+const innerA = document.getElementById("a").contentWindow;
+const innerB = document.getElementById("b").contentWindow;
+
+test(() => {
+  const container = innerA.document.createElement("div");
+  document.body.appendChild(container);
+  assert_true(container instanceof innerA.HTMLDivElement, "precondition: container keeps realm A after adoption");
+
+  container.innerHTML = "<p></p>"; // <p>'s node document is the top-level document
+  innerB.document.body.appendChild(container); // move to realm B without wrapping <p>
+
+  const p = container.querySelector("p");
+  assert_equals(p.ownerDocument, innerB.document, "moved into realm B's document");
+  assert_true(p instanceof window.HTMLParagraphElement, "realm is the top-level document it was parsed into");
+}, "Element parsed into an adopted container takes the node-document realm, not the container's creation realm");
+
+test(() => {
+  const container = innerA.document.createElement("div");
+  document.body.appendChild(container);
+  container.innerHTML = "text";
+  innerB.document.body.appendChild(container);
+  const text = container.firstChild;
+  assert_true(text instanceof window.Text, "realm is the top-level document it was parsed into");
+}, "Text parsed into an adopted container takes the node-document realm, not the container's creation realm");
+
+test(() => {
+  const container = innerA.document.createElement("div");
+  innerA.document.body.appendChild(container);
+  container.innerHTML = "<p></p>"; // <p>'s node document is realm A's document
+  innerB.document.body.appendChild(container); // hop through B
+  document.body.appendChild(container); // then to the top-level document
+  const p = container.querySelector("p");
+  assert_equals(p.ownerDocument, document, "ended up in the top-level document");
+  assert_true(p instanceof innerA.HTMLParagraphElement, "keeps its creation realm A across multiple adoptions");
+}, "Never-wrapped node keeps its creation realm across multiple adoptions");
+
+test(() => {
+  innerA.customElements.define("x-mixed", class extends innerA.HTMLElement {});
+  window.customElements.define("x-mixed", class extends HTMLElement {});
+
+  const container = innerA.document.createElement("div");
+  document.body.appendChild(container);
+  container.innerHTML = "<x-mixed></x-mixed>"; // upgraded with the top-level registry
+  innerB.document.body.appendChild(container);
+
+  const el = container.querySelector("x-mixed");
+  assert_true(el instanceof window.customElements.get("x-mixed"), "uses the node-document (top-level) realm and registry");
+}, "Custom element parsed into an adopted container uses the node-document realm and registry");
+</script>

--- a/dom/nodes/node-realm-preserved-across-adoption.html
+++ b/dom/nodes/node-realm-preserved-across-adoption.html
@@ -7,86 +7,74 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <body>
+<iframe></iframe>
 <script>
 // A node is created in its node document's realm (https://github.com/whatwg/dom/issues/977).
-// That realm is assigned when the node is CREATED and must not change if the
+// That realm is assigned when the node is created and must not change if the
 // node is later adopted into a document belonging to a different realm.
 //
-// These subtests create a node in an inner (iframe) realm's document WITHOUT
+// These subtests create a node in an inner (iframe) realm's document without
 // ever exposing it to script (so no JS wrapper exists yet), then adopt it into
-// the top-level document, and only THEN inspect it. The spec says the node's
+// the top-level document, and only then inspect it. The spec says the node's
 // realm is the inner realm (its node document's realm at creation time). An
 // engine that instead assigns the realm lazily, when the wrapper is first
 // created, would wrongly report the top-level realm here.
 
-const ready = new Promise(resolve => {
-  const iframe = document.createElement("iframe");
-  iframe.onload = () => resolve(iframe.contentWindow);
-  document.body.appendChild(iframe);
-});
+const inner = document.querySelector("iframe").contentWindow;
 
-// Asserts node is an instance of the inner realm's interface and not the
-// top-level realm's, i.e. its realm was preserved across adoption.
-function assertInnerRealm(inner, node, iface) {
+function assertInnerRealm(node, iface) {
   assert_true(node instanceof inner[iface],
               `is an inner-realm ${iface}`);
-  assert_false(node instanceof window[iface],
-               `is not a top-level-realm ${iface}`);
 }
 
 // Built-in element created by parsing into an inner-realm node, then adopted.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const container = inner.document.createElement("div");
   container.innerHTML = "<p></p>"; // <p> created in inner document, not wrapped
   const p = container.firstChild;
   document.body.appendChild(container); // adopts container and <p> to top-level
   assert_equals(p.ownerDocument, document, "p was adopted into the top-level document");
-  assertInnerRealm(inner, p, "HTMLParagraphElement");
+  assertInnerRealm(p, "HTMLParagraphElement");
 }, "Built-in element keeps its creation realm after adoption");
 
 // Text node created by parsing into an inner-realm node, then adopted.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const container = inner.document.createElement("div");
   container.innerHTML = "text"; // Text created in inner document, not wrapped
   const text = container.firstChild;
   document.body.appendChild(container);
   assert_equals(text.ownerDocument, document, "text was adopted into the top-level document");
-  assertInnerRealm(inner, text, "Text");
+  assertInnerRealm(text, "Text");
 }, "Text node keeps its creation realm after adoption");
 
 // Comment node created by parsing into an inner-realm node, then adopted.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const container = inner.document.createElement("div");
   container.innerHTML = "<!--comment-->"; // Comment created in inner document, not wrapped
   const comment = container.firstChild;
   document.body.appendChild(container);
   assert_equals(comment.ownerDocument, document, "comment was adopted into the top-level document");
-  assertInnerRealm(inner, comment, "Comment");
+  assertInnerRealm(comment, "Comment");
 }, "Comment node keeps its creation realm after adoption");
 
 // Element created directly by createElement in the inner document, then adopted.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const container = inner.document.createElement("div");
   const child = inner.document.createElement("span");
   container.appendChild(child); // child never wrapped in the inner realm
   document.body.appendChild(container);
   assert_equals(child.ownerDocument, document, "child was adopted into the top-level document");
-  assertInnerRealm(inner, child, "HTMLSpanElement");
+  assertInnerRealm(child, "HTMLSpanElement");
 }, "createElement()d element keeps its creation realm after adoption");
 
 // A deeper tree: only the root is touched before adoption; a never-wrapped
 // descendant must still report the inner realm.
-promise_test(async () => {
-  const inner = await ready;
+test(() => {
   const container = inner.document.createElement("div");
   container.innerHTML = "<section><b>x</b></section>";
   document.body.appendChild(container);
   const b = container.querySelector("b");
   assert_equals(b.ownerDocument, document, "descendant was adopted into the top-level document");
-  assertInnerRealm(inner, b, "HTMLElement");
+  assertInnerRealm(b, "HTMLElement");
 }, "Never-wrapped descendant keeps its creation realm after adoption");
 </script>

--- a/dom/nodes/node-realm-preserved-across-adoption.html
+++ b/dom/nodes/node-realm-preserved-across-adoption.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node's realm is fixed at creation and preserved across adoption</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// A node is created in its node document's realm (https://github.com/whatwg/dom/issues/977).
+// That realm is assigned when the node is CREATED and must not change if the
+// node is later adopted into a document belonging to a different realm.
+//
+// These subtests create a node in an inner (iframe) realm's document WITHOUT
+// ever exposing it to script (so no JS wrapper exists yet), then adopt it into
+// the top-level document, and only THEN inspect it. The spec says the node's
+// realm is the inner realm (its node document's realm at creation time). An
+// engine that instead assigns the realm lazily, when the wrapper is first
+// created, would wrongly report the top-level realm here.
+
+const ready = new Promise(resolve => {
+  const iframe = document.createElement("iframe");
+  iframe.onload = () => resolve(iframe.contentWindow);
+  document.body.appendChild(iframe);
+});
+
+// Asserts node is an instance of the inner realm's interface and not the
+// top-level realm's, i.e. its realm was preserved across adoption.
+function assertInnerRealm(inner, node, iface) {
+  assert_true(node instanceof inner[iface],
+              `is an inner-realm ${iface}`);
+  assert_false(node instanceof window[iface],
+               `is not a top-level-realm ${iface}`);
+}
+
+// Built-in element created by parsing into an inner-realm node, then adopted.
+promise_test(async () => {
+  const inner = await ready;
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<p></p>"; // <p> created in inner document, not wrapped
+  const p = container.firstChild;
+  document.body.appendChild(container); // adopts container and <p> to top-level
+  assert_equals(p.ownerDocument, document, "p was adopted into the top-level document");
+  assertInnerRealm(inner, p, "HTMLParagraphElement");
+}, "Built-in element keeps its creation realm after adoption");
+
+// Text node created by parsing into an inner-realm node, then adopted.
+promise_test(async () => {
+  const inner = await ready;
+  const container = inner.document.createElement("div");
+  container.innerHTML = "text"; // Text created in inner document, not wrapped
+  const text = container.firstChild;
+  document.body.appendChild(container);
+  assert_equals(text.ownerDocument, document, "text was adopted into the top-level document");
+  assertInnerRealm(inner, text, "Text");
+}, "Text node keeps its creation realm after adoption");
+
+// Comment node created by parsing into an inner-realm node, then adopted.
+promise_test(async () => {
+  const inner = await ready;
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<!--comment-->"; // Comment created in inner document, not wrapped
+  const comment = container.firstChild;
+  document.body.appendChild(container);
+  assert_equals(comment.ownerDocument, document, "comment was adopted into the top-level document");
+  assertInnerRealm(inner, comment, "Comment");
+}, "Comment node keeps its creation realm after adoption");
+
+// Element created directly by createElement in the inner document, then adopted.
+promise_test(async () => {
+  const inner = await ready;
+  const container = inner.document.createElement("div");
+  const child = inner.document.createElement("span");
+  container.appendChild(child); // child never wrapped in the inner realm
+  document.body.appendChild(container);
+  assert_equals(child.ownerDocument, document, "child was adopted into the top-level document");
+  assertInnerRealm(inner, child, "HTMLSpanElement");
+}, "createElement()d element keeps its creation realm after adoption");
+
+// A deeper tree: only the root is touched before adoption; a never-wrapped
+// descendant must still report the inner realm.
+promise_test(async () => {
+  const inner = await ready;
+  const container = inner.document.createElement("div");
+  container.innerHTML = "<section><b>x</b></section>";
+  document.body.appendChild(container);
+  const b = container.querySelector("b");
+  assert_equals(b.ownerDocument, document, "descendant was adopted into the top-level document");
+  assertInnerRealm(inner, b, "HTMLElement");
+}, "Never-wrapped descendant keeps its creation realm after adoption");
+</script>

--- a/dom/nodes/node-realm-preserved-across-frameless-adoption.html
+++ b/dom/nodes/node-realm-preserved-across-frameless-adoption.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>A node created in a frameless document keeps its creation realm across adoption</title>
+<link rel=help href="https://dom.spec.whatwg.org/#concept-create-node">
+<link rel=help href="https://dom.spec.whatwg.org/#concept-node-adopt">
+<link rel=help href="https://github.com/whatwg/dom/issues/977">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<iframe></iframe>
+<script>
+// A document created via DOMImplementation.createHTMLDocument() (or DOMParser)
+// has no browsing context; its realm is that of the document that created it.
+// A node created in such a frameless document must keep that creation realm when
+// adopted into a document belonging to a different realm.
+//
+// Here the frameless document is created by the inner (iframe) realm. Each subtree
+// is built with innerHTML and only inspected after adoption, so no wrapper exists
+// until then; the correct realm is the inner one, not the top-level one.
+
+const inner = document.querySelector("iframe").contentWindow;
+
+function assertInnerRealm(node, iface) {
+  assert_true(node instanceof inner[iface], `is an inner-realm ${iface}`);
+}
+
+// The frameless document belongs to the inner realm (createHTMLDocument() was
+// called on the inner realm's DOMImplementation), so its context document is
+// the inner document.
+function innerFramelessDocument() {
+  return inner.document.implementation.createHTMLDocument("");
+}
+
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "<p></p>"; // <p> created in the frameless document, not wrapped
+  document.body.appendChild(container); // adopts container and <p> to top-level
+  const p = container.querySelector("p"); // first access, after adoption
+  assert_equals(p.ownerDocument, document, "p was adopted into the top-level document");
+  assertInnerRealm(p, "HTMLParagraphElement");
+}, "Built-in element from a frameless document keeps its creation realm after adoption");
+
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "text"; // Text created in the frameless document, not wrapped
+  document.body.appendChild(container);
+  const text = container.firstChild;
+  assert_equals(text.ownerDocument, document, "text was adopted into the top-level document");
+  assertInnerRealm(text, "Text");
+}, "Text node from a frameless document keeps its creation realm after adoption");
+
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "<!--comment-->"; // Comment created in the frameless document, not wrapped
+  document.body.appendChild(container);
+  const comment = container.firstChild;
+  assert_equals(comment.ownerDocument, document, "comment was adopted into the top-level document");
+  assertInnerRealm(comment, "Comment");
+}, "Comment node from a frameless document keeps its creation realm after adoption");
+
+// A deeper tree: a never-wrapped descendant of a frameless-document subtree must
+// still report the inner realm once adopted.
+test(() => {
+  const container = innerFramelessDocument().createElement("div");
+  container.innerHTML = "<section><b>x</b></section>";
+  document.body.appendChild(container);
+  const b = container.querySelector("b");
+  assert_equals(b.ownerDocument, document, "descendant was adopted into the top-level document");
+  assertInnerRealm(b, "HTMLElement");
+}, "Never-wrapped descendant from a frameless document keeps its creation realm after adoption");
+</script>


### PR DESCRIPTION
Tests that DOM node creation uses the [relevant realm](https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm) of the document the node is created for, rather than whatever realm happens to be running the algorithm. See whatwg/dom#977.

Each test forces the two realms apart by creating/adopting a node into a document whose realm differs from the one invoking the operation (or by invoking a creation method belonging to another realm), then asserts the created node is an instance of the target document realm's interface and not the other realm's.

- `dom/nodes/create-element-realm-after-adoption.html` — built-in and custom elements created while parsing `innerHTML` into a host adopted into another document.
- `dom/nodes/attach-shadow-realm-after-adoption.html` — `attachShadow()` on an adopted host (built-in and custom-element hosts), and via another realm's method.
- `dom/nodes/node-creation-realm.html` — the other node types (`Text`, `Comment`, `CDATASection`, `ProcessingInstruction`, `DocumentFragment`, `Attr`, `DocumentType`, `Document`) via the `createX()` factory methods, `importNode()`, `cloneNode()`, `Range.cloneContents()`, and `innerHTML`.

These encode the resolution being pursued in whatwg/dom#977; some subtests are expected to fail in engines that have not yet aligned (notably built-in element and shadow-root creation in Chromium and WebKit).
