### PR TITLE
Add integration point CDATA tests

### DIFF
--- a/html/syntax/parsing/resources/html5test-com.dat
+++ b/html/syntax/parsing/resources/html5test-com.dat
@@ -155,8 +155,8 @@
 | <html>
 |   <head>
 |   <body>
-|     <svg>
-|       <title>
+|     <svg svg>
+|       <svg title>
 |         "x"
 
 #data
@@ -165,8 +165,8 @@
 | <html>
 |   <head>
 |   <body>
-|     <svg>
-|       <foreignObject>
+|     <svg svg>
+|       <svg foreignObject>
 |         "x"
 
 #data
@@ -175,8 +175,8 @@
 | <html>
 |   <head>
 |   <body>
-|     <svg>
-|       <foreignObject>
+|     <svg svg>
+|       <svg foreignObject>
 |         <p>
 |           <!-- [CDATA[x]] -->
 
@@ -186,7 +186,7 @@
 | <html>
 |   <head>
 |   <body>
-|     <math>
+|     <math math>
 |       "x"
 
 #data
@@ -195,8 +195,8 @@
 | <html>
 |   <head>
 |   <body>
-|     <math>
-|       <mtext>
+|     <math math>
+|       <math mtext>
 |         "x"
 
 #data
@@ -205,8 +205,8 @@
 | <html>
 |   <head>
 |   <body>
-|     <math>
-|       <mtext>
+|     <math math>
+|       <math mtext>
 |         <i>
 |           <!-- [CDATA[x]] -->
 

--- a/html/syntax/parsing/resources/html5test-com.dat
+++ b/html/syntax/parsing/resources/html5test-com.dat
@@ -150,6 +150,67 @@
 |   <body>
 
 #data
+<svg><title><![CDATA[x]]>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <svg>
+|       <title>
+|         "x"
+
+#data
+<svg><foreignobject><![CDATA[x]]>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <svg>
+|       <foreignObject>
+|         "x"
+
+#data
+<svg><foreignobject><p><![CDATA[x]]>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <svg>
+|       <foreignObject>
+|         <p>
+|           <!-- [CDATA[x]] -->
+
+#data
+<math><![CDATA[x]]>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math>
+|       "x"
+
+#data
+<math><mtext><![CDATA[x]]>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math>
+|       <mtext>
+|         "x"
+
+#data
+<math><mtext><i><![CDATA[x]]>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math>
+|       <mtext>
+|         <i>
+|           <!-- [CDATA[x]] -->
+
+#data
 <![CDATA[x]]>
 #errors
 (1,2): expected-dashes-or-doctype


### PR DESCRIPTION
Add tree construction tests for apparent CDATA sections in different contexts.

Browsers currently have different behaviors and this has confused implementors in the past, see https://github.com/whatwg/html/issues/8558 and WordPress' HTML parser I work on.

See https://github.com/whatwg/html/issues/4016 and https://github.com/whatwg/html/issues/4016#issuecomment-4913918477:

> [Here's an example:](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Csvg%3E%00(null%20becomes%20U%2BFFFD%20in%20foreign%20content)%3Ctitle%3E%00%3C!%5BCDATA%5Bthis%20should%20be%20text%5D%5D%3E%3C%2Ftitle%3E%3Cdesc%3E%3C!%5BCDATA%5Bthis%20should%20be%20text%5D%5D%3E%3C%2Fdesc%3E%3CforeignObject%3E%3C!%5BCDATA%5Bthis%20should%20be%20text%5D%5D%3E%3C%2FforeignObject%3E%3C%2Fsvg%3E%3Cmath%3E%3Cannotation-xml%20encoding%3D%22text%2Fhtml%22%3E%3C!%5BCDATA%5Bthis%20should%20be%20text%5D%5D%3E%3C%2Fannotation-xml%3E%3Cmtext%3E%00(null%20character%20token%20is%20ignored%20in%20HTML%20insertion%20modes)%3C!%5BCDATA%5Bthis%20should%20be%20text%5D%5D%3E%3C%2Fmtext%3E%3C%2Fmath%3E)
> 
> ```html
> <svg>␀(null becomes U+FFFD in foreign content)
>   <title><![CDATA[this should be text]]></title>
>   <desc><![CDATA[this should be text]]></desc>
>   <foreignObject><![CDATA[this should be text]]></foreignObject>
> </svg>
> <math>
>   <annotation-xml encoding="text/html"><![CDATA[this should be text]]></annotation-xml>
>   <mtext>␀(null character token is ignored in HTML insertion modes)<![CDATA[this should be text]]></mtext>
> </math>
> ```
> 
> (The above example includes some null bytes, shown as `␀` for clarity.)
> 
> All tested browsers handle character tokens correctly: U+0000 NULL is ignored at integration points and becomes U+FFFD (�) in foreign content. The issue is limited to CDATA section tokenization.
> 
> In my testing of Chrome 150, Safari 26.5, Edge 150, and Firefox 152, **only Firefox adheres to the spec.**
> 
> <table><thead><tr><th>Chrome, Safari, Edge<th>Firefox</thead>
> <tbody><td><pre>
> └─HTML
>   ├─HEAD
>   └─BODY
>     ├─svg:svg
>     │ ├─#text �(null becomes U+FFFD in foreign content)
>     │ ├─svg:title
>     │ │ └─#comment [CDATA[this should be text]]
>     │ ├─svg:desc
>     │ │ └─#comment [CDATA[this should be text]]
>     │ └─svg:foreignObject
>     │   └─#comment [CDATA[this should be text]]
>     └─math:math
>       ├─math:annotation-xml encoding="text/html"
>       │ └─#comment [CDATA[this should be text]]
>       └─math:mtext
>         ├─#text (null character token is ignored in HTML insertion modes)
>         └─#comment [CDATA[this should be text]]</pre><td><pre>
> └─HTML
>   ├─HEAD
>   └─BODY
>     ├─svg:svg
>     │ ├─#text �(null becomes U+FFFD in foreign content)
>     │ ├─svg:title
>     │ │ └─#text this should be text
>     │ ├─svg:desc
>     │ │ └─#text this should be text
>     │ └─svg:foreignObject
>     │   └─#text this should be text
>     └─math:math
>       ├─math:annotation-xml encoding="text/html"
>       │ └─#text this should be text
>       └─math:mtext
>         └─#text (null character token is ignored in HTML insertion modes)this should be text
> </pre></table>