### PR TITLE
Relative <base> in about:blank and about:srcdoc documents

### DIFF
--- a/dom/nodes/Document-base-url-not-live.window.js
+++ b/dom/nodes/Document-base-url-not-live.window.js
@@ -1,0 +1,54 @@
+// Confirms that the base URL an about:blank or about:srcdoc document inherits
+// from its initiator/container is a snapshot taken at creation, not a live view
+// of the initiator's current base URL.
+//
+// Reading baseURI is not enough on its own: implementations cache the base URL,
+// so a live-but-cached implementation would still return the creation-time value
+// on read. To distinguish snapshot from live, the container's base URL is changed
+// and the child is then forced to recompute its base URL (by inserting and
+// removing a <base>). A snapshot yields the creation-time value; a live view
+// yields the container's new base URL.
+//
+// See https://github.com/whatwg/dom/issues/454
+
+function makeIframe(doc, configure) {
+  return new Promise(resolve => {
+    const iframe = doc.createElement("iframe");
+    configure(iframe);
+    iframe.addEventListener("load", () => resolve(iframe), { once: true });
+    doc.body.appendChild(iframe);
+  });
+}
+
+// Inserting then removing a <base> makes the document recompute its base URL.
+function forceBaseURLRecompute(doc) {
+  const base = doc.createElement("base");
+  base.setAttribute("href", "http://example.org/forced/");
+  doc.head.appendChild(base);
+  doc.head.removeChild(base);
+}
+
+function notLiveTest(configureChild) {
+  return async t => {
+    const container = await makeIframe(document, f => f.src = "about:blank");
+    t.add_cleanup(() => container.remove());
+    const cdoc = container.contentDocument;
+
+    const child = await makeIframe(cdoc, configureChild);
+    const childDoc = child.contentDocument;
+    const inherited = childDoc.baseURI;
+
+    const cbase = cdoc.createElement("base");
+    cbase.setAttribute("href", "http://example.com/changed/");
+    cdoc.head.appendChild(cbase);
+    assert_equals(cdoc.baseURI, "http://example.com/changed/", "container base URL changed");
+
+    forceBaseURLRecompute(childDoc);
+    assert_equals(childDoc.baseURI, inherited,
+      "child base URL is a snapshot from creation, not the container's current base URL");
+  };
+}
+
+promise_test(notLiveTest(f => f.src = "about:blank"), "about:blank base URL is not live");
+
+promise_test(notLiveTest(f => f.srcdoc = "x"), "about:srcdoc base URL is not live");

--- a/dom/nodes/Document-base-url-not-live.window.js
+++ b/dom/nodes/Document-base-url-not-live.window.js
@@ -1,13 +1,6 @@
-// Confirms that the base URL an about:blank or about:srcdoc document inherits
-// from its initiator/container is a snapshot taken at creation, not a live view
-// of the initiator's current base URL.
-//
-// Reading baseURI is not enough on its own: implementations cache the base URL,
-// so a live-but-cached implementation would still return the creation-time value
-// on read. To distinguish snapshot from live, the container's base URL is changed
-// and the child is then forced to recompute its base URL (by inserting and
-// removing a <base>). A snapshot yields the creation-time value; a live view
-// yields the container's new base URL.
+// Reading baseURI cannot distinguish a snapshot from a live lookup on its own, as
+// implementations cache the base URL. So change the container's base URL and then
+// force the child to recompute by inserting and removing a <base>.
 //
 // See https://github.com/whatwg/dom/issues/454
 
@@ -20,7 +13,6 @@ function makeIframe(doc, configure) {
   });
 }
 
