### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=301807

### DIFF
--- a/css/css-viewport/zoom/zoom-iframe-dynamic.html
+++ b/css/css-viewport/zoom/zoom-iframe-dynamic.html
@@ -34,6 +34,7 @@ promise_test(async function(t) {
   iframe.style.zoom = 2;
   await dpiChangePromise;
   assert_equals(iframe.contentWindow.devicePixelRatio, 2 * parentDpi, "DPI should have doubled on the frame");
+  assert_equals(window.devicePixelRatio, parentDpi, "DPI should not change on parent");
   assert_equals(iframe.getBoundingClientRect().width, origSize.width * 2, "Width should have doubled as well");
   assert_equals(iframe.getBoundingClientRect().height, origSize.height * 2, "Height should have doubled as well");
 });


### PR DESCRIPTION
WebKit export from bug: [\[CSS Zoom\] Page zoom should affect devicePixelRatio equally in all frames](https://bugs.webkit.org/show_bug.cgi?id=301807)