### PR TITLE
script: Decrement running count of loading fonts only after marking document tree as dirty

### DIFF
--- a/css/css-font-loading/remove-rule-while-font-face-is-loading-ref.html
+++ b/css/css-font-loading/remove-rule-while-font-face-is-loading-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="/fonts/ahem.css">
+    </head>
+    <body>
+        <div style="font-family: Ahem">This text should be rendered using Ahem</div>
+    </body>
+</html>

--- a/css/css-font-loading/remove-rule-while-font-face-is-loading.html
+++ b/css/css-font-loading/remove-rule-while-font-face-is-loading.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <title>Removing a @font-face while it is loading works</title>
+        <meta name="assert" content="Removing a @font-face while it is loading works" />
+        <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+        <link rel="stylesheet" href="/fonts/ahem.css">
+        <link rel="match" href="remove-rule-while-font-face-is-loading-ref.html">
+        <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-face-rule">
+    </head>
+    <body>
+        <!-- Ensures that the Lato font is actually loaded once the @font-face rule is available -->
+        <div style="font-family: Lato, Ahem">This text should be rendered using Ahem</div>
+        <script>
+          let style = document.createElement("style");
+          style.textContent = `
+            @font-face {
+                font-family: Lato;
+                src: url("/fonts/Lato-Medium.ttf?pipe=trickle(d1)");
+            }
+          `;
+          document.body.appendChild(style);
+          window.requestAnimationFrame(() => {
+            style.remove();
+
+            document.fonts.ready.then(() => {
+              document.documentElement.classList.remove("reftest-wait");
+            })
+          })
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
This fixes a race condition which occurs right after a web font loads.

The script thread won't mark nodes as dirty until it receives `ScriptThreadMessage::WebFontLoaded`, but if `Document::maybe_fulfill_font_ready_promise runs` before that then will notice that no more fonts are loading and subsequently resolve `document.fonts.ready`. And then a promise handler attached to document.fonts.ready can observe outdated layout data.

Instead, I've applied the suggestion from martin (https://github.com/servo/servo/issues/36094#issuecomment-5000826287) to delay decrementing the running count of loading web fonts until the script thread has dirtied the document tree.

Testing: This is very timing-dependent and we do not have a reliable way to test this. I did run the test from https://github.com/servo/servo/issues/36094 around 1000 times and did not observe intermittent failures. This change also adds one test to a different regression i encountered while developing.

Fixes https://github.com/servo/servo/issues/36094
Fixes https://github.com/servo/servo/issues/46581
Fixes https://github.com/servo/servo/issues/46579
Fixes https://github.com/servo/servo/issues/46566
Fixes https://github.com/servo/servo/issues/46520
Fixes https://github.com/servo/servo/issues/46591


Reviewed in servo/servo#46586