### PR TITLE
layout: Avoid setting FragmentFlags for HTML elements on pseudo-elements

### DIFF
--- a/css/css-backgrounds/background-color-body-propagation-010.html
+++ b/css/css-backgrounds/background-color-body-propagation-010.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: Do not propagate background from `body::before`</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#special-backgrounds">
+<link rel="help" href="https://github.com/servo/servo/issues/41084">
+<link rel="match" href="background-color-no-body-propagation-ref.html">
+<style>
+body::before {
+  content: "This text should have a green background.";
+  display: block;
+  background-color: green;
+}
+</style>

--- a/css/css-backgrounds/background-color-root-propagation-003.html
+++ b/css/css-backgrounds/background-color-root-propagation-003.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: Do not propagate background from `html::before`</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#special-backgrounds">
+<link rel="help" href="https://github.com/servo/servo/issues/41084">
+<link rel="match" href="background-color-no-body-propagation-ref.html">
+<style>
+html::before {
+  content: "This text should have a green background.";
+  display: block;
+  margin: 8px;
+  background-color: green;
+}
+</style>

--- a/html/rendering/widgets/button-layout/centering-004-ref.html
+++ b/html/rendering/widgets/button-layout/centering-004-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+button > div {
+  display: flow-root;
+  height: 200px;
+}
+</style>
+<button>
+  <div>ABC</div>
+</button>

--- a/html/rendering/widgets/button-layout/centering-004.html
+++ b/html/rendering/widgets/button-layout/centering-004.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A ::before originated by a button doesn't center vertically</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="help" href="https://github.com/servo/servo/issues/46639">
+<link rel="match" href="centering-004-ref.html">
+<style>
+button::before {
+  content: "ABC";
+  display: flow-root;
+  height: 200px;
+}
+</style>
+<button></button>


### PR DESCRIPTION
For example, a `::before` originated by a `<button>` was marked with `FragmentFlags::IS_BUTTON`, so its contents were wrongly centered vertically, as if it was another `<button>`.

Or a `::before` originated by the body element used to be marked with `FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT`, so if the body propagated its background to the viewport, we would also avoid painting the background of that `::before`.

The exception is the `<br>` element. Layout logic expects the flag to appear both on the element itself, and on its `::before`.

Testing: Adding 3 new tests
Fixes: #<!-- nolink -->41084
Fixes: #<!-- nolink -->46639

Reviewed in servo/servo#46640