### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=308486

### DIFF
--- a/css/css-viewport/zoom/column-rule-width.html
+++ b/css/css-viewport/zoom/column-rule-width.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to column-rule-width</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/column-rule-width-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  column-rule-style: solid;
+  column-rule-width: 5px;
+  column-rule-color: transparent;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  font-size: 16px;
+  column-count: 2;
+  column-rule-style: solid;
+  overflow: clip;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-rule-width: 5px; zoom: 1;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-rule-width: inherit; zoom: 1;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-rule-width: 5px; zoom: 2;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-rule-width: inherit; zoom: 2;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/css/css-viewport/zoom/outline-offset.html
+++ b/css/css-viewport/zoom/outline-offset.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to outline-offset</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/outline-offset-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  outline-style: solid;
+  outline-width: 1px;
+  outline-offset: 5px;
+  outline-color: transparent;
+}
+.container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  outline-width: 1px;
+  outline-style: solid;
+  outline-color: black;
+}
+.spacer {
+  display: inline-block;
+  width: 40px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching outlines.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="outline-offset: 5px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="outline-offset: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="outline-offset: 5px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="outline-offset: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/css/css-viewport/zoom/outline-width.html
+++ b/css/css-viewport/zoom/outline-width.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to outline-width</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/outline-width-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  outline-style: solid;
+  outline-width: 5px;
+  outline-color: transparent;
+}
+.container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  outline-style: solid;
+  outline-color: black;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching outlines.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="outline-width: 5px; zoom: 1;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="outline-width: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="outline-width: 5px; zoom: 2;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="outline-width: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/css/css-viewport/zoom/reference/column-rule-width-ref.html
+++ b/css/css-viewport/zoom/reference/column-rule-width-ref.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  column-rule-style: solid;
+  column-rule-width: 5px;
+  column-rule-color: transparent;
+  border: solid black 1px;
+}
+.container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  font-size: 16px;
+  column-count: 2;
+  column-rule-style: solid;
+  overflow: clip;
+}
+.container-zoomed {
+  display: inline-block;
+  width: 400px;
+  height: 200px;
+  font-size: 32px;
+  column-count: 2;
+  column-rule-style: solid;
+  overflow: clip;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="column-rule-width: 5px;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="column-rule-width: 5px;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoomed" style="column-rule-width: 10px;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoomed" style="column-rule-width: 10px;">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/css/css-viewport/zoom/reference/outline-offset-ref.html
+++ b/css/css-viewport/zoom/reference/outline-offset-ref.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  outline-style: solid;
+}
+#container-zoomed {
+  display: inline-block;
+  width: 400px;
+  height: 200px;
+  outline-style: solid;
+}
+#spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching outlines.</p>
+<div class="group">
+  <div id="container" style="outline-offset: 5px; outline-width: 1px;">
+  </div>
+  <div id="spacer"></div>
+  <div style="display: inline-block;">
+    <div id="container" style="outline-offset: 5px; outline-width: 1px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div id="container-zoomed" style="outline-offset: 10px; outline-width: 2px;">
+  </div>
+  <div id="spacer"></div>
+  <div style="display: inline-block;">
+    <div id="container-zoomed" style="outline-offset: 10px; outline-width: 2px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/css/css-viewport/zoom/reference/outline-width-ref.html
+++ b/css/css-viewport/zoom/reference/outline-width-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.outer {
+  display: inline-block;
+  outline-style: solid;
+  outline-width: 5px;
+  outline-color: transparent;
+}
+.container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  outline-style: solid;
+}
+.container-zoomed {
+  display: inline-block;
+  width: 400px;
+  height: 200px;
+  outline-style: solid;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching outlines.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="outline-width: 5px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="outline-width: 5px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoomed" style="outline-width: 10px;">
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoomed" style="outline-width: 10px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[EvaluationTimeZoom\] Convert border, outline and column-rule-width properties to evaluation time zoom](https://bugs.webkit.org/show_bug.cgi?id=308486)