### PR TITLE
Bump marionette dependency to 3.7.1

### DIFF
--- a/tools/wptrunner/requirements_firefox.txt
+++ b/tools/wptrunner/requirements_firefox.txt
@@ -1,4 +1,4 @@
-marionette_driver==3.7.0
+marionette_driver==3.7.1
 mozcrash==2.2.1
 mozdevice==4.2.0
 mozinstall==2.1.0


### PR DESCRIPTION
We released a new version of Marionette via https://bugzilla.mozilla.org/show_bug.cgi?id=2055407. That means we need to bump the dependency.

@lutien can you please review? Thanks!