### PR TITLE
Report worker errors in OffscreenCanvas reftests

### DIFF
--- a/common/reftest-wait.js
+++ b/common/reftest-wait.js
@@ -42,6 +42,103 @@ function failIfNot(condition, msg) {
 }
 
 /**
+ * Display the failure reason and stop waiting for a screenshot.
+ *
+ * Does nothing for a mismatch-only reftest (no `match` reference is also
+ * present), since an error page necessarily differs from the reference and
+ * would spuriously pass instead of correctly timing out.
+ * @param {Error|ErrorEvent|PromiseRejectionEvent|*} error - The error that caused the failure.
+ */
+function failOnError(error) {
+  // Only <link>s explicitly in the XHTML namespace count as match/mismatch
+  // links, matching the manifest's own namespace-qualified lookup.
+  const links = document.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "link");
+  let hasMatch = false;
+  let hasMismatch = false;
+  for (const link of links) {
+    const rel = link.getAttribute("rel");
+    if (rel === "match") {
+      hasMatch = true;
+    } else if (rel === "mismatch") {
+      hasMismatch = true;
+    }
+  }
+  if (hasMismatch && !hasMatch) {
+    return;
+  }
+
+  let message;
+  if (typeof PromiseRejectionEvent !== "undefined" && error instanceof PromiseRejectionEvent) {
+    if (error.reason && error.reason.message) {
+      message = "Unhandled rejection: " + error.reason.message;
+    } else {
+      message = "Unhandled rejection";
+    }
+  } else {
+    if (error.message) {
+      message = "Uncaught exception: " + error.message;
+    } else {
+      message = "Uncaught exception";
+    }
+  }
+
+  const node = document.createElementNS("http://www.w3.org/1999/xhtml", "div");
+  node.textContent = message;
+
+  if (document.body) {
+    document.body.insertBefore(node, document.body.firstChild);
+  } else {
+    const root = document.documentElement;
+    const is_html = (root &&
+                     root.namespaceURI === "http://www.w3.org/1999/xhtml" &&
+                     root.localName === "html");
+    const is_svg = ("SVGSVGElement" in self && root instanceof SVGSVGElement);
+    if (is_svg) {
+      const foreignObject = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+      foreignObject.setAttribute("width", "100%");
+      foreignObject.setAttribute("height", "100%");
+      root.insertBefore(foreignObject, root.firstChild);
+      foreignObject.appendChild(node);
+    } else if (is_html) {
+      root.appendChild(document.createElementNS("http://www.w3.org/1999/xhtml", "body"))
+          .appendChild(node);
+    } else {
+      root.insertBefore(node, root.firstChild);
+    }
+  }
+
+  takeScreenshot();
+}
+
+/**
+ * Wrap `func` so a synchronous exception it throws is reported via
+ * failOnError() instead of propagating as an uncaught error. For use
+ * wrapping a callback, e.g. an event listener.
+ * @param {Function} func - Callback to wrap.
+ * @returns {Function} The wrapped callback.
+ */
+function reftestStep(func) {
+  return function(...args) {
+    try {
+      return func.apply(this, args);
+    } catch (e) {
+      failOnError(e);
+    }
+  };
+}
+
+/**
+ * Call `func` immediately, reporting via failOnError() either a
+ * synchronous exception it throws or an asynchronous rejection of the
+ * promise it returns.
+ * @param {Function} func - Function to call, typically async.
+ */
+function reftestPromise(func) {
+  const result = reftestStep(func)();
+  Promise.resolve(result).catch(failOnError);
+}
+
+/**
  * Once a text track cue becomes active, pause the video, wait
  * for layout to update, then call takeScreenshot().
  */

--- a/html/canvas/offscreen/compositing/2d.composite.grid.filter.no_shadow.drawImage.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.filter.no_shadow.drawImage.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.filter.no_shadow.drawImage-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.filter.no_shadow.drawImage</title>
 <h1>2d.composite.grid.filter.no_shadow.drawImage</h1>
@@ -18,43 +19,52 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -68,43 +78,52 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -118,43 +137,52 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -168,43 +196,52 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -218,43 +255,52 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -268,43 +314,52 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -318,43 +373,52 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -368,43 +432,52 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -418,43 +491,52 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -468,43 +550,52 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -518,43 +609,52 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -568,43 +668,52 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -618,43 +727,52 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -668,43 +786,52 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -718,43 +845,52 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -768,43 +904,52 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -818,43 +963,52 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -868,43 +1022,52 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -918,43 +1081,52 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -968,43 +1140,52 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1018,43 +1199,52 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1068,43 +1258,52 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1118,43 +1317,52 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1168,43 +1376,52 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1218,43 +1435,52 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1268,43 +1494,52 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.filter.no_shadow.fillRect.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.filter.no_shadow.fillRect.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.filter.no_shadow.fillRect-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.filter.no_shadow.fillRect</title>
 <h1>2d.composite.grid.filter.no_shadow.fillRect</h1>
@@ -18,40 +19,49 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -65,40 +75,49 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -112,40 +131,49 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -159,40 +187,49 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -206,40 +243,49 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -253,40 +299,49 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -300,40 +355,49 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -347,40 +411,49 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -394,40 +467,49 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -441,40 +523,49 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -488,40 +579,49 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -535,40 +635,49 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -582,40 +691,49 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -629,40 +747,49 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -676,40 +803,49 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -723,40 +859,49 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -770,40 +915,49 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -817,40 +971,49 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -864,40 +1027,49 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -911,40 +1083,49 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -958,40 +1139,49 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1005,40 +1195,49 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1052,40 +1251,49 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1099,40 +1307,49 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1146,40 +1363,49 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1193,40 +1419,49 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.filter.no_shadow.pattern.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.filter.no_shadow.pattern.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.filter.no_shadow.pattern-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.filter.no_shadow.pattern</title>
 <h1>2d.composite.grid.filter.no_shadow.pattern</h1>
@@ -18,44 +19,53 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -69,44 +79,53 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -120,44 +139,53 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -171,44 +199,53 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -222,44 +259,53 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -273,44 +319,53 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -324,44 +379,53 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -375,44 +439,53 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -426,44 +499,53 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -477,44 +559,53 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -528,44 +619,53 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -579,44 +679,53 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -630,44 +739,53 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -681,44 +799,53 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -732,44 +859,53 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -783,44 +919,53 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -834,44 +979,53 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -885,44 +1039,53 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -936,44 +1099,53 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -987,44 +1159,53 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1038,44 +1219,53 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1089,44 +1279,53 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1140,44 +1339,53 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1191,44 +1399,53 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1242,44 +1459,53 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1293,44 +1519,53 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      // No shadow.
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.filter.shadow.drawImage.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.filter.shadow.drawImage.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.filter.shadow.drawImage-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.filter.shadow.drawImage</title>
 <h1>2d.composite.grid.filter.shadow.drawImage</h1>
@@ -18,45 +19,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -70,45 +80,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -122,45 +141,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -174,45 +202,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -226,45 +263,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -278,45 +324,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -330,45 +385,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -382,45 +446,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -434,45 +507,54 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -486,45 +568,54 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -538,45 +629,54 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -590,45 +690,54 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -642,45 +751,54 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -694,45 +812,54 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -746,45 +873,54 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -798,45 +934,54 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -850,45 +995,54 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -902,45 +1056,54 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -954,45 +1117,54 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1006,45 +1178,54 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1058,45 +1239,54 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1110,45 +1300,54 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1162,45 +1361,54 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1214,45 +1422,54 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1266,45 +1483,54 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1318,45 +1544,54 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.filter.shadow.fillRect.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.filter.shadow.fillRect.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.filter.shadow.fillRect-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.filter.shadow.fillRect</title>
 <h1>2d.composite.grid.filter.shadow.fillRect</h1>
@@ -18,42 +19,51 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -67,42 +77,51 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -116,42 +135,51 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -165,42 +193,51 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -214,42 +251,51 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -263,42 +309,51 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -312,42 +367,51 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -361,42 +425,51 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -410,42 +483,51 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -459,42 +541,51 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -508,42 +599,51 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -557,42 +657,51 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -606,42 +715,51 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -655,42 +773,51 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -704,42 +831,51 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -753,42 +889,51 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -802,42 +947,51 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -851,42 +1005,51 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -900,42 +1063,51 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -949,42 +1121,51 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -998,42 +1179,51 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1047,42 +1237,51 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1096,42 +1295,51 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1145,42 +1353,51 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1194,42 +1411,51 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1243,42 +1469,51 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.filter.shadow.pattern.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.filter.shadow.pattern.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.filter.shadow.pattern-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.filter.shadow.pattern</title>
 <h1>2d.composite.grid.filter.shadow.pattern</h1>
@@ -18,46 +19,55 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -71,46 +81,55 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -124,46 +143,55 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -177,46 +205,55 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -230,46 +267,55 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -283,46 +329,55 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -336,46 +391,55 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -389,46 +453,55 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -442,46 +515,55 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -495,46 +577,55 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -548,46 +639,55 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -601,46 +701,55 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -654,46 +763,55 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -707,46 +825,55 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -760,46 +887,55 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -813,46 +949,55 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -866,46 +1011,55 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -919,46 +1073,55 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -972,46 +1135,55 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1025,46 +1197,55 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1078,46 +1259,55 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1131,46 +1321,55 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1184,46 +1383,55 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1237,46 +1445,55 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1290,46 +1507,55 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1343,46 +1569,55 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        ctx.filter = 'drop-shadow(5px -5px 0px rgb(255, 154, 100))';
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.no_shadow.drawImage.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.no_shadow.drawImage.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.no_filter.no_shadow.drawImage-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.no_filter.no_shadow.drawImage</title>
 <h1>2d.composite.grid.no_filter.no_shadow.drawImage</h1>
@@ -18,43 +19,52 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -68,43 +78,52 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -118,43 +137,52 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -168,43 +196,52 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -218,43 +255,52 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -268,43 +314,52 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -318,43 +373,52 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -368,43 +432,52 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -418,43 +491,52 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -468,43 +550,52 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -518,43 +609,52 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -568,43 +668,52 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -618,43 +727,52 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -668,43 +786,52 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -718,43 +845,52 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -768,43 +904,52 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -818,43 +963,52 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -868,43 +1022,52 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -918,43 +1081,52 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -968,43 +1140,52 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1018,43 +1199,52 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1068,43 +1258,52 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1118,43 +1317,52 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1168,43 +1376,52 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1218,43 +1435,52 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1268,43 +1494,52 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.no_shadow.fillRect.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.no_shadow.fillRect.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.no_filter.no_shadow.fillRect-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.no_filter.no_shadow.fillRect</title>
 <h1>2d.composite.grid.no_filter.no_shadow.fillRect</h1>
@@ -18,40 +19,49 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -65,40 +75,49 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -112,40 +131,49 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -159,40 +187,49 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -206,40 +243,49 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -253,40 +299,49 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -300,40 +355,49 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -347,40 +411,49 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -394,40 +467,49 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -441,40 +523,49 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -488,40 +579,49 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -535,40 +635,49 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -582,40 +691,49 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -629,40 +747,49 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -676,40 +803,49 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -723,40 +859,49 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -770,40 +915,49 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -817,40 +971,49 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -864,40 +1027,49 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -911,40 +1083,49 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -958,40 +1139,49 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1005,40 +1195,49 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1052,40 +1251,49 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1099,40 +1307,49 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1146,40 +1363,49 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1193,40 +1419,49 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.no_shadow.pattern.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.no_shadow.pattern.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.no_filter.no_shadow.pattern-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.no_filter.no_shadow.pattern</title>
 <h1>2d.composite.grid.no_filter.no_shadow.pattern</h1>
@@ -18,44 +19,53 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -69,44 +79,53 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -120,44 +139,53 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -171,44 +199,53 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -222,44 +259,53 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -273,44 +319,53 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -324,44 +379,53 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -375,44 +439,53 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -426,44 +499,53 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -477,44 +559,53 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -528,44 +619,53 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -579,44 +679,53 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -630,44 +739,53 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -681,44 +799,53 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -732,44 +859,53 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -783,44 +919,53 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -834,44 +979,53 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -885,44 +1039,53 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -936,44 +1099,53 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -987,44 +1159,53 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1038,44 +1219,53 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1089,44 +1279,53 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1140,44 +1339,53 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1191,44 +1399,53 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1242,44 +1459,53 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1293,44 +1519,53 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      // No shadow.
+        // No filter.
+        // No shadow.
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.shadow.drawImage.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.shadow.drawImage.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.no_filter.shadow.drawImage-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.no_filter.shadow.drawImage</title>
 <h1>2d.composite.grid.no_filter.shadow.drawImage</h1>
@@ -18,45 +19,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -70,45 +80,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -122,45 +141,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -174,45 +202,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -226,45 +263,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -278,45 +324,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -330,45 +385,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -382,45 +446,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -434,45 +507,54 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -486,45 +568,54 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -538,45 +629,54 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -590,45 +690,54 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -642,45 +751,54 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -694,45 +812,54 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -746,45 +873,54 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -798,45 +934,54 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -850,45 +995,54 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -902,45 +1056,54 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -954,45 +1117,54 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1006,45 +1178,54 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1058,45 +1239,54 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1110,45 +1300,54 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1162,45 +1361,54 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1214,45 +1422,54 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1266,45 +1483,54 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1318,45 +1544,54 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.drawImage(img_canvas, 5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.drawImage(img_canvas, 5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.shadow.fillRect.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.shadow.fillRect.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.no_filter.shadow.fillRect-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.no_filter.shadow.fillRect</title>
 <h1>2d.composite.grid.no_filter.shadow.fillRect</h1>
@@ -18,42 +19,51 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -67,42 +77,51 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -116,42 +135,51 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -165,42 +193,51 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -214,42 +251,51 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -263,42 +309,51 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -312,42 +367,51 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -361,42 +425,51 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -410,42 +483,51 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -459,42 +541,51 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -508,42 +599,51 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -557,42 +657,51 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -606,42 +715,51 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -655,42 +773,51 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -704,42 +831,51 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -753,42 +889,51 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -802,42 +947,51 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -851,42 +1005,51 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -900,42 +1063,51 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -949,42 +1121,51 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -998,42 +1179,51 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1047,42 +1237,51 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1096,42 +1295,51 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1145,42 +1353,51 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1194,42 +1411,51 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1243,42 +1469,51 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      ctx.fillStyle = 'rgb(52, 255, 52)';
-      ctx.fillRect(5, 5, 50, 30);
+        ctx.fillStyle = 'rgb(52, 255, 52)';
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.shadow.pattern.w.html
+++ b/html/canvas/offscreen/compositing/2d.composite.grid.no_filter.shadow.pattern.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.composite.grid.no_filter.shadow.pattern-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-4; totalPixels=0-33000">
 <title>Canvas test: 2d.composite.grid.no_filter.shadow.pattern</title>
 <h1>2d.composite.grid.no_filter.shadow.pattern</h1>
@@ -18,46 +19,55 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -71,46 +81,55 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-in';
+        ctx.globalCompositeOperation = 'source-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -124,46 +143,55 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-out';
+        ctx.globalCompositeOperation = 'source-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -177,46 +205,55 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'source-atop';
+        ctx.globalCompositeOperation = 'source-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -230,46 +267,55 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-over';
+        ctx.globalCompositeOperation = 'destination-over';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -283,46 +329,55 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-in';
+        ctx.globalCompositeOperation = 'destination-in';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -336,46 +391,55 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = 'destination-out';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -389,46 +453,55 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'destination-atop';
+        ctx.globalCompositeOperation = 'destination-atop';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -442,46 +515,55 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighter';
+        ctx.globalCompositeOperation = 'lighter';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -495,46 +577,55 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'copy';
+        ctx.globalCompositeOperation = 'copy';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -548,46 +639,55 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'xor';
+        ctx.globalCompositeOperation = 'xor';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -601,46 +701,55 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'multiply';
+        ctx.globalCompositeOperation = 'multiply';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -654,46 +763,55 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'screen';
+        ctx.globalCompositeOperation = 'screen';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -707,46 +825,55 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'overlay';
+        ctx.globalCompositeOperation = 'overlay';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -760,46 +887,55 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'darken';
+        ctx.globalCompositeOperation = 'darken';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -813,46 +949,55 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'lighten';
+        ctx.globalCompositeOperation = 'lighten';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -866,46 +1011,55 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-dodge';
+        ctx.globalCompositeOperation = 'color-dodge';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -919,46 +1073,55 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color-burn';
+        ctx.globalCompositeOperation = 'color-burn';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -972,46 +1135,55 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hard-light';
+        ctx.globalCompositeOperation = 'hard-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1025,46 +1197,55 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'soft-light';
+        ctx.globalCompositeOperation = 'soft-light';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1078,46 +1259,55 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'difference';
+        ctx.globalCompositeOperation = 'difference';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1131,46 +1321,55 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'exclusion';
+        ctx.globalCompositeOperation = 'exclusion';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1184,46 +1383,55 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'hue';
+        ctx.globalCompositeOperation = 'hue';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1237,46 +1445,55 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'saturation';
+        ctx.globalCompositeOperation = 'saturation';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1290,46 +1507,55 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'color';
+        ctx.globalCompositeOperation = 'color';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1343,46 +1569,55 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(80, 60);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(80, 60);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
-      ctx.fillRect(15, 15, 50, 30);
+        ctx.fillStyle = 'rgba(0, 102, 240, 0.8)';
+        ctx.fillRect(15, 15, 50, 30);
 
-      ctx.translate(25, 20);
-      ctx.rotate(Math.PI / 2);
-      ctx.scale(0.6, 1.2);
-      ctx.translate(-25, -20);
+        ctx.translate(25, 20);
+        ctx.rotate(Math.PI / 2);
+        ctx.scale(0.6, 1.2);
+        ctx.translate(-25, -20);
 
-      ctx.globalAlpha = 0.5;
+        ctx.globalAlpha = 0.5;
 
-      // No filter.
-      ctx.shadowOffsetX = 20;
-      ctx.shadowOffsetY = 20;
-      ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
+        // No filter.
+        ctx.shadowOffsetX = 20;
+        ctx.shadowOffsetY = 20;
+        ctx.shadowColor = 'rgba(154, 0, 154, 0.8)';
 
-      ctx.globalCompositeOperation = 'luminosity';
+        ctx.globalCompositeOperation = 'luminosity';
 
-      const img_canvas = new OffscreenCanvas(80, 60);
-      const img_ctx = img_canvas.getContext('2d');
-      img_ctx.fillStyle = 'rgb(52, 255, 52)';
-      img_ctx.fillRect(0, 0, 80, 60);
-      ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
-      ctx.fillRect(5, 5, 50, 30);
+        const img_canvas = new OffscreenCanvas(80, 60);
+        const img_ctx = img_canvas.getContext('2d');
+        img_ctx.fillStyle = 'rgb(52, 255, 52)';
+        img_ctx.fillRect(0, 0, 80, 60);
+        ctx.fillStyle = ctx.createPattern(img_canvas, 'repeat');
+        ctx.fillRect(5, 5, 50, 30);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.colorInterpolationMethod.w.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.colorInterpolationMethod.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.gradient.colorInterpolationMethod-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-1; totalPixels=0-60000">
 <title>Canvas test: 2d.gradient.colorInterpolationMethod</title>
 <h1>2d.gradient.colorInterpolationMethod</h1>
@@ -18,29 +19,38 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'srgb';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'srgb';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -54,29 +64,38 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hsl';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hsl';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -90,29 +109,38 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hwb';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hwb';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -126,29 +154,38 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'srgb-linear';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'srgb-linear';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -162,29 +199,38 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'display-p3-linear';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'display-p3-linear';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -198,29 +244,38 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'display-p3';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'display-p3';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -234,29 +289,38 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'a98-rgb';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'a98-rgb';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -270,29 +334,38 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'prophoto-rgb';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'prophoto-rgb';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -306,29 +379,38 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'rec2020';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'rec2020';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -342,29 +424,38 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'lab';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'lab';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -378,29 +469,38 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'oklab';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'oklab';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -414,29 +514,38 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'lch';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'lch';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -450,29 +559,38 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'oklch';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'oklch';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -486,29 +604,38 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'xyz';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'xyz';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -522,29 +649,38 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'xyz-d50';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'xyz-d50';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -558,29 +694,38 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'xyz-d65';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 50);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'xyz-d65';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.hueInterpolationMethod.w.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.hueInterpolationMethod.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.gradient.hueInterpolationMethod-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-1; totalPixels=0-60000">
 <title>Canvas test: 2d.gradient.hueInterpolationMethod</title>
 <h1>2d.gradient.hueInterpolationMethod</h1>
@@ -19,42 +20,51 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hsl';
-      g.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hsl';
+        g.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hsl';
-      g2.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hsl';
+        g2.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -69,42 +79,51 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hsl';
-      g.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hsl';
+        g.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hsl';
-      g2.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hsl';
+        g2.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -119,42 +138,51 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hsl';
-      g.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hsl';
+        g.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hsl';
-      g2.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hsl';
+        g2.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -169,42 +197,51 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hsl';
-      g.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hsl';
+        g.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hsl';
-      g2.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hsl';
+        g2.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -219,42 +256,51 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hwb';
-      g.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hwb';
+        g.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hwb';
-      g2.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hwb';
+        g2.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -269,42 +315,51 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hwb';
-      g.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hwb';
+        g.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hwb';
-      g2.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hwb';
+        g2.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -319,42 +374,51 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hwb';
-      g.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hwb';
+        g.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hwb';
-      g2.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hwb';
+        g2.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -369,42 +433,51 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'hwb';
-      g.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'hwb';
+        g.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'hwb';
-      g2.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'hwb';
+        g2.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -419,42 +492,51 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'lch';
-      g.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'lch';
+        g.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'lch';
-      g2.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'lch';
+        g2.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -469,42 +551,51 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'lch';
-      g.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'lch';
+        g.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'lch';
-      g2.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'lch';
+        g2.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -519,42 +610,51 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'lch';
-      g.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'lch';
+        g.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'lch';
-      g2.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'lch';
+        g2.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -569,42 +669,51 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'lch';
-      g.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'lch';
+        g.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'lch';
-      g2.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'lch';
+        g2.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -619,42 +728,51 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'oklch';
-      g.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'oklch';
+        g.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'oklch';
-      g2.hueInterpolationMethod = 'shorter';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'oklch';
+        g2.hueInterpolationMethod = 'shorter';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -669,42 +787,51 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'oklch';
-      g.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'oklch';
+        g.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'oklch';
-      g2.hueInterpolationMethod = 'longer';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'oklch';
+        g2.hueInterpolationMethod = 'longer';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -719,42 +846,51 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'oklch';
-      g.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'oklch';
+        g.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'oklch';
-      g2.hueInterpolationMethod = 'increasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'oklch';
+        g2.hueInterpolationMethod = 'increasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -769,42 +905,51 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 50);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 50);
+        const ctx = canvas.getContext('2d');
 
-      // Generate two gradients, one from red to green, the other from red to blue.
-      // In the first instance "shorter" is equivalent to "increasing".
-      // In the second, "shorter" is equivalent to "decreasing".
+        // Generate two gradients, one from red to green, the other from red to blue.
+        // In the first instance "shorter" is equivalent to "increasing".
+        // In the second, "shorter" is equivalent to "decreasing".
 
-      var g = ctx.createLinearGradient(0, 0, 100, 0);
-      g.addColorStop(0, 'color(srgb 1 0 0)');
-      g.addColorStop(1, 'color(srgb 0 1 0)');
-      g.colorInterpolationMethod = 'oklch';
-      g.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g;
-      ctx.fillRect(0, 0, 100, 25);
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, 'color(srgb 1 0 0)');
+        g.addColorStop(1, 'color(srgb 0 1 0)');
+        g.colorInterpolationMethod = 'oklch';
+        g.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 100, 25);
 
