### PR TITLE
[Extensions] Move test event listener registration to after install

### DIFF
--- a/resources/web-extensions-helper.js
+++ b/resources/web-extensions-helper.js
@@ -28,10 +28,16 @@ globalThis.runTestsWithWebExtension = function(extensionPath) {
     test.done();
 
     if (data.remainingTests) {
+      // There are still tests to perform, don't do any cleanup yet.
       return;
     }
 
-    cleanupListeners();
+    // Tests have now completed so cleanup.
+
+    browser.test.onTestStarted.removeListener(onTestStartedListener);
+    browser.test.onTestFinished.removeListener(onTestFinishedListener);
+
+    // Uninstall the extension before marking the test suite as done.
     installPromise
         .then((extension_id) => {
           return test_driver.uninstall_web_extension(extension_id);
@@ -41,22 +47,13 @@ globalThis.runTestsWithWebExtension = function(extensionPath) {
         });
   }
 
-  function cleanupListeners() {
-    browser.test.onTestStarted.removeListener(onTestStartedListener);
-    browser.test.onTestFinished.removeListener(onTestFinishedListener);
-  }
-
-  // Attach event listeners synchronously before calling `install_web_extension`
-  // to prevent a possible race condition for some browsers where the extension
-  // could install and run tests before `installPromise` resolves.
-  browser.test.onTestStarted.addListener(onTestStartedListener);
-  browser.test.onTestFinished.addListener(onTestFinishedListener);
-
   installPromise =
       test_driver.install_web_extension({type: 'path', path: extensionPath});
 
-  return installPromise.catch((error) => {
-    cleanupListeners();
-    throw error;
+  return installPromise.then(() => {
+    // Add the test listeners *after* extension install to ensure all browser's will 
+    // fire test events successfully.
+    browser.test.onTestStarted.addListener(onTestStartedListener);
+    browser.test.onTestFinished.addListener(onTestFinishedListener);
   });
 }

--- a/resources/web-extensions-helper.js
+++ b/resources/web-extensions-helper.js
@@ -51,7 +51,7 @@ globalThis.runTestsWithWebExtension = function(extensionPath) {
       test_driver.install_web_extension({type: 'path', path: extensionPath});
 
   return installPromise.then(() => {
-    // Add the test listeners *after* extension install to ensure all browser's will 
+    // Add the test listeners *after* extension install to ensure all browser's will
     // fire test events successfully.
     browser.test.onTestStarted.addListener(onTestStartedListener);
     browser.test.onTestFinished.addListener(onTestFinishedListener);


### PR DESCRIPTION
PR #60541[1] changed listener registration to occur before test extension install to accommodate Chrome's implementation. However, this unwittingly broke Safari. Safari requires that the test extension be installed before the test event listeners can be registered. When they are registered before they do not fire at all. This didn't affect Firefox which continued to run extension WPT successfully.

After this commit we revert back to the listener registration before the above change. Safari should now fire test events successfully. I also did some associated cleanup and added a couple clarifying comments.

This will intentionally break Chrome for extension WPT temporarily until Chrome's test event queuing impl is implemented in https://crrev.com/c/8087101.

[1]: https://github.com/web-platform-tests/wpt/commit/08558510b11e31f06558e2d1ba4cac02442a3392