### PR TITLE
[Extensions][WPT] Fix Safari test extension uninstall.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1052,7 +1052,7 @@ class WebDriverWebExtensionsProtocolPart(WebExtensionsProtocolPart):
         if path is not None:
             path = self._resolve_path(path)
 
-        return self.webdriver.web_extensions.install(type, path, value)
+        return self.webdriver.web_extensions.install(type, path, value)["extension"]
 
     def uninstall_web_extension(self, extension_id):
         return self.webdriver.web_extensions.uninstall(extension_id)


### PR DESCRIPTION
The bidi spec returns `{ "extension": "<extension_id>" }` (see wpt/tools/webdriver/webdriver/bidi/modules/web_extension.py `_install` method). However, `WebDriverWebExtensionsProtocolPart` install assumes that the raw extension ID is returned (`return
self.webdriver.web_extensions.install(type, path, value)`). This wasn't broken until PR #60872 which made web-extensions-helpers.js assume that the install was returning just the extension_id.

After this change WebDriverWebExtensionsProtocolPart now returns just the extension_id, aligning all browsers to return just an extension_id. `installPromise` will now consistently resolve to only the extension_id in web-extensions-helpers.js. Safari should now successfully uninstall the test extensions.