-      var g2 = ctx.createLinearGradient(0, 0, 100, 0);
-      g2.addColorStop(0, 'color(srgb 1 0 0)');
-      g2.addColorStop(1, 'color(srgb 0 0 1)');
-      g2.colorInterpolationMethod = 'oklch';
-      g2.hueInterpolationMethod = 'decreasing';
-      ctx.fillStyle = g2;
-      ctx.fillRect(0, 25, 100, 25);
+        var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+        g2.addColorStop(0, 'color(srgb 1 0 0)');
+        g2.addColorStop(1, 'color(srgb 0 0 1)');
+        g2.colorInterpolationMethod = 'oklch';
+        g2.hueInterpolationMethod = 'decreasing';
+        ctx.fillStyle = g2;
+        ctx.fillRect(0, 25, 100, 25);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.discrete.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.discrete.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.canvasFilterObject.componentTransfer.discrete.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.canvasFilterObject.componentTransfer.discrete.tentative</title>
 <h1>2d.filter.canvasFilterObject.componentTransfer.discrete.tentative</h1>
@@ -12,43 +13,52 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    tableValuesR = [0, 0, 1, 1];
-    tableValuesG = [2, 0, 0.5, 3];
-    tableValuesB = [1, -1, 5, 0];
-    ctx.filter = new CanvasFilter({name: 'componentTransfer',
-        funcR: {type: 'discrete', tableValues: tableValuesR},
-        funcG: {type: 'discrete', tableValues: tableValuesG},
-        funcB: {type: 'discrete', tableValues: tableValuesB},
-    });
+      tableValuesR = [0, 0, 1, 1];
+      tableValuesG = [2, 0, 0.5, 3];
+      tableValuesB = [1, -1, 5, 0];
+      ctx.filter = new CanvasFilter({name: 'componentTransfer',
+          funcR: {type: 'discrete', tableValues: tableValuesR},
+          funcG: {type: 'discrete', tableValues: tableValuesG},
+          funcB: {type: 'discrete', tableValues: tableValuesB},
+      });
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.gamma.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.gamma.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.canvasFilterObject.componentTransfer.gamma.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.canvasFilterObject.componentTransfer.gamma.tentative</title>
 <h1>2d.filter.canvasFilterObject.componentTransfer.gamma.tentative</h1>
@@ -12,46 +13,55 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    const amplitudes = [2, 1.1, 0.5];
-    const exponents = [5, 3, 1];
-    const offsets = [0.25, 0, 0.5];
-    ctx.filter = new CanvasFilter({name: 'componentTransfer',
-        funcR: {type: 'gamma', amplitude: amplitudes[0],
-          exponent: exponents[0], offset: offsets[0]},
-        funcG: {type: 'gamma', amplitude: amplitudes[1],
-          exponent: exponents[1], offset: offsets[1]},
-        funcB: {type: 'gamma', amplitude: amplitudes[2],
-          exponent: exponents[2], offset: offsets[2]},
-    });
+      const amplitudes = [2, 1.1, 0.5];
+      const exponents = [5, 3, 1];
+      const offsets = [0.25, 0, 0.5];
+      ctx.filter = new CanvasFilter({name: 'componentTransfer',
+          funcR: {type: 'gamma', amplitude: amplitudes[0],
+            exponent: exponents[0], offset: offsets[0]},
+          funcG: {type: 'gamma', amplitude: amplitudes[1],
+            exponent: exponents[1], offset: offsets[1]},
+          funcB: {type: 'gamma', amplitude: amplitudes[2],
+            exponent: exponents[2], offset: offsets[2]},
+      });
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.identity.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.identity.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.canvasFilterObject.componentTransfer.identity.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.canvasFilterObject.componentTransfer.identity.tentative</title>
 <h1>2d.filter.canvasFilterObject.componentTransfer.identity.tentative</h1>
 <p class="desc">Test pixels on CanvasFilter() componentTransfer with identity type</p>
@@ -11,40 +12,49 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.filter = new CanvasFilter({name: 'componentTransfer',
-        funcR: {type: 'identity'},
-        funcG: {type: 'identity'},
-        funcB: {type: 'identity'},
-    });
+      ctx.filter = new CanvasFilter({name: 'componentTransfer',
+          funcR: {type: 'identity'},
+          funcG: {type: 'identity'},
+          funcB: {type: 'identity'},
+      });
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.linear.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.linear.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.canvasFilterObject.componentTransfer.linear.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.canvasFilterObject.componentTransfer.linear.tentative</title>
 <h1>2d.filter.canvasFilterObject.componentTransfer.linear.tentative</h1>
@@ -12,42 +13,51 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    const slopes = [0.5, 1.2, -0.2];
-    const intercepts = [0.25, 0, 0.5];
-    ctx.filter = new CanvasFilter({name: 'componentTransfer',
-        funcR: {type: 'linear', slope: slopes[0], intercept: intercepts[0]},
-        funcG: {type: 'linear', slope: slopes[1], intercept: intercepts[1]},
-        funcB: {type: 'linear', slope: slopes[2], intercept: intercepts[2]},
-    });
+      const slopes = [0.5, 1.2, -0.2];
+      const intercepts = [0.25, 0, 0.5];
+      ctx.filter = new CanvasFilter({name: 'componentTransfer',
+          funcR: {type: 'linear', slope: slopes[0], intercept: intercepts[0]},
+          funcG: {type: 'linear', slope: slopes[1], intercept: intercepts[1]},
+          funcB: {type: 'linear', slope: slopes[2], intercept: intercepts[2]},
+      });
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.table.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.componentTransfer.table.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.canvasFilterObject.componentTransfer.table.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.canvasFilterObject.componentTransfer.table.tentative</title>
 <h1>2d.filter.canvasFilterObject.componentTransfer.table.tentative</h1>
@@ -12,43 +13,52 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    tableValuesR = [0, 0, 1, 1];
-    tableValuesG = [2, 0, 0.5, 3];
-    tableValuesB = [1, -1, 5, 0];
-    ctx.filter = new CanvasFilter({name: 'componentTransfer',
-        funcR: {type: 'table', tableValues: tableValuesR},
-        funcG: {type: 'table', tableValues: tableValuesG},
-        funcB: {type: 'table', tableValues: tableValuesB},
-    });
+      tableValuesR = [0, 0, 1, 1];
+      tableValuesG = [2, 0, 0.5, 3];
+      tableValuesB = [1, -1, 5, 0];
+      ctx.filter = new CanvasFilter({name: 'componentTransfer',
+          funcR: {type: 'table', tableValues: tableValuesR},
+          funcG: {type: 'table', tableValues: tableValuesG},
+          funcB: {type: 'table', tableValues: tableValuesB},
+      });
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.dropShadow.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.dropShadow.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.canvasFilterObject.dropShadow.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.canvasFilterObject.dropShadow.tentative</title>
 <h1>2d.filter.canvasFilterObject.dropShadow.tentative</h1>
 <p class="desc">Test CanvasFilter() dropShadow object.</p>
@@ -11,86 +12,95 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(520, 420);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(520, 420);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(0, 0, 520, 50);
-    ctx.fillRect(0, 100, 520, 50);
-    ctx.fillRect(0, 200, 520, 50);
-    ctx.fillRect(0, 300, 520, 50);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(0, 0, 520, 50);
+      ctx.fillRect(0, 100, 520, 50);
+      ctx.fillRect(0, 200, 520, 50);
+      ctx.fillRect(0, 300, 520, 50);
 
-    ctx.fillStyle = 'crimson';
+      ctx.fillStyle = 'crimson';
 
-    // Parameter defaults.
-    ctx.filter = new CanvasFilter({name: 'dropShadow'});
-    ctx.fillRect(10, 10, 80, 80);
-    // All parameters specified.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
-       floodColor: 'purple', floodOpacity: 0.7});
-    ctx.fillRect(110, 10, 80, 80);
-    // Named color.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'purple'});
-    ctx.fillRect(10, 110, 80, 80);
-    // System color.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'LinkText'});
-    ctx.fillRect(110, 110, 80, 80);
-    // Numerical color.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'rgba(20, 50, 130, 1)'});
-    ctx.fillRect(210, 110, 80, 80);
-    // Transparent floodColor.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'rgba(20, 50, 130, 0.7)'});
-    ctx.fillRect(310, 110, 80, 80);
-    // Transparent floodColor and floodOpacity.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'rgba(20, 50, 130, 0.7)', floodOpacity: 0.7});
-    ctx.fillRect(410, 110, 80, 80);
-    // No blur.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 0,
-       floodColor: 'purple'});
-    ctx.fillRect(10, 210, 80, 80);
-    // Single float blur.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
-       floodColor: 'purple'});
-    ctx.fillRect(110, 210, 80, 80);
-    // Single negative float blur.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: -5,
-       floodColor: 'purple'});
-    ctx.fillRect(210, 210, 80, 80);
-    // Two floats (X&Y) blur.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [3, 5],
-       floodColor: 'purple'});
-    ctx.fillRect(310, 210, 80, 80);
-    // Two negative floats (X&Y) blur.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [-3, -5],
-       floodColor: 'purple'});
-    ctx.fillRect(410, 210, 80, 80);
-    // Degenerate parameter values.
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: [-5], dy: [], stdDeviation: null,
-       floodColor: 'purple', floodOpacity: [2]});
-    ctx.fillRect(10, 310, 80, 80);
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: null, dy: '5', stdDeviation: [[-5], ['3']],
-       floodColor: 'purple', floodOpacity: '0.8'});
-    ctx.fillRect(110, 310, 80, 80);
-    ctx.filter = new CanvasFilter({name: 'dropShadow', dx: true, dy: ['10'], stdDeviation: false,
-       floodColor: 'purple', floodOpacity: ['0.4']});
-    ctx.fillRect(210, 310, 80, 80);
+      // Parameter defaults.
+      ctx.filter = new CanvasFilter({name: 'dropShadow'});
+      ctx.fillRect(10, 10, 80, 80);
+      // All parameters specified.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
+         floodColor: 'purple', floodOpacity: 0.7});
+      ctx.fillRect(110, 10, 80, 80);
+      // Named color.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'purple'});
+      ctx.fillRect(10, 110, 80, 80);
+      // System color.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'LinkText'});
+      ctx.fillRect(110, 110, 80, 80);
+      // Numerical color.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'rgba(20, 50, 130, 1)'});
+      ctx.fillRect(210, 110, 80, 80);
+      // Transparent floodColor.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'rgba(20, 50, 130, 0.7)'});
+      ctx.fillRect(310, 110, 80, 80);
+      // Transparent floodColor and floodOpacity.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'rgba(20, 50, 130, 0.7)', floodOpacity: 0.7});
+      ctx.fillRect(410, 110, 80, 80);
+      // No blur.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 0,
+         floodColor: 'purple'});
+      ctx.fillRect(10, 210, 80, 80);
+      // Single float blur.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
+         floodColor: 'purple'});
+      ctx.fillRect(110, 210, 80, 80);
+      // Single negative float blur.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: -5,
+         floodColor: 'purple'});
+      ctx.fillRect(210, 210, 80, 80);
+      // Two floats (X&Y) blur.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [3, 5],
+         floodColor: 'purple'});
+      ctx.fillRect(310, 210, 80, 80);
+      // Two negative floats (X&Y) blur.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [-3, -5],
+         floodColor: 'purple'});
+      ctx.fillRect(410, 210, 80, 80);
+      // Degenerate parameter values.
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: [-5], dy: [], stdDeviation: null,
+         floodColor: 'purple', floodOpacity: [2]});
+      ctx.fillRect(10, 310, 80, 80);
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: null, dy: '5', stdDeviation: [[-5], ['3']],
+         floodColor: 'purple', floodOpacity: '0.8'});
+      ctx.fillRect(110, 310, 80, 80);
+      ctx.filter = new CanvasFilter({name: 'dropShadow', dx: true, dy: ['10'], stdDeviation: false,
+         floodColor: 'purple', floodOpacity: ['0.4']});
+      ctx.fillRect(210, 310, 80, 80);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.gaussianBlur.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.gaussianBlur.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.filter.canvasFilterObject.gaussianBlur.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.canvasFilterObject.gaussianBlur.tentative</title>
 <h1>2d.filter.canvasFilterObject.gaussianBlur.tentative</h1>
 <p class="desc">Test CanvasFilter() with gaussianBlur.</p>
