### PR TITLE
View timeline insets account for scroll-padding by default

### DIFF
--- a/scroll-animations/view-timelines/view-timeline-snapport.html
+++ b/scroll-animations/view-timelines/view-timeline-snapport.html
@@ -43,7 +43,7 @@
     await runAndWaitForFrameUpdate(() => {
       container.scrollTop = 600;
     });
-    assert_percents_equal(anim.currentTime, 0);
+    assert_percents_equal(anim.currentTime, -12.5);
 
     // 50%
     await runAndWaitForFrameUpdate(() => {
@@ -56,6 +56,6 @@
       container.scrollTop = 1000;
     });
     assert_percents_equal(anim.currentTime, 100);
-  }, 'Default ViewTimeline is not affected by scroll-padding');
+  }, 'Default ViewTimeline is affected by scroll-padding');
 </script>
 </html>


### PR DESCRIPTION
This matches the resolution for CSS WG issue 11644 (https://github.com/w3c/csswg-drafts/issues/11644).