### PR TITLE
Move Early hints tests to a popup model

### DIFF
--- a/loading/early-hints/404-with-early-hints.h2.window.js
+++ b/loading/early-hints/404-with-early-hints.h2.window.js
@@ -1,10 +1,9 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("resource-url",
-        SAME_ORIGIN_RESOURCES_URL + "/square.png?" + token());
-    const test_url = "resources/404-with-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("resource-url",
+    SAME_ORIGIN_RESOURCES_URL + "/square.png?" + token());
+const test_url = "resources/404-with-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/404-with-early-hints.h2.window.js
+++ b/loading/early-hints/404-with-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/arbitrary-header-in-early-hints.h2.window.js
+++ b/loading/early-hints/arbitrary-header-in-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=resources/early-hints-helpers.sub.js
 const test_url = "resources/arbitrary-header-in-early-hints.h2.py";
 fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/arbitrary-header-in-early-hints.h2.window.js
+++ b/loading/early-hints/arbitrary-header-in-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-test(() => {
-    const test_url = "resources/arbitrary-header-in-early-hints.h2.py";
-    window.location.replace(new URL(test_url, window.location));
-});
+// META: timeout=long
+const test_url = "resources/arbitrary-header-in-early-hints.h2.py";
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/arbitrary-header-in-early-hints.h2.window.js
+++ b/loading/early-hints/arbitrary-header-in-early-hints.h2.window.js
@@ -1,3 +1,4 @@
 // META: timeout=long
+// META: script=resources/early-hints-helpers.sub.js
 const test_url = "resources/arbitrary-header-in-early-hints.h2.py";
 fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/coep-early-hints-none-final-require-corp.h2.window.js
+++ b/loading/early-hints/coep-early-hints-none-final-require-corp.h2.window.js
@@ -1,9 +1,8 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "unsafe-none";
-    const final_policy = "require-corp";
-    navigateToCrossOriginEmbedderPolicyMismatchTest(early_hints_policy,
-        final_policy);
-});
+const early_hints_policy = "unsafe-none";
+const final_policy = "require-corp";
+fetch_tests_from_window(navigateToCrossOriginEmbedderPolicyMismatchTest(early_hints_policy,
+    final_policy));

--- a/loading/early-hints/coep-early-hints-none-final-require-corp.h2.window.js
+++ b/loading/early-hints/coep-early-hints-none-final-require-corp.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/coep-early-hints-require-corp-final-none.h2.window.js
+++ b/loading/early-hints/coep-early-hints-require-corp-final-none.h2.window.js
@@ -1,9 +1,8 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "require-corp";
-    const final_policy = "unsafe-none";
-    navigateToCrossOriginEmbedderPolicyMismatchTest(early_hints_policy,
-        final_policy);
-});
+const early_hints_policy = "require-corp";
+const final_policy = "unsafe-none";
+fetch_tests_from_window(navigateToCrossOriginEmbedderPolicyMismatchTest(early_hints_policy,
+    final_policy));

