### PR TITLE
[WebTransport] Correctly test use of WebTransportOptions.datagramsReadableType

### DIFF
--- a/webtransport/datagrams.https.any.js
+++ b/webtransport/datagrams.https.any.js
@@ -119,7 +119,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   // Establish a WebTransport session.
-  const wt = new WebTransport(webtransport_url('echo.py'));
+  const wt = new WebTransport(webtransport_url('echo.py'), { 'datagramsReadableType' : 'bytes' });
   await wt.ready;
 
   const writer = wt.datagrams.createWritable().getWriter();
@@ -145,8 +145,14 @@ promise_test(async t => {
 }, 'Successfully reading datagrams with BYOB reader.');
 
 promise_test(async t => {
-  // Establish a WebTransport session.
   const wt = new WebTransport(webtransport_url('echo.py'));
+  await wt.ready;
+  assert_throws_js(TypeError, () => { wt.datagrams.readable.getReader({ mode: 'byob' }) });
+}, 'Reading datagrams with BYOB reader without datagramsReadableType should fail.');
+
+promise_test(async t => {
+  // Establish a WebTransport session.
+  const wt = new WebTransport(webtransport_url('echo.py'), { 'datagramsReadableType' : 'bytes' });
   await wt.ready;
 
   const writer = wt.datagrams.createWritable().getWriter();


### PR DESCRIPTION
https://www.w3.org/TR/webtransport/#dom-webtransportoptions-datagramsreadabletype says to use a readable byte stream if datagramsReadableType is specified, but to use a readable stream otherwise.  https://streams.spec.whatwg.org/#readable-byte-stream says the former is needed to use byob buffers.

This change is from https://github.com/WebKit/WebKit/pull/69795