@@ -17,29 +18,38 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.filter = new CanvasFilter({
-          name: 'gaussianBlur',
-          stdDeviation: [4, 0],
-      });
-      ctx.fillRect(25, 25, 50, 50);
+        ctx.fillStyle = 'teal';
+        ctx.filter = new CanvasFilter({
+            name: 'gaussianBlur',
+            stdDeviation: [4, 0],
+        });
+        ctx.fillRect(25, 25, 50, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -53,29 +63,38 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.filter = new CanvasFilter({
-          name: 'gaussianBlur',
-          stdDeviation: [4, 1],
-      });
-      ctx.fillRect(25, 25, 50, 50);
+        ctx.fillStyle = 'teal';
+        ctx.filter = new CanvasFilter({
+            name: 'gaussianBlur',
+            stdDeviation: [4, 1],
+        });
+        ctx.fillRect(25, 25, 50, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -89,29 +108,38 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.filter = new CanvasFilter({
-          name: 'gaussianBlur',
-          stdDeviation: [4, 4],
-      });
-      ctx.fillRect(25, 25, 50, 50);
+        ctx.fillStyle = 'teal';
+        ctx.filter = new CanvasFilter({
+            name: 'gaussianBlur',
+            stdDeviation: [4, 4],
+        });
+        ctx.fillRect(25, 25, 50, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -125,29 +153,38 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.filter = new CanvasFilter({
-          name: 'gaussianBlur',
-          stdDeviation: [1, 4],
-      });
-      ctx.fillRect(25, 25, 50, 50);
+        ctx.fillStyle = 'teal';
+        ctx.filter = new CanvasFilter({
+            name: 'gaussianBlur',
+            stdDeviation: [1, 4],
+        });
+        ctx.fillRect(25, 25, 50, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -161,29 +198,38 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.filter = new CanvasFilter({
-          name: 'gaussianBlur',
-          stdDeviation: [0, 4],
-      });
-      ctx.fillRect(25, 25, 50, 50);
+        ctx.fillStyle = 'teal';
+        ctx.filter = new CanvasFilter({
+            name: 'gaussianBlur',
+            stdDeviation: [0, 4],
+        });
+        ctx.fillRect(25, 25, 50, 50);
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/filters/2d.filter.drop-shadow-globalAlpha.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.drop-shadow-globalAlpha.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.drop-shadow-globalAlpha-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.drop-shadow-globalAlpha</title>
 <h1>2d.filter.drop-shadow-globalAlpha</h1>
 <p class="desc">Tests the context drop-shadow filter with a globalAlpha</p>
@@ -11,25 +12,34 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.filter = 'drop-shadow(10px 5px 0px rgb(255, 165, 0))';
-    ctx.globalAlpha = 0.5
-    ctx.fillStyle = 'rgb(128, 0, 128)';
-    ctx.fillRect(10, 10, 60, 30);
+      ctx.filter = 'drop-shadow(10px 5px 0px rgb(255, 165, 0))';
+      ctx.globalAlpha = 0.5
+      ctx.fillStyle = 'rgb(128, 0, 128)';
+      ctx.fillRect(10, 10, 60, 30);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.discrete.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.discrete.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.layers.componentTransfer.discrete.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.layers.componentTransfer.discrete.tentative</title>
 <h1>2d.filter.layers.componentTransfer.discrete.tentative</h1>
@@ -12,44 +13,53 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    tableValuesR = [0, 0, 1, 1];
-    tableValuesG = [2, 0, 0.5, 3];
-    tableValuesB = [1, -1, 5, 0];
-    ctx.beginLayer({filter: {name: 'componentTransfer',
-        funcR: {type: 'discrete', tableValues: tableValuesR},
-        funcG: {type: 'discrete', tableValues: tableValuesG},
-        funcB: {type: 'discrete', tableValues: tableValuesB},
-    }});
+      tableValuesR = [0, 0, 1, 1];
+      tableValuesG = [2, 0, 0.5, 3];
+      tableValuesB = [1, -1, 5, 0];
+      ctx.beginLayer({filter: {name: 'componentTransfer',
+          funcR: {type: 'discrete', tableValues: tableValuesR},
+          funcG: {type: 'discrete', tableValues: tableValuesG},
+          funcB: {type: 'discrete', tableValues: tableValuesB},
+      }});
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+      ctx.endLayer();
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-    ctx.endLayer();
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.gamma.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.gamma.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.layers.componentTransfer.gamma.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.layers.componentTransfer.gamma.tentative</title>
 <h1>2d.filter.layers.componentTransfer.gamma.tentative</h1>
@@ -12,47 +13,56 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    const amplitudes = [2, 1.1, 0.5];
-    const exponents = [5, 3, 1];
-    const offsets = [0.25, 0, 0.5];
-    ctx.beginLayer({filter: {name: 'componentTransfer',
-        funcR: {type: 'gamma', amplitude: amplitudes[0],
-          exponent: exponents[0], offset: offsets[0]},
-        funcG: {type: 'gamma', amplitude: amplitudes[1],
-          exponent: exponents[1], offset: offsets[1]},
-        funcB: {type: 'gamma', amplitude: amplitudes[2],
-          exponent: exponents[2], offset: offsets[2]},
-    }});
+      const amplitudes = [2, 1.1, 0.5];
+      const exponents = [5, 3, 1];
+      const offsets = [0.25, 0, 0.5];
+      ctx.beginLayer({filter: {name: 'componentTransfer',
+          funcR: {type: 'gamma', amplitude: amplitudes[0],
+            exponent: exponents[0], offset: offsets[0]},
+          funcG: {type: 'gamma', amplitude: amplitudes[1],
+            exponent: exponents[1], offset: offsets[1]},
+          funcB: {type: 'gamma', amplitude: amplitudes[2],
+            exponent: exponents[2], offset: offsets[2]},
+      }});
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+      ctx.endLayer();
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-    ctx.endLayer();
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.identity.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.identity.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.layers.componentTransfer.identity.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.layers.componentTransfer.identity.tentative</title>
 <h1>2d.filter.layers.componentTransfer.identity.tentative</h1>
 <p class="desc">Test pixels on CanvasFilter() componentTransfer with identity type</p>
@@ -11,41 +12,50 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: {name: 'componentTransfer',
-        funcR: {type: 'identity'},
-        funcG: {type: 'identity'},
-        funcB: {type: 'identity'},
-    }});
+      ctx.beginLayer({filter: {name: 'componentTransfer',
+          funcR: {type: 'identity'},
+          funcG: {type: 'identity'},
+          funcB: {type: 'identity'},
+      }});
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+      ctx.endLayer();
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-    ctx.endLayer();
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.linear.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.linear.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.layers.componentTransfer.linear.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.layers.componentTransfer.linear.tentative</title>
 <h1>2d.filter.layers.componentTransfer.linear.tentative</h1>
@@ -12,43 +13,52 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    const slopes = [0.5, 1.2, -0.2];
-    const intercepts = [0.25, 0, 0.5];
-    ctx.beginLayer({filter: {name: 'componentTransfer',
-        funcR: {type: 'linear', slope: slopes[0], intercept: intercepts[0]},
-        funcG: {type: 'linear', slope: slopes[1], intercept: intercepts[1]},
-        funcB: {type: 'linear', slope: slopes[2], intercept: intercepts[2]},
-    }});
+      const slopes = [0.5, 1.2, -0.2];
+      const intercepts = [0.25, 0, 0.5];
+      ctx.beginLayer({filter: {name: 'componentTransfer',
+          funcR: {type: 'linear', slope: slopes[0], intercept: intercepts[0]},
+          funcG: {type: 'linear', slope: slopes[1], intercept: intercepts[1]},
+          funcB: {type: 'linear', slope: slopes[2], intercept: intercepts[2]},
+      }});
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+      ctx.endLayer();
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-    ctx.endLayer();
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.table.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.componentTransfer.table.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.layers.componentTransfer.table.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-2; totalPixels=0-500">
 <title>Canvas test: 2d.filter.layers.componentTransfer.table.tentative</title>
 <h1>2d.filter.layers.componentTransfer.table.tentative</h1>
@@ -12,44 +13,53 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    tableValuesR = [0, 0, 1, 1];
-    tableValuesG = [2, 0, 0.5, 3];
-    tableValuesB = [1, -1, 5, 0];
-    ctx.beginLayer({filter: {name: 'componentTransfer',
-        funcR: {type: 'table', tableValues: tableValuesR},
-        funcG: {type: 'table', tableValues: tableValuesG},
-        funcB: {type: 'table', tableValues: tableValuesB},
-    }});
+      tableValuesR = [0, 0, 1, 1];
+      tableValuesG = [2, 0, 0.5, 3];
+      tableValuesB = [1, -1, 5, 0];
+      ctx.beginLayer({filter: {name: 'componentTransfer',
+          funcR: {type: 'table', tableValues: tableValuesR},
+          funcG: {type: 'table', tableValues: tableValuesG},
+          funcB: {type: 'table', tableValues: tableValuesB},
+      }});
 
-    const inputColors = [
-        [255, 255, 255],
-        [0, 0, 0],
-        [127, 0, 34],
-        [252, 186, 3],
-        [50, 68, 87],
-    ];
+      const inputColors = [
+          [255, 255, 255],
+          [0, 0, 0],
+          [127, 0, 34],
+          [252, 186, 3],
+          [50, 68, 87],
+      ];
 
-    for (let i = 0 ; i < inputColors.length ; ++i) {
-        const color = inputColors[i];
-        ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        ctx.fillRect(i * 10, i * 10, 10, 10);
+      for (let i = 0 ; i < inputColors.length ; ++i) {
+          const color = inputColors[i];
+          ctx.fillStyle = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          ctx.fillRect(i * 10, i * 10, 10, 10);
+      }
+      ctx.endLayer();
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-    ctx.endLayer();
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.dropShadow.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.dropShadow.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.filter.layers.dropShadow.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.layers.dropShadow.tentative</title>
 <h1>2d.filter.layers.dropShadow.tentative</h1>
 <p class="desc">Test CanvasFilter() dropShadow object.</p>
@@ -11,101 +12,110 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(520, 420);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(520, 420);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(0, 0, 520, 50);
-    ctx.fillRect(0, 100, 520, 50);
-    ctx.fillRect(0, 200, 520, 50);
-    ctx.fillRect(0, 300, 520, 50);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(0, 0, 520, 50);
+      ctx.fillRect(0, 100, 520, 50);
+      ctx.fillRect(0, 200, 520, 50);
+      ctx.fillRect(0, 300, 520, 50);
 
-    ctx.fillStyle = 'crimson';
+      ctx.fillStyle = 'crimson';
 
-    // Parameter defaults.
-    ctx.beginLayer({filter: {name: 'dropShadow'}});
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
-    // All parameters specified.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
-       floodColor: 'purple', floodOpacity: 0.7}});
-    ctx.fillRect(110, 10, 80, 80);
-    ctx.endLayer();
-    // Named color.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'purple'}});
-    ctx.fillRect(10, 110, 80, 80);
-    ctx.endLayer();
-    // System color.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'LinkText'}});
-    ctx.fillRect(110, 110, 80, 80);
-    ctx.endLayer();
-    // Numerical color.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'rgba(20, 50, 130, 1)'}});
-    ctx.fillRect(210, 110, 80, 80);
-    ctx.endLayer();
-    // Transparent floodColor.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'rgba(20, 50, 130, 0.7)'}});
-    ctx.fillRect(310, 110, 80, 80);
-    ctx.endLayer();
-    // Transparent floodColor and floodOpacity.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
-       floodColor: 'rgba(20, 50, 130, 0.7)', floodOpacity: 0.7}});
-    ctx.fillRect(410, 110, 80, 80);
-    ctx.endLayer();
-    // No blur.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 0,
-       floodColor: 'purple'}});
-    ctx.fillRect(10, 210, 80, 80);
-    ctx.endLayer();
-    // Single float blur.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
-       floodColor: 'purple'}});
-    ctx.fillRect(110, 210, 80, 80);
-    ctx.endLayer();
-    // Single negative float blur.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: -5,
-       floodColor: 'purple'}});
-    ctx.fillRect(210, 210, 80, 80);
-    ctx.endLayer();
-    // Two floats (X&Y) blur.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [3, 5],
-       floodColor: 'purple'}});
-    ctx.fillRect(310, 210, 80, 80);
-    ctx.endLayer();
-    // Two negative floats (X&Y) blur.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [-3, -5],
-       floodColor: 'purple'}});
-    ctx.fillRect(410, 210, 80, 80);
-    ctx.endLayer();
-    // Degenerate parameter values.
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: [-5], dy: [], stdDeviation: null,
-       floodColor: 'purple', floodOpacity: [2]}});
-    ctx.fillRect(10, 310, 80, 80);
-    ctx.endLayer();
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: null, dy: '5', stdDeviation: [[-5], ['3']],
-       floodColor: 'purple', floodOpacity: '0.8'}});
-    ctx.fillRect(110, 310, 80, 80);
-    ctx.endLayer();
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: true, dy: ['10'], stdDeviation: false,
-       floodColor: 'purple', floodOpacity: ['0.4']}});
-    ctx.fillRect(210, 310, 80, 80);
-    ctx.endLayer();
+      // Parameter defaults.
+      ctx.beginLayer({filter: {name: 'dropShadow'}});
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
+      // All parameters specified.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
+         floodColor: 'purple', floodOpacity: 0.7}});
+      ctx.fillRect(110, 10, 80, 80);
+      ctx.endLayer();
+      // Named color.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'purple'}});
+      ctx.fillRect(10, 110, 80, 80);
+      ctx.endLayer();
+      // System color.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'LinkText'}});
+      ctx.fillRect(110, 110, 80, 80);
+      ctx.endLayer();
+      // Numerical color.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'rgba(20, 50, 130, 1)'}});
+      ctx.fillRect(210, 110, 80, 80);
+      ctx.endLayer();
+      // Transparent floodColor.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'rgba(20, 50, 130, 0.7)'}});
+      ctx.fillRect(310, 110, 80, 80);
+      ctx.endLayer();
+      // Transparent floodColor and floodOpacity.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 3,
+         floodColor: 'rgba(20, 50, 130, 0.7)', floodOpacity: 0.7}});
+      ctx.fillRect(410, 110, 80, 80);
+      ctx.endLayer();
+      // No blur.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 0,
+         floodColor: 'purple'}});
+      ctx.fillRect(10, 210, 80, 80);
+      ctx.endLayer();
+      // Single float blur.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: 5,
+         floodColor: 'purple'}});
+      ctx.fillRect(110, 210, 80, 80);
+      ctx.endLayer();
+      // Single negative float blur.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: -5,
+         floodColor: 'purple'}});
+      ctx.fillRect(210, 210, 80, 80);
+      ctx.endLayer();
+      // Two floats (X&Y) blur.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [3, 5],
+         floodColor: 'purple'}});
+      ctx.fillRect(310, 210, 80, 80);
+      ctx.endLayer();
+      // Two negative floats (X&Y) blur.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 9, dy: 12, stdDeviation: [-3, -5],
+         floodColor: 'purple'}});
+      ctx.fillRect(410, 210, 80, 80);
+      ctx.endLayer();
+      // Degenerate parameter values.
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: [-5], dy: [], stdDeviation: null,
+         floodColor: 'purple', floodOpacity: [2]}});
+      ctx.fillRect(10, 310, 80, 80);
+      ctx.endLayer();
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: null, dy: '5', stdDeviation: [[-5], ['3']],
+         floodColor: 'purple', floodOpacity: '0.8'}});
+      ctx.fillRect(110, 310, 80, 80);
+      ctx.endLayer();
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: true, dy: ['10'], stdDeviation: false,
+         floodColor: 'purple', floodOpacity: ['0.4']}});
+      ctx.fillRect(210, 310, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/filters/2d.filter.layers.gaussianBlur.tentative.w.html
+++ b/html/canvas/offscreen/filters/2d.filter.layers.gaussianBlur.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.filter.layers.gaussianBlur.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.filter.layers.gaussianBlur.tentative</title>
 <h1>2d.filter.layers.gaussianBlur.tentative</h1>
 <p class="desc">Test CanvasFilter() with gaussianBlur.</p>
@@ -17,30 +18,39 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.beginLayer({filter: {
-          name: 'gaussianBlur',
-          stdDeviation: [4, 0],
-      }});
-      ctx.fillRect(25, 25, 50, 50);
-      ctx.endLayer();
+        ctx.fillStyle = 'teal';
+        ctx.beginLayer({filter: {
+            name: 'gaussianBlur',
+            stdDeviation: [4, 0],
+        }});
+        ctx.fillRect(25, 25, 50, 50);
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -54,30 +64,39 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.beginLayer({filter: {
-          name: 'gaussianBlur',
-          stdDeviation: [4, 1],
-      }});
-      ctx.fillRect(25, 25, 50, 50);
-      ctx.endLayer();
+        ctx.fillStyle = 'teal';
+        ctx.beginLayer({filter: {
+            name: 'gaussianBlur',
+            stdDeviation: [4, 1],
+        }});
+        ctx.fillRect(25, 25, 50, 50);
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -91,30 +110,39 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.beginLayer({filter: {
-          name: 'gaussianBlur',
-          stdDeviation: [4, 4],
-      }});
-      ctx.fillRect(25, 25, 50, 50);
-      ctx.endLayer();
+        ctx.fillStyle = 'teal';
+        ctx.beginLayer({filter: {
+            name: 'gaussianBlur',
+            stdDeviation: [4, 4],
+        }});
+        ctx.fillRect(25, 25, 50, 50);
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -128,30 +156,39 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.beginLayer({filter: {
-          name: 'gaussianBlur',
-          stdDeviation: [1, 4],
-      }});
-      ctx.fillRect(25, 25, 50, 50);
-      ctx.endLayer();
+        ctx.fillStyle = 'teal';
+        ctx.beginLayer({filter: {
+            name: 'gaussianBlur',
+            stdDeviation: [1, 4],
+        }});
+        ctx.fillRect(25, 25, 50, 50);
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -165,30 +202,39 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(100, 100);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(100, 100);
+        const ctx = canvas.getContext('2d');
 
-      ctx.fillStyle = 'teal';
-      ctx.beginLayer({filter: {
-          name: 'gaussianBlur',
-          stdDeviation: [0, 4],
-      }});
-      ctx.fillRect(25, 25, 50, 50);
-      ctx.endLayer();
+        ctx.fillStyle = 'teal';
+        ctx.beginLayer({filter: {
+            name: 'gaussianBlur',
+            stdDeviation: [0, 4],
+        }});
+        ctx.fillRect(25, 25, 50, 50);
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.isotropic.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.isotropic.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.anisotropic-blur.isotropic.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.anisotropic-blur.isotropic.tentative</title>
 <h1>2d.layer.anisotropic-blur.isotropic.tentative</h1>
 <p class="desc">Checks that layers allow gaussian blur with separate X and Y components.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [4, 4] }});
+      ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [4, 4] }});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.mostly-x.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.mostly-x.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.anisotropic-blur.mostly-x.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.anisotropic-blur.mostly-x.tentative</title>
 <h1>2d.layer.anisotropic-blur.mostly-x.tentative</h1>
 <p class="desc">Checks that layers allow gaussian blur with separate X and Y components.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [4, 1] }});
+      ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [4, 1] }});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.mostly-y.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.mostly-y.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.anisotropic-blur.mostly-y.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.anisotropic-blur.mostly-y.tentative</title>
 <h1>2d.layer.anisotropic-blur.mostly-y.tentative</h1>
 <p class="desc">Checks that layers allow gaussian blur with separate X and Y components.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [1, 4] }});
+      ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [1, 4] }});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.x-only.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.x-only.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.anisotropic-blur.x-only.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.anisotropic-blur.x-only.tentative</title>
 <h1>2d.layer.anisotropic-blur.x-only.tentative</h1>
 <p class="desc">Checks that layers allow gaussian blur with separate X and Y components.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [4, 0] }});
+      ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [4, 0] }});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.y-only.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.anisotropic-blur.y-only.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.anisotropic-blur.y-only.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.anisotropic-blur.y-only.tentative</title>
 <h1>2d.layer.anisotropic-blur.y-only.tentative</h1>
 <p class="desc">Checks that layers allow gaussian blur with separate X and Y components.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [0, 4] }});
+      ctx.beginLayer({filter: { name: 'gaussianBlur', stdDeviation: [0, 4] }});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.no-clipping.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.no-clipping.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.blur-from-outside-canvas.no-clipping.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.blur-from-outside-canvas.no-clipping.ctx-filter</title>
 <h1>2d.layer.blur-from-outside-canvas.no-clipping.ctx-filter</h1>
 <p class="desc">Checks blur leaking inside from drawing outside the canvas</p>
@@ -11,36 +12,45 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    // No clipping.
+      // No clipping.
 
