### PR TITLE
layout: Implement block-axis centering for buttons

### DIFF
--- a/html/rendering/widgets/button-layout/centering-001-ref.html
+++ b/html/rendering/widgets/button-layout/centering-001-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+div {
+  display: table-cell;
+  width: 200px;
+  height: 200px;
+  text-align: center;
+  vertical-align: middle;
+}
+</style>
+<button><div>ABC</div></button>

--- a/html/rendering/widgets/button-layout/centering-001.html
+++ b/html/rendering/widgets/button-layout/centering-001.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Text inside of a button gets centered vertically and horizontally</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="match" href="centering-001-ref.html">
+<style>
+button {
+  box-sizing: content-box;
+  width: 200px;
+  height: 200px;
+}
+</style>
+<button>ABC</button>

--- a/html/rendering/widgets/button-layout/centering-002.html
+++ b/html/rendering/widgets/button-layout/centering-002.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Text inside of an input with button layout gets centered vertically and horizontally</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="match" href="centering-001-ref.html">
+<style>
+input {
+  box-sizing: content-box;
+  width: 200px;
+  height: 200px;
+}
+</style>
+<input type="button" value="ABC">

--- a/html/rendering/widgets/button-layout/centering-003-ref.html
+++ b/html/rendering/widgets/button-layout/centering-003-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.wrapper {
+  display: table-cell;
+  width: 200px;
+  height: 200px;
+  vertical-align: middle;
+}
+.wrapper > div {
+  width: 100px;
+  border: solid;
+  text-align: center;
+}
+</style>
+<button>
+  <div class="wrapper">
+    <div>ABC</div>
+  </div>
+</button>

--- a/html/rendering/widgets/button-layout/centering-003.html
+++ b/html/rendering/widgets/button-layout/centering-003.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Block-level inside of a button gets centered vertically but not horizontally</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="help" href="https://github.com/whatwg/html/issues/12701">
+<link rel="match" href="centering-003-ref.html">
+<style>
+button {
+  box-sizing: content-box;
+  width: 200px;
+  height: 200px;
+}
+button > div {
+  width: 100px;
+  border: solid;
+}
+</style>
+<button>
+  <div>ABC</div>
+</button>


### PR DESCRIPTION
Mark `<button>` elements and `<input>` that lay out as buttons with a new `FragmentFlags::IS_BUTTON` flag. Then, if they contain a block formatting context, center their contents in the block axis.

This is done similarly as for `vertical-align` on table cells: we wrap the contents inside a `PositioningFragment`, which is then shifted to appear at the correct place. But unlike table cells, this is done before caching the layout results, not afterwards.

In the future, when we implement `align-content` for block containers, we should probably switch to that.

Testing: 1 tests passes, and adding 3 new tests
Fixes: #<!-- nolink -->41432

Reviewed in servo/servo#46590