--- a/loading/early-hints/coep-early-hints-require-corp-final-none.h2.window.js
+++ b/loading/early-hints/coep-early-hints-require-corp-final-none.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-absent-final-absent.h2.window.js
+++ b/loading/early-hints/csp-early-hints-absent-final-absent.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-absent-final-absent.h2.window.js
+++ b/loading/early-hints/csp-early-hints-absent-final-absent.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "absent";
-    const final_policy = "absent";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "absent";
+const final_policy = "absent";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-absent-final-allowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-absent-final-allowed.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "absent";
-    const final_policy = "allowed";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "absent";
+const final_policy = "allowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-absent-final-allowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-absent-final-allowed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-absent-final-disallowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-absent-final-disallowed.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "absent";
-    const final_policy = "disallowed";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "absent";
+const final_policy = "disallowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-absent-final-disallowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-absent-final-disallowed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-allowed-final-absent.h2.window.js
+++ b/loading/early-hints/csp-early-hints-allowed-final-absent.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "allowed";
-    const final_policy = "absent";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "allowed";
+const final_policy = "absent";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-allowed-final-absent.h2.window.js
+++ b/loading/early-hints/csp-early-hints-allowed-final-absent.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-allowed-final-allowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-allowed-final-allowed.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "allowed";
-    const final_policy = "allowed";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "allowed";
+const final_policy = "allowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-allowed-final-allowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-allowed-final-allowed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-allowed-final-disallowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-allowed-final-disallowed.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "allowed";
-    const final_policy = "disallowed";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "allowed";
+const final_policy = "disallowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-allowed-final-disallowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-allowed-final-disallowed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-disallowed-final-absent.h2.window.js
+++ b/loading/early-hints/csp-early-hints-disallowed-final-absent.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "disallowed";
-    const final_policy = "absent";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "disallowed";
+const final_policy = "absent";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-disallowed-final-absent.h2.window.js
+++ b/loading/early-hints/csp-early-hints-disallowed-final-absent.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-disallowed-final-allowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-disallowed-final-allowed.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "disallowed";
-    const final_policy = "allowed";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "disallowed";
+const final_policy = "allowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-disallowed-final-allowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-disallowed-final-allowed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/csp-early-hints-disallowed-final-disallowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-disallowed-final-disallowed.h2.window.js
@@ -1,8 +1,7 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "disallowed";
-    const final_policy = "disallowed";
-    navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy);
-});
+const early_hints_policy = "disallowed";
+const final_policy = "disallowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyBasicTest(early_hints_policy, final_policy));

