### PR TITLE
[digital-credentials] Test CSP sandbox header propagates opacity to nested frames

### DIFF
--- a/digital-credentials/get-opaque-origin-combinations.https.html
+++ b/digital-credentials/get-opaque-origin-combinations.https.html
@@ -97,6 +97,18 @@
           <\/script>`;
         },
       ],
+      [
+        "plain iframe nested inside a Content-Security-Policy: sandbox document (CSP-derived flags propagate)",
+        (frame, id) => {
+          frame.src = SUPPORT + "dc-nest-csp-sandbox.html?id=" + id;
+        },
+      ],
+      [
+        "allow-same-origin iframe nested inside a Content-Security-Policy: sandbox document (cannot escape)",
+        (frame, id) => {
+          frame.src = SUPPORT + "dc-nest-csp-sandbox.html?id=" + id + "&child=aso";
+        },
+      ],
     ];
     OPAQUE.forEach(([label, configure], index) => {
       promise_test(

--- a/digital-credentials/support/dc-nest-csp-sandbox.html
+++ b/digital-credentials/support/dc-nest-csp-sandbox.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8" />
+<!--
+  Served with `Content-Security-Policy: sandbox allow-scripts` (see the .headers file), so THIS
+  document has an opaque origin via CSP-derived sandboxing flags. It embeds a child that calls
+  get(). The child inherits this document's active sandboxing flag set (per "determine the
+  creation sandboxing flags"), so the child is opaque too — this exercises CSP-header sandbox
+  PROPAGATION across a nesting boundary, distinct from the iframe `sandbox` attribute path.
+  With ?child=aso the child requests allow-same-origin, which must NOT let it escape the
+  propagated opacity.
+-->
+<body></body>
+<script>
+  const params = new URL(location.href).searchParams;
+  const id = params.get("id");
+  const frame = document.createElement("iframe");
+  frame.allow = "digital-credentials-get";
+  if (params.get("child") === "aso") frame.sandbox = "allow-scripts allow-same-origin";
+  frame.src =
+    "/digital-credentials/support/dc-report-get.html?id=" + encodeURIComponent(id);
+  document.body.appendChild(frame);
+</script>

--- a/digital-credentials/support/dc-nest-csp-sandbox.html.headers
+++ b/digital-credentials/support/dc-nest-csp-sandbox.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts


### PR DESCRIPTION
`get-opaque-origin-combinations.https.html` already covers the iframe `sandbox` attribute propagating an opaque origin to descendant frames, but it only exercises a `Content-Security-Policy: sandbox` header on the document itself — never across a nesting boundary.

This adds two cases showing the CSP header's opacity also propagates to nested frames, so `navigator.credentials.get()` from a deeper frame rejects with `SecurityError`:

- a plain child nested inside a CSP: sandbox document, and
- an `allow-same-origin` child, which must not be able to escape the propagated opacity.

Per HTML, a document's CSP-derived sandboxing flags are unioned into its active sandboxing flag set, which feeds a child browsing context's creation sandboxing flags, so the sandboxed origin flag reaches descendants exactly as the attribute does. Verified passing in WebKit.
