### PR TITLE
Cloning a document copies its base URL

### DIFF
--- a/dom/nodes/Document-cloneNode-about-base-url.window.js
+++ b/dom/nodes/Document-cloneNode-about-base-url.window.js
@@ -1,0 +1,65 @@
+// An about:blank document inherits its initiator's base URL. Cloning copies the
+// computed base URL, so the clone reports the same value.
+// See https://github.com/whatwg/dom/issues/454
+
+const BASE_HREF = "http://example.com/foo/bar";
+
+function aboutBlankDocument(t) {
+  return new Promise(resolve => {
+    const iframe = document.createElement("iframe");
+    iframe.src = "about:blank";
+    iframe.onload = () => resolve(iframe);
+    t.add_cleanup(() => iframe.remove());
+    document.body.appendChild(iframe);
+  });
+}
+
+promise_test(async t => {
+  const doc = (await aboutBlankDocument(t)).contentDocument;
+  assert_equals(doc.URL, "about:blank", "URL");
+  assert_equals(doc.baseURI, document.baseURI, "inherited base URL");
+}, "An about:blank document inherits the initiator base URL");
+
+promise_test(async t => {
+  const doc = (await aboutBlankDocument(t)).contentDocument;
+  const expected = doc.baseURI;
+
+  const deep = doc.cloneNode(true);
+  assert_equals(deep.URL, "about:blank", "URL");
+  assert_equals(deep.baseURI, expected, "baseURI");
+}, "Deep clone of an about:blank document");
+
+promise_test(async t => {
+  const doc = (await aboutBlankDocument(t)).contentDocument;
+  const expected = doc.baseURI;
+
+  const shallow = doc.cloneNode(false);
+  assert_equals(shallow.URL, "about:blank", "URL");
+  assert_equals(shallow.baseURI, expected, "baseURI");
+}, "Shallow clone of an about:blank document");
+
+// The inherited base URL is a snapshot, not a live lookup: the clone keeps it
+// after the source iframe is detached.
+promise_test(async t => {
+  const iframe = await aboutBlankDocument(t);
+  const doc = iframe.contentDocument;
+  const expected = doc.baseURI;
+
+  const shallow = doc.cloneNode(false);
+  const deep = doc.cloneNode(true);
+  iframe.remove();
+
+  assert_equals(shallow.baseURI, expected, "shallow");
+  assert_equals(deep.baseURI, expected, "deep");
+}, "Clone of an about:blank document after detaching the source");
+
+promise_test(async t => {
+  const doc = (await aboutBlankDocument(t)).contentDocument;
+  const base = doc.createElement("base");
+  base.setAttribute("href", BASE_HREF);
+  doc.head.appendChild(base);
+  assert_equals(doc.baseURI, BASE_HREF, "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, BASE_HREF, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, BASE_HREF, "shallow");
+}, "Clone of an about:blank document with a <base>");

--- a/dom/nodes/Document-cloneNode-base-url-xml.window.js
+++ b/dom/nodes/Document-cloneNode-base-url-xml.window.js
@@ -1,0 +1,33 @@
+// There is no xml:base: only an HTML <base> element (including one in the XHTML
+// namespace) contributes to the document base URL.
+// See https://github.com/whatwg/dom/issues/454
+
+const BASE_HREF = "http://example.com/foo/bar";
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<root><base href="${BASE_HREF}"/></root>`, "application/xml");
+  assert_equals(doc.baseURI, doc.URL, "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, doc.URL, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, doc.URL, "shallow");
+}, "Clone of an XML document ignores a non-HTML <base> element");
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<html xmlns="http://www.w3.org/1999/xhtml">` +
+    `<head><base href="${BASE_HREF}"/></head><body></body></html>`,
+    "application/xhtml+xml");
+  assert_equals(doc.baseURI, BASE_HREF, "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, BASE_HREF, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, BASE_HREF, "shallow");
+}, "Clone of an XHTML document with a <base>");
+
+test(() => {
+  const doc = new DOMParser().parseFromString("<root/>", "application/xml");
+  assert_equals(doc.baseURI, doc.URL, "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, doc.URL, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, doc.URL, "shallow");
+}, "Clone of an XML document without a <base>");

--- a/dom/nodes/Document-cloneNode-base-url.window.js
+++ b/dom/nodes/Document-cloneNode-base-url.window.js
@@ -1,0 +1,121 @@
+// Cloning a document copies its computed base URL. A shallow clone therefore
+// reports the same base URL as the source even though it has no <base> element.
+// See https://github.com/whatwg/dom/issues/454
+
+const BASE_HREF = "http://example.com/foo/bar";
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="${BASE_HREF}">`, "text/html");
+  assert_equals(doc.baseURI, BASE_HREF, "source");
+
+  const deep = doc.cloneNode(true);
+  assert_equals(deep.URL, doc.URL, "URL");
+  assert_equals(deep.baseURI, BASE_HREF, "baseURI");
+}, "Deep clone of a document with a <base>");
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="${BASE_HREF}">`, "text/html");
+  assert_equals(doc.baseURI, BASE_HREF, "source");
+
+  const shallow = doc.cloneNode(false);
+  assert_equals(shallow.URL, doc.URL, "URL");
+  assert_equals(shallow.baseURI, BASE_HREF, "baseURI");
+}, "Shallow clone of a document with a <base>");
+
+test(() => {
+  const doc = new DOMParser().parseFromString("<!DOCTYPE html>", "text/html");
+  assert_equals(doc.baseURI, doc.URL, "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, doc.URL, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, doc.URL, "shallow");
+}, "Clone of a document without a <base>");
+
+test(() => {
+  const doc = document.implementation.createHTMLDocument("");
+  assert_equals(doc.URL, "about:blank", "URL");
+  assert_equals(doc.baseURI, "about:blank", "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, "about:blank", "deep");
+  assert_equals(doc.cloneNode(false).baseURI, "about:blank", "shallow");
+}, "Clone of a createHTMLDocument() document without a <base>");
+
+test(() => {
+  const doc = document.implementation.createHTMLDocument("");
+  const base = doc.createElement("base");
+  base.setAttribute("href", BASE_HREF);
+  doc.head.appendChild(base);
+  assert_equals(doc.baseURI, BASE_HREF, "source");
+
+  assert_equals(doc.cloneNode(true).baseURI, BASE_HREF, "deep");
+  assert_equals(doc.cloneNode(false).baseURI, BASE_HREF, "shallow");
+}, "Clone of a createHTMLDocument() document with a <base>");
+
+// A relative <base> must resolve exactly once, against the copied URL, rather
+// than a second time against the source's already-computed base URL.
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="sub/">`, "text/html");
+  const expected = new URL("sub/", doc.URL).href;
+  assert_equals(doc.baseURI, expected, "source");
+  assert_equals(doc.cloneNode(true).baseURI, expected, "baseURI");
+}, "Deep clone of a document with a relative <base>");
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="sub/">`, "text/html");
+  const expected = new URL("sub/", doc.URL).href;
+  assert_equals(doc.baseURI, expected, "source");
+  assert_equals(doc.cloneNode(false).baseURI, expected, "baseURI");
+}, "Shallow clone of a document with a relative <base>");
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="${BASE_HREF}">`, "text/html");
+  const shallow = doc.cloneNode(false);
+
+  doc.querySelector("base").remove();
+  assert_equals(doc.baseURI, doc.URL, "source updated");
+  assert_equals(shallow.baseURI, BASE_HREF, "clone unchanged");
+}, "Shallow clone is unaffected by later mutation of the source");
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="${BASE_HREF}">`, "text/html");
+  const shallow = doc.cloneNode(false);
+
+  shallow.appendChild(shallow.createComment("mutate"));
+  assert_equals(shallow.baseURI, BASE_HREF);
+}, "Shallow clone's base URL survives later mutation of the clone");
+
+test(() => {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><base href="${BASE_HREF}">`, "text/html");
+  const shallow = doc.cloneNode(false);
+  assert_equals(shallow.baseURI, BASE_HREF, "before inserting <base>");
+
+  const base = shallow.createElement("base");
+  base.setAttribute("href", "http://example.org/other/");
+  shallow.appendChild(base);
+  assert_equals(shallow.baseURI, "http://example.org/other/",
+    "an inserted <base> wins over the copied base URL");
+}, "Inserting a <base> into a shallow clone overrides the copied base URL");
+
+async_test(t => {
+  const blobURL = URL.createObjectURL(
+    new Blob(["<!doctype html>"], { type: "text/html" }));
+  t.add_cleanup(() => URL.revokeObjectURL(blobURL));
+
+  const iframe = document.createElement("iframe");
+  iframe.src = blobURL;
+  iframe.onload = t.step_func_done(() => {
+    const doc = iframe.contentDocument;
+    assert_equals(doc.baseURI, blobURL, "source");
+
+    assert_equals(doc.cloneNode(true).baseURI, blobURL, "deep");
+    assert_equals(doc.cloneNode(false).baseURI, blobURL, "shallow");
+    iframe.remove();
+  });
+  document.body.appendChild(iframe);
+}, "Clone of a blob: URL document");


### PR DESCRIPTION
Tests that cloning a document copies its base URL, so `node.baseURI` on a clone reports the source document's computed base URL.

- Deep clone carries the `<base>` element; shallow clone (no `<base>`) reports the same base URL via the copied override.
- Documents without a `<base>`; `createHTMLDocument()`; `about:blank` base URL inheritance.
- XML/XHTML (no `xml:base`); `blob:` URLs.
- Snapshot independence from later source mutation; durability across clone mutation; an inserted `<base>` taking precedence over the copied base URL.

For https://github.com/whatwg/dom/issues/454.

Some subtests assert the spec-intended behavior and will fail in engines until they implement it.