-    ctx.filter = 'blur(30px)';
-    ctx.beginLayer();
+      ctx.filter = 'blur(30px)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'turquoise';
-    ctx.fillRect(201, 50, 100, 100);
-    ctx.fillStyle = 'indigo';
-    ctx.fillRect(50, 201, 100, 100);
-    ctx.fillStyle = 'orange';
-    ctx.fillRect(-1, 50, -100, 100);
-    ctx.fillStyle = 'brown';
-    ctx.fillRect(50, -1, 100, -100);
+      ctx.fillStyle = 'turquoise';
+      ctx.fillRect(201, 50, 100, 100);
+      ctx.fillStyle = 'indigo';
+      ctx.fillRect(50, 201, 100, 100);
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(-1, 50, -100, 100);
+      ctx.fillStyle = 'brown';
+      ctx.fillRect(50, -1, 100, -100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.no-clipping.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.no-clipping.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.blur-from-outside-canvas.no-clipping.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.blur-from-outside-canvas.no-clipping.layer-filter.tentative</title>
 <h1>2d.layer.blur-from-outside-canvas.no-clipping.layer-filter.tentative</h1>
 <p class="desc">Checks blur leaking inside from drawing outside the canvas</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    // No clipping.
+      // No clipping.
 
-    ctx.beginLayer({filter: [ {name: 'gaussianBlur', stdDeviation: 30} ]});
+      ctx.beginLayer({filter: [ {name: 'gaussianBlur', stdDeviation: 30} ]});
 
-    ctx.fillStyle = 'turquoise';
-    ctx.fillRect(201, 50, 100, 100);
-    ctx.fillStyle = 'indigo';
-    ctx.fillRect(50, 201, 100, 100);
-    ctx.fillStyle = 'orange';
-    ctx.fillRect(-1, 50, -100, 100);
-    ctx.fillStyle = 'brown';
-    ctx.fillRect(50, -1, 100, -100);
+      ctx.fillStyle = 'turquoise';
+      ctx.fillRect(201, 50, 100, 100);
+      ctx.fillStyle = 'indigo';
+      ctx.fillRect(50, 201, 100, 100);
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(-1, 50, -100, 100);
+      ctx.fillStyle = 'brown';
+      ctx.fillRect(50, -1, 100, -100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.with-clipping.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.with-clipping.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.blur-from-outside-canvas.with-clipping.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.blur-from-outside-canvas.with-clipping.ctx-filter</title>
 <h1>2d.layer.blur-from-outside-canvas.with-clipping.ctx-filter</h1>
 <p class="desc">Checks blur leaking inside from drawing outside the canvas</p>
@@ -11,38 +12,47 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const clipRegion = new Path2D();
-    clipRegion.rect(20, 20, 160, 160);
-    ctx.clip(clipRegion);
+      const clipRegion = new Path2D();
+      clipRegion.rect(20, 20, 160, 160);
+      ctx.clip(clipRegion);
 
-    ctx.filter = 'blur(30px)';
-    ctx.beginLayer();
+      ctx.filter = 'blur(30px)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'turquoise';
-    ctx.fillRect(201, 50, 100, 100);
-    ctx.fillStyle = 'indigo';
-    ctx.fillRect(50, 201, 100, 100);
-    ctx.fillStyle = 'orange';
-    ctx.fillRect(-1, 50, -100, 100);
-    ctx.fillStyle = 'brown';
-    ctx.fillRect(50, -1, 100, -100);
+      ctx.fillStyle = 'turquoise';
+      ctx.fillRect(201, 50, 100, 100);
+      ctx.fillStyle = 'indigo';
+      ctx.fillRect(50, 201, 100, 100);
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(-1, 50, -100, 100);
+      ctx.fillStyle = 'brown';
+      ctx.fillRect(50, -1, 100, -100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.with-clipping.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.blur-from-outside-canvas.with-clipping.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.blur-from-outside-canvas.with-clipping.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.blur-from-outside-canvas.with-clipping.layer-filter.tentative</title>
 <h1>2d.layer.blur-from-outside-canvas.with-clipping.layer-filter.tentative</h1>
 <p class="desc">Checks blur leaking inside from drawing outside the canvas</p>
@@ -11,37 +12,46 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const clipRegion = new Path2D();
-    clipRegion.rect(20, 20, 160, 160);
-    ctx.clip(clipRegion);
+      const clipRegion = new Path2D();
+      clipRegion.rect(20, 20, 160, 160);
+      ctx.clip(clipRegion);
 
-    ctx.beginLayer({filter: [ {name: 'gaussianBlur', stdDeviation: 30} ]});
+      ctx.beginLayer({filter: [ {name: 'gaussianBlur', stdDeviation: 30} ]});
 
-    ctx.fillStyle = 'turquoise';
-    ctx.fillRect(201, 50, 100, 100);
-    ctx.fillStyle = 'indigo';
-    ctx.fillRect(50, 201, 100, 100);
-    ctx.fillStyle = 'orange';
-    ctx.fillRect(-1, 50, -100, 100);
-    ctx.fillStyle = 'brown';
-    ctx.fillRect(50, -1, 100, -100);
+      ctx.fillStyle = 'turquoise';
+      ctx.fillRect(201, 50, 100, 100);
+      ctx.fillStyle = 'indigo';
+      ctx.fillRect(50, 201, 100, 100);
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(-1, 50, -100, 100);
+      ctx.fillStyle = 'brown';
+      ctx.fillRect(50, -1, 100, -100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clearRect.full.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clearRect.full.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clearRect.full-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clearRect.full</title>
 <h1>2d.layer.clearRect.full</h1>
 <p class="desc">clearRect inside a layer can clear all of the layer content.</p>
@@ -11,30 +12,39 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 50);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 50);
 
-    ctx.beginLayer();
-    ctx.fillStyle = 'red';
-    ctx.fillRect(20, 20, 80, 50);
-    ctx.fillStyle = 'green';
-    ctx.clearRect(0, 0, 100, 100);
-    ctx.endLayer();
+      ctx.beginLayer();
+      ctx.fillStyle = 'red';
+      ctx.fillRect(20, 20, 80, 50);
+      ctx.fillStyle = 'green';
+      ctx.clearRect(0, 0, 100, 100);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clearRect.partial.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clearRect.partial.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clearRect.partial-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clearRect.partial</title>
 <h1>2d.layer.clearRect.partial</h1>
 <p class="desc">clearRect inside a layer can clear a portion of the layer content.</p>
@@ -11,29 +12,38 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 50);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 50);
 
-    ctx.beginLayer();
-    ctx.fillStyle = 'red';
-    ctx.fillRect(20, 20, 80, 50);
-    ctx.clearRect(30, 30, 60, 30);
-    ctx.endLayer();
+      ctx.beginLayer();
+      ctx.fillStyle = 'red';
+      ctx.fillRect(20, 20, 80, 50);
+      ctx.clearRect(30, 30, 60, 30);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clip-inside-and-outside.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clip-inside-and-outside.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clip-inside-and-outside.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clip-inside-and-outside.ctx-filter</title>
 <h1>2d.layer.clip-inside-and-outside.ctx-filter</h1>
 <p class="desc">Check clipping set inside and outside the layer</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.filter = 'blur(12px)';
-    ctx.beginLayer();
+      ctx.filter = 'blur(12px)';
+      ctx.beginLayer();
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clip-inside-and-outside.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clip-inside-and-outside.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clip-inside-and-outside.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clip-inside-and-outside.layer-filter.tentative</title>
 <h1>2d.layer.clip-inside-and-outside.layer-filter.tentative</h1>
 <p class="desc">Check clipping set inside and outside the layer</p>
@@ -11,34 +12,43 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.beginLayer({filter: {name: "gaussianBlur", stdDeviation: 12}});
+      ctx.beginLayer({filter: {name: "gaussianBlur", stdDeviation: 12}});
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clip-inside.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clip-inside.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clip-inside.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clip-inside.ctx-filter</title>
 <h1>2d.layer.clip-inside.ctx-filter</h1>
 <p class="desc">Check clipping set inside the layer</p>
@@ -11,31 +12,40 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.filter = 'blur(12px)';
-    ctx.beginLayer();
+      ctx.filter = 'blur(12px)';
+      ctx.beginLayer();
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clip-inside.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clip-inside.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clip-inside.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clip-inside.layer-filter.tentative</title>
 <h1>2d.layer.clip-inside.layer-filter.tentative</h1>
 <p class="desc">Check clipping set inside the layer</p>
@@ -11,30 +12,39 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: {name: "gaussianBlur", stdDeviation: 12}});
+      ctx.beginLayer({filter: {name: "gaussianBlur", stdDeviation: 12}});
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clip-outside.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clip-outside.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clip-outside.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clip-outside.ctx-filter</title>
 <h1>2d.layer.clip-outside.ctx-filter</h1>
 <p class="desc">Check clipping set outside the layer</p>
@@ -11,30 +12,39 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.filter = 'blur(12px)';
-    ctx.beginLayer();
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
+      ctx.filter = 'blur(12px)';
+      ctx.beginLayer();
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.clip-outside.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.clip-outside.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.clip-outside.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.clip-outside.layer-filter.tentative</title>
 <h1>2d.layer.clip-outside.layer-filter.tentative</h1>
 <p class="desc">Check clipping set outside the layer</p>
@@ -11,29 +12,38 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginPath();
-    ctx.rect(15, 15, 70, 70);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(15, 15, 70, 70);
+      ctx.clip();
 
-    ctx.beginLayer({filter: {name: "gaussianBlur", stdDeviation: 12}});
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(10, 10, 80, 80);
-    ctx.endLayer();
+      ctx.beginLayer({filter: {name: "gaussianBlur", stdDeviation: 12}});
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(10, 10, 80, 80);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.cross-layer-paths.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.cross-layer-paths.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.cross-layer-paths-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.cross-layer-paths</title>
 <h1>2d.layer.cross-layer-paths</h1>
 <p class="desc">Checks that path defined in a layer is usable outside.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer();
-    ctx.translate(50, 0);
-    ctx.moveTo(0, 0);
-    ctx.endLayer();
-    ctx.lineTo(50, 100);
-    ctx.stroke();
+      ctx.beginLayer();
+      ctx.translate(50, 0);
+      ctx.moveTo(0, 0);
+      ctx.endLayer();
+      ctx.lineTo(50, 100);
+      ctx.stroke();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.css-filters.blur-and-shadow.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.css-filters.blur-and-shadow.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.css-filters.blur-and-shadow.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.css-filters.blur-and-shadow.tentative</title>
 <h1>2d.layer.css-filters.blur-and-shadow.tentative</h1>
 <p class="desc">Checks that beginLayer works with a CSS filter string as input.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: 'blur(5px) drop-shadow(10px 10px 5px orange)'});
+      ctx.beginLayer({filter: 'blur(5px) drop-shadow(10px 10px 5px orange)'});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.css-filters.blur.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.css-filters.blur.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.css-filters.blur.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.css-filters.blur.tentative</title>
 <h1>2d.layer.css-filters.blur.tentative</h1>
 <p class="desc">Checks that beginLayer works with a CSS filter string as input.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: 'blur(10px)'});
+      ctx.beginLayer({filter: 'blur(10px)'});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.css-filters.shadow.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.css-filters.shadow.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.css-filters.shadow.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.css-filters.shadow.tentative</title>
 <h1>2d.layer.css-filters.shadow.tentative</h1>
 <p class="desc">Checks that beginLayer works with a CSS filter string as input.</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: 'drop-shadow(-10px -10px 5px purple)'});
+      ctx.beginLayer({filter: 'drop-shadow(-10px -10px 5px purple)'});
 
-    ctx.fillStyle = 'teal';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'teal';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.ctm.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.ctm.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.ctm.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.ctm.ctx-filter</title>
 <h1>2d.layer.ctm.ctx-filter</h1>
 <p class="desc">Checks that parent transforms don't affect context filters.</p>
@@ -11,45 +12,54 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'grey';
-    ctx.translate(30, 90);
-    ctx.scale(2, 2);
-    ctx.rotate(Math.PI / 2);
+      ctx.fillStyle = 'grey';
+      ctx.translate(30, 90);
+      ctx.scale(2, 2);
+      ctx.rotate(Math.PI / 2);
 
-    // The transform doesn't apply to context filter on normal draw calls.
-    ctx.save();
-    ctx.filter = 'drop-shadow(10px 10px 0px red)';
-    ctx.fillRect(-30, -5, 60, 10);
-    ctx.restore();
+      // The transform doesn't apply to context filter on normal draw calls.
+      ctx.save();
+      ctx.filter = 'drop-shadow(10px 10px 0px red)';
+      ctx.fillRect(-30, -5, 60, 10);
+      ctx.restore();
 
-    // Likewise, the transform doesn't apply to context filter applied on layer.
-    ctx.save();
-    ctx.filter = 'drop-shadow(10px 10px 0px green)';
-    ctx.beginLayer();
-    ctx.fillRect(-30, -25, 60, 10);
-    ctx.endLayer();
-    ctx.restore();
+      // Likewise, the transform doesn't apply to context filter applied on layer.
+      ctx.save();
+      ctx.filter = 'drop-shadow(10px 10px 0px green)';
+      ctx.beginLayer();
+      ctx.fillRect(-30, -25, 60, 10);
+      ctx.endLayer();
+      ctx.restore();
 
-    // Filters inside layers aren't affected by transform either.
-    ctx.beginLayer();
-    ctx.filter = 'drop-shadow(5px 5px 0px blue)';
-    ctx.fillRect(-30, -45, 60, 10);
-    ctx.endLayer();
+      // Filters inside layers aren't affected by transform either.
+      ctx.beginLayer();
+      ctx.filter = 'drop-shadow(5px 5px 0px blue)';
+      ctx.fillRect(-30, -45, 60, 10);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.ctm.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.ctm.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.ctm.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.ctm.layer-filter.tentative</title>
 <h1>2d.layer.ctm.layer-filter.tentative</h1>
 <p class="desc">Checks that parent transforms affect layer filters.</p>
@@ -11,36 +12,45 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    // Transforms inside the layer should not apply to the layer's filter.
-    ctx.beginLayer({filter: 'drop-shadow(5px 5px 0px grey)'});
-    ctx.translate(30, 90);
-    ctx.scale(2, 2);
-    ctx.rotate(Math.PI / 2);
-    ctx.fillRect(-30, -5, 60, 10);
-    ctx.endLayer();
+      // Transforms inside the layer should not apply to the layer's filter.
+      ctx.beginLayer({filter: 'drop-shadow(5px 5px 0px grey)'});
+      ctx.translate(30, 90);
+      ctx.scale(2, 2);
+      ctx.rotate(Math.PI / 2);
+      ctx.fillRect(-30, -5, 60, 10);
+      ctx.endLayer();
 
-    // Transforms in the layer's parent should apply to the layer's filter.
-    ctx.translate(80, 90);
-    ctx.scale(2, 2);
-    ctx.rotate(Math.PI / 2);
-    ctx.beginLayer({filter: 'drop-shadow(5px 5px 0px grey)'});
-    ctx.fillRect(-30, -5, 60, 10);
-    ctx.endLayer();
+      // Transforms in the layer's parent should apply to the layer's filter.
+      ctx.translate(80, 90);
+      ctx.scale(2, 2);
+      ctx.rotate(Math.PI / 2);
+      ctx.beginLayer({filter: 'drop-shadow(5px 5px 0px grey)'});
+      ctx.fillRect(-30, -5, 60, 10);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.ctm.resetTransform.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.ctm.resetTransform.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.ctm.resetTransform-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.ctm.resetTransform</title>
 <h1>2d.layer.ctm.resetTransform</h1>
 <p class="desc">Tests resetTransform inside layers.</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.translate(40, 0);
+      ctx.translate(40, 0);
 
-    ctx.beginLayer();
-    ctx.rotate(2);
-    ctx.beginLayer();
-    ctx.scale(5, 6);
-    ctx.resetTransform();
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(0, 0, 20, 20);
-    ctx.endLayer();
-    ctx.endLayer();
+      ctx.beginLayer();
+      ctx.rotate(2);
+      ctx.beginLayer();
+      ctx.scale(5, 6);
+      ctx.resetTransform();
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(0, 0, 20, 20);
+      ctx.endLayer();
+      ctx.endLayer();
 
-    ctx.fillStyle = 'green';
-    ctx.fillRect(0, 0, 20, 20);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(0, 0, 20, 20);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.ctm.setTransform.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.ctm.setTransform.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.ctm.setTransform-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.ctm.setTransform</title>
 <h1>2d.layer.ctm.setTransform</h1>
 <p class="desc">Tests setTransform inside layers.</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.translate(80, 0);
+      ctx.translate(80, 0);
 
-    ctx.beginLayer();
-    ctx.rotate(2);
-    ctx.beginLayer();
-    ctx.scale(5, 6);
-    ctx.setTransform(4, 0, 0, 2, 20, 10);
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(0, 0, 10, 10);
-    ctx.endLayer();
-    ctx.endLayer();
+      ctx.beginLayer();
+      ctx.rotate(2);
+      ctx.beginLayer();
+      ctx.scale(5, 6);
+      ctx.setTransform(4, 0, 0, 2, 20, 10);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(0, 0, 10, 10);
+      ctx.endLayer();
+      ctx.endLayer();
 
-    ctx.fillStyle = 'green';
-    ctx.fillRect(0, 0, 20, 20);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(0, 0, 20, 20);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.ctm.shadow-in-transformed-layer.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.ctm.shadow-in-transformed-layer.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.ctm.shadow-in-transformed-layer-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.ctm.shadow-in-transformed-layer</title>
 <h1>2d.layer.ctm.shadow-in-transformed-layer</h1>
 <p class="desc">Check shadows inside of a transformed layer.</p>
@@ -11,38 +12,47 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.translate(80, 90);
-    ctx.scale(2, 2);
-    ctx.rotate(Math.PI / 2);
+      ctx.translate(80, 90);
+      ctx.scale(2, 2);
+      ctx.rotate(Math.PI / 2);
 
-    ctx.beginLayer();
-    ctx.shadowOffsetX = 10;
-    ctx.shadowOffsetY = 10;
-    ctx.shadowColor = 'grey';
-    ctx.fillRect(-30, -5, 60, 10);
+      ctx.beginLayer();
+      ctx.shadowOffsetX = 10;
+      ctx.shadowOffsetY = 10;
+      ctx.shadowColor = 'grey';
+      ctx.fillRect(-30, -5, 60, 10);
 
-    const canvas2 = new OffscreenCanvas(100, 100);
-    const ctx2 = canvas2.getContext('2d');
-    ctx2.fillStyle = 'blue';
-    ctx2.fillRect(0, 0, 40, 10);
-    ctx.drawImage(canvas2, -30, -30);
+      const canvas2 = new OffscreenCanvas(100, 100);
+      const ctx2 = canvas2.getContext('2d');
+      ctx2.fillStyle = 'blue';
+      ctx2.fillRect(0, 0, 40, 10);
+      ctx.drawImage(canvas2, -30, -30);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.draw-in-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.draw-in-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.draw-in-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.draw-in-filter</title>
 <h1>2d.layer.draw-in-filter</h1>
 <p class="desc">Tests that draw calls happening inside the filter definition aren't affected by the filter.</p>
