### PR TITLE
script: Mark document tree as dirty when web fonts are removed

### DIFF
--- a/css/css-fonts/remove-loaded-font-face-rule-ref.html
+++ b/css/css-fonts/remove-loaded-font-face-rule-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="/fonts/ahem.css">
+    </head>
+    <body>
+        <div style="font-family: Ahem">This text should be rendered using Ahem</div>
+    </body>
+</html>

--- a/css/css-fonts/remove-loaded-font-face-rule.html
+++ b/css/css-fonts/remove-loaded-font-face-rule.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <title>Removing a loaded @font-face rule updates layout</title>
+        <meta name="assert" content="Removing a loaded @font-face rule updates layout" />
+        <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+        <link rel="stylesheet" href="/fonts/ahem.css">
+        <link rel="match" href="remove-loaded-font-face-rule-ref.html">
+        <link rel="help" href="https://github.com/servo/servo/issues/46372>"
+    </head>
+    <body>
+        <div style="font-family: Lato, Ahem">This text should be rendered using Ahem</div>
+        <style id="target">
+            @font-face {
+                font-family: Lato;
+                src: url("/fonts/Lato-Medium.ttf");
+            }
+        </style>
+        <script>
+          document.fonts.ready.then(() => {
+            target.remove();
+
+            document.fonts.ready.then(() => {
+              document.documentElement.classList.remove("reftest-wait");
+            });
+          });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
We already do this for when web fonts load, but not when existing `@font-face` rules are removed:
https://github.com/servo/servo/blob/1180606311f21580205750b5afab2e783d443c69/components/script/script_thread.rs#L3337-L3346

Testing: This change adds a test
Fixes https://github.com/servo/servo/issues/46372
Reviewed in servo/servo#46568