### PR TITLE
Test foster parenting into a Document with an element child

### DIFF
--- a/html/syntax/parsing/foster-parenting-into-document-with-element-child.html
+++ b/html/syntax/parsing/foster-parenting-into-document-with-element-child.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Foster parenting into another Document that already has an element child</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// The inline script makes the on-stack <table> the document element of a second
+// Document; the following <b> is then foster-parented into that Document, which
+// already has an element child, and so must be dropped on the floor.
+const SRCDOC = `<table><tr><script>
+  var other = document.implementation.createHTMLDocument("");
+  other.documentElement.remove();
+  other.appendChild(document.querySelector("table"));
+  window.other = other;
+<\/script><b id="fostered">x</b>`;
+
+async_test(t => {
+  const iframe = document.createElement("iframe");
+  iframe.srcdoc = SRCDOC;
+  iframe.onload = t.step_func_done(() => {
+    const other = iframe.contentWindow.other;
+    const table = other.querySelector("table");
+    assert_true(!!table, "table was moved into the second Document");
+    assert_equals(table.parentNode, other, "table is the second Document's child");
+
+    const outcome = other.getElementById("fostered") ? "inserted-into-second-document"
+                  : iframe.contentDocument.getElementById("fostered") ? "inserted-into-iframe-document"
+                  : "dropped";
+    assert_equals(outcome, "dropped", "the foster-parented <b> should be dropped on the floor");
+    assert_equals(other.childElementCount, 1, "the second Document should still have one element child (the table)");
+  });
+  document.body.appendChild(iframe);
+}, "A foster-parented element whose adjusted insertion location is another Document that already has an element child is dropped on the floor");
+</script>

--- a/html/syntax/parsing/html5lib_url.html
+++ b/html/syntax/parsing/html5lib_url.html
@@ -29,6 +29,7 @@
 <meta name="variant" content="?file=scriptdata01">
 <meta name="variant" content="?file=scripted_adoption01">
 <meta name="variant" content="?file=scripted_ark">
+<meta name="variant" content="?file=scripted_foster01">
 <meta name="variant" content="?file=scripted_webkit01">
 <meta name="variant" content="?file=search-element">
 <meta name="variant" content="?file=svg">

--- a/html/syntax/parsing/html5lib_write.html
+++ b/html/syntax/parsing/html5lib_write.html
@@ -27,6 +27,7 @@
 <meta name="variant" content="?file=scriptdata01">
 <meta name="variant" content="?file=scripted_adoption01">
 <meta name="variant" content="?file=scripted_ark">
+<meta name="variant" content="?file=scripted_foster01">
 <meta name="variant" content="?file=scripted_webkit01">
 <meta name="variant" content="?file=search-element">
 <meta name="variant" content="?file=tables01">

--- a/html/syntax/parsing/html5lib_write_single.html
+++ b/html/syntax/parsing/html5lib_write_single.html
@@ -27,6 +27,7 @@
 <meta name="variant" content="?file=scriptdata01">
 <meta name="variant" content="?file=scripted_adoption01">
 <meta name="variant" content="?file=scripted_ark">
+<meta name="variant" content="?file=scripted_foster01">
 <meta name="variant" content="?file=scripted_webkit01">
 <meta name="variant" content="?file=search-element">
 <meta name="variant" content="?file=tables01">

--- a/html/syntax/parsing/resources/scripted_foster01.dat
+++ b/html/syntax/parsing/resources/scripted_foster01.dat
@@ -1,0 +1,21 @@
+#data
+<table><tr><script>var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)</script><b>
+#errors
+#script-on
+#document
+| <table>
+|   <tbody>
+|     <tr>
+|       <script>
+|         "var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)"
+
+#data
+<table><tr><script>var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)</script>FOSTERTEXT
+#errors
+#script-on
+#document
+| <table>
+|   <tbody>
+|     <tr>
+|       <script>
+|         "var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)"


### PR DESCRIPTION
When the HTML parser's adjusted insertion location is a Document that already has an element child, the foster-parented node is dropped on the floor: "insert an element at the adjusted insertion location" aborts, and "insert a character" likewise for text. This is reachable when script reparents an on-stack `<table>` to be a Document's document element.

- `resources/scripted_foster01.dat`: same-document element and text cases.
- `foster-parenting-into-document-with-element-child.html`: the multi-document case, where the foster target is a separate Document.

See https://github.com/whatwg/html/issues/1706