-// Inserting then removing a <base> makes the document recompute its base URL.
 function forceBaseURLRecompute(doc) {
   const base = doc.createElement("base");
   base.setAttribute("href", "http://example.org/forced/");

--- a/dom/nodes/Document-cloneNode-about-base-url-relative.window.js
+++ b/dom/nodes/Document-cloneNode-about-base-url-relative.window.js
@@ -1,0 +1,43 @@
+// Tracking test for a relative <base> href in an about:blank document, and how
+// it interacts with cloning.
+//
+// Per the "fallback base URL" algorithm, an about:blank document's fallback
+// base URL is its initiator's base URL, and a <base> element resolves its href
+// against the fallback base URL. So a relative <base href="sub/"> should resolve
+// against the inherited base URL. Browsers currently resolve it against
+// "about:blank" instead, which is an open question: fix the browsers or special
+// case about:blank in the specification.
+//
+// See https://github.com/whatwg/dom/issues/454
+
+function aboutBlankDocument(t) {
+  return new Promise(resolve => {
+    const iframe = document.createElement("iframe");
+    iframe.src = "about:blank";
+    iframe.onload = () => resolve(iframe);
+    t.add_cleanup(() => iframe.remove());
+    document.body.appendChild(iframe);
+  });
+}
+
+promise_test(async t => {
+  const doc = (await aboutBlankDocument(t)).contentDocument;
+  const expected = new URL("sub/", doc.baseURI).href;
+
+  const base = doc.createElement("base");
+  base.setAttribute("href", "sub/");
+  doc.head.appendChild(base);
+  assert_equals(doc.baseURI, expected);
+}, "A relative <base> in an about:blank document resolves against the inherited base URL");
+
+promise_test(async t => {
+  const doc = (await aboutBlankDocument(t)).contentDocument;
+  const expected = new URL("sub/", doc.baseURI).href;
+
+  const base = doc.createElement("base");
+  base.setAttribute("href", "sub/");
+  doc.head.appendChild(base);
+
+  assert_equals(doc.cloneNode(true).baseURI, expected, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, expected, "shallow");
+}, "Clone of an about:blank document with a relative <base>");

--- a/dom/nodes/Document-cloneNode-about-base-url-relative.window.js
+++ b/dom/nodes/Document-cloneNode-about-base-url-relative.window.js
@@ -1,12 +1,11 @@
-// Tracking test for a relative <base> href in an about:blank document, and how
-// it interacts with cloning.
+// A relative <base> href in an about:blank document, and how it interacts with
+// cloning.
 //
-// Per the "fallback base URL" algorithm, an about:blank document's fallback
-// base URL is its initiator's base URL, and a <base> element resolves its href
-// against the fallback base URL. So a relative <base href="sub/"> should resolve
-// against the inherited base URL. Browsers currently resolve it against
-// "about:blank" instead, which is an open question: fix the browsers or special
-// case about:blank in the specification.
+// The base URL an about:blank document inherits from its initiator is exposed
+// through the no-<base> path (base URL override), so ordinary relative URLs
+// resolve against it. A <base> element, however, resolves its href against the
+// document's own URL, so a relative <base href="sub/"> resolves against
+// about:blank rather than the inherited base URL. Cloning does not change this.
 //
 // See https://github.com/whatwg/dom/issues/454
 
@@ -22,22 +21,20 @@ function aboutBlankDocument(t) {
 
 promise_test(async t => {
   const doc = (await aboutBlankDocument(t)).contentDocument;
-  const expected = new URL("sub/", doc.baseURI).href;
 
   const base = doc.createElement("base");
   base.setAttribute("href", "sub/");
   doc.head.appendChild(base);
-  assert_equals(doc.baseURI, expected);
-}, "A relative <base> in an about:blank document resolves against the inherited base URL");
+  assert_equals(doc.baseURI, "about:blank");
+}, "A relative <base> in an about:blank document resolves against about:blank");
 
 promise_test(async t => {
   const doc = (await aboutBlankDocument(t)).contentDocument;
-  const expected = new URL("sub/", doc.baseURI).href;
 
   const base = doc.createElement("base");
   base.setAttribute("href", "sub/");
   doc.head.appendChild(base);
 
-  assert_equals(doc.cloneNode(true).baseURI, expected, "deep");
-  assert_equals(doc.cloneNode(false).baseURI, expected, "shallow");
+  assert_equals(doc.cloneNode(true).baseURI, "about:blank", "deep");
+  assert_equals(doc.cloneNode(false).baseURI, "about:blank", "shallow");
 }, "Clone of an about:blank document with a relative <base>");

