### PR TITLE
layout: Correctly slice decorations on fragmented boxes

### DIFF
--- a/css/css-break/box-decoration-break-clone-clip-path-ref.html
+++ b/css/css-break/box-decoration-break-clone-clip-path-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    margin-left: 10px;
+    width: 10px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if below there is two purple squares on top of one another.</p>
+<span>
+  <span class="inner"></span>
+  <br>
+  <span class="inner"></span>
+</span>

--- a/css/css-break/box-decoration-break-clone-clip-path.html
+++ b/css/css-break/box-decoration-break-clone-clip-path.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>clip-path should apply to each fragment individually with box-decoration-break: clone.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-masking/#the-clip-path">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6383#issuecomment-960244091">
+<link rel="match" href="box-decoration-break-clone-clip-path-ref.html">
+<meta name="assert" content="clip-path should apply to each fragment individually with box-decoration-break: clone.">
+<style>
+  #fragmented {
+    clip-path: inset(0px 10px 0px 10px);
+    box-decoration-break: clone;
+  }
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    width: 30px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if below there is two purple squares on top of one another.</p>
+<span id="fragmented">
+  <span class="inner"></span>
+  <br>
+  <span class="inner"></span>
+</span>

--- a/css/css-break/box-decoration-break-slice-border-radius-ref.html
+++ b/css/css-break/box-decoration-break-slice-border-radius-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  body {
+    margin-left: 100px;
+    line-height: 3em;
+  }
+  .breakable {
+    border: 2px solid black;
+    background: linear-gradient(to right, pink, lightblue);
+    border-radius: 50%;
+    padding: 6px;
+  }
+  .long, .short {
+    display: inline-block;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+  .long {
+    width: 100px;
+  }
+  .short {
+    width: 50px;
+  }
+  .cover {
+    position: absolute;
+    background-color: white;
+    width: 300px;
+    height: 1lh;
+  }
+</style>
+Unbroken span for reference:<br>
+<span class="breakable" id="reference">
+  <span class="long"></span><span class="short"></span>
+</span><br>
+The span, broken into two pieces that could conceivably be put back together in a seamless fashion:<br>
+<span class="breakable">
+  <span class="long"></span><span class="cover"></span><span class="short"></span>
+</span><br>
+
+<span class="breakable" style="margin-left:-108px">
+  <span class="long"></span><span class="cover" style="transform: translateX(-300px)"></span><span class="short"></span>
+</span>
+

--- a/css/css-break/box-decoration-break-slice-border-radius-ref.html
+++ b/css/css-break/box-decoration-break-slice-border-radius-ref.html
@@ -7,7 +7,7 @@
   }
   .breakable {
     border: 2px solid black;
-    background: linear-gradient(to right, pink, lightblue);
+    background: lightgray;
     border-radius: 50%;
     padding: 6px;
   }

--- a/css/css-break/box-decoration-break-slice-border-radius.html
+++ b/css/css-break/box-decoration-break-slice-border-radius.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>box-decoration-break:slice should be able to slice a border radius in half.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="match" href="box-decoration-break-slice-border-radius-ref.html">
+<meta name="assert" content="box-decoration-break:slice should be able to slice a border radius in half.">
+<!--
+  Feel free to expand these fuzzyness values as needed, so long as the box fragments correctly.
+  This could be solved by getting rid of the gradient instead, but I very much like the gradient as a visual aid.
+-->
+<meta name=fuzzy content="maxDifference=0-2;totalPixels=0-2000">
+<style>
+  body {
+    margin-left: 100px;
+    line-height: 3em;
+  }
+  .breakable {
+    border: 2px solid black;
+    background: linear-gradient(to right, pink, lightblue);
+    border-radius: 50%;
+    padding: 6px;
+  }
+  .long, .short {
+    display: inline-block;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+  .long {
+    width: 100px;
+  }
+  .short {
+    width: 50px;
+  }
+</style>
+Unbroken span for reference:<br>
+<span class="breakable">
+  <span class="long"></span><span class="short"></span>
+</span><br>
+The span, broken into two pieces that could conceivably be put back together in a seamless fashion:<br>
+<span class="breakable">
+  <span class="long"></span><br>
+  <span class="short"></span>
+</span>

--- a/css/css-break/box-decoration-break-slice-border-radius.html
+++ b/css/css-break/box-decoration-break-slice-border-radius.html
@@ -4,11 +4,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
 <link rel="match" href="box-decoration-break-slice-border-radius-ref.html">
 <meta name="assert" content="box-decoration-break:slice should be able to slice a border radius in half.">
-<!--
-  Feel free to expand these fuzzyness values as needed, so long as the box fragments correctly.
-  This could be solved by getting rid of the gradient instead, but I very much like the gradient as a visual aid.
--->
-<meta name=fuzzy content="maxDifference=0-2;totalPixels=0-2000">
 <style>
   body {
     margin-left: 100px;
@@ -16,7 +11,7 @@
   }
   .breakable {
     border: 2px solid black;
-    background: linear-gradient(to right, pink, lightblue);
+    background: lightgray;
     border-radius: 50%;
     padding: 6px;
   }

--- a/css/css-break/box-decoration-break-slice-clip-path-ref.html
+++ b/css/css-break/box-decoration-break-slice-clip-path-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    width: 40px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if there is two boxes of equal size below, with the first one offset towards the right by 20px.</p>
+<span>
+  <span class="inner" style="margin-left: 20px"></span>
+  <br>
+  <span class="inner"></span>
+</span>

--- a/css/css-break/box-decoration-break-slice-clip-path.html
+++ b/css/css-break/box-decoration-break-slice-clip-path.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>clip-path should apply to the unfragmented box as a whole.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-masking/#the-clip-path">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6383#issuecomment-960244091">
+<link rel="match" href="box-decoration-break-slice-clip-path-ref.html">
+<meta name="assert" content="clip-path should apply to the unfragmented box as a whole.">
+<style>
+  #fragmented {
+    clip-path: inset(0px 20px 0px 20px);
+  }
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    width: 60px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if there is two boxes of equal size below, with the first one offset towards the right by 20px.</p>
+<span id="fragmented">
+  <span class="inner"></span>
+  <br>
+  <span class="inner"></span>
+</span>


### PR DESCRIPTION
Specifically, this makes it so that the original, unfragmented size of fragmented inline boxes is tracked on the fragments, so that they can draw their backgrounds and borders as if unfragmented and then clip them to what is actually part of the fragment in question.
This draw-then-clip seems to me like the most reasonable way to do this, since the fragmentation should be able to cut something like a border-radius in half. (as verified by the newly added web platform test)

There's a new web platform test for this that verifies that a border radius is sized correctly and can be sliced in half by fragmentation:
<img width="900" height="287" alt="image" src="https://github.com/user-attachments/assets/c5042832-7355-47e6-8504-2f234ae7a27d" />

There are also some new failures around hit-testing on rounded fragments with vertical text. These are expected since Servo does not do vertical text correctly yet and so we've gone from rounding all corners to rounding only some corners, with respect to an incorrect inline direction.

Fixes: #<!-- nolink -->20747

Reviewed in servo/servo#46459