@@ -11,32 +12,41 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 100);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 100);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: {
-      get name() {
-        ctx.fillStyle = 'blue';
-        ctx.fillRect(10, 10, 30, 30);
-        return 'gaussianBlur';
-      },
-      stdDeviation: 5
-    }});
-    ctx.fillStyle = 'green';
-    ctx.fillRect(60, 60, 30, 30);
-    ctx.endLayer();
+      ctx.beginLayer({filter: {
+        get name() {
+          ctx.fillStyle = 'blue';
+          ctx.fillRect(10, 10, 30, 30);
+          return 'gaussianBlur';
+        },
+        stdDeviation: 5
+      }});
+      ctx.fillStyle = 'green';
+      ctx.fillRect(60, 60, 30, 30);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.drawImage.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.drawImage.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.drawImage.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.drawImage.ctx-filter</title>
 <h1>2d.layer.drawImage.ctx-filter</h1>
 <p class="desc">Checks that drawImage writes the image to the layer and not the parent directly.</p>
@@ -11,40 +12,49 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'skyblue';
-    ctx.fillRect(0, 0, 100, 100);
+      ctx.fillStyle = 'skyblue';
+      ctx.fillRect(0, 0, 100, 100);
 
-    ctx.filter = 'drop-shadow(-10px -10px 0px navy)';
-    ctx.beginLayer();
+      ctx.filter = 'drop-shadow(-10px -10px 0px navy)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'maroon';
-    ctx.fillRect(20, 20, 50, 50);
+      ctx.fillStyle = 'maroon';
+      ctx.fillRect(20, 20, 50, 50);
 
-    ctx.globalCompositeOperation = 'xor';
+      ctx.globalCompositeOperation = 'xor';
 
-    // The image should xor only with the layer content, not the parents'.
-    const canvas_image = new OffscreenCanvas(200,200);
-    const ctx_image = canvas_image.getContext("2d");
-    ctx_image.fillStyle = 'pink';
-    ctx_image.fillRect(40, 40, 50, 50);
-    ctx.drawImage(canvas_image, 0, 0);
+      // The image should xor only with the layer content, not the parents'.
+      const canvas_image = new OffscreenCanvas(200,200);
+      const ctx_image = canvas_image.getContext("2d");
+      ctx_image.fillStyle = 'pink';
+      ctx_image.fillRect(40, 40, 50, 50);
+      ctx.drawImage(canvas_image, 0, 0);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.drawImage.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.drawImage.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.drawImage.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.drawImage.layer-filter.tentative</title>
 <h1>2d.layer.drawImage.layer-filter.tentative</h1>
 <p class="desc">Checks that drawImage writes the image to the layer and not the parent directly.</p>
@@ -11,40 +12,49 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'skyblue';
-    ctx.fillRect(0, 0, 100, 100);
+      ctx.fillStyle = 'skyblue';
+      ctx.fillRect(0, 0, 100, 100);
 
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: -10, dy: -10,
-                             stdDeviation: 0, floodColor: 'navy'}});
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: -10, dy: -10,
+                               stdDeviation: 0, floodColor: 'navy'}});
 
-    ctx.fillStyle = 'maroon';
-    ctx.fillRect(20, 20, 50, 50);
+      ctx.fillStyle = 'maroon';
+      ctx.fillRect(20, 20, 50, 50);
 
-    ctx.globalCompositeOperation = 'xor';
+      ctx.globalCompositeOperation = 'xor';
 
-    // The image should xor only with the layer content, not the parents'.
-    const canvas_image = new OffscreenCanvas(200,200);
-    const ctx_image = canvas_image.getContext("2d");
-    ctx_image.fillStyle = 'pink';
-    ctx_image.fillRect(40, 40, 50, 50);
-    ctx.drawImage(canvas_image, 0, 0);
+      // The image should xor only with the layer content, not the parents'.
+      const canvas_image = new OffscreenCanvas(200,200);
+      const ctx_image = canvas_image.getContext("2d");
+      ctx_image.fillStyle = 'pink';
+      ctx_image.fillRect(40, 40, 50, 50);
+      ctx.drawImage(canvas_image, 0, 0);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.global-states.ctx-filter.no-transform.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.ctx-filter.no-transform.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.ctx-filter.no-transform-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.ctx-filter.no-transform</title>
 <h1>2d.layer.global-states.ctx-filter.no-transform</h1>
 <p class="desc">Checks that layers correctly use global render states.</p>
@@ -19,45 +20,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -73,45 +83,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -127,45 +146,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -181,45 +209,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -235,45 +272,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -289,45 +335,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -343,45 +398,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -397,45 +461,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -451,48 +524,57 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -508,48 +590,57 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -565,48 +656,57 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -622,48 +722,57 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -679,48 +788,57 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -736,48 +854,57 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -793,48 +920,57 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -850,48 +986,57 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.ctx-filter.rotation.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.ctx-filter.rotation.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.ctx-filter.rotation-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.ctx-filter.rotation</title>
 <h1>2d.layer.global-states.ctx-filter.rotation</h1>
 <p class="desc">Checks that layers correctly use global render states.</p>
@@ -19,47 +20,56 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -75,47 +85,56 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -131,47 +150,56 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -187,47 +215,56 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -243,47 +280,56 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -299,47 +345,56 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -355,47 +410,56 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -411,47 +475,56 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -467,50 +540,59 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -526,50 +608,59 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -585,50 +676,59 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -644,50 +744,59 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -703,50 +812,59 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -762,50 +880,59 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -821,50 +948,59 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -880,50 +1016,59 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.filter.ctx-filter.no-transform.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.filter.ctx-filter.no-transform.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.filter.ctx-filter.no-transform.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.filter.ctx-filter.no-transform.tentative</title>
 <h1>2d.layer.global-states.filter.ctx-filter.no-transform.tentative</h1>
 <p class="desc">Checks that layers with filters correctly use global render states.</p>
@@ -19,45 +20,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -73,45 +83,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -127,45 +146,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -181,45 +209,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -235,45 +272,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -289,45 +335,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -343,45 +398,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -397,45 +461,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -451,48 +524,57 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -508,48 +590,57 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -565,48 +656,57 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -622,48 +722,57 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -679,48 +788,57 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -736,48 +854,57 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -793,48 +920,57 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -850,48 +986,57 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.filter.ctx-filter.rotation.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.filter.ctx-filter.rotation.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.filter.ctx-filter.rotation.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.filter.ctx-filter.rotation.tentative</title>
 <h1>2d.layer.global-states.filter.ctx-filter.rotation.tentative</h1>
 <p class="desc">Checks that layers with filters correctly use global render states.</p>
@@ -19,47 +20,56 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -75,47 +85,56 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -131,47 +150,56 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -187,47 +215,56 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -243,47 +280,56 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -299,47 +345,56 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -355,47 +410,56 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -411,47 +475,56 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -467,50 +540,59 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -526,50 +608,59 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -585,50 +676,59 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -644,50 +744,59 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -703,50 +812,59 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -762,50 +880,59 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -821,50 +948,59 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -880,50 +1016,59 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        ctx.filter = 'drop-shadow(-4px -4px 0 fuchsia)';
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.filter.no-cxt-filter.no-transform.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.filter.no-cxt-filter.no-transform.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.filter.no-cxt-filter.no-transform.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.filter.no-cxt-filter.no-transform.tentative</title>
 <h1>2d.layer.global-states.filter.no-cxt-filter.no-transform.tentative</h1>
 <p class="desc">Checks that layers with filters correctly use global render states.</p>
@@ -19,45 +20,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -73,45 +83,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -127,45 +146,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -181,45 +209,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -235,45 +272,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -289,45 +335,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -343,45 +398,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -397,45 +461,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -451,48 +524,57 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -508,48 +590,57 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -565,48 +656,57 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -622,48 +722,57 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -679,48 +788,57 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -736,48 +854,57 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -793,48 +920,57 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -850,48 +986,57 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.filter.no-cxt-filter.rotation.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.filter.no-cxt-filter.rotation.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.filter.no-cxt-filter.rotation.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.filter.no-cxt-filter.rotation.tentative</title>
 <h1>2d.layer.global-states.filter.no-cxt-filter.rotation.tentative</h1>
 <p class="desc">Checks that layers with filters correctly use global render states.</p>
@@ -19,47 +20,56 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -75,47 +85,56 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -131,47 +150,56 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -187,47 +215,56 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -243,47 +280,56 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -299,47 +345,56 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -355,47 +410,56 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -411,47 +475,56 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -467,50 +540,59 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -526,50 +608,59 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -585,50 +676,59 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -644,50 +744,59 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -703,50 +812,59 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -762,50 +880,59 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -821,50 +948,59 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -880,50 +1016,59 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer({filter: [
-          {name: 'dropShadow',
-              dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
-          {name: 'componentTransfer',
-              funcA: {type: "table", tableValues: [0, 0.8]}}]});
+        ctx.beginLayer({filter: [
+            {name: 'dropShadow',
+                dx: 8, dy: 8, stdDeviation: 0, floodColor: '#00f'},
+            {name: 'componentTransfer',
+                funcA: {type: "table", tableValues: [0, 0.8]}}]});
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.no-cxt-filter.no-transform.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.no-cxt-filter.no-transform.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.no-cxt-filter.no-transform-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.no-cxt-filter.no-transform</title>
 <h1>2d.layer.global-states.no-cxt-filter.no-transform</h1>
 <p class="desc">Checks that layers correctly use global render states.</p>
@@ -19,45 +20,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -73,45 +83,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -127,45 +146,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -181,45 +209,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -235,45 +272,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -289,45 +335,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -343,45 +398,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -397,45 +461,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -451,48 +524,57 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -508,48 +590,57 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -565,48 +656,57 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -622,48 +722,57 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -679,48 +788,57 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -736,48 +854,57 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -793,48 +920,57 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -850,48 +986,57 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      // No transform.
+        // No transform.
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.global-states.no-cxt-filter.rotation.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.global-states.no-cxt-filter.rotation.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.global-states.no-cxt-filter.rotation-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.global-states.no-cxt-filter.rotation</title>
 <h1>2d.layer.global-states.no-cxt-filter.rotation</h1>
 <p class="desc">Checks that layers correctly use global render states.</p>
@@ -19,47 +20,56 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -75,47 +85,56 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -131,47 +150,56 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -187,47 +215,56 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -243,47 +280,56 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -299,47 +345,56 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -355,47 +410,56 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -411,47 +475,56 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      // No shadow.
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        // No shadow.
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -467,50 +540,59 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -526,50 +608,59 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      // No globalCompositeOperation.
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        // No globalCompositeOperation.
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -585,50 +676,59 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -644,50 +744,59 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -703,50 +812,59 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -762,50 +880,59 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -821,50 +948,59 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      // No globalAlpha.
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        // No globalAlpha.
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -880,50 +1016,59 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 40);
-      ctx.rotate(Math.PI);
-      ctx.translate(-45, -45);
+        ctx.translate(50, 40);
+        ctx.rotate(Math.PI);
+        ctx.translate(-45, -45);
 
-      ctx.fillStyle = 'rgba(128, 128, 128, 1)';
-      ctx.fillRect(20, 15, 50, 50);
+        ctx.fillStyle = 'rgba(128, 128, 128, 1)';
+        ctx.fillRect(20, 15, 50, 50);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = -7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
-      ctx.shadowBlur = 3;
-      // No filter.
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = -7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.shadowBlur = 3;
+        // No filter.
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      // Enable compositing in the layer to validate that draw calls in the layer
-      // won't individually composite with the background.
-      ctx.globalCompositeOperation = 'screen';
+        // Enable compositing in the layer to validate that draw calls in the layer
+        // won't individually composite with the background.
+        ctx.globalCompositeOperation = 'screen';
 
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      ctx.fillRect(10, 25, 40, 45);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(30, 5, 45, 40);
+        ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+        ctx.fillRect(10, 25, 40, 45);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(30, 5, 45, 40);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.globalCompositeOperation.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.globalCompositeOperation.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.layer.globalCompositeOperation-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.globalCompositeOperation</title>
 <h1>2d.layer.globalCompositeOperation</h1>
 <p class="desc">Checks that layers work with all globalCompositeOperation values.</p>
@@ -17,45 +18,54 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-over';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -69,45 +79,54 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-in';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-in';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -121,45 +140,54 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-out';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-out';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -173,45 +201,54 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'source-atop';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'source-atop';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -225,45 +262,54 @@
   </canvas>
   <script id="myWorker4" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'destination-over';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'destination-over';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker4').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas4');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -277,45 +323,54 @@
   </canvas>
   <script id="myWorker5" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'destination-in';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'destination-in';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker5').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas5');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -329,45 +384,54 @@
   </canvas>
   <script id="myWorker6" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'destination-out';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker6').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas6');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -381,45 +445,54 @@
   </canvas>
   <script id="myWorker7" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'destination-atop';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'destination-atop';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker7').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas7');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -433,45 +506,54 @@
   </canvas>
   <script id="myWorker8" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'lighter';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker8').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas8');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -485,45 +567,54 @@
   </canvas>
   <script id="myWorker9" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'copy';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'copy';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker9').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas9');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -537,45 +628,54 @@
   </canvas>
   <script id="myWorker10" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'xor';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'xor';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker10').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas10');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -589,45 +689,54 @@
   </canvas>
   <script id="myWorker11" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'multiply';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker11').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas11');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -641,45 +750,54 @@
   </canvas>
   <script id="myWorker12" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'screen';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'screen';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker12').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas12');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -693,45 +811,54 @@
   </canvas>
   <script id="myWorker13" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'overlay';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'overlay';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker13').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas13');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -745,45 +872,54 @@
   </canvas>
   <script id="myWorker14" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'darken';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'darken';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker14').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas14');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -797,45 +933,54 @@
   </canvas>
   <script id="myWorker15" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'lighten';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'lighten';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker15').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas15');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -849,45 +994,54 @@
   </canvas>
   <script id="myWorker16" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'color-dodge';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'color-dodge';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker16').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas16');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -901,45 +1055,54 @@
   </canvas>
   <script id="myWorker17" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'color-burn';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'color-burn';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker17').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas17');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -953,45 +1116,54 @@
   </canvas>
   <script id="myWorker18" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'hard-light';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'hard-light';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker18').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas18');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1005,45 +1177,54 @@
   </canvas>
   <script id="myWorker19" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'soft-light';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'soft-light';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker19').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas19');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1057,45 +1238,54 @@
   </canvas>
   <script id="myWorker20" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'difference';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'difference';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker20').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas20');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1109,45 +1299,54 @@
   </canvas>
   <script id="myWorker21" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'exclusion';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'exclusion';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker21').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas21');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1161,45 +1360,54 @@
   </canvas>
   <script id="myWorker22" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'hue';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'hue';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker22').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas22');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1213,45 +1421,54 @@
   </canvas>
   <script id="myWorker23" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'saturation';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'saturation';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker23').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas23');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1265,45 +1482,54 @@
   </canvas>
   <script id="myWorker24" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'color';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'color';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker24').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas24');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -1317,45 +1543,54 @@
   </canvas>
   <script id="myWorker25" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(90, 90);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(90, 90);
+        const ctx = canvas.getContext('2d');
 
-      ctx.translate(50, 50);
-      ctx.scale(2, 2);
-      ctx.rotate(Math.PI);
-      ctx.translate(-25, -25);
+        ctx.translate(50, 50);
+        ctx.scale(2, 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-25, -25);
 
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
-      ctx.fillRect(15, 15, 25, 25);
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.8)';
+        ctx.fillRect(15, 15, 25, 25);
 
-      ctx.globalAlpha = 0.75;
-      ctx.globalCompositeOperation = 'luminosity';
-      ctx.shadowOffsetX = 7;
-      ctx.shadowOffsetY = 7;
-      ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
+        ctx.globalAlpha = 0.75;
+        ctx.globalCompositeOperation = 'luminosity';
+        ctx.shadowOffsetX = 7;
+        ctx.shadowOffsetY = 7;
+        ctx.shadowColor = 'rgba(255, 165, 0, 0.5)';
 
-      ctx.beginLayer();
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(204, 0, 0, 1)';
-      ctx.fillRect(10, 25, 25, 20);
-      ctx.fillStyle = 'rgba(0, 204, 0, 1)';
-      ctx.fillRect(25, 10, 20, 25);
+        ctx.fillStyle = 'rgba(204, 0, 0, 1)';
+        ctx.fillRect(10, 25, 25, 20);
+        ctx.fillStyle = 'rgba(0, 204, 0, 1)';
+        ctx.fillRect(25, 10, 20, 25);
 
-      ctx.endLayer();
+        ctx.endLayer();
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker25').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas25');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/layers/2d.layer.nested-ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.nested-ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.nested-ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.nested-ctx-filter</title>
 <h1>2d.layer.nested-ctx-filter</h1>
 <p class="desc">Tests nested canvas layers with context filters.</p>
@@ -11,30 +12,39 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.filter = 'drop-shadow(20px 20px 0px red)';
-    ctx.beginLayer();
-    ctx.filter = 'drop-shadow(10px 10px 0px green)';
-    ctx.beginLayer();
-    ctx.filter = 'drop-shadow(5px 5px 0px blue)';
-    ctx.fillStyle = 'grey';
-    ctx.fillRect(10, 10, 100, 100);
-    ctx.endLayer();
-    ctx.endLayer();
+      ctx.filter = 'drop-shadow(20px 20px 0px red)';
+      ctx.beginLayer();
+      ctx.filter = 'drop-shadow(10px 10px 0px green)';
+      ctx.beginLayer();
+      ctx.filter = 'drop-shadow(5px 5px 0px blue)';
+      ctx.fillStyle = 'grey';
+      ctx.fillRect(10, 10, 100, 100);
+      ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.nested-filters.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.nested-filters.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.nested-filters.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.nested-filters.tentative</title>
 <h1>2d.layer.nested-filters.tentative</h1>
 <p class="desc">Checks that nested layers work properly when both apply filters.</p>
@@ -11,40 +12,49 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(400, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(400, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: -20, dy: -20,
-      stdDeviation: 0, floodColor: 'yellow'}});
-    ctx.beginLayer({filter: 'drop-shadow(-10px -10px 0 blue)'});
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: -20, dy: -20,
+        stdDeviation: 0, floodColor: 'yellow'}});
+      ctx.beginLayer({filter: 'drop-shadow(-10px -10px 0 blue)'});
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(50, 50, 100, 100);
 
-    ctx.endLayer();
-    ctx.endLayer();
+      ctx.endLayer();
+      ctx.endLayer();
 
