### PR TITLE
Custom elements: test the active custom element constructor map

### DIFF
--- a/custom-elements/createElement-reentrant-construction.window.js
+++ b/custom-elements/createElement-reentrant-construction.window.js
@@ -1,0 +1,53 @@
+// create an element does not push onto the construction stack; the constructor
+// creates the element. So a re-entrant createElement() for the same element
+// yields two independent elements rather than hitting an "already constructed"
+// marker.
+
+// A failed construction is reported rather than rethrown by create an element.
+setup({allow_uncaught_exception: true});
+
+test(() => {
+  let nested;
+  let needsReentry = true;
+  class Reentrant extends HTMLElement {
+    constructor() {
+      if (needsReentry) {
+        needsReentry = false;
+        nested = document.createElement('reentrant-before-super');
+      }
+      super();
+    }
+  }
+  customElements.define('reentrant-before-super', Reentrant);
+
+  const outer = document.createElement('reentrant-before-super');
+
+  assert_true(nested instanceof Reentrant, 'the re-entrant createElement() constructs an element');
+  assert_equals(nested.localName, 'reentrant-before-super');
+  assert_true(outer instanceof Reentrant, 'the outer createElement() constructs an element');
+  assert_equals(outer.localName, 'reentrant-before-super');
+  assert_not_equals(outer, nested, 'the two createElement() calls construct distinct elements');
+}, 'Re-entrant createElement() of the same element before super()');
+
+test(() => {
+  let nested;
+  let needsReentry = true;
+  class Reentrant extends HTMLElement {
+    constructor() {
+      super();
+      if (needsReentry) {
+        needsReentry = false;
+        nested = document.createElement('reentrant-after-super');
+      }
+    }
+  }
+  customElements.define('reentrant-after-super', Reentrant);
+
+  const outer = document.createElement('reentrant-after-super');
+
+  assert_true(nested instanceof Reentrant, 'the re-entrant createElement() constructs an element');
+  assert_equals(nested.localName, 'reentrant-after-super');
+  assert_true(outer instanceof Reentrant, 'the outer createElement() constructs an element');
+  assert_equals(outer.localName, 'reentrant-after-super');
+  assert_not_equals(outer, nested, 'the two createElement() calls construct distinct elements');
+}, 'Re-entrant createElement() of the same element after super()');

--- a/custom-elements/registries/constructor-direct-call-fallback-registry.window.js
+++ b/custom-elements/registries/constructor-direct-call-fallback-registry.window.js
@@ -1,0 +1,75 @@
+// https://html.spec.whatwg.org/multipage/custom-elements.html#html-element-constructors
+// https://dom.spec.whatwg.org/#concept-create-element
+
+function createShadowForTest(t, customElementRegistry) {
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({mode: 'open', customElementRegistry});
+  document.body.appendChild(host);
+  t.add_cleanup(() => host.remove());
+  return shadow;
+}
+
+// GlobalOnly is only defined in the global registry, so `new GlobalOnly()` must
+// resolve against it even during a scoped upgrade.
+class GlobalOnly extends HTMLElement {}
+window.customElements.define('global-only-element', GlobalOnly);
+
+test(t => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      super();
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-1', ScopedElement);
+
+  const shadow = createShadowForTest(t, registry);
+  shadow.innerHTML = '<scoped-element-1></scoped-element-1>';
+
+  const shadowElement = shadow.firstChild;
+  assert_true(shadowElement instanceof ScopedElement);
+  assert_equals(shadowElement.localName, 'scoped-element-1');
+
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped upgrade');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element after super() during a scoped upgrade');
+
+test(t => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+      super();
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-2', ScopedElement);
+
+  const shadow = createShadowForTest(t, registry);
+  shadow.innerHTML = '<scoped-element-2></scoped-element-2>';
+
+  const shadowElement = shadow.firstChild;
+  assert_true(shadowElement instanceof ScopedElement);
+  assert_equals(shadowElement.localName, 'scoped-element-2');
+
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped upgrade');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element before super() during a scoped upgrade');

