### PR TITLE
Ensure the scroll-timeline shorthand serializes to an empty string when its longhands don't match the base property's length

### DIFF
--- a/scroll-animations/css/scroll-timeline-shorthand.html
+++ b/scroll-animations/css/scroll-timeline-shorthand.html
@@ -110,15 +110,15 @@ test_shorthand_contraction('scroll-timeline', {
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b, --c',
   'scroll-timeline-axis': 'inline, inline',
-}, '--a inline, --b inline, --c inline');
+}, '');
 
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b, --c, --d, --e, --f',
   'scroll-timeline-axis': 'inline, x',
-}, '--a inline, --b x, --c inline, --d x, --e inline, --f x');
+}, '');
 
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b',
   'scroll-timeline-axis': 'inline, inline, inline',
-}, '--a inline, --b inline');
+}, '');
 </script>


### PR DESCRIPTION
Solves scroll-animations spec mismatch per CSS WG issue 13500 (https://github.com/w3c/csswg-drafts/issues/13500).