-    ctx.beginLayer({filter: 'drop-shadow(20px 20px 0 blue)'});
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: 10, dy: 10,
-      stdDeviation: 0, floodColor: 'yellow'}});
+      ctx.beginLayer({filter: 'drop-shadow(20px 20px 0 blue)'});
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: 10, dy: 10,
+        stdDeviation: 0, floodColor: 'yellow'}});
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(250, 50, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(250, 50, 100, 100);
 
-    ctx.endLayer();
-    ctx.endLayer();
+      ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.nested.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.nested.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.nested-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.nested</title>
 <h1>2d.layer.nested</h1>
 <p class="desc">Tests nested canvas layers.</p>
@@ -11,43 +12,52 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    var circle = new Path2D();
-    circle.arc(90, 90, 40, 0, 2 * Math.PI);
-    ctx.fill(circle);
+      var circle = new Path2D();
+      circle.arc(90, 90, 40, 0, 2 * Math.PI);
+      ctx.fill(circle);
 
-    ctx.globalCompositeOperation = 'source-in';
+      ctx.globalCompositeOperation = 'source-in';
 
-    ctx.beginLayer();
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'rgba(0, 0, 255, 1)';
-    ctx.fillRect(60, 60, 75, 50);
+      ctx.fillStyle = 'rgba(0, 0, 255, 1)';
+      ctx.fillRect(60, 60, 75, 50);
 
-    ctx.globalAlpha = 0.5;
+      ctx.globalAlpha = 0.5;
 
-    ctx.beginLayer();
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-    ctx.fillRect(50, 50, 75, 50);
-    ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-    ctx.fillRect(70, 70, 75, 50);
+      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+      ctx.fillRect(50, 50, 75, 50);
+      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+      ctx.fillRect(70, 70, 75, 50);
 
-    ctx.endLayer();
-    ctx.endLayer();
+      ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.shadow.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.shadow.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.non-invertible-matrix.shadow-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.non-invertible-matrix.shadow</title>
 <h1>2d.layer.non-invertible-matrix.shadow</h1>
 <p class="desc">Test drawing layers when the transform is not invertible.</p>
@@ -11,48 +12,57 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(30, 30, 50, 50);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(30, 30, 50, 50);
 
-    // Anything below will be non-rasterizable.
-    ctx.scale(1, 0);
+      // Anything below will be non-rasterizable.
+      ctx.scale(1, 0);
 
-    ctx.shadowOffsetX = 0;
-    ctx.shadowOffsetY = 20;
-    ctx.shadowColor = 'rgba(255, 165, 0, 0.6)';
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 20;
+      ctx.shadowColor = 'rgba(255, 165, 0, 0.6)';
 
-    // Open the layer with a non-invertible matrix. The whole layer will be
-    // non-rasterizable.
-    ctx.beginLayer();
+      // Open the layer with a non-invertible matrix. The whole layer will be
+      // non-rasterizable.
+      ctx.beginLayer();
 
-    // Because the transform is global, the matrix is still non-invertible.
-    ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-    ctx.fillRect(40, 70, 50, 50);
+      // Because the transform is global, the matrix is still non-invertible.
+      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+      ctx.fillRect(40, 70, 50, 50);
 
-    // Set a valid matrix in the middle of the layer. This makes the global
-    // matrix invertible again, but because because the layer was opened with a
-    // non-invertible matrix, the whole layer remains non-rasterizable.
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
+      // Set a valid matrix in the middle of the layer. This makes the global
+      // matrix invertible again, but because because the layer was opened with a
+      // non-invertible matrix, the whole layer remains non-rasterizable.
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-    ctx.fillStyle = 'green';
-    ctx.fillRect(70, 40, 50, 50);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(70, 40, 50, 50);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.non-invertible-matrix-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.non-invertible-matrix</title>
 <h1>2d.layer.non-invertible-matrix</h1>
 <p class="desc">Test drawing layers when the transform is not invertible.</p>
@@ -11,44 +12,53 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(30, 30, 50, 50);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(30, 30, 50, 50);
 
-    // Anything below will be non-rasterizable.
-    ctx.scale(1, 0);
+      // Anything below will be non-rasterizable.
+      ctx.scale(1, 0);
 
-    // Open the layer with a non-invertible matrix. The whole layer will be
-    // non-rasterizable.
-    ctx.beginLayer();
+      // Open the layer with a non-invertible matrix. The whole layer will be
+      // non-rasterizable.
+      ctx.beginLayer();
 
-    // Because the transform is global, the matrix is still non-invertible.
-    ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-    ctx.fillRect(40, 70, 50, 50);
+      // Because the transform is global, the matrix is still non-invertible.
+      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+      ctx.fillRect(40, 70, 50, 50);
 
-    // Set a valid matrix in the middle of the layer. This makes the global
-    // matrix invertible again, but because because the layer was opened with a
-    // non-invertible matrix, the whole layer remains non-rasterizable.
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
+      // Set a valid matrix in the middle of the layer. This makes the global
+      // matrix invertible again, but because because the layer was opened with a
+      // non-invertible matrix, the whole layer remains non-rasterizable.
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-    ctx.fillStyle = 'green';
-    ctx.fillRect(70, 40, 50, 50);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(70, 40, 50, 50);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.with-render-states.filtered-layer.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.with-render-states.filtered-layer.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.non-invertible-matrix.with-render-states.filtered-layer.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.non-invertible-matrix.with-render-states.filtered-layer.tentative</title>
 <h1>2d.layer.non-invertible-matrix.with-render-states.filtered-layer.tentative</h1>
 <p class="desc">Test drawing layers when the transform is not invertible.</p>
@@ -11,53 +12,62 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(30, 30, 50, 50);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(30, 30, 50, 50);
 
-    // Anything below will be non-rasterizable.
-    ctx.scale(1, 0);
+      // Anything below will be non-rasterizable.
+      ctx.scale(1, 0);
 
-    ctx.globalAlpha = 0.8;
-    ctx.globalCompositeOperation = 'multiply';
-    ctx.shadowOffsetX = 0;
-    ctx.shadowOffsetY = 20;
-    ctx.shadowColor = 'rgba(255, 165, 0, 0.6)';
-    ctx.filter = 'blur(10px)';
+      ctx.globalAlpha = 0.8;
+      ctx.globalCompositeOperation = 'multiply';
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 20;
+      ctx.shadowColor = 'rgba(255, 165, 0, 0.6)';
+      ctx.filter = 'blur(10px)';
 
-    // Open the layer with a non-invertible matrix. The whole layer will be
-    // non-rasterizable.
-    ctx.beginLayer({filter:
-                    {name: 'dropShadow', dx: 10, dy: 0, stdDeviation: 0,
-                    floodColor: 'rgba(128, 128, 255, 0.7)'}});
+      // Open the layer with a non-invertible matrix. The whole layer will be
+      // non-rasterizable.
+      ctx.beginLayer({filter:
+                      {name: 'dropShadow', dx: 10, dy: 0, stdDeviation: 0,
+                      floodColor: 'rgba(128, 128, 255, 0.7)'}});
 
-    // Because the transform is global, the matrix is still non-invertible.
-    ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-    ctx.fillRect(40, 70, 50, 50);
+      // Because the transform is global, the matrix is still non-invertible.
+      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+      ctx.fillRect(40, 70, 50, 50);
 
-    // Set a valid matrix in the middle of the layer. This makes the global
-    // matrix invertible again, but because because the layer was opened with a
-    // non-invertible matrix, the whole layer remains non-rasterizable.
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
+      // Set a valid matrix in the middle of the layer. This makes the global
+      // matrix invertible again, but because because the layer was opened with a
+      // non-invertible matrix, the whole layer remains non-rasterizable.
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-    ctx.fillStyle = 'green';
-    ctx.fillRect(70, 40, 50, 50);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(70, 40, 50, 50);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.with-render-states.plain-layer.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.non-invertible-matrix.with-render-states.plain-layer.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.non-invertible-matrix.with-render-states.plain-layer-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.non-invertible-matrix.with-render-states.plain-layer</title>
 <h1>2d.layer.non-invertible-matrix.with-render-states.plain-layer</h1>
 <p class="desc">Test drawing layers when the transform is not invertible.</p>
@@ -11,51 +12,60 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(30, 30, 50, 50);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(30, 30, 50, 50);
 
-    // Anything below will be non-rasterizable.
-    ctx.scale(1, 0);
+      // Anything below will be non-rasterizable.
+      ctx.scale(1, 0);
 
-    ctx.globalAlpha = 0.8;
-    ctx.globalCompositeOperation = 'multiply';
-    ctx.shadowOffsetX = 0;
-    ctx.shadowOffsetY = 20;
-    ctx.shadowColor = 'rgba(255, 165, 0, 0.6)';
-    ctx.filter = 'blur(10px)';
+      ctx.globalAlpha = 0.8;
+      ctx.globalCompositeOperation = 'multiply';
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 20;
+      ctx.shadowColor = 'rgba(255, 165, 0, 0.6)';
+      ctx.filter = 'blur(10px)';
 
-    // Open the layer with a non-invertible matrix. The whole layer will be
-    // non-rasterizable.
-    ctx.beginLayer();
+      // Open the layer with a non-invertible matrix. The whole layer will be
+      // non-rasterizable.
+      ctx.beginLayer();
 
-    // Because the transform is global, the matrix is still non-invertible.
-    ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-    ctx.fillRect(40, 70, 50, 50);
+      // Because the transform is global, the matrix is still non-invertible.
+      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+      ctx.fillRect(40, 70, 50, 50);
 
-    // Set a valid matrix in the middle of the layer. This makes the global
-    // matrix invertible again, but because because the layer was opened with a
-    // non-invertible matrix, the whole layer remains non-rasterizable.
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
+      // Set a valid matrix in the middle of the layer. This makes the global
+      // matrix invertible again, but because because the layer was opened with a
+      // non-invertible matrix, the whole layer remains non-rasterizable.
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-    ctx.fillStyle = 'green';
-    ctx.fillRect(70, 40, 50, 50);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(70, 40, 50, 50);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.opaque-canvas.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.opaque-canvas.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.opaque-canvas.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.opaque-canvas.ctx-filter</title>
 <h1>2d.layer.opaque-canvas.ctx-filter</h1>
 <p class="desc">Checks that layer blending works inside opaque canvas</p>
@@ -11,39 +12,48 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(300, 300);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(300, 300);
+      const ctx = canvas.getContext('2d');
 
-    const canvas2 = new OffscreenCanvas(200, 200);
-    const ctx2 = canvas2.getContext('2d', {alpha: false});
+      const canvas2 = new OffscreenCanvas(200, 200);
+      const ctx2 = canvas2.getContext('2d', {alpha: false});
 
-    ctx2.fillStyle = 'purple';
-    ctx2.fillRect(10, 10, 100, 100);
+      ctx2.fillStyle = 'purple';
+      ctx2.fillRect(10, 10, 100, 100);
 
-    ctx2.filter = 'drop-shadow(-10px 10px 0px rgba(200, 100, 50, 0.5))';
-    ctx2.beginLayer();
-    ctx2.fillStyle = 'green';
-    ctx2.fillRect(50, 50, 100, 100);
-    ctx2.globalAlpha = 0.8;
-    ctx2.fillStyle = 'yellow';
-    ctx2.fillRect(75, 25, 100, 100);
-    ctx2.endLayer();
+      ctx2.filter = 'drop-shadow(-10px 10px 0px rgba(200, 100, 50, 0.5))';
+      ctx2.beginLayer();
+      ctx2.fillStyle = 'green';
+      ctx2.fillRect(50, 50, 100, 100);
+      ctx2.globalAlpha = 0.8;
+      ctx2.fillStyle = 'yellow';
+      ctx2.fillRect(75, 25, 100, 100);
+      ctx2.endLayer();
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(0, 0, 300, 300);
-    ctx.drawImage(canvas2, 0, 0);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(0, 0, 300, 300);
+      ctx.drawImage(canvas2, 0, 0);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.opaque-canvas.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.opaque-canvas.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.opaque-canvas.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.opaque-canvas.layer-filter.tentative</title>
 <h1>2d.layer.opaque-canvas.layer-filter.tentative</h1>
 <p class="desc">Checks that layer blending works inside opaque canvas</p>
@@ -11,40 +12,49 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(300, 300);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(300, 300);
+      const ctx = canvas.getContext('2d');
 
-    const canvas2 = new OffscreenCanvas(200, 200);
-    const ctx2 = canvas2.getContext('2d', {alpha: false});
+      const canvas2 = new OffscreenCanvas(200, 200);
+      const ctx2 = canvas2.getContext('2d', {alpha: false});
 
-    ctx2.fillStyle = 'purple';
-    ctx2.fillRect(10, 10, 100, 100);
+      ctx2.fillStyle = 'purple';
+      ctx2.fillRect(10, 10, 100, 100);
 
-    ctx2.beginLayer({filter: {name: 'dropShadow', dx: -10, dy: 10,
-                              stdDeviation: 0,
-                              floodColor: 'rgba(200, 100, 50, 0.5)'}});
-    ctx2.fillStyle = 'green';
-    ctx2.fillRect(50, 50, 100, 100);
-    ctx2.globalAlpha = 0.8;
-    ctx2.fillStyle = 'yellow';
-    ctx2.fillRect(75, 25, 100, 100);
-    ctx2.endLayer();
+      ctx2.beginLayer({filter: {name: 'dropShadow', dx: -10, dy: 10,
+                                stdDeviation: 0,
+                                floodColor: 'rgba(200, 100, 50, 0.5)'}});
+      ctx2.fillStyle = 'green';
+      ctx2.fillRect(50, 50, 100, 100);
+      ctx2.globalAlpha = 0.8;
+      ctx2.fillStyle = 'yellow';
+      ctx2.fillRect(75, 25, 100, 100);
+      ctx2.endLayer();
 
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(0, 0, 300, 300);
-    ctx.drawImage(canvas2, 0, 0);
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(0, 0, 300, 300);
+      ctx.drawImage(canvas2, 0, 0);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.reset.filtered_layer.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.reset.filtered_layer.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.reset.filtered_layer.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.reset.filtered_layer.tentative</title>
 <h1>2d.layer.reset.filtered_layer.tentative</h1>
 <p class="desc">Checks that reset discards any pending layers.</p>
@@ -11,44 +12,53 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    // Global states:
-    ctx.globalAlpha = 0.3;
-    ctx.globalCompositeOperation = 'source-in';
-    ctx.shadowOffsetX = -3;
-    ctx.shadowOffsetY = 3;
-    ctx.shadowColor = 'rgba(0, 30, 0, 0.3)';
-    ctx.shadowBlur = 3;
-    ctx.filter = 'blur(5px)';
+      // Global states:
+      ctx.globalAlpha = 0.3;
+      ctx.globalCompositeOperation = 'source-in';
+      ctx.shadowOffsetX = -3;
+      ctx.shadowOffsetY = 3;
+      ctx.shadowColor = 'rgba(0, 30, 0, 0.3)';
+      ctx.shadowBlur = 3;
+      ctx.filter = 'blur(5px)';
 
-    ctx.beginLayer({filter: {name: 'dropShadow', dx: -3, dy: 3}});
+      ctx.beginLayer({filter: {name: 'dropShadow', dx: -3, dy: 3}});
 
-    // Layer states:
-    ctx.globalAlpha = 0.6;
-    ctx.globalCompositeOperation = 'source-in';
-    ctx.shadowOffsetX = -6;
-    ctx.shadowOffsetY = 6;
-    ctx.shadowColor = 'rgba(0, 60, 0, 0.6)';
-    ctx.shadowBlur = 3;
-    ctx.filter = 'blur(15px)';
+      // Layer states:
+      ctx.globalAlpha = 0.6;
+      ctx.globalCompositeOperation = 'source-in';
+      ctx.shadowOffsetX = -6;
+      ctx.shadowOffsetY = 6;
+      ctx.shadowColor = 'rgba(0, 60, 0, 0.6)';
+      ctx.shadowBlur = 3;
+      ctx.filter = 'blur(15px)';
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillRect(10, 10, 75, 50);
+      ctx.fillRect(10, 10, 75, 50);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.reset.plain_layer.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.reset.plain_layer.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.reset.plain_layer-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.reset.plain_layer</title>
 <h1>2d.layer.reset.plain_layer</h1>
 <p class="desc">Checks that reset discards any pending layers.</p>
@@ -11,44 +12,53 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    // Global states:
-    ctx.globalAlpha = 0.3;
-    ctx.globalCompositeOperation = 'source-in';
-    ctx.shadowOffsetX = -3;
-    ctx.shadowOffsetY = 3;
-    ctx.shadowColor = 'rgba(0, 30, 0, 0.3)';
-    ctx.shadowBlur = 3;
-    ctx.filter = 'blur(5px)';
+      // Global states:
+      ctx.globalAlpha = 0.3;
+      ctx.globalCompositeOperation = 'source-in';
+      ctx.shadowOffsetX = -3;
+      ctx.shadowOffsetY = 3;
+      ctx.shadowColor = 'rgba(0, 30, 0, 0.3)';
+      ctx.shadowBlur = 3;
+      ctx.filter = 'blur(5px)';
 
-    ctx.beginLayer();
+      ctx.beginLayer();
 
-    // Layer states:
-    ctx.globalAlpha = 0.6;
-    ctx.globalCompositeOperation = 'source-in';
-    ctx.shadowOffsetX = -6;
-    ctx.shadowOffsetY = 6;
-    ctx.shadowColor = 'rgba(0, 60, 0, 0.6)';
-    ctx.shadowBlur = 3;
-    ctx.filter = 'blur(15px)';
+      // Layer states:
+      ctx.globalAlpha = 0.6;
+      ctx.globalCompositeOperation = 'source-in';
+      ctx.shadowOffsetX = -6;
+      ctx.shadowOffsetY = 6;
+      ctx.shadowColor = 'rgba(0, 60, 0, 0.6)';
+      ctx.shadowBlur = 3;
+      ctx.filter = 'blur(15px)';
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillRect(10, 10, 75, 50);
+      ctx.fillRect(10, 10, 75, 50);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.resize-canvas-in-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.resize-canvas-in-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.resize-canvas-in-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.resize-canvas-in-filter</title>
 <h1>2d.layer.resize-canvas-in-filter</h1>
 <p class="desc">Tests resizing the canvas in a layer filter.</p>
@@ -11,34 +12,43 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    canvas.width = 10;
-    canvas.height = 10;
-    ctx.beginLayer({filter: {
-      get name() {
-        canvas.width = 200;
-        canvas.height = 200;
-        return 'gaussianBlur';
-      },
-      stdDeviation: 5
-    }});
-    ctx.fillStyle = 'green';
-    ctx.fillRect(50, 50, 100, 100);
-    ctx.endLayer();
+      canvas.width = 10;
+      canvas.height = 10;
+      ctx.beginLayer({filter: {
+        get name() {
+          canvas.width = 200;
+          canvas.height = 200;
+          return 'gaussianBlur';
+        },
+        stdDeviation: 5
+      }});
+      ctx.fillStyle = 'green';
+      ctx.fillRect(50, 50, 100, 100);
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.restore-style.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.restore-style.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.restore-style-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-1; totalPixels=0-950">
 <title>Canvas test: 2d.layer.restore-style</title>
 <h1>2d.layer.restore-style</h1>
@@ -12,31 +13,40 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'rgba(0,0,255,1)';
-    ctx.fillRect(50, 50, 75, 50);
-    ctx.globalAlpha = 0.5;
+      ctx.fillStyle = 'rgba(0,0,255,1)';
+      ctx.fillRect(50, 50, 75, 50);
+      ctx.globalAlpha = 0.5;
 
-    ctx.beginLayer();
-    ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-    ctx.fillRect(60, 60, 75, 50);
-    ctx.endLayer();
+      ctx.beginLayer();
+      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+      ctx.fillRect(60, 60, 75, 50);
+      ctx.endLayer();
 
-    ctx.fillRect(70, 70, 75, 50);
+      ctx.fillRect(70, 70, 75, 50);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.several-complex.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.several-complex.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.several-complex-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <meta name=fuzzy content="maxDifference=0-3; totalPixels=0-6318">
 <title>Canvas test: 2d.layer.several-complex</title>
 <h1>2d.layer.several-complex</h1>
@@ -12,40 +13,49 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(500, 500);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(500, 500);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'rgba(0, 0, 255, 1)';
-    ctx.fillRect(50, 50, 95, 70);
+      ctx.fillStyle = 'rgba(0, 0, 255, 1)';
+      ctx.fillRect(50, 50, 95, 70);
 
-    ctx.globalAlpha = 0.5;
-    ctx.shadowOffsetX = -10;
-    ctx.shadowOffsetY = 10;
-    ctx.shadowColor = 'orange';
-    ctx.shadowBlur = 3
+      ctx.globalAlpha = 0.5;
+      ctx.shadowOffsetX = -10;
+      ctx.shadowOffsetY = 10;
+      ctx.shadowColor = 'orange';
+      ctx.shadowBlur = 3
 
-    for (let i = 0; i < 5; i++) {
-      ctx.beginLayer();
+      for (let i = 0; i < 5; i++) {
+        ctx.beginLayer();
 
-      ctx.fillStyle = 'rgba(225, 0, 0, 1)';
-      ctx.fillRect(60 + i, 40 + i, 75, 50);
-      ctx.fillStyle = 'rgba(0, 255, 0, 1)';
-      ctx.fillRect(80 + i, 60 + i, 75, 50);
+        ctx.fillStyle = 'rgba(225, 0, 0, 1)';
+        ctx.fillRect(60 + i, 40 + i, 75, 50);
+        ctx.fillStyle = 'rgba(0, 255, 0, 1)';
+        ctx.fillRect(80 + i, 60 + i, 75, 50);
 
-      ctx.endLayer();
+        ctx.endLayer();
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter</title>
 <h1>2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,36 +12,45 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 10000;
+      const delta = 10000;
 
-    const clipRegion = new Path2D();
-    clipRegion.rect(20, 20, 160, 160);
-    ctx.clip(clipRegion);
+      const clipRegion = new Path2D();
+      clipRegion.rect(20, 20, 160, 160);
+      ctx.clip(clipRegion);
 
-    const dx = -(200 + delta);
-    const dy = -(200 + delta);
-    ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
-    ctx.beginLayer();
+      const dx = -(200 + delta);
+      const dy = -(200 + delta);
+      ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative</title>
 <h1>2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,37 +12,46 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 10000;
+      const delta = 10000;
 
-    const clipRegion = new Path2D();
-    clipRegion.rect(20, 20, 160, 160);
-    ctx.clip(clipRegion);
+      const clipRegion = new Path2D();
+      clipRegion.rect(20, 20, 160, 160);
+      ctx.clip(clipRegion);
 
-    ctx.beginLayer({filter: [
-        {name: 'dropShadow', dx: -(200 + delta),
-          dy: -(200 + delta), stdDeviation: 0,
-          floodColor: 'green'},
-        ]});
+      ctx.beginLayer({filter: [
+          {name: 'dropShadow', dx: -(200 + delta),
+            dy: -(200 + delta), stdDeviation: 0,
+            floodColor: 'green'},
+          ]});
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.long-distance.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.long-distance.ctx-filter</title>
 <h1>2d.layer.shadow-from-outside-canvas.long-distance.ctx-filter</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,34 +12,43 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 10000;
+      const delta = 10000;
 
-    // No clipping.
+      // No clipping.
 
-    const dx = -(200 + delta);
-    const dy = -(200 + delta);
-    ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
-    ctx.beginLayer();
+      const dx = -(200 + delta);
+      const dy = -(200 + delta);
+      ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.long-distance.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.long-distance.layer-filter.tentative</title>
 <h1>2d.layer.shadow-from-outside-canvas.long-distance.layer-filter.tentative</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 10000;
+      const delta = 10000;
 
-    // No clipping.
+      // No clipping.
 
-    ctx.beginLayer({filter: [
-        {name: 'dropShadow', dx: -(200 + delta),
-          dy: -(200 + delta), stdDeviation: 0,
-          floodColor: 'green'},
-        ]});
+      ctx.beginLayer({filter: [
+          {name: 'dropShadow', dx: -(200 + delta),
+            dy: -(200 + delta), stdDeviation: 0,
+            floodColor: 'green'},
+          ]});
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter</title>
 <h1>2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,36 +12,45 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 1;
+      const delta = 1;
 
-    const clipRegion = new Path2D();
-    clipRegion.rect(20, 20, 160, 160);
-    ctx.clip(clipRegion);
+      const clipRegion = new Path2D();
+      clipRegion.rect(20, 20, 160, 160);
+      ctx.clip(clipRegion);
 
-    const dx = -(200 + delta);
-    const dy = -(200 + delta);
-    ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
-    ctx.beginLayer();
+      const dx = -(200 + delta);
+      const dy = -(200 + delta);
+      ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative</title>
 <h1>2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,37 +12,46 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 1;
+      const delta = 1;
 
-    const clipRegion = new Path2D();
-    clipRegion.rect(20, 20, 160, 160);
-    ctx.clip(clipRegion);
+      const clipRegion = new Path2D();
+      clipRegion.rect(20, 20, 160, 160);
+      ctx.clip(clipRegion);
 
-    ctx.beginLayer({filter: [
-        {name: 'dropShadow', dx: -(200 + delta),
-          dy: -(200 + delta), stdDeviation: 0,
-          floodColor: 'green'},
-        ]});
+      ctx.beginLayer({filter: [
+          {name: 'dropShadow', dx: -(200 + delta),
+            dy: -(200 + delta), stdDeviation: 0,
+            floodColor: 'green'},
+          ]});
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance.ctx-filter.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance.ctx-filter.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.short-distance.ctx-filter-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.short-distance.ctx-filter</title>
 <h1>2d.layer.shadow-from-outside-canvas.short-distance.ctx-filter</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,34 +12,43 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 1;
+      const delta = 1;
 
-    // No clipping.
+      // No clipping.
 
-    const dx = -(200 + delta);
-    const dy = -(200 + delta);
-    ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
-    ctx.beginLayer();
+      const dx = -(200 + delta);
+      const dy = -(200 + delta);
+      ctx.filter = 'drop-shadow(' + dx + 'px ' + dy + 'px 0px green)';
+      ctx.beginLayer();
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance.layer-filter.tentative.w.html
+++ b/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance.layer-filter.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.layer.shadow-from-outside-canvas.short-distance.layer-filter.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.layer.shadow-from-outside-canvas.short-distance.layer-filter.tentative</title>
 <h1>2d.layer.shadow-from-outside-canvas.short-distance.layer-filter.tentative</h1>
 <p class="desc">Checks shadow produced by object drawn outside the canvas</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    const delta = 1;
+      const delta = 1;
 
-    // No clipping.
+      // No clipping.
 
-    ctx.beginLayer({filter: [
-        {name: 'dropShadow', dx: -(200 + delta),
-          dy: -(200 + delta), stdDeviation: 0,
-          floodColor: 'green'},
-        ]});
+      ctx.beginLayer({filter: [
+          {name: 'dropShadow', dx: -(200 + delta),
+            dy: -(200 + delta), stdDeviation: 0,
+            floodColor: 'green'},
+          ]});
 
-    ctx.fillStyle = 'red';
-    ctx.fillRect(200 + delta, 200 + delta, 100, 100);
+      ctx.fillStyle = 'red';
+      ctx.fillRect(200 + delta, 200 + delta, 100, 100);
 
-    ctx.endLayer();
+      ctx.endLayer();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/path-objects/2d.path.clip.scale.w.html
+++ b/html/canvas/offscreen/path-objects/2d.path.clip.scale.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.path.clip.scale-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.path.clip.scale</title>
 <h1>2d.path.clip.scale</h1>
 <p class="desc">clip() with non-identity transform applies the correct clip region</p>
@@ -11,31 +12,40 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.scale(2, 2);
-    ctx.beginPath();
-    ctx.rect(0, 0, 100, 200);
-    ctx.clip();
+      ctx.scale(2, 2);
+      ctx.beginPath();
+      ctx.rect(0, 0, 100, 200);
+      ctx.clip();
 
-    // Earlier in Servo, a regression was introduced.
-    // This only had fill the left half of square, as clip rect
-    // stored was not transformed.
-    ctx.fillStyle = 'green';
-    ctx.fillRect(0, 0, 200, 200);
+      // Earlier in Servo, a regression was introduced.
+      // This only had fill the left half of square, as clip rect
+      // stored was not transformed.
+      ctx.fillStyle = 'green';
+      ctx.fillRect(0, 0, 200, 200);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.after-rasterization.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.after-rasterization.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.after-rasterization-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.after-rasterization</title>
 <h1>2d.reset.after-rasterization</h1>
 <p class="desc">Reset after rasterizing a frame discards frame content.</p>
@@ -11,29 +12,38 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-    ctx.fillRect(0, 0, 100, 50);
+      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+      ctx.fillRect(0, 0, 100, 50);
 
-    ctx.getImageData(0, 0, 1, 1);  // Force previous draw calls to be rendered.
-    ctx.reset();
+      ctx.getImageData(0, 0, 1, 1);  // Force previous draw calls to be rendered.
+      ctx.reset();
 
-    ctx.fillStyle = 'rgba(0, 255, 0, 0.5)';
-    ctx.fillRect(0, 0, 100, 25);
+      ctx.fillStyle = 'rgba(0, 255, 0, 0.5)';
+      ctx.fillRect(0, 0, 100, 25);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.render.drop_shadow.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.render.drop_shadow.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.render.drop_shadow-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.render.drop_shadow</title>
 <h1>2d.reset.render.drop_shadow</h1>
 <p class="desc">check that drop shadows are correctly rendered after reset</p>
@@ -11,29 +12,38 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(500, 500);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(500, 500);
+      const ctx = canvas.getContext('2d');
 
-    ctx.shadowOffsetX = 10;
-    ctx.shadowOffsetY = 10;
-    ctx.shadowColor = "red";
-    ctx.shadowBlur = 10;
+      ctx.shadowOffsetX = 10;
+      ctx.shadowOffsetY = 10;
+      ctx.shadowColor = "red";
+      ctx.shadowBlur = 10;
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillRect(100, 100, 100, 100);
+      ctx.fillRect(100, 100, 100, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.render.global_composite_operation.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.render.global_composite_operation.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.render.global_composite_operation-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.render.global_composite_operation</title>
 <h1>2d.reset.render.global_composite_operation</h1>
 <p class="desc">check that canvas correctly renders rectangles with the default global composite operation after reset</p>
@@ -11,27 +12,36 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(400, 400);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(400, 400);
+      const ctx = canvas.getContext('2d');
 
-    ctx.globalCompositeOperation = "xor";
+      ctx.globalCompositeOperation = "xor";
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillRect(10, 10, 100, 100);
-    ctx.fillRect(50, 50, 100, 100);
+      ctx.fillRect(10, 10, 100, 100);
+      ctx.fillRect(50, 50, 100, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.render.line.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.render.line.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.render.line-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.render.line</title>
 <h1>2d.reset.render.line</h1>
 <p class="desc">check that lines are correctly rendered after reset</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(400, 400);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(400, 400);
+      const ctx = canvas.getContext('2d');
 
-    ctx.lineWidth = 10;
-    ctx.lineCap = "round";
-    ctx.lineJoin = "bevel";
-    ctx.lineDashOffset = 10;
-    ctx.setLineDash([20]);
+      ctx.lineWidth = 10;
+      ctx.lineCap = "round";
+      ctx.lineJoin = "bevel";
+      ctx.lineDashOffset = 10;
+      ctx.setLineDash([20]);
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.beginPath();
-    ctx.moveTo(100, 100);
-    ctx.lineTo(100, 300);
-    ctx.lineTo(300, 300);
-    ctx.lineTo(300, 100);
-    ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(100, 100);
+      ctx.lineTo(100, 300);
+      ctx.lineTo(300, 300);
+      ctx.lineTo(300, 100);
+      ctx.stroke();
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.render.misc.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.render.misc.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.render.misc-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.render.misc</title>
 <h1>2d.reset.render.misc</h1>
 <p class="desc">check that canvas correctly renders rectangles after reset (states not covered by other tests)</p>
@@ -11,30 +12,39 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(400, 400);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(400, 400);
+      const ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = "red";
-    ctx.strokeStyle = "red";
-    ctx.globalAlpha = 0.5;
-    ctx.filter = "blur(2px)";
+      ctx.fillStyle = "red";
+      ctx.strokeStyle = "red";
+      ctx.globalAlpha = 0.5;
+      ctx.filter = "blur(2px)";
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillRect(0, 0, 100, 100);
-    ctx.strokeRect(150, 150, 100, 100);
+      ctx.fillRect(0, 0, 100, 100);
+      ctx.strokeRect(150, 150, 100, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.render.miter_limit.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.render.miter_limit.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.render.miter_limit-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.render.miter_limit</title>
 <h1>2d.reset.render.miter_limit</h1>
 <p class="desc">check that the lines are correctly rendered with the default miter limit after reset</p>
@@ -11,34 +12,43 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(400, 400);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(400, 400);
+      const ctx = canvas.getContext('2d');
 
-    ctx.miterLimit = 6;
+      ctx.miterLimit = 6;
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.lineWidth = 10;
+      ctx.lineWidth = 10;
 
-    ctx.beginPath();
-    ctx.moveTo(0, 100);
-    for (let i = 0; i < 24; i++) {
-      const dy = i % 2 === 0 ? 25 : -25;
-      ctx.lineTo(Math.pow(i, 1.5) * 2, 75 + dy);
+      ctx.beginPath();
+      ctx.moveTo(0, 100);
+      for (let i = 0; i < 24; i++) {
+        const dy = i % 2 === 0 ? 25 : -25;
+        ctx.lineTo(Math.pow(i, 1.5) * 2, 75 + dy);
+      }
+      ctx.stroke();
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-    ctx.stroke();
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.render.text.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.render.text.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.render.text-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.render.text</title>
 <h1>2d.reset.render.text</h1>
 <p class="desc">check that text is correctly rendered after reset</p>
@@ -11,35 +12,44 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(400, 400);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(400, 400);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = "24px serif";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "hanging";
-    ctx.direction = "rtl";
-    ctx.letterSpacing = "10px";
-    ctx.fontKerning = "none";
-    ctx.fontStretch = "semi-condensed";
-    ctx.fontVariantCaps = "titling-caps";
-    ctx.textRendering = "optimizeLegibility";
-    ctx.wordSpacing = "20px";
+      ctx.font = "24px serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "hanging";
+      ctx.direction = "rtl";
+      ctx.letterSpacing = "10px";
+      ctx.fontKerning = "none";
+      ctx.fontStretch = "semi-condensed";
+      ctx.fontVariantCaps = "titling-caps";
+      ctx.textRendering = "optimizeLegibility";
+      ctx.wordSpacing = "20px";
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillText("Lorem ipsum dolor sit amet, consectetur adipiscing elit", 0, 10);
+      ctx.fillText("Lorem ipsum dolor sit amet, consectetur adipiscing elit", 0, 10);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.state.clip.w.html
+++ b/html/canvas/offscreen/reset/2d.reset.state.clip.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.reset.state.clip-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.reset.state.clip</title>
 <h1>2d.reset.state.clip</h1>
 <p class="desc">check that the clip is reset</p>
@@ -11,30 +12,39 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(200, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(200, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.beginPath();
-    ctx.rect(0, 0, 100, 100);
-    ctx.clip();
+      ctx.beginPath();
+      ctx.rect(0, 0, 100, 100);
+      ctx.clip();
 
-    ctx.fillRect(0, 0, 200, 200);
+      ctx.fillRect(0, 0, 200, 200);
 
-    ctx.reset();
+      ctx.reset();
 
-    ctx.fillRect(0, 0, 200, 200);
+      ctx.fillRect(0, 0, 200, 200);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.drawing.style.reset.fontKerning.none2.w.html
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.reset.fontKerning.none2.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.drawing.style.reset.fontKerning.none2-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.drawing.style.reset.fontKerning.none2</title>
 <h1>2d.text.drawing.style.reset.fontKerning.none2</h1>
 <p class="desc">FontKerning value still applies after font changes.</p>
@@ -11,25 +12,34 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = '10px serif';
-    ctx.fontKerning = "none";
-    ctx.font = '20px serif';
-    ctx.fillText("TATATA", 20, 30);
+      ctx.font = '10px serif';
+      ctx.fontKerning = "none";
+      ctx.font = '20px serif';
+      ctx.fillText("TATATA", 20, 30);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.fontVariantCaps.after.reset.font.w.html
+++ b/html/canvas/offscreen/text/2d.text.fontVariantCaps.after.reset.font.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.fontVariantCaps.after.reset.font-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.fontVariantCaps.after.reset.font</title>
 <h1>2d.text.fontVariantCaps.after.reset.font</h1>
 <p class="desc">Testing if the fontVariantCaps is reset after font change</p>
@@ -11,28 +12,37 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(300, 300);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(300, 300);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = "32px serif";
-    ctx.fontVariantCaps = "small-caps";
+      ctx.font = "32px serif";
+      ctx.fontVariantCaps = "small-caps";
 
-    ctx.font = "31px serif";
-    ctx.fillText("Hello World", 20, 40);
-    ctx.fontVariantCaps = "small-caps";
-    ctx.fillText("Hello World", 20, 80);
+      ctx.font = "31px serif";
+      ctx.fillText("Hello World", 20, 40);
+      ctx.fontVariantCaps = "small-caps";
+      ctx.fillText("Hello World", 20, 80);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.fontVariantCaps1.w.html
+++ b/html/canvas/offscreen/text/2d.text.fontVariantCaps1.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.fontVariantCaps1-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.fontVariantCaps1</title>
 <h1>2d.text.fontVariantCaps1</h1>
 <p class="desc">Testing small caps setting in fontVariant</p>
@@ -11,25 +12,34 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = "32px serif";
-    ctx.fontVariantCaps = "small-caps";
-    // This should render the same as font = "small-caps 32px serif".
-    ctx.fillText("Hello World", 20, 100);
+      ctx.font = "32px serif";
+      ctx.fontVariantCaps = "small-caps";
+      // This should render the same as font = "small-caps 32px serif".
+      ctx.fillText("Hello World", 20, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.fontVariantCaps3.w.html
+++ b/html/canvas/offscreen/text/2d.text.fontVariantCaps3.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.fontVariantCaps3-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.fontVariantCaps3</title>
 <h1>2d.text.fontVariantCaps3</h1>
 <p class="desc">Testing small caps setting in fontVariant</p>
@@ -11,26 +12,35 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = "32px serif";
-    ctx.fontVariantCaps = "all-small-caps";
-    // This should render the same as using font = "small-caps 32px serif"
-    // with all the underlying text in lowercase.
-    ctx.fillText("Hello World", 20, 100);
+      ctx.font = "32px serif";
+      ctx.fontVariantCaps = "all-small-caps";
+      // This should render the same as using font = "small-caps 32px serif"
+      // with all the underlying text in lowercase.
+      ctx.fillText("Hello World", 20, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.fontVariantCaps4.w.html
+++ b/html/canvas/offscreen/text/2d.text.fontVariantCaps4.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.fontVariantCaps4-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.fontVariantCaps4</title>
 <h1>2d.text.fontVariantCaps4</h1>
 <p class="desc">Testing small caps setting in fontVariant</p>
@@ -11,26 +12,35 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = "small-caps 32px serif";
-    // fontVariantCaps overrides the small-caps setting from the font attribute
-    // (spec unclear, cf. https://github.com/whatwg/html/issues/8103)
-    ctx.fontVariantCaps = "all-small-caps";
-    ctx.fillText("Hello World", 20, 100);
+      ctx.font = "small-caps 32px serif";
+      // fontVariantCaps overrides the small-caps setting from the font attribute
+      // (spec unclear, cf. https://github.com/whatwg/html/issues/8103)
+      ctx.fontVariantCaps = "all-small-caps";
+      ctx.fillText("Hello World", 20, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.fontVariantCaps5.w.html
+++ b/html/canvas/offscreen/text/2d.text.fontVariantCaps5.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.fontVariantCaps5-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.fontVariantCaps5</title>
 <h1>2d.text.fontVariantCaps5</h1>
 <p class="desc">Testing small caps setting in fontVariant</p>
@@ -11,26 +12,35 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = "small-caps 32px serif";
-    // fontVariantCaps 'normal' does not override the setting from the font attribute.
-    // (spec unclear, cf. https://github.com/whatwg/html/issues/8103)
-    ctx.fontVariantCaps = "normal";
-    ctx.fillText("Hello World", 20, 100);
+      ctx.font = "small-caps 32px serif";
+      // fontVariantCaps 'normal' does not override the setting from the font attribute.
+      // (spec unclear, cf. https://github.com/whatwg/html/issues/8103)
+      ctx.fontVariantCaps = "normal";
+      ctx.fillText("Hello World", 20, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.fontVariantCaps6.w.html
+++ b/html/canvas/offscreen/text/2d.text.fontVariantCaps6.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.fontVariantCaps6-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.fontVariantCaps6</title>
 <h1>2d.text.fontVariantCaps6</h1>
 <p class="desc">Testing small caps setting in fontVariant</p>
@@ -11,26 +12,35 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(100, 50);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(100, 50);
+      const ctx = canvas.getContext('2d');
 
-    // fontVariantCaps is reset when the font attribute is set.
-    // (spec unclear, cf. https://github.com/whatwg/html/issues/8103)
-    ctx.fontVariantCaps = "all-small-caps";
-    ctx.font = "32px serif";
-    ctx.fillText("Hello World", 20, 100);
+      // fontVariantCaps is reset when the font attribute is set.
+      // (spec unclear, cf. https://github.com/whatwg/html/issues/8103)
+      ctx.fontVariantCaps = "all-small-caps";
+      ctx.font = "32px serif";
+      ctx.fillText("Hello World", 20, 100);
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-align.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-align.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.text.measure.fillTextCluster-align.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.fillTextCluster-align.tentative</title>
 <h1>2d.text.measure.fillTextCluster-align.tentative</h1>
 <p class="desc">Test that fillTextCluster() correctly positions the text, taking into account the textAlign from the context at the time the text was measured.</p>
@@ -17,37 +18,46 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = canvas.width / 2;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = canvas.width / 2;
+        const y = canvas.height / 2;
 
-      ctx.textAlign = 'left';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textAlign = 'left';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -61,37 +71,46 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = canvas.width / 2;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = canvas.width / 2;
+        const y = canvas.height / 2;
 
-      ctx.textAlign = 'center';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textAlign = 'center';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -105,37 +124,46 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = canvas.width / 2;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = canvas.width / 2;
+        const y = canvas.height / 2;
 
-      ctx.textAlign = 'right';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textAlign = 'right';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-baseline.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-baseline.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.text.measure.fillTextCluster-baseline.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.fillTextCluster-baseline.tentative</title>
 <h1>2d.text.measure.fillTextCluster-baseline.tentative</h1>
 <p class="desc">Test that fillTextCluster() correctly positions the text, taking into account the textBaseline from the context at the time the text was measured.</p>
@@ -17,37 +18,46 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'top';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'top';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -61,37 +71,46 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'middle';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'middle';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -105,37 +124,46 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'bottom';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'bottom';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -149,37 +177,46 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'alphabetic';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'alphabetic';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a fillText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a fillText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-drawing-styles-change.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-drawing-styles-change.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.text.measure.fillTextCluster-drawing-styles-change.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.fillTextCluster-drawing-styles-change.tentative</title>
 <h1>2d.text.measure.fillTextCluster-drawing-styles-change.tentative</h1>
 <p class="desc">Test that fillTextCluster() renders using the drawing styles as they were when `ctx.measureText()` was called, regardless of any changes in the context since.</p>
@@ -17,38 +18,47 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.letterSpacing = '2px';
+        ctx.letterSpacing = '2px';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.letterSpacing = '6px';
+        ctx.letterSpacing = '6px';
 
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, 10, 25);
+        }
+
+        ctx.fillText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.fillText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -62,38 +72,47 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.wordSpacing = '2px';
+        ctx.wordSpacing = '2px';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.wordSpacing = '10px';
+        ctx.wordSpacing = '10px';
 
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, 10, 25);
+        }
+
+        ctx.fillText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.fillText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -107,38 +126,47 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.fontKerning = 'none';
+        ctx.fontKerning = 'none';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.fontKerning = 'normal';
+        ctx.fontKerning = 'normal';
 
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, 10, 25);
+        }
+
+        ctx.fillText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.fillText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -152,38 +180,47 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.fontVariantCaps = 'small-caps';
+        ctx.fontVariantCaps = 'small-caps';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.fontVariantCaps = 'all-small-caps';
+        ctx.fontVariantCaps = 'all-small-caps';
 
-      for (const cluster of clusters) {
-          ctx.fillTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.fillTextCluster(cluster, 10, 25);
+        }
+
+        ctx.fillText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.fillText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-font-change.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.fillTextCluster-font-change.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.measure.fillTextCluster-font-change.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.fillTextCluster-font-change.tentative</title>
 <h1>2d.text.measure.fillTextCluster-font-change.tentative</h1>
 <p class="desc">Test that fillTextCluster() renders in the font used originally when the text was measured, even if the font set on the context has changed since.</p>
@@ -11,33 +12,42 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(500, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(500, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = '50px sans-serif';
-    const text = 'Hello ♦️ World!';
-    let tm = ctx.measureText(text);
-    const clusters = tm.getTextClusters();
+      ctx.font = '50px sans-serif';
+      const text = 'Hello ♦️ World!';
+      let tm = ctx.measureText(text);
+      const clusters = tm.getTextClusters();
 
-    ctx.font = '80px serif';
+      ctx.font = '80px serif';
 
-    const x = 100;
-    const y = 100;
-    for (const cluster of clusters) {
-        ctx.fillTextCluster(cluster, x, y);
+      const x = 100;
+      const y = 100;
+      for (const cluster of clusters) {
+          ctx.fillTextCluster(cluster, x, y);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-align.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-align.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.text.measure.strokeTextCluster-align.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.strokeTextCluster-align.tentative</title>
 <h1>2d.text.measure.strokeTextCluster-align.tentative</h1>
 <p class="desc">Test that strokeTextCluster() correctly positions the text, taking into account the textAlign from the context at the time the text was measured.</p>
@@ -17,37 +18,46 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = canvas.width / 2;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = canvas.width / 2;
+        const y = canvas.height / 2;
 
-      ctx.textAlign = 'left';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textAlign = 'left';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -61,37 +71,46 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = canvas.width / 2;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = canvas.width / 2;
+        const y = canvas.height / 2;
 
-      ctx.textAlign = 'center';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textAlign = 'center';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -105,37 +124,46 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = canvas.width / 2;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = canvas.width / 2;
+        const y = canvas.height / 2;
 
-      ctx.textAlign = 'right';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textAlign = 'right';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-baseline.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-baseline.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.text.measure.strokeTextCluster-baseline.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.strokeTextCluster-baseline.tentative</title>
 <h1>2d.text.measure.strokeTextCluster-baseline.tentative</h1>
 <p class="desc">Test that strokeTextCluster() correctly positions the text, taking into account the textBaseline from the context at the time the text was measured.</p>
@@ -17,37 +18,46 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'top';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'top';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -61,37 +71,46 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'middle';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'middle';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -105,37 +124,46 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'bottom';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'bottom';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -149,37 +177,46 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(180, 43);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(180, 43);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ☺️ א';
-      const x = 20;
-      const y = canvas.height / 2;
+        ctx.font = '20px serif';
+        const text = 'Test ☺️ א';
+        const x = 20;
+        const y = canvas.height / 2;
 
-      ctx.textBaseline = 'alphabetic';
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        ctx.textBaseline = 'alphabetic';
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      // Rendering all clusters with the same (x, y) parameters must be
-      // equivalent to a strokeText() call at (x, y).
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, x, y);
+        // Rendering all clusters with the same (x, y) parameters must be
+        // equivalent to a strokeText() call at (x, y).
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, x, y);
+        }
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.w.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="2d.text.measure.strokeTextCluster-drawing-styles-change.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.strokeTextCluster-drawing-styles-change.tentative</title>
 <h1>2d.text.measure.strokeTextCluster-drawing-styles-change.tentative</h1>
 <p class="desc">Test that strokeTextCluster() renders using the drawing styles as they were when `ctx.measureText()` was called, regardless of any changes in the context since.</p>
@@ -17,38 +18,47 @@
   </canvas>
   <script id="myWorker0" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.letterSpacing = '2px';
+        ctx.letterSpacing = '2px';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.letterSpacing = '6px';
+        ctx.letterSpacing = '6px';
 
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, 10, 25);
+        }
+
+        ctx.strokeText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.strokeText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker0').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas0');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -62,38 +72,47 @@
   </canvas>
   <script id="myWorker1" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.wordSpacing = '2px';
+        ctx.wordSpacing = '2px';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.wordSpacing = '10px';
+        ctx.wordSpacing = '10px';
 
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, 10, 25);
+        }
+
+        ctx.strokeText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.strokeText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker1').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas1');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -107,38 +126,47 @@
   </canvas>
   <script id="myWorker2" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.fontKerning = 'none';
+        ctx.fontKerning = 'none';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.fontKerning = 'normal';
+        ctx.fontKerning = 'normal';
 
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, 10, 25);
+        }
+
+        ctx.strokeText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.strokeText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker2').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas2');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);
@@ -152,38 +180,47 @@
   </canvas>
   <script id="myWorker3" type="text/worker">
     self.onmessage = function(e) {
-      const canvas = new OffscreenCanvas(250, 80);
-      const ctx = canvas.getContext('2d');
+      try {
+        const canvas = new OffscreenCanvas(250, 80);
+        const ctx = canvas.getContext('2d');
 
-      ctx.font = '20px serif';
-      const text = 'Test ♦️ find';
+        ctx.font = '20px serif';
+        const text = 'Test ♦️ find';
 
-      ctx.fontVariantCaps = 'small-caps';
+        ctx.fontVariantCaps = 'small-caps';
 
-      let tm = ctx.measureText(text);
-      const clusters = tm.getTextClusters();
+        let tm = ctx.measureText(text);
+        const clusters = tm.getTextClusters();
 
-      ctx.fontVariantCaps = 'all-small-caps';
+        ctx.fontVariantCaps = 'all-small-caps';
 
-      for (const cluster of clusters) {
-          ctx.strokeTextCluster(cluster, 10, 25);
+        for (const cluster of clusters) {
+            ctx.strokeTextCluster(cluster, 10, 25);
+        }
+
+        ctx.strokeText(text, 10, 50);
+
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
       }
-
-      ctx.strokeText(text, 10, 50);
-
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker3').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas3');
       const outputCtx = outputCanvas.getContext('2d');
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);

