### PR TITLE
script: Implement forwarddelete command

### DIFF
--- a/editing/crashtests/forwarddelete-after-editable-slot-element-outside-body.html
+++ b/editing/crashtests/forwarddelete-after-editable-slot-element-outside-body.html
@@ -1,28 +1,17 @@
 <!doctype html>
-<html>
+<html contentEditable="true">
 <head>
 <meta charset="utf-8">
+<title>ForwardDelete should not crash when trying to forwardDelete at the end of the document, outside of body.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-  const slot = document.createElement("slot");
-  document.documentElement.appendChild(slot);
-  const anchor = document.querySelector("a[contenteditable]");
-  const selection = document.getSelection()
-  getSelection().collapse(anchor, 0);
-  getSelection().setBaseAndExtent(
-    document, 0,
-    document.documentElement, document.documentElement.childNodes.length
-  );
-  const range = selection.getRangeAt(0);
-  document.documentElement.contentEditable = true;
-  document.documentElement.contentEditable = false;
-  range.collapse(false);
-  getSelection().removeAllRanges();
-  getSelection().addRange(range);
-  document.documentElement.contentEditable = true;
+  getSelection().selectAllChildren(document.documentElement);
+  getSelection().collapseToEnd();
   document.execCommand("forwardDelete");
 });
 </script>
-</head><body>
-<a contenteditable></a>
-</body></html>
+</head>
+<body></body>
+<slot></slot>
+</html>


### PR DESCRIPTION
This implements (most of) the [forwarddelete](https://w3c.github.io/editing/docs/execCommand/#the-forwarddelete-command) command. Singular TODO about forwarddelete'ing stuff with combining diacritics and such.

Testing: They pass now. Better yet, none of them crash anymore. There is one new timeout though.

I've also taken the liberty to basically rewrite `forwarddelete-after-editable-slot-element-outside-body.html`, since we failed it and the test case was a complete mess. Apparently the Firefox people got that one from a fuzzer some years ago and decided to just dump it into WPT without any cleanup: https://bugzilla.mozilla.org/show_bug.cgi?id=1706145
Reviewed in servo/servo#46608