### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279041

### DIFF
--- a/css/css-viewport/zoom/svg-foreignObject-font-size-ref.html
+++ b/css/css-viewport/zoom/svg-foreignObject-font-size-ref.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Zoom: foreignObject font-size reference</title>
+<style>
+  :root {
+      zoom: 4;
+      font-size: 16px;
+  }
+</style>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>

--- a/css/css-viewport/zoom/svg-foreignObject-font-size.html
+++ b/css/css-viewport/zoom/svg-foreignObject-font-size.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Zoom: foreignObject font-size should not be double-zoomed</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="svg-foreignObject-font-size-ref.html">
+<style>
+  :root {
+      zoom: 4;
+      font-size: 16px;
+  }
+</style>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div style="font-size:16px">TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div style="font-size:inherit">TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25" style="font-size:inherit">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [\[SVG\] zoom is applied twice to font-size in foreignObject](https://bugs.webkit.org/show_bug.cgi?id=279041)