### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=306014

### DIFF
--- a/css/css-viewport/zoom/box-shadow-inset-spread.html
+++ b/css/css-viewport/zoom/box-shadow-inset-spread.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inset box-shadow 1px spread stays even under fractional zoom</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#box-shadow">
+<link rel="match" href="reference/box-shadow-inset-spread-ref.html">
+<style>
+  body { margin: 0; }
+  .zoom { zoom: 1.2; }
+  .box {
+    margin: 8px;
+    width: 100px; height: 60px;
+    box-shadow: inset 0 0 0 1px green;
+    background: white;
+  }
+</style>
+<div class="zoom"><div class="box"></div></div>

--- a/css/css-viewport/zoom/reference/box-shadow-inset-spread-ref.html
+++ b/css/css-viewport/zoom/reference/box-shadow-inset-spread-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inset box-shadow 1px spread stays even under fractional zoom</title>
+<style>
+  body { margin: 0; }
+  .box {
+    margin: 9.6px;
+    width: 120px; height: 72px;
+    box-shadow: inset 0 0 0 1px green;
+    background: white;
+  }
+</style>
+<div class="box"></div>


### PR DESCRIPTION
WebKit export from bug: [box-shadow rendering is broken when zoom is used](https://bugs.webkit.org/show_bug.cgi?id=306014)