### PR TITLE
Dont cache failed module fetch extra tests

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module-fetch-tester.py
+++ b/html/semantics/scripting-1/the-script-element/module-fetch-tester.py
@@ -1,0 +1,50 @@
+# Test helper for module fetch caching tests (whatwg/html#10327).
+#
+# Serves a JavaScript module and tracks how many times each key has been
+# requested, so tests can assert how many fetches actually reached the server.
+# It needs no separate configuration request, so a re-import of the same
+# specifier can be started synchronously from a rejection/error handler (while
+# draining the microtask queue).
+#
+# Query parameters:
+#   key=<uuid>          Required. Identifies an independent request counter.
+#   action=stat         Return the request count for key as text/plain, without
+#                       counting this request or serving a module.
+#   mode=always-fail    Respond to every request with an HTTP 404.
+#   mode=fail-first     (default) Respond to the first request for key with an
+#                       HTTP 404, and serve a JS module for every later request.
+#
+# All requests except action=stat increment the counter.
+
+def main(request, response):
+    key = request.GET.first(b"key")
+
+    if request.GET.first(b"action", None) == b"stat":
+        with request.server.stash.lock:
+            run_count = request.server.stash.take(key)
+            if run_count is None:
+                run_count = 0
+            request.server.stash.put(key, run_count)
+        response.headers.set(b"Content-Type", b"text/plain")
+        response.content = str(run_count)
+        return
+
+    with request.server.stash.lock:
+        run_count = request.server.stash.take(key)
+        if run_count is None:
+            run_count = 0
+        run_count += 1
+        request.server.stash.put(key, run_count)
+
+    mode = request.GET.first(b"mode", b"fail-first")
+    should_fail = mode == b"always-fail" or (mode == b"fail-first" and run_count == 1)
+
+    if should_fail:
+        # Fail with an HTTP error, which must not be cached.
+        response.status = 404
+        response.headers.set(b"Content-Type", b"text/plain")
+        response.content = b"not found"
+        return
+
+    response.headers.set(b"Content-Type", b"application/javascript")
+    response.content = b"export default 'hello';"

