### PR TITLE
Processing instruction: Fix template tree construction test

### DIFF
--- a/html/syntax/parsing/resources/processing-instructions.dat
+++ b/html/syntax/parsing/resources/processing-instructions.dat
@@ -1001,8 +1001,8 @@ there=1?>
 #document
 | <html>
 |   <head>
-|   <body>
 |     <template>
 |       content
 |         <?pi ?>
+|   <body>
 


### PR DESCRIPTION
e0d8cc13ecda5b72946a8df5428ffcb620540819 introduced an incorrect tree construction where `<template><?pi>` asserted that the TEMPLATE was inserted in BODY instead of in HEAD.

@lexborisov noticed this (https://github.com/web-platform-tests/wpt/commit/e0d8cc13ecda5b72946a8df5428ffcb620540819#r192285372).

In this test, the TEMPLATE should be inserted under HEAD.

[Live dom viewer link (PI are not supported in all browsers, PI may vary, structure should not).](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Ctemplate%3E%3C%3Fpi%3E)

```
└─HTML
  ├─HEAD
  │ └─TEMPLATE
  │   └─pi
  └─BODY
```