### PR TITLE
Fix sequential focus starting point for slot elements

### DIFF
--- a/html/interaction/focus/sequential-focus-navigation-starting-point.tentative.html
+++ b/html/interaction/focus/sequential-focus-navigation-starting-point.tentative.html
@@ -150,6 +150,44 @@
   <button id="button4" data-next>button 4</button>
 </template>
 
+<template data-description="Focus navigation starting point should be maintained when ancestor of slotted focused element is removed.">
+  <div data-shadow>
+    <template><slot name="a"
+      ></slot><slot name="b"
+      ></slot><slot name="c"
+      ></slot><slot name="d"
+      ></slot><slot name="e"
+      ></slot></template>
+    <button slot="a">button 1</button>
+    <div slot="c" data-remove>
+      <button data-focus>focus</button>
+    </div>
+    <button slot="e">button 5</button>
+    <button data-prev slot="b">button 2</button>
+    <button data-next slot="d">button 4</button>
+  </div>
+</template>
+
+<template data-description="Focus navigation starting point should be maintained when slotted shadow host is removed.">
+  <div data-shadow>
+    <template><slot name="a"
+      ></slot><slot name="b"
+      ></slot><slot name="c"
+      ></slot><slot name="d"
+      ></slot><slot name="e"
+      ></slot></template>
+    <button slot="a">button 1</button>
+    <div slot="c" data-remove data-shadow>
+      <template>
+        <button data-focus>focus</button>
+      </template>
+    </div>
+    <button slot="e">button 5</button>
+    <button data-prev slot="b">button 2</button>
+    <button data-next slot="d">button 4</button>
+  </div>
+</template>
+
 <script>
 "use strict";
 


### PR DESCRIPTION
This patch fixes the resulting sequential focus starting point in the case that the currently focused element is being slotted and then gets removed. Without this patch, sequential focus gets reset to the start of the document, and with this patch it goes to the next element it would have gone to if the element never got removed.

This fix makes us match the behavior in firefox and safari.

Also fixed a crash in FixupRemovedNodeAcrossShadowBoundary by checking if the node being removed is immediately before the range boundary.

Fixed: 512749482
Change-Id: I9a997ea269ebcac69270a5bc9bf63957148e79a2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7853014
Commit-Queue: Joey Arhar <jarhar@chromium.org>
Reviewed-by: Joey Arhar <jarhar@chromium.org>
Reviewed-by: David Baron <dbaron@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1658892}

---

Manual export of https://crrev.com/c/7853014, which could not be applied cleanly on ec4f7f1772cb82f16080807b1bc230083027f46f.