--- a/html/semantics/scripting-1/the-script-element/module/concurrent-failed-imports.html
+++ b/html/semantics/scripting-1/the-script-element/module/concurrent-failed-imports.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <title>Concurrent failed module script loads</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/utils.js"></script>
+</head>
+
+<body>
+<script>
+  // Static <script type=module> variant of
+  // module/dynamic-import/concurrent-failed-imports.any.js, providing additional
+  // coverage for "Don't cache HTTP errors in the module map"
+  // (https://github.com/whatwg/html/pull/10327).
+  //
+  // These exercise the same concurrency guarantees of the module map's
+  // "list of callbacks" mechanism, but driven by inserted <script type=module>
+  // elements rather than dynamic import():
+  //  1. Concurrent module script loads of a failing module are joined into a
+  //     single fetch, and every joined load fails.
+  //  2. Each joined load is notified with the result of *its own* fetch, even if
+  //     a sibling's error handler synchronously inserts a new module script for
+  //     the same specifier (which, because failures are not cached, performs a
+  //     fresh fetch). A joined load must never observe the internal
+  //     placeholder/list value nor another fetch's result.
+
+  const testerUrl = (key, params = '') => `../module-fetch-tester.py?key=${key}${params}`;
+
+  async function getStat(key) {
+    const response = await fetch(testerUrl(key, '&action=stat'), { cache: 'no-cache' });
+    const stat = await response.text();
+    return stat.trim();
+  }
+
+  // Inserts a <script type=module> for `src` and resolves with "load" or "error"
+  // depending on which event fires.
+  function loadModuleScript(src) {
+    return new Promise(resolve => {
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.src = src;
+      script.onload = () => resolve("load");
+      script.onerror = () => resolve("error");
+      document.body.appendChild(script);
+    });
+  }
+</script>
+
+<script type="module">
+  promise_test(async t => {
+    const key = token();
+
+    // module-fetch-tester.py with mode=always-fail responds with an HTTP 404 to
+    // every request, and counts how many requests reached the server.
+    const src = testerUrl(key, '&mode=always-fail');
+
+    // Insert several module scripts for the same specifier at once. They should
+    // be joined into a single fetch via the module map, and all must fail.
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => loadModuleScript(src)));
+    for (let i = 0; i < results.length; i++) {
+      assert_equals(results[i], "error",
+        `concurrent module script #${i + 1} of a failing module must fire error`);
+    }
+
+    // Despite five concurrent loads, the module must only have been fetched once.
+    assert_equals(await getStat(key), "1",
+      "concurrent module script loads of a failing module should be joined into a single fetch");
+  }, "Multiple concurrent <script type=module> loads of a failing module should all fail but only fetch once");
+</script>
+
+<script type="module">
+  promise_test(async t => {
+    const key = token();
+
+    // module-fetch-tester.py (default mode=fail-first) fails the first request
+    // for a given key and succeeds on every subsequent request, so script #3 can
+    // be inserted directly from script #1's error handler with no intervening
+    // configuration fetch. This reproduces the module map callback race
+    // discussed in whatwg/html#10327.
+    const url = testerUrl(key);
+
+    let script3Result = null;
+
+    // script #1 and script #2 point at the same specifier and are inserted
+    // together, so they are joined into a single fetch. That fetch is the first
+    // request for this key, so it fails:
+    //  - Both script #1 and script #2 must fire error.
+    //  - script #1's error handler synchronously inserts script #3 for the same
+    //    specifier. Because the failed fetch was not cached, script #3 performs
+    //    a fresh fetch, which (being the second request) succeeds and loads.
+    //  - script #2 must still fire error: it is tied to the first (failed) fetch
+    //    and must not observe the module map's list placeholder nor script #3's
+    //    successful result.
+    const script1 = document.createElement('script');
+    script1.type = 'module';
+    const script2 = document.createElement('script');
+    script2.type = 'module';
+
+    const script1Done = new Promise((resolve, reject) => {
+      script1.onload = () => reject(new Error("script #1 must not load; the first fetch failed"));
+      script1.onerror = () => {
+        // Insert script #3 for the same specifier directly. This must trigger a
+        // fresh fetch, since the failed fetch was not cached.
+        const script3 = document.createElement('script');
+        script3.type = 'module';
+        script3.src = url;
+        script3.onload = () => { script3Result = "load"; resolve(); };
+        script3.onerror = () => { script3Result = "error"; resolve(); };
+        document.body.appendChild(script3);
+      };
+    });
+
+    const script2Done = new Promise((resolve, reject) => {
+      script2.onload = () => reject(new Error("script #2 must not load; it is tied to the failed fetch"));
+      script2.onerror = () => resolve(); // expected
+    });
+
+    script1.src = url;
+    script2.src = url;
+    document.body.appendChild(script1);
+    document.body.appendChild(script2);
+
+    await Promise.all([script1Done, script2Done]);
+    assert_equals(script3Result, "load",
+      "script #3 should perform a fresh fetch and load, since the failed fetch was not cached");
+  }, "A joined <script type=module> load is notified with its own fetch result even if a " +
+     "sibling's error handler re-inserts a script for the same specifier");
+</script>
+</body>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/concurrent-failed-imports.any.js
@@ -1,0 +1,81 @@
+// META: global=window,dedicatedworker,sharedworker
+// META: script=/common/utils.js
+
+// Additional coverage for "Don't cache HTTP errors in the module map"
+// (https://github.com/whatwg/html/pull/10327), complementing the tests in
+// repeated-imports.any.js.
+//
+// These focus on the concurrency guarantees of the module map's
+// "list of callbacks" mechanism, which the spec change relies on:
+//  1. Concurrent imports of a failing module are joined into a single fetch,
+//     and every joined import rejects.
+//  2. Each joined import is notified with the result of *its own* fetch, even
+//     if a sibling import's rejection handler synchronously starts a new import
+//     of the same specifier (which, because failures are not cached, performs a
+//     fresh fetch). A joined import must never observe the internal
+//     placeholder/list value nor another fetch's result.
+
+promise_test(async test => {
+    const uuid_token = token();
+    // module-fetch-tester.py with mode=always-fail responds with an HTTP 404 to
+    // every request, and counts how many requests reached the server.
+    const url = `../../module-fetch-tester.py?key=${uuid_token}&mode=always-fail`;
+
+    // Start several imports of the same specifier concurrently. They should be
+    // joined into a single fetch via the module map, and all must reject.
+    const importPromises = [];
+    for (let i = 0; i < 5; i++) {
+        importPromises.push(import(`${url}`));
+    }
+    await Promise.all(importPromises.map((p, i) =>
+        promise_rejects_js(test, TypeError, p,
+            `concurrent import #${i + 1} of a failing module must reject`)));
+
+    // Despite five concurrent imports, the module must only have been fetched
+    // once, because they were joined into a single in-flight fetch.
+    const request_counter = await fetch(
+        `../../module-fetch-tester.py?key=${uuid_token}&action=stat`, { cache: 'no-cache' });
+    assert_equals(await request_counter.text(), "1",
+        "concurrent imports of a failing module should be joined into a single fetch");
+}, "Multiple concurrent imports of a failing module should all reject but only fetch once");
+
+promise_test(async test => {
+    const uuid_token = token();
+    // module-fetch-tester.py (default mode=fail-first) fails the first request
+    // for a given key and succeeds on every subsequent request, so import #3 can
+    // be started *synchronously* from import #1's rejection handler (while
+    // draining the microtask queue), with no intervening configuration
+    // fetch/task. This reproduces the module map callback race discussed in
+    // whatwg/html#10327.
+    const url = `../../module-fetch-tester.py?key=${uuid_token}`;
+
+    // import #1 and import #2 are started in parallel, so they are joined into a
+    // single fetch. That fetch is the first request for this key, so it fails:
+    //  - Both import #1 and import #2 must reject with the result of that fetch.
+    //  - import #1's rejection handler synchronously re-imports the same
+    //    specifier (import #3). Because the failed fetch was not cached, import
+    //    #3 performs a fresh fetch, which (being the second request) succeeds.
+    //  - import #2 must still reject: it is tied to the first (failed) fetch and
+    //    must not observe the module map's list placeholder nor import #3's
+    //    successful result.
+    const import1Promise = import(`${url}`);
+    const import2Promise = import(`${url}`);
+
+    // import #2 must reject with a TypeError from the first, failed fetch.
+    const import2Check = promise_rejects_js(test, TypeError, import2Promise,
+        "import #2 must reject with the first (failed) fetch result, not resolve " +
+        "with import #3's success");
+
+    // import #1 rejects; from its rejection handler we re-import the same
+    // specifier (import #3) synchronously, which must succeed on the second request.
+    const import1Check = import1Promise.then(
+        () => assert_unreached("import #1 must not resolve; the first fetch failed"),
+        () => import(`${url}`).then(ns => { // import #3
+            assert_equals(ns.default, "hello",
+                "import #3 should perform a fresh fetch and succeed, since the " +
+                "failed fetch was not cached");
+        }));
+
+    await Promise.all([import1Check, import2Check]);
+}, "A joined import is notified with its own fetch result even if a sibling's " +
+   "rejection handler re-imports the same specifier");


### PR DESCRIPTION
Complements https://github.com/web-platform-tests/wpt/pull/55505 in tests for https://github.com/whatwg/html/pull/10327

Needs to be rebased and only landed after https://github.com/web-platform-tests/wpt/pull/55505 lands!