### PR TITLE
[jpegxl] Add fuzzy matching to jpegxl/cmyk-basic-conversion-reftest

### DIFF
--- a/jpegxl/cmyk-basic-conversion-reftest.html
+++ b/jpegxl/cmyk-basic-conversion-reftest.html
@@ -2,6 +2,7 @@
 <link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
 <link rel="match" href="cmyk-basic-conversion-reftest-ref.html">
 <meta name="assert" content="CMYK JPEG XL conversion/rendering should match PNG reference output.">
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-3000">
 <link rel="stylesheet" href="resources/jpegxl-reftest.css">
 
 <img src="resources/conformance_cmyk_layers.jxl">


### PR DESCRIPTION
Follow up to #61191 now that `djxl` got a [fix](https://github.com/libjxl/libjxl/pull/4301) for CMYK.