--- a/loading/early-hints/csp-early-hints-disallowed-final-disallowed.h2.window.js
+++ b/loading/early-hints/csp-early-hints-disallowed-final-disallowed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/embed-object.h2.window.js
+++ b/loading/early-hints/embed-object.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/embed-object.h2.window.js
+++ b/loading/early-hints/embed-object.h2.window.js
@@ -1,3 +1,4 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/iframe-pdf.h2.window.js
+++ b/loading/early-hints/iframe-pdf.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/iframe-pdf.h2.window.js
+++ b/loading/early-hints/iframe-pdf.h2.window.js
@@ -1,3 +1,4 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/iframe-x-frame-options-deny.h2.window.js
+++ b/loading/early-hints/iframe-x-frame-options-deny.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/iframe-x-frame-options-deny.h2.window.js
+++ b/loading/early-hints/iframe-x-frame-options-deny.h2.window.js
@@ -1,3 +1,4 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/invalid-headers-in-early-hints.h2.window.js
+++ b/loading/early-hints/invalid-headers-in-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 async function testInvalidHeader(t, header_value) {
     const params = new URLSearchParams();
     params.set("header-value", header_value);

--- a/loading/early-hints/invalid-headers-in-early-hints.h2.window.js
+++ b/loading/early-hints/invalid-headers-in-early-hints.h2.window.js
@@ -1,3 +1,4 @@
+// META: timeout=long
 async function testInvalidHeader(t, header_value) {
     const params = new URLSearchParams();
     params.set("header-value", header_value);

--- a/loading/early-hints/modulepreload-as-worker-cross-origin.h2.window.js
+++ b/loading/early-hints/modulepreload-as-worker-cross-origin.h2.window.js
@@ -1,15 +1,14 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
 // see modulepreload-in-early-hints.h2.window.js for params explanation
-test(() => {
-    const params = new URLSearchParams();
-    params.set("description",
-        'Modulepreload should not load with as="worker" from cross-origin url');
-    params.set("resource-url",
-        CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("as", "worker");
-    params.set("should-preload", false);
-    const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("description",
+    'Modulepreload should not load with as="worker" from cross-origin url');
+params.set("resource-url",
+    CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("as", "worker");
+params.set("should-preload", false);
+const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/modulepreload-as-worker-cross-origin.h2.window.js
+++ b/loading/early-hints/modulepreload-as-worker-cross-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/modulepreload-as-worker.h2.window.js
+++ b/loading/early-hints/modulepreload-as-worker.h2.window.js
@@ -1,15 +1,14 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
 // see modulepreload-in-early-hints.h2.window.js for params explanation
-test(() => {
-    const params = new URLSearchParams();
-    params.set("description",
-        'Modulepreload should load with as="worker" from same-origin url');
-    params.set("resource-url",
-        SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("as", "worker");
-    params.set("should-preload", true);
-    const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("description",
+    'Modulepreload should load with as="worker" from same-origin url');
+params.set("resource-url",
+    SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("as", "worker");
+params.set("should-preload", true);
+const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/modulepreload-as-worker.h2.window.js
+++ b/loading/early-hints/modulepreload-as-worker.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/modulepreload-cross-origin.h2.window.js
+++ b/loading/early-hints/modulepreload-cross-origin.h2.window.js
@@ -1,13 +1,12 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
 // see modulepreload-in-early-hints.h2.window.js for params explanation
-test(() => {
-    const params = new URLSearchParams();
-    params.set("description", "Modulepreload works in early hints from cross-origin url");
-    params.set("resource-url",
-        CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("should-preload", true);
-    const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("description", "Modulepreload works in early hints from cross-origin url");
+params.set("resource-url",
+    CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("should-preload", true);
+const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/modulepreload-cross-origin.h2.window.js
+++ b/loading/early-hints/modulepreload-cross-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/modulepreload-in-early-hints.h2.window.js
+++ b/loading/early-hints/modulepreload-in-early-hints.h2.window.js
@@ -1,3 +1,4 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
@@ -9,12 +10,10 @@
 //
 // [1]: resources/modulepreload-in-early-hints.h2.py
 // [2]: resources/modulepreload-in-early-hints.h2.html
-test(() => {
-    const params = new URLSearchParams();
-    params.set("description", "Modulepreload works in early hints");
-    params.set("resource-url",
-        SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("should-preload", true);
-    const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("description", "Modulepreload works in early hints");
+params.set("resource-url",
+    SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("should-preload", true);
+const test_url = "resources/modulepreload-in-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/modulepreload-in-early-hints.h2.window.js
+++ b/loading/early-hints/modulepreload-in-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/multiple-early-hints-responses.h2.window.js
+++ b/loading/early-hints/multiple-early-hints-responses.h2.window.js
@@ -1,11 +1,10 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("first-preload", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("second-preload", CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("second-preload-origin", CROSS_ORIGIN);
-    const test_url = "resources/multiple-early-hints-responses.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("first-preload", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("second-preload", CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("second-preload-origin", CROSS_ORIGIN);
+const test_url = "resources/multiple-early-hints-responses.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/multiple-early-hints-responses.h2.window.js
+++ b/loading/early-hints/multiple-early-hints-responses.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preconnect-in-early-hints.h2.window.js
+++ b/loading/early-hints/preconnect-in-early-hints.h2.window.js
@@ -1,12 +1,11 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const resource_origin = CROSS_ORIGIN;
-    const resource_url = CROSS_ORIGIN + RESOURCES_PATH + "/empty.js?" + token();
-    const params = new URLSearchParams();
-    params.set("resource-origin", resource_origin);
-    params.set("resource-url", resource_url);
-    const test_url = "resources/preconnect-in-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const resource_origin = CROSS_ORIGIN;
+const resource_url = CROSS_ORIGIN + RESOURCES_PATH + "/empty.js?" + token();
+const params = new URLSearchParams();
+params.set("resource-origin", resource_origin);
+params.set("resource-url", resource_url);
+const test_url = "resources/preconnect-in-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/preconnect-in-early-hints.h2.window.js
+++ b/loading/early-hints/preconnect-in-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-fetch.h2.window.js
+++ b/loading/early-hints/preload-fetch.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=resources/early-hints-helpers.sub.js
 
 const preloads = [{

--- a/loading/early-hints/preload-fetch.h2.window.js
+++ b/loading/early-hints/preload-fetch.h2.window.js
@@ -1,10 +1,9 @@
+// META: timeout=long
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const preloads = [{
-        "url": "empty.json?" + Date.now(),
-        "as_attr": "fetch",
-        "crossorigin_attr": "",
-    }];
-    navigateToTestWithEarlyHints("resources/preload-fetch.html", preloads);
-});
+const preloads = [{
+    "url": "empty.json?" + Date.now(),
+    "as_attr": "fetch",
+    "crossorigin_attr": "",
+}];
+fetch_tests_from_window(navigateToTestWithEarlyHints("resources/preload-fetch.html", preloads));

--- a/loading/early-hints/preload-fetchpriority.h2.window.js
+++ b/loading/early-hints/preload-fetchpriority.h2.window.js
@@ -1,11 +1,10 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const preloads = ["low", "high", "auto"].map(fetchpriority => { return {
-        "url": "empty.js?" + token() + fetchpriority,
-        "as_attr": "script",
-        "fetchpriority_attr": fetchpriority,
-    }});
-    navigateToTestWithEarlyHints("resources/preload-fetchpriority.html", preloads);
-});
+const preloads = ["low", "high", "auto"].map(fetchpriority => { return {
+    "url": "empty.js?" + token() + fetchpriority,
+    "as_attr": "script",
+    "fetchpriority_attr": fetchpriority,
+}});
+fetch_tests_from_window(navigateToTestWithEarlyHints("resources/preload-fetchpriority.html", preloads));

--- a/loading/early-hints/preload-fetchpriority.h2.window.js
+++ b/loading/early-hints/preload-fetchpriority.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-finished-before-final-response.h2.window.js
+++ b/loading/early-hints/preload-finished-before-final-response.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-finished-before-final-response.h2.window.js
+++ b/loading/early-hints/preload-finished-before-final-response.h2.window.js
@@ -1,11 +1,10 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    const id = token();
-    params.set("resource-url", SAME_ORIGIN_RESOURCES_URL + "/fetch-and-record-js.h2.py?id=" + id);
-    params.set("resource-id", id);
-    const test_url = "resources/preload-finished-before-final-response.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+const id = token();
+params.set("resource-url", SAME_ORIGIN_RESOURCES_URL + "/fetch-and-record-js.h2.py?id=" + id);
+params.set("resource-id", id);
+const test_url = "resources/preload-finished-before-final-response.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/preload-finished-while-receiving-final-response-body.h2.window.js
+++ b/loading/early-hints/preload-finished-while-receiving-final-response-body.h2.window.js
@@ -1,11 +1,10 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    const id = token();
-    params.set("resource-url", SAME_ORIGIN_RESOURCES_URL + "/fetch-and-record-js.h2.py?id=" + id);
-    params.set("resource-id", id);
-    const test_url = "resources/preload-finished-while-receiving-final-response-body.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+const id = token();
+params.set("resource-url", SAME_ORIGIN_RESOURCES_URL + "/fetch-and-record-js.h2.py?id=" + id);
+params.set("resource-id", id);
+const test_url = "resources/preload-finished-while-receiving-final-response-body.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/preload-finished-while-receiving-final-response-body.h2.window.js
+++ b/loading/early-hints/preload-finished-while-receiving-final-response-body.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-in-flight-when-consumed.h2.window.js
+++ b/loading/early-hints/preload-in-flight-when-consumed.h2.window.js
@@ -1,11 +1,10 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    const id = token();
-    params.set("resource-url", SAME_ORIGIN_RESOURCES_URL + "/delayed-js.h2.py?id=" + id);
-    params.set("resource-id", id);
-    const test_url = "resources/preload-in-flight-when-consumed.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+const id = token();
+params.set("resource-url", SAME_ORIGIN_RESOURCES_URL + "/delayed-js.h2.py?id=" + id);
+params.set("resource-id", id);
+const test_url = "resources/preload-in-flight-when-consumed.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/preload-in-flight-when-consumed.h2.window.js
+++ b/loading/early-hints/preload-in-flight-when-consumed.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-initiator-type.h2.window.js
+++ b/loading/early-hints/preload-initiator-type.h2.window.js
@@ -1,9 +1,8 @@
+// META: timeout=long
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const preloads = [{
-        "url": "empty.js?" + Date.now(),
-        "as_attr": "script",
-    }];
-    navigateToTestWithEarlyHints("resources/preload-initiator-type.html", preloads);
-});
+const preloads = [{
+    "url": "empty.js?" + Date.now(),
+    "as_attr": "script",
+}];
+fetch_tests_from_window(navigateToTestWithEarlyHints("resources/preload-initiator-type.html", preloads));

--- a/loading/early-hints/preload-initiator-type.h2.window.js
+++ b/loading/early-hints/preload-initiator-type.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=resources/early-hints-helpers.sub.js
 
 const preloads = [{

--- a/loading/early-hints/preload-with-csp-document-disallow.h2.window.js
+++ b/loading/early-hints/preload-with-csp-document-disallow.h2.window.js
@@ -1,7 +1,6 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "allowed";
-    navigateToContentSecurityPolicyDocumentDisallowTest(early_hints_policy);
-});
+const early_hints_policy = "allowed";
+fetch_tests_from_window(navigateToContentSecurityPolicyDocumentDisallowTest(early_hints_policy));

--- a/loading/early-hints/preload-with-csp-document-disallow.h2.window.js
+++ b/loading/early-hints/preload-with-csp-document-disallow.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-with-invalid-as.h2.window.js
+++ b/loading/early-hints/preload-with-invalid-as.h2.window.js
@@ -1,14 +1,13 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("description",
-        "An early hints preload with an invalid `as` attribute should be ignored.");
-    params.set("resource-url",
-        SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("as", "invalid");
-    params.set("should-preload", false);
-    const test_url = "resources/preload-as-test.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("description",
+    "An early hints preload with an invalid `as` attribute should be ignored.");
+params.set("resource-url",
+    SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("as", "invalid");
+params.set("should-preload", false);
+const test_url = "resources/preload-as-test.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/preload-with-invalid-as.h2.window.js
+++ b/loading/early-hints/preload-with-invalid-as.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-without-as.h2.window.js
+++ b/loading/early-hints/preload-without-as.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/preload-without-as.h2.window.js
+++ b/loading/early-hints/preload-without-as.h2.window.js
@@ -1,13 +1,12 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("description",
-        "An early hints preload without `as` attribute should be ignored.");
-    params.set("resource-url",
-        SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("should-preload", false);
-    const test_url = "resources/preload-as-test.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("description",
+    "An early hints preload without `as` attribute should be ignored.");
+params.set("resource-url",
+    SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("should-preload", false);
+const test_url = "resources/preload-as-test.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/preload-without-csp-document-disallow.h2.window.js
+++ b/loading/early-hints/preload-without-csp-document-disallow.h2.window.js
@@ -1,7 +1,6 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const early_hints_policy = "absent";
-    navigateToContentSecurityPolicyDocumentDisallowTest(early_hints_policy);
-});
+const early_hints_policy = "absent";
+fetch_tests_from_window(navigateToContentSecurityPolicyDocumentDisallowTest(early_hints_policy));

--- a/loading/early-hints/preload-without-csp-document-disallow.h2.window.js
+++ b/loading/early-hints/preload-without-csp-document-disallow.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/redirect-cross-origin-between-early-hints.h2.window.js
+++ b/loading/early-hints/redirect-cross-origin-between-early-hints.h2.window.js
@@ -1,14 +1,13 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("preload-before-redirect", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("preload-after-redirect", CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("redirect-url", CROSS_ORIGIN_RESOURCES_URL + "/redirect-between-early-hints.h2.py");
-    params.set("final-test-page", "redirect-cross-origin-between-early-hints.html");
+const params = new URLSearchParams();
+params.set("preload-before-redirect", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("preload-after-redirect", CROSS_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("redirect-url", CROSS_ORIGIN_RESOURCES_URL + "/redirect-between-early-hints.h2.py");
+params.set("final-test-page", "redirect-cross-origin-between-early-hints.html");
 
-    params.set("test-step", "redirect");
-    const test_url = "resources/redirect-between-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+params.set("test-step", "redirect");
+const test_url = "resources/redirect-between-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/redirect-cross-origin-between-early-hints.h2.window.js
+++ b/loading/early-hints/redirect-cross-origin-between-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/redirect-cross-origin.h2.window.js
+++ b/loading/early-hints/redirect-cross-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/redirect-cross-origin.h2.window.js
+++ b/loading/early-hints/redirect-cross-origin.h2.window.js
@@ -1,10 +1,9 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("preload-url", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("redirect-url", CROSS_ORIGIN_RESOURCES_URL + "/redirect-cross-origin.html");
-    const test_url = "resources/redirect-with-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("preload-url", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("redirect-url", CROSS_ORIGIN_RESOURCES_URL + "/redirect-cross-origin.html");
+const test_url = "resources/redirect-with-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/redirect-same-origin-between-early-hints.h2.window.js
+++ b/loading/early-hints/redirect-same-origin-between-early-hints.h2.window.js
@@ -1,14 +1,13 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("preload-before-redirect", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("preload-after-redirect", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("redirect-url", SAME_ORIGIN_RESOURCES_URL + "/redirect-between-early-hints.h2.py");
-    params.set("final-test-page", "redirect-same-origin-between-early-hints.html");
+const params = new URLSearchParams();
+params.set("preload-before-redirect", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("preload-after-redirect", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("redirect-url", SAME_ORIGIN_RESOURCES_URL + "/redirect-between-early-hints.h2.py");
+params.set("final-test-page", "redirect-same-origin-between-early-hints.html");
 
-    params.set("test-step", "redirect");
-    const test_url = "resources/redirect-between-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+params.set("test-step", "redirect");
+const test_url = "resources/redirect-between-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/redirect-same-origin-between-early-hints.h2.window.js
+++ b/loading/early-hints/redirect-same-origin-between-early-hints.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/redirect-same-origin.h2.window.js
+++ b/loading/early-hints/redirect-same-origin.h2.window.js
@@ -1,10 +1,9 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => {
-    const params = new URLSearchParams();
-    params.set("preload-url", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
-    params.set("redirect-url", SAME_ORIGIN_RESOURCES_URL + "/redirect-same-origin.html");
-    const test_url = "resources/redirect-with-early-hints.h2.py?" + params.toString();
-    window.location.replace(new URL(test_url, window.location));
-});
+const params = new URLSearchParams();
+params.set("preload-url", SAME_ORIGIN_RESOURCES_URL + "/empty.js?" + token());
+params.set("redirect-url", SAME_ORIGIN_RESOURCES_URL + "/redirect-same-origin.html");
+const test_url = "resources/redirect-with-early-hints.h2.py?" + params.toString();
+fetch_tests_from_window(openWindow(new URL(test_url, window.location)));

--- a/loading/early-hints/redirect-same-origin.h2.window.js
+++ b/loading/early-hints/redirect-same-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/referrer-policy-no-referrer.h2.window.js
+++ b/loading/early-hints/referrer-policy-no-referrer.h2.window.js
@@ -1,4 +1,5 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => testReferrerPolicy("no-referrer"));
+fetch_tests_from_window(testReferrerPolicy("no-referrer"));

--- a/loading/early-hints/referrer-policy-no-referrer.h2.window.js
+++ b/loading/early-hints/referrer-policy-no-referrer.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/referrer-policy-origin-when-cross-origin.h2.window.js
+++ b/loading/early-hints/referrer-policy-origin-when-cross-origin.h2.window.js
@@ -1,4 +1,5 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => testReferrerPolicy("origin-when-cross-origin"));
+fetch_tests_from_window(testReferrerPolicy("origin-when-cross-origin"));

--- a/loading/early-hints/referrer-policy-origin-when-cross-origin.h2.window.js
+++ b/loading/early-hints/referrer-policy-origin-when-cross-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/referrer-policy-origin.h2.window.js
+++ b/loading/early-hints/referrer-policy-origin.h2.window.js
@@ -1,4 +1,5 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => testReferrerPolicy("origin"));
+fetch_tests_from_window(testReferrerPolicy("origin"));

--- a/loading/early-hints/referrer-policy-origin.h2.window.js
+++ b/loading/early-hints/referrer-policy-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/referrer-policy-same-origin.h2.window.js
+++ b/loading/early-hints/referrer-policy-same-origin.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/referrer-policy-same-origin.h2.window.js
+++ b/loading/early-hints/referrer-policy-same-origin.h2.window.js
@@ -1,4 +1,5 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => testReferrerPolicy("same-origin"));
+fetch_tests_from_window(testReferrerPolicy("same-origin"));

--- a/loading/early-hints/referrer-policy-unsafe-url.h2.window.js
+++ b/loading/early-hints/referrer-policy-unsafe-url.h2.window.js
@@ -1,4 +1,5 @@
+// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 
-test(() => testReferrerPolicy("unsafe-url"));
+fetch_tests_from_window(testReferrerPolicy("unsafe-url"));

--- a/loading/early-hints/referrer-policy-unsafe-url.h2.window.js
+++ b/loading/early-hints/referrer-policy-unsafe-url.h2.window.js
@@ -1,4 +1,3 @@
-// META: timeout=long
 // META: script=/common/utils.js
 // META: script=resources/early-hints-helpers.sub.js
 

--- a/loading/early-hints/resources/404-with-early-hints.html
+++ b/loading/early-hints/resources/404-with-early-hints.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/arbitrary-header-in-early-hints.html
+++ b/loading/early-hints/resources/arbitrary-header-in-early-hints.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
 promise_test(async (t) => {

--- a/loading/early-hints/resources/coep-mismatch.html
+++ b/loading/early-hints/resources/coep-mismatch.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/csp-basic.html
+++ b/loading/early-hints/resources/csp-basic.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/csp-document-disallow.html
+++ b/loading/early-hints/resources/csp-document-disallow.html
@@ -2,7 +2,6 @@
 <meta charset=utf-8>
 <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/early-hints-helpers.sub.js
+++ b/loading/early-hints/resources/early-hints-helpers.sub.js
@@ -18,11 +18,8 @@ const CROSS_ORIGIN_RESOURCES_URL = CROSS_ORIGIN + RESOURCES_PATH;
  */
 function openWindow(url) {
     const win = window.open(url, "_blank");
-    add_completion_callback(() => {
-        if (win) {
-            win.close();
-        }
-    });
+    assert_not_equals(win, null, "window.open() should open a popup");
+    add_completion_callback(() => win.close());
     return win;
 }
 

--- a/loading/early-hints/resources/early-hints-helpers.sub.js
+++ b/loading/early-hints/resources/early-hints-helpers.sub.js
@@ -8,6 +8,25 @@ const SAME_ORIGIN_RESOURCES_URL = SAME_ORIGIN + RESOURCES_PATH;
 const CROSS_ORIGIN_RESOURCES_URL = CROSS_ORIGIN + RESOURCES_PATH;
 
 /**
+ * Opens `url` in an auxiliary top-level browsing context (popup) and registers
+ * cleanup. The returned window runs the test page and reports its subtests back
+ * to the opener via `fetch_tests_from_window()`, so the test runner's top-level
+ * window is never navigated away (which is racy for navigation tests).
+ *
+ * @param {string|URL} url
+ * @returns {Window}
+ */
+function openWindow(url) {
+    const win = window.open(url, "_blank");
+    add_completion_callback(() => {
+        if (win) {
+            win.close();
+        }
+    });
+    return win;
+}
+
+/**
  * Navigate to a test page with an Early Hints response.
  *
  * @typedef {Object} Preload
@@ -32,7 +51,7 @@ function navigateToTestWithEarlyHints(test_url, preloads, exclude_preloads_from_
         params.append("preloads", JSON.stringify(preload));
     }
     const url = RESOURCES_PATH +"/early-hints-test-loader.h2.py?" + params.toString();
-    window.location.replace(new URL(url, window.location));
+    return openWindow(new URL(url, window.location));
 }
 
 /**
@@ -72,7 +91,7 @@ function navigateToTestWithEarlyHintsPreconnects(test_url, preconnects) {
     }
     const url = RESOURCES_PATH + "/early-hints-test-loader.h2.py?" +
         params.toString();
-    window.location.replace(new URL(url, window.location));
+    return openWindow(new URL(url, window.location));
 }
 
 /**
@@ -152,7 +171,7 @@ function testReferrerPolicy(referrer_policy) {
 
     const path = "resources/referrer-policy-test-loader.h2.py?" + params.toString();
     const url = new URL(path, window.location);
-    window.location.replace(url);
+    return openWindow(url);
 }
 
 /**
@@ -177,7 +196,7 @@ function navigateToContentSecurityPolicyBasicTest(
     params.set("final-policy", final_policy);
 
     const url = "resources/csp-basic-loader.h2.py?" + params.toString();
-    window.location.replace(new URL(url, window.location));
+    return openWindow(new URL(url, window.location));
 }
 
 /**
@@ -201,7 +220,7 @@ function navigateToContentSecurityPolicyDocumentDisallowTest(early_hints_policy)
     params.set("early-hints-policy", early_hints_policy);
 
     const url = "resources/csp-document-disallow-loader.h2.py?" + params.toString();
-    window.location.replace(new URL(url, window.location));
+    return openWindow(new URL(url, window.location));
 }
 
 /**
@@ -220,5 +239,5 @@ function navigateToCrossOriginEmbedderPolicyMismatchTest(
     params.set("final-policy", final_policy);
 
     const url = "resources/coep-mismatch.h2.py?" + params.toString();
-    window.location.replace(new URL(url, window.location));
+    return openWindow(new URL(url, window.location));
 }

--- a/loading/early-hints/resources/modulepreload-in-early-hints.html
+++ b/loading/early-hints/resources/modulepreload-in-early-hints.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/multiple-early-hints-responses.html
+++ b/loading/early-hints/resources/multiple-early-hints-responses.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preconnect-in-early-hints.html
+++ b/loading/early-hints/resources/preconnect-in-early-hints.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-as-test.html
+++ b/loading/early-hints/resources/preload-as-test.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-fetch.html
+++ b/loading/early-hints/resources/preload-fetch.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-fetchpriority.html
+++ b/loading/early-hints/resources/preload-fetchpriority.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-finished-before-final-response.html
+++ b/loading/early-hints/resources/preload-finished-before-final-response.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-finished-while-receiving-final-response-body.html
+++ b/loading/early-hints/resources/preload-finished-while-receiving-final-response-body.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-in-flight-when-consumed.html
+++ b/loading/early-hints/resources/preload-in-flight-when-consumed.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/preload-initiator-type.html
+++ b/loading/early-hints/resources/preload-initiator-type.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/redirect-cross-origin-between-early-hints.html
+++ b/loading/early-hints/resources/redirect-cross-origin-between-early-hints.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/redirect-cross-origin.html
+++ b/loading/early-hints/resources/redirect-cross-origin.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/redirect-same-origin-between-early-hints.html
+++ b/loading/early-hints/resources/redirect-same-origin-between-early-hints.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/redirect-same-origin.html
+++ b/loading/early-hints/resources/redirect-same-origin.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>

--- a/loading/early-hints/resources/referrer-policy-test.html
+++ b/loading/early-hints/resources/referrer-policy-test.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="early-hints-helpers.sub.js"></script>
 <body>
 <script>


### PR DESCRIPTION
When trying to import the Early Hints WPTs to Safari, I saw a lot of flakiness, especially in WebKit's "stress mode" test runner. It seems that the flakiness were coming from the use of `location.replace`.
This PR changes the model for EarlyHints test and have them use a popup window, while fetching the test results from that window. This seems like a potentially more stable model.