--- a/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-font-change.tentative.w.html
+++ b/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-font-change.tentative.w.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="2d.text.measure.strokeTextCluster-font-change.tentative-expected.html">
+<script src="/common/reftest-wait.js"></script>
 <title>Canvas test: 2d.text.measure.strokeTextCluster-font-change.tentative</title>
 <h1>2d.text.measure.strokeTextCluster-font-change.tentative</h1>
 <p class="desc">Test that strokeTextCluster() renders in the font used originally when the text was measured, even if the font set on the context has changed since.</p>
@@ -11,33 +12,42 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = function(e) {
-    const canvas = new OffscreenCanvas(500, 200);
-    const ctx = canvas.getContext('2d');
+    try {
+      const canvas = new OffscreenCanvas(500, 200);
+      const ctx = canvas.getContext('2d');
 
-    ctx.font = '50px sans-serif';
-    const text = 'Hello ♦️ World!';
-    let tm = ctx.measureText(text);
-    const clusters = tm.getTextClusters();
+      ctx.font = '50px sans-serif';
+      const text = 'Hello ♦️ World!';
+      let tm = ctx.measureText(text);
+      const clusters = tm.getTextClusters();
 
-    ctx.font = '80px serif';
+      ctx.font = '80px serif';
 
-    const x = 100;
-    const y = 100;
-    for (const cluster of clusters) {
-        ctx.strokeTextCluster(cluster, x, y);
+      const x = 100;
+      const y = 100;
+      for (const cluster of clusters) {
+          ctx.strokeTextCluster(cluster, x, y);
+      }
+
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
     }
-
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d');
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/tools/templates/reftest_worker.html
+++ b/html/canvas/tools/templates/reftest_worker.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <html class="reftest-wait">
 <link rel="match" href="{{ reference_file_link }}">
+<script src="/common/reftest-wait.js"></script>
 {% if fuzzy %}<meta name=fuzzy content="{{ fuzzy }}">
 {% endif %}
 {% if timeout %}<meta name="timeout" content="{{ timeout }}">
@@ -16,22 +17,31 @@
 </canvas>
 <script id='myWorker' type='text/worker'>
   self.onmessage = {% if test_type == 'promise' %}async {% endif %}function(e) {
-    const canvas = new OffscreenCanvas({{ size[0] }}, {{ size[1] }});
-    const ctx = canvas.getContext('2d'{% if attributes %}, {{ attributes }}{% endif %});
+    try {
+      const canvas = new OffscreenCanvas({{ size[0] }}, {{ size[1] }});
+      const ctx = canvas.getContext('2d'{% if attributes %}, {{ attributes }}{% endif %});
 
-    {{ code | trim | indent(4) }}
+      {{ code | trim | indent(6) }}
 
-    const bitmap = canvas.transferToImageBitmap();
-    self.postMessage(bitmap, bitmap);
+      const bitmap = canvas.transferToImageBitmap();
+      self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+    } catch (error) {
+      self.postMessage({ type: 'error', message: error });
+    }
   };
 </script>
 <script>
   const blob = new Blob([document.getElementById('myWorker').textContent]);
   const worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener('message', msg => {
+  worker.onerror = failOnError;
+  worker.onmessage = reftestStep(msg => {
+    if (msg.data.type === 'error') {
+      failOnError(msg.data.message);
+      return;
+    }
     const outputCtx = document.getElementById("canvas").getContext('2d'{% if attributes %}, {{ attributes }}{% endif %});
-    outputCtx.drawImage(msg.data, 0, 0);
-    document.documentElement.classList.remove("reftest-wait");
+    outputCtx.drawImage(msg.data.bitmap, 0, 0);
+    takeScreenshot();
   });
   worker.postMessage(null);
 </script>

--- a/html/canvas/tools/templates/reftest_worker_grid.html
+++ b/html/canvas/tools/templates/reftest_worker_grid.html
@@ -4,6 +4,7 @@
 <html class="reftest-wait">
 <link rel="stylesheet" href="/html/canvas/resources/canvas-grid-reftest.css">
 <link rel="match" href="{{ reference_file_link }}">
+<script src="/common/reftest-wait.js"></script>
 {% if fuzzy %}<meta name=fuzzy content="{{ fuzzy }}">
 {% endif %}
 {% if timeout %}<meta name="timeout" content="{{ timeout }}">
@@ -29,28 +30,37 @@
   <script id="myWorker{{ variant.id }}" type="text/worker">
     {% set async = 'async ' if test_type == 'promise' else '' %}
     self.onmessage = {{async}}function(e) {
-      const canvas = new OffscreenCanvas({{
-          variant.size[0] }}, {{ variant.size[1] }});
-      const ctx = canvas.getContext('2d'{%
-          if variant.attributes %}, {{ variant.attributes }}{% endif %});
+      try {
+        const canvas = new OffscreenCanvas({{
+            variant.size[0] }}, {{ variant.size[1] }});
+        const ctx = canvas.getContext('2d'{%
+            if variant.attributes %}, {{ variant.attributes }}{% endif %});
 
-      {{ variant.code | trim | indent(6) }}
+        {{ variant.code | trim | indent(8) }}
 
-      const bitmap = canvas.transferToImageBitmap();
-      self.postMessage(bitmap, bitmap);
+        const bitmap = canvas.transferToImageBitmap();
+        self.postMessage({ type: 'bitmap', bitmap }, [bitmap]);
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error });
+      }
     };
   </script>
   <script type="module">
     const blob = new Blob([document.getElementById('myWorker{{
         variant.id }}').textContent]);
     const worker = new Worker(URL.createObjectURL(blob));
-    worker.addEventListener('message', msg => {
+    worker.onerror = failOnError;
+    worker.onmessage = reftestStep(msg => {
+      if (msg.data.type === 'error') {
+        failOnError(msg.data.message);
+        return;
+      }
       const outputCanvas = document.getElementById('canvas{{ variant.id }}');
       const outputCtx = outputCanvas.getContext('2d'{%
           if variant.attributes %}, {{ variant.attributes }}{% endif %});
-      outputCtx.drawImage(msg.data, 0, 0);
+      outputCtx.drawImage(msg.data.bitmap, 0, 0);
       if (--pending_tests == 0) {
-        document.documentElement.classList.remove('reftest-wait');
+        takeScreenshot();
       }
     });
     worker.postMessage(null);


### PR DESCRIPTION
Some of these directories are among those contributing the most timeouts to Safari, and avoiding needlessly waiting frees up CI capacity for both PRs and other full runs.