### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=319289

### DIFF
--- a/scroll-animations/scroll-timelines/play-animation.html
+++ b/scroll-animations/scroll-timelines/play-animation.html
@@ -225,9 +225,6 @@ promise_test(async t => {
   // Set pending playback rate to the opposite direction
   animation.updatePlaybackRate(-1);
   assert_true(animation.pending);
-  // Note: Updating the playback rate calls play without rewind. For a
-  // scroll-timeline, this will immediately apply the playback rate.
-  // TODO: Determine if we should defer applying the new playback rate.
   assert_equals(animation.playbackRate, 1);
 
   // When we play, we should align to the target end, NOT to zero (which


### PR DESCRIPTION
WebKit export from bug: [\[web-animations-2\] Auto-aligning the start time should apply a pending playback rate](https://bugs.webkit.org/show_bug.cgi?id=319289)