--- a/custom-elements/registries/constructor-reentry-createElement.window.js
+++ b/custom-elements/registries/constructor-reentry-createElement.window.js
@@ -1,0 +1,119 @@
+// Exercises the active custom element constructor map through the DOM
+// "create an element" path rather than the HTML "upgrade an element" path.
+// https://github.com/whatwg/html/issues/12691
+
+// create an element reports constructor exceptions rather than rethrowing them.
+setup({allow_uncaught_exception: true});
+
+test(() => {
+  let nestedElement;
+  let needsReentry = true;
+  class Reentry extends HTMLElement {
+    constructor() {
+      super();
+      if (needsReentry) {
+        needsReentry = false;
+        nestedElement = document.createElement('global-reentry');
+      }
+    }
+  }
+  window.customElements.define('global-reentry', Reentry);
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-reentry', Reentry);
+
+  const element = document.createElement('scoped-reentry', {customElementRegistry: registry});
+
+  assert_true(element instanceof Reentry);
+  assert_equals(element.localName, 'scoped-reentry');
+  assert_true(nestedElement instanceof Reentry);
+  assert_equals(nestedElement.localName, 'global-reentry');
+}, 'Re-entry via createElement with a different registry after super()');
+
+// The re-entrant construction overwrites the map entry for the shared
+// constructor and must restore it, or the outer super() falls back to the wrong
+// registry.
+test(() => {
+  let nestedElement;
+  let needsReentry = true;
+  class Reentry extends HTMLElement {
+    constructor() {
+      if (needsReentry) {
+        needsReentry = false;
+        nestedElement = document.createElement('global-reentry-before');
+      }
+      super();
+    }
+  }
+  window.customElements.define('global-reentry-before', Reentry);
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-reentry-before', Reentry);
+
+  const element = document.createElement('scoped-reentry-before', {customElementRegistry: registry});
+
+  assert_true(element instanceof Reentry);
+  assert_equals(element.localName, 'scoped-reentry-before');
+  assert_true(nestedElement instanceof Reentry);
+  assert_equals(nestedElement.localName, 'global-reentry-before');
+  assert_not_equals(element, nestedElement);
+}, 'Re-entry via createElement with a different registry before super()');
+
+// GlobalOnly is a different constructor, so it has its own construction stack
+// and resolves against the global registry.
+class GlobalOnly extends HTMLElement {}
+window.customElements.define('global-only-element', GlobalOnly);
+
+test(() => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      super();
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-after', ScopedElement);
+
+  const element = document.createElement('scoped-element-after', {customElementRegistry: registry});
+
+  assert_true(element instanceof ScopedElement);
+  assert_equals(element.localName, 'scoped-element-after');
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped createElement construction');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element after super() during a scoped createElement construction');
+
+test(() => {
+  let nestedElement;
+  let nestedError;
+  class ScopedElement extends HTMLElement {
+    constructor() {
+      try {
+        nestedElement = new GlobalOnly();
+      } catch (e) {
+        nestedError = e;
+      }
+      super();
+    }
+  }
+
+  const registry = new CustomElementRegistry();
+  registry.define('scoped-element-before', ScopedElement);
+
+  const element = document.createElement('scoped-element-before', {customElementRegistry: registry});
+
+  assert_true(element instanceof ScopedElement);
+  assert_equals(element.localName, 'scoped-element-before');
+  assert_equals(nestedError, undefined,
+      'new GlobalOnly() should not throw during a scoped createElement construction');
+  assert_true(nestedElement instanceof GlobalOnly);
+  assert_equals(nestedElement.localName, 'global-only-element');
+}, 'Direct construction of a global-only element before super() during a scoped createElement construction');


### PR DESCRIPTION
Add coverage for how the active custom element constructor map is consulted and restored across re-entrant construction:

- Directly constructing a custom element whose definition lives only in the global registry resolves against the global registry, even while an upgrade or a scoped `createElement()` construction is in progress.
- Re-entrant `createElement()` with a different registry for the same constructor restores the outer registry, so the outer `super()` still resolves correctly.
- Re-entrant `createElement()` for the same element constructs two independent elements (create an element does not push onto the construction stack).

See https://github.com/whatwg/html/issues/12691.