### PR TITLE
script: Halt "update the rendering" for `Document` if rAF blocks rendering

### DIFF
--- a/html/dom/render-blocking/render-blocking-during-update-the-rendering-crash.html
+++ b/html/dom/render-blocking/render-blocking-during-update-the-rendering-crash.html
@@ -1,0 +1,11 @@
+<body>
+    <link rel="help" href="https://github.com/servo/servo/issues/46303">
+    <div id="container">
+        <link id="link" href="x">
+    </div>
+
+    <script>
+        document.replaceChild(container, document.childNodes[0]);
+        requestAnimationFrame(() => { link.rel = "stylesheet" });
+    </script>
+</body>


### PR DESCRIPTION
A `requestAnimationFrame` can do things that put a `Document` in
render-blocking mode during the process of "update the rendering." If
that happens we should just bail out of the rendering update for the
`Document` until it is time to render. This prevents a panic due to an
assertion failure.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->46303.

Reviewed in servo/servo#46604