### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=319473

### DIFF
--- a/css/css-view-transitions/scroller-child.html
+++ b/css/css-view-transitions/scroller-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-child-ref.html">
-<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-800">
+<meta name="fuzzy" content="maxDifference=0-25; totalPixels=0-800">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/scroller.html
+++ b/css/css-view-transitions/scroller.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-ref.html">
-<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-10">
+<meta name="fuzzy" content="maxDifference=0-25; totalPixels=0-176">
 <script src="/common/reftest-wait.js"></script>
 
 <style>


### PR DESCRIPTION
WebKit export from bug: [css/css-view-transitions/scroller.html and scroller-child.html are failing on WPT bots](https://bugs.webkit.org/show_bug.cgi?id=319473)