### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318844

### DIFF
--- a/css/css-lists/outside-marker-in-multicol-relpos-content-ref.html
+++ b/css/css-lists/outside-marker-in-multicol-relpos-content-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+    margin-left: 20px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<div class="list">
+    <div class="columnFiller"></div>
+    <div class="itemContent">item</div>
+</div>
+</body>
+</html>

--- a/css/css-lists/outside-marker-in-multicol-relpos-content.html
+++ b/css/css-lists/outside-marker-in-multicol-relpos-content.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: outside marker position for content flowing into a later multicol column</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="match" href="outside-marker-in-multicol-relpos-content-ref.html">
+<meta name="assert" content="An outside list marker for content that flows into a later column of a multi-column list item must paint adjacent to that column; relative positioning of the item content must not shift it.">
+<style>
+.container {
+    margin-left: 20px;
+}
+.list {
+    display: list-item;
+    columns: 2;
+    column-fill: auto;
+    height: 100px;
+    padding-inline-start: 20px;
+    width: 100px;
+}
+
+.list::marker {
+    color: magenta;
+}
+
+.columnFiller {
+    height: 100px;
+    width: 20px;
+    background: green;
+}
+
+.itemContent {
+    position: relative;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="list">
+        <div class="columnFiller"></div>
+        <div class="itemContent">item</div>
+    </div>
+</div>
+</body>
+</html>

--- a/css/css-lists/outside-marker-with-relpos-block-content-ref.html
+++ b/css/css-lists/outside-marker-with-relpos-block-content-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.list {
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>

--- a/css/css-lists/outside-marker-with-relpos-block-content.html
+++ b/css/css-lists/outside-marker-with-relpos-block-content.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Lists: outside marker position with relatively positioned list and block content</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="match" href="outside-marker-with-relpos-block-content-ref.html">
+<meta name="assert" content="Outside list markers must not overlap when the list and its block-level item content are relatively positioned.">
+<style>
+.list {
+    position: relative;
+    margin: 0;
+    padding-inline-start: 20px;
+    font: 16px/1.4 monospace;
+}
+
+.itemContent {
+    position: relative;
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<ol class="list">
+    <li class="item"><p class="itemContent">Item A</p></li>
+    <li class="item"><p class="itemContent">Item B</p></li>
+    <li class="item"><p class="itemContent">Item C</p></li>
+</ol>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [List Markers (bullets/numbers) are overlapping on each other when position is set to relative](https://bugs.webkit.org/show_bug.cgi?id=318844)