### PR TITLE
Map text-fit to web-feature

### DIFF
--- a/css/css-text/text-fit/WEB_FEATURES.yml
+++ b/css/css-text/text-fit/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: text-fit
+  files: "**"


### PR DESCRIPTION
Adds `css/css-text/text-fit/WEB_FEATURES.yml` mapping the existing `text-fit` test directory to the [`text-fit`](https://webstatus.dev/features/text-fit) web-features identifier.

The `text-fit` property shipped in Chrome/Chrome Android 150 and Edge 150, and a full test suite already lives in `css/css-text/text-fit/`, but no `WEB_FEATURES.yml` names it — so the feature currently reports N/A test coverage on webstatus.dev despite being tested. This closes that mapping gap.

The directory is flat and exclusively covers the `text-fit` property, so `files: "**"` applies per the ideal case in [out-of-band-metadata](https://web-platform-tests.org/writing-tests/out-of-band-metadata.html).

```yaml
features:
- name: text-fit
  files: "**"
```

Verified locally:
- `./wpt lint css/css-text/text-fit/WEB_FEATURES.yml` — clean
- `./wpt web-features-manifest` — resolves `text-fit` and maps all tests in the directory