--- a/dom/nodes/Document-cloneNode-about-base-url-relative.window.js
+++ b/dom/nodes/Document-cloneNode-about-base-url-relative.window.js
@@ -1,12 +1,3 @@
-// A relative <base> href in an about:blank document, and how it interacts with
-// cloning.
-//
-// The base URL an about:blank document inherits from its initiator is exposed
-// through the no-<base> path (base URL override), so ordinary relative URLs
-// resolve against it. A <base> element, however, resolves its href against the
-// document's own URL, so a relative <base href="sub/"> resolves against
-// about:blank rather than the inherited base URL. Cloning does not change this.
-//
 // See https://github.com/whatwg/dom/issues/454
 
 function aboutBlankDocument(t) {

--- a/dom/nodes/Document-cloneNode-srcdoc-base-url.window.js
+++ b/dom/nodes/Document-cloneNode-srcdoc-base-url.window.js
@@ -1,11 +1,11 @@
-// Tracking test for a relative <base> href in an about:srcdoc document, and how
-// it interacts with cloning. Parallels the about:blank case.
+// A relative <base> href in an about:srcdoc document, and how it interacts with
+// cloning. Parallels the about:blank case.
 //
-// Per the "fallback base URL" algorithm, an iframe srcdoc document's base URL is
-// its container's base URL, and a <base> element resolves its href against the
-// fallback base URL. So a relative <base href="sub/"> should resolve against the
-// inherited base URL, both for the document and its clones. Cloning drops the
-// container relationship, which is where this gets interesting.
+// The base URL an about:srcdoc document inherits from its container is exposed
+// through the no-<base> path (base URL override), so ordinary relative URLs
+// resolve against it. A <base> element, however, resolves its href against the
+// document's own URL, so a relative <base href="sub/"> resolves against
+// about:srcdoc rather than the inherited base URL. Cloning does not change this.
 //
 // See https://github.com/whatwg/dom/issues/454
 
@@ -21,14 +21,12 @@ function srcdocDocument(t, srcdoc) {
 
 promise_test(async t => {
   const doc = (await srcdocDocument(t, "<base href='sub/'>x")).contentDocument;
-  const expected = new URL("sub/", document.baseURI).href;
-  assert_equals(doc.baseURI, expected);
-}, "A relative <base> in an about:srcdoc document resolves against the inherited base URL");
+  assert_equals(doc.baseURI, "about:srcdoc");
+}, "A relative <base> in an about:srcdoc document resolves against about:srcdoc");
 
 promise_test(async t => {
   const doc = (await srcdocDocument(t, "<base href='sub/'>x")).contentDocument;
-  const expected = new URL("sub/", document.baseURI).href;
 
-  assert_equals(doc.cloneNode(true).baseURI, expected, "deep");
-  assert_equals(doc.cloneNode(false).baseURI, expected, "shallow");
+  assert_equals(doc.cloneNode(true).baseURI, "about:srcdoc", "deep");
+  assert_equals(doc.cloneNode(false).baseURI, "about:srcdoc", "shallow");
 }, "Clone of an about:srcdoc document with a relative <base>");

--- a/dom/nodes/Document-cloneNode-srcdoc-base-url.window.js
+++ b/dom/nodes/Document-cloneNode-srcdoc-base-url.window.js
@@ -1,0 +1,34 @@
+// Tracking test for a relative <base> href in an about:srcdoc document, and how
+// it interacts with cloning. Parallels the about:blank case.
+//
+// Per the "fallback base URL" algorithm, an iframe srcdoc document's base URL is
+// its container's base URL, and a <base> element resolves its href against the
+// fallback base URL. So a relative <base href="sub/"> should resolve against the
+// inherited base URL, both for the document and its clones. Cloning drops the
+// container relationship, which is where this gets interesting.
+//
+// See https://github.com/whatwg/dom/issues/454
+
+function srcdocDocument(t, srcdoc) {
+  return new Promise(resolve => {
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = srcdoc;
+    iframe.onload = () => resolve(iframe);
+    t.add_cleanup(() => iframe.remove());
+    document.body.appendChild(iframe);
+  });
+}
+
+promise_test(async t => {
+  const doc = (await srcdocDocument(t, "<base href='sub/'>x")).contentDocument;
+  const expected = new URL("sub/", document.baseURI).href;
+  assert_equals(doc.baseURI, expected);
+}, "A relative <base> in an about:srcdoc document resolves against the inherited base URL");
+
+promise_test(async t => {
+  const doc = (await srcdocDocument(t, "<base href='sub/'>x")).contentDocument;
+  const expected = new URL("sub/", document.baseURI).href;
+
+  assert_equals(doc.cloneNode(true).baseURI, expected, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, expected, "shallow");
+}, "Clone of an about:srcdoc document with a relative <base>");

--- a/dom/nodes/Document-cloneNode-srcdoc-base-url.window.js
+++ b/dom/nodes/Document-cloneNode-srcdoc-base-url.window.js
@@ -1,12 +1,3 @@
-// A relative <base> href in an about:srcdoc document, and how it interacts with
-// cloning. Parallels the about:blank case.
-//
-// The base URL an about:srcdoc document inherits from its container is exposed
-// through the no-<base> path (base URL override), so ordinary relative URLs
-// resolve against it. A <base> element, however, resolves its href against the
-// document's own URL, so a relative <base href="sub/"> resolves against
-// about:srcdoc rather than the inherited base URL. Cloning does not change this.
-//
 // See https://github.com/whatwg/dom/issues/454
 
 function srcdocDocument(t, srcdoc) {

--- a/html/infrastructure/urls/base-url/document-base-uri-synthetic-document.html
+++ b/html/infrastructure/urls/base-url/document-base-uri-synthetic-document.html
@@ -2,7 +2,6 @@
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1486750">
 <link rel=help href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">
-<link rel=help href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/html/infrastructure/urls/base-url/document-base-url-document-open.html
+++ b/html/infrastructure/urls/base-url/document-base-url-document-open.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>document.open() does not change an about: document's inherited base URL</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<base href="/base-url-override/">
+<body>
+<script>
+// See https://github.com/whatwg/dom/issues/454
+
+const INHERITED_BASE_URL = new URL("/base-url-override/", location.href).href;
+
+// document.open() copies the calling document's URL, without its fragment.
+const REWRITTEN_URL = (() => {
+  const url = new URL(location.href);
+  url.hash = "";
+  return url.href;
+})();
+
+function loadIframe(t, configure) {
+  return new Promise(resolve => {
+    const iframe = document.createElement("iframe");
+    configure(iframe);
+    iframe.addEventListener("load", () => resolve(iframe), { once: true });
+    t.add_cleanup(() => iframe.remove());
+    document.body.append(iframe);
+  });
+}
+
+function documentOpenTest(configure) {
+  return async t => {
+    assert_equals(document.baseURI, INHERITED_BASE_URL, "this document's base URL");
+    assert_not_equals(document.baseURI, REWRITTEN_URL,
+                      "this document's base URL has to differ from its URL");
+
+    const doc = (await loadIframe(t, configure)).contentDocument;
+    assert_equals(doc.baseURI, INHERITED_BASE_URL, "inherited base URL");
+
+    doc.open();
+    assert_equals(doc.URL, REWRITTEN_URL, "URL after document.open()");
+    assert_equals(doc.baseURI, INHERITED_BASE_URL, "base URL after document.open()");
+    doc.close();
+  };
+}
+
+promise_test(documentOpenTest(() => {}),
+             "document.open() on an initial about:blank document");
+
+promise_test(documentOpenTest(iframe => iframe.src = "about:blank"),
+             "document.open() on an about:blank document");
+
+promise_test(documentOpenTest(iframe => iframe.srcdoc = "x"),
+             "document.open() on an about:srcdoc document");
+</script>

--- a/html/infrastructure/urls/terminology-0/document-base-url-about-srcdoc.https.window.js
+++ b/html/infrastructure/urls/terminology-0/document-base-url-about-srcdoc.https.window.js
@@ -13,10 +13,10 @@ const runTest = (description, iframe_sandbox) => {
     `;
     const child_base_uri = new Promise(r => onmessage = e => r(e.data));
     document.body.appendChild(iframe);
-    // [spec]: https://html.spec.whatwg.org/C/#fallback-base-url
-    // Step 1: If document is an iframe srcdoc document, then return the
-    //         document base URL of document's browsing context's container
-    //         document.
+    // [spec]: https://html.spec.whatwg.org/C/#document-base-url
+    // Step 2: If document's base URL override is non-null, then return it. For
+    //         an iframe srcdoc document it is a snapshot of the initiator
+    //         document's document base URL.
     assert_equals(await child_base_uri, document.baseURI);
   }, description);
 }

--- a/html/infrastructure/urls/terminology-0/document-base-url.html
+++ b/html/infrastructure/urls/terminology-0/document-base-url.html
@@ -18,6 +18,12 @@
       assert_equals(actual, expected, "img src should resolve correctly");
     }
 
+    function assert_unresolvable_url(doc) {
+      var img = doc.createElement("img");
+      img.src = "foo";
+      assert_equals(img.src, "foo", "img src should not resolve");
+    }
+
     var t1 = async_test("The document base URL of a document containing one or more base elements with href attributes is the frozen base URL of the first base element in the document that has an href attribute, in tree order.");
 
     function on_load() {
@@ -61,8 +67,8 @@
         var doc = iframe.contentDocument;
         var base = doc.body.appendChild(doc.createElement("base"));
         base.href = "sub/";
-        assert_resolve_url(doc, location.href.replace("/document-base-url.html", "/sub"));
-        assert_equals(doc.baseURI, document.baseURI.replace("/document-base-url.html", "/sub/"));
+        assert_unresolvable_url(doc);
+        assert_equals(doc.baseURI, "about:blank");
       });
       iframe.setAttribute("src", "about:blank");
       document.body.appendChild(iframe);
@@ -82,8 +88,8 @@
       var iframe = document.createElement("iframe");
       iframe.onload = this.step_func_done(function () {
         var doc = iframe.contentDocument;
-        assert_resolve_url(doc, location.href.replace("/document-base-url.html", "/sub"));
-        assert_equals(doc.baseURI, document.baseURI.replace("/document-base-url.html", "/sub/"),
+        assert_unresolvable_url(doc);
+        assert_equals(doc.baseURI, "about:srcdoc",
                       "The srcdoc document's base URL should be set by the <base> tag.");
       });
       iframe.setAttribute("srcdoc", "<base href='sub/'><p>foobar</p>");

--- a/html/infrastructure/urls/terminology-0/nontraditional-about-srcdoc.html
+++ b/html/infrastructure/urls/terminology-0/nontraditional-about-srcdoc.html
@@ -34,10 +34,10 @@ promise_test(async t => {
       'The request referrer is retrieved from the parent document for ' +
       'about:srcdoc documents');
 
-  // Observe that the "about base URL" is retrieved [1] for `document.baseURI`
-  // as well, indicating that the document is treated like a normal srcdoc
-  // document.
-  // [1]: https://html.spec.whatwg.org/#fallback-base-url
+  // Observe that the inherited base URL (the "base URL override") is retrieved
+  // [1] for `document.baseURI` as well, indicating that the document is treated
+  // like a normal srcdoc document.
+  // [1]: https://html.spec.whatwg.org/#document-base-url
   assert_equals(iframe.contentDocument.baseURI, location.href,
       'The about base URL is retrieved as the base URL for srcdoc documents');
 }, 'about:srcdoc with document.open() is treated like a normal about:srcdoc document');

--- a/html/semantics/document-metadata/the-base-element/base_about_blank.html
+++ b/html/semantics/document-metadata/the-base-element/base_about_blank.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>base element in about:blank document should resolve against its fallback base URI</title>
+<title>base element in about:blank document should resolve against the document's URL</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <iframe></iframe>
@@ -10,10 +11,9 @@ addEventListener("load", t.step_func_done(function() {
   var doc = frames[0].document;
   var b = doc.createElement("base");
   b.setAttribute("href", "test");
-  var newBaseValue = location.href.replace(/\/[^/]*$/, "/") + "test";
-  assert_equals(b.href, newBaseValue);
-  assert_equals(doc.baseURI, location.href);
+  assert_equals(b.href, "test", "href getter, relative to about:blank");
+  assert_equals(doc.baseURI, location.href, "baseURI without a base element");
   doc.head.appendChild(b);
-  assert_equals(doc.baseURI, newBaseValue);
+  assert_equals(doc.baseURI, "about:blank", "baseURI with a relative base href");
 }));
 </script>

--- a/html/semantics/document-metadata/the-base-element/base_srcdoc.html
+++ b/html/semantics/document-metadata/the-base-element/base_srcdoc.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>base element in srcdoc document should resolve against its fallback base URI</title>
+<title>base element in srcdoc document should resolve against the document's URL</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <iframe srcdoc=""></iframe>
@@ -10,10 +11,9 @@ addEventListener("load", t.step_func_done(function() {
   var doc = frames[0].document;
   var b = doc.createElement("base");
   b.setAttribute("href", "test");
-  var newBaseValue = location.href.replace(/\/[^/]*$/, "/") + "test";
-  assert_equals(b.href, newBaseValue);
-  assert_equals(doc.baseURI, location.href);
+  assert_equals(b.href, "test", "href getter, relative to about:srcdoc");
+  assert_equals(doc.baseURI, location.href, "baseURI without a base element");
   doc.head.appendChild(b);
-  assert_equals(doc.baseURI, newBaseValue);
+  assert_equals(doc.baseURI, "about:srcdoc", "baseURI with a relative base href");
 }));
 </script>


### PR DESCRIPTION
A relative `<base>` `href` resolves against the document's own URL, not against the base URL an `about:blank` or `about:srcdoc` document inherits from its initiator. So `<base href="sub/">` in such a document resolves against `about:blank`/`about:srcdoc`, which fails to parse as those URLs have an opaque path, leaving the document base URL as the document's URL. Ordinary relative URLs keep inheriting, through the base URL override. Cloning does not change any of this.

Also covered:

- The inherited base URL is a snapshot taken at creation, not a live view of the initiator's base URL.
- `document.open()` rewriting a document's URL does not change its inherited base URL.

Existing tests that asserted resolution against the inherited base URL are updated: `base_about_blank.html`, `base_srcdoc.html`, and two subtests of `document-base-url.html`.

Specification changes: https://github.com/whatwg/html/pull/12674 & https://github.com/whatwg/dom/pull/1492.

For https://github.com/whatwg/dom/issues/454.

Some subtests assert the spec-intended behavior and will fail in engines until they implement it.
