### PR TITLE
Adopt webvtt-test.css and webvtt-ref.css in more webvtt wpt tests

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html
@@ -1,32 +1,8 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, repositioning (up) when 2 cues overlap completely</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-ref.css">
 <div class="video">
-    <span class="cue">
-        <div><span class="cueText">This is another test subtitle</span></div>
-        <div><span class="cueText">This is a test subtitle</span></div>
-    </span>
+    <div class="cue" style="bottom: 5%;"><span class="cue-background">This is another test subtitle</span></div>
+    <div class="cue" style="bottom: 0%;"><span class="cue-background">This is a test subtitle</span></div>
 </div>

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html
@@ -3,16 +3,9 @@
 <title>WebVTT rendering, repositioning (up) when 2 cues overlap completely</title>
 <link rel="match" href="2_cues_overlapping_completely_move_up-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); this.currentTime = 2;" onseeked="this.onseeked = null; takeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; this.pause(); this.currentTime = 2;" onseeked="this.onseeked = null; takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/2_cues_overlapping_completely_move_up.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
@@ -1,38 +1,8 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, repositioning (down) when 2 cues overlap partially</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-#cue1 {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    margin-top: -4.5px;
-    text-align: center
-}
-#cue2 {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    margin-top: 4.5px;
-    text-align: center
-}
-.cue {
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class="video"><span class="cue" id="cue1"><span>This is a test subtitle</span></span><span class="cue" id="cue2"><span>This is another test subtitle</span></span></div>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue" style="top: 50%;"><span class="cue-background">This is a test subtitle</span></div>
+    <div class="cue" style="top: 55%;"><span class="cue-background">This is another test subtitle</span></div>
+</div>

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down.html
@@ -3,16 +3,9 @@
 <title>WebVTT rendering, repositioning (down) when 2 cues overlap partially</title>
 <link rel="match" href="2_cues_overlapping_partially_move_down-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); this.currentTime = 2;" onseeked="this.onseeked = null; takeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; this.pause(); this.currentTime = 2;" onseeked="this.onseeked = null; takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/2_cues_overlapping_partially_move_down.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html
@@ -1,36 +1,8 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, repositioning (down) when 2 cues overlap partially</title>
+<title>Reference for WebVTT rendering, repositioning (up) when 2 cues overlap partially</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-}
-.cueTextGoingUp {
-    position: relative;
-    top: -1.8px; /* 1% height of video's height */
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-ref.css">
 <div class="video">
-    <span class="cue">
-        <div><span class="cueText cueTextGoingUp">This is another test subtitle</span></div>
-        <div><span class="cueText">This is a test subtitle</span></div>
-    </span>
+    <div class="cue" style="bottom: 5%;"><span class="cue-background">This is another test subtitle</span></div>
+    <div class="cue" style="bottom: 0%;"><span class="cue-background">This is a test subtitle</span></div>
 </div>

--- a/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up.html
@@ -1,18 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, repositioning (down) when 2 cues overlap partially</title>
+<title>WebVTT rendering, repositioning (up) when 2 cues overlap partially</title>
 <link rel="match" href="2_cues_overlapping_partially_move_up-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); this.currentTime = 2;" onseeked="this.onseeked = null; takeScreenshot();">
+<video autoplay onplaying="this.onplaying = null; this.pause(); this.currentTime = 2;" onseeked="this.onseeked = null; takeScreenshot();">
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/2_cues_overlapping_partially_move_up.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
@@ -3,37 +3,9 @@
 <title>Reference for WebVTT rendering, 2 tracks enabled at the same time</title>
 <script src="/common/reftest-wait.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: white;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-ref.css">
 <div class="video">
-  <video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-  </video>
-  <span class="cue">
-    <div><span class="cueText">This is a <u>test subtitle</u></span></div>
-    <div><span class="cueText">This is a test subtitle</span></div>
-  </span>
+    <div class="cue" style="bottom: 5%;"><span class="cue-background">This is a <u>test subtitle</u></span></div>
+    <div class="cue" style="bottom: 0%;"><span class="cue-background">This is a test subtitle</span></div>
 </div>
 </html>

--- a/webvtt/rendering/cues-with-video/processing-model/2_tracks.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_tracks.html
@@ -2,16 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, 2 tracks enabled at the same time</title>
 <link rel="match" href="2_tracks-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
@@ -2,39 +2,11 @@
 <html class="reftest-wait">
 <title>Reference for WebVTT rendering, 3 tracks enabled at the same time</title>
 <script src="/common/reftest-wait.js"></script>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: white;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-ref.css">
 <div class="video">
-  <video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-  </video>
-  <span class="cue">
-    <div><span class="cueText">This is a <b>test subtitle</b></span></div>
-    <div><span class="cueText">This is a <u>test subtitle</u></span></div>
-    <div><span class="cueText">This is a test subtitle</span></div>
-  </span>
+    <div class="cue" style="bottom: 10%;"><span class="cue-background">This is a <b>test subtitle</b></span></div>
+    <div class="cue" style="bottom: 5%;"><span class="cue-background">This is a <u>test subtitle</u></span></div>
+    <div class="cue" style="bottom: 0%;"><span class="cue-background">This is a test subtitle</span></div>
 </div>
 </html>

--- a/webvtt/rendering/cues-with-video/processing-model/3_tracks.html
+++ b/webvtt/rendering/cues-with-video/processing-model/3_tracks.html
@@ -3,15 +3,9 @@
 <title>WebVTT rendering, 3 tracks enabled at the same time</title>
 <link rel="match" href="3_tracks-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html
@@ -1,27 +1,9 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test</span></span></div>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue">
+        <span class="cue-background">This is a test</span>
+    </div>
+</div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:center</title>
 <link rel="match" href="align_center-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-ref.html
@@ -1,27 +1,9 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center, position:50%</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test</span></span></div>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue">
+        <span class="cue-background">This is a test</span>
+    </div>
+</div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:center, position:50%</title>
 <link rel="match" href="align_center_position_50-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_50.vtt">


### PR DESCRIPTION
Adopt webvtt-test.css and webvtt-ref.css in these tests:
2_cues_overlapping_completely_move_up,
2_cues_overlapping_partially_move_down, 
2_cues_overlapping_partially_move_up, 
2_tracks, 
3_tracks,
align_center,
align_center_position_50.
(and their -ref.html counterparts).

The renderings of the updated ref files were approved by Eric Carlson and Gary Katsevman at the [WebVTT interop meeting on July 22, 2026](https://github.com/web-platform-tests/interop-webvtt/issues/21).
