### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320095

### DIFF
--- a/svg/coordinate-systems/viewBox-invalid-attribute-baseval.tentative.html
+++ b/svg/coordinate-systems/viewBox-invalid-attribute-baseval.tentative.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVGSVGElement.viewBox.baseVal for an invalid (negative-dimension) viewBox attribute</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute">
+<meta name="assert" content="Tentative: SVG 2 does not define viewBox.baseVal when the viewBox attribute is invalid (negative width/height). This documents the current WebKit behavior (reset to {0,0,0,0}); Gecko and Blink retain the raw parsed values, so cross-engine results differ.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<svg id="s" xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 -100 50">
+  <rect width="10" height="10" fill="red"/>
+</svg>
+<script>
+test(() => {
+  const vb = document.getElementById("s").viewBox.baseVal;
+  assert_equals(vb.x, 0, "x");
+  assert_equals(vb.y, 0, "y");
+  assert_equals(vb.width, 0, "width");
+  assert_equals(vb.height, 0, "height");
+}, "invalid (negative-width) viewBox attribute exposes baseVal {0, 0, 0, 0}");
+</script>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-001-expected.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-001-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element renders nothing</title>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-001.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-001.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200" viewBox="0 0 0 100">
+  <title>A viewBox with zero width disables rendering of the element</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute"/>
+  <h:link rel="match" href="viewBox-zero-disables-rendering-ref.svg"/>
+  <h:meta name="assert" content="A value of zero for the viewBox width disables rendering of the element, so its content is not painted."/>
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-002-expected.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-002-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element renders nothing</title>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-002.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-002.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200" viewBox="0 0 100 0">
+  <title>A viewBox with zero height disables rendering of the element</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute"/>
+  <h:link rel="match" href="viewBox-zero-disables-rendering-ref.svg"/>
+  <h:meta name="assert" content="A value of zero for the viewBox height disables rendering of the element, so its content is not painted."/>
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-003-expected.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-003-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element renders nothing</title>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-003.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-003.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200" viewBox="0 0 0 0">
+  <title>A viewBox with zero width and zero height disables rendering of the element</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute"/>
+  <h:link rel="match" href="viewBox-zero-disables-rendering-ref.svg"/>
+  <h:meta name="assert" content="A value of zero for both the viewBox width and height disables rendering of the element, so its content is not painted."/>
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-contexts-ref.html
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-contexts-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: nothing rendered</title>
+<body style="margin:0">
+</body>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-contexts.html
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-contexts.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Zero viewBox disables rendering in inline, nested and SVG-as-image contexts</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute">
+<link rel="match" href="viewBox-zero-disables-rendering-contexts-ref.html">
+<meta name="assert" content="A zero-width viewBox disables rendering of the element in every context: an inline outer svg, a nested inner svg, and an svg referenced as an image.">
+<body style="margin:0">
+  <!-- inline outer svg -->
+  <svg width="100" height="100" viewBox="0 0 0 100"><rect width="100" height="100" fill="green"/></svg>
+  <!-- nested inner svg carries the zero viewBox -->
+  <svg width="100" height="100"><svg width="100" height="100" viewBox="0 0 0 100"><rect width="100" height="100" fill="green"/></svg></svg>
+  <!-- svg referenced as an image (secure static mode) -->
+  <img width="100" height="100" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='100'%20height='100'%20viewBox='0%200%200%20100'%3E%3Crect%20width='100'%20height='100'%20fill='green'/%3E%3C/svg%3E">
+</body>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-marker-expected.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-marker-expected.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: only the path stroke, no marker</title>
+  <path d="M20,20 L180,20" stroke="black" stroke-width="1" fill="none"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-marker-ref.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-marker-ref.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: only the path stroke, no marker</title>
+  <path d="M20,20 L180,20" stroke="black" stroke-width="1" fill="none"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-marker.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-marker.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>A marker with a zero viewBox is not rendered</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute"/>
+  <h:link rel="match" href="viewBox-zero-disables-rendering-marker-ref.svg"/>
+  <h:meta name="assert" content="A marker whose viewBox has a zero width disables rendering; only the path stroke is painted, not the marker."/>
+  <defs>
+    <marker id="m" viewBox="0 0 0 100" markerWidth="100" markerHeight="100" refX="0" refY="0" markerUnits="userSpaceOnUse">
+      <rect width="100" height="100" fill="green"/>
+    </marker>
+  </defs>
+  <path d="M20,20 L180,20" stroke="black" stroke-width="1" fill="none" marker-start="url(#m)"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-pattern-expected.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-pattern-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element renders nothing</title>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-pattern.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-pattern.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>A pattern with a zero viewBox disables rendering of its content (empty fill)</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute"/>
+  <h:link rel="match" href="viewBox-zero-disables-rendering-ref.svg"/>
+  <h:meta name="assert" content="A pattern whose viewBox has a zero width disables rendering of its content, so a shape painted with the pattern shows nothing."/>
+  <defs>
+    <pattern id="p" viewBox="0 0 0 100" width="200" height="200" patternUnits="userSpaceOnUse">
+      <rect width="100" height="100" fill="green"/>
+    </pattern>
+  </defs>
+  <rect width="200" height="200" fill="url(#p)"/>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-ref.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-ref.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element renders nothing</title>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-symbol-expected.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-symbol-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element renders nothing</title>
+</svg>

--- a/svg/coordinate-systems/viewBox-zero-disables-rendering-symbol.svg
+++ b/svg/coordinate-systems/viewBox-zero-disables-rendering-symbol.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>A symbol with a zero viewBox disables rendering of its referenced content</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute"/>
+  <h:link rel="match" href="viewBox-zero-disables-rendering-ref.svg"/>
+  <h:meta name="assert" content="A symbol whose viewBox has a zero width disables rendering; the instance created by use paints nothing."/>
+  <symbol id="s" viewBox="0 0 0 100"><rect width="100" height="100" fill="green"/></symbol>
+  <use href="#s" x="0" y="0" width="200" height="200"/>
+</svg>

--- a/svg/geometry/parsing/negative-presentation-attribute-computed.svg
+++ b/svg/geometry/parsing/negative-presentation-attribute-computed.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="400px" height="200px">
+  <title>SVG Geometry Properties: negative presentation-attribute values compute to the initial value</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:meta name="assert" content="A negative value supplied as a presentation attribute for r, rx or ry is invalid and computes to the property's initial value (auto for rx/ry, 0 for r); cx/cy accept negatives."/>
+  </metadata>
+  <ellipse id="e-rx" cx="50" cy="50" rx="-20" ry="30"/>
+  <ellipse id="e-ry" cx="50" cy="50" rx="30" ry="-20"/>
+  <circle  id="c-r"  cx="50" cy="50" r="-20"/>
+  <circle  id="c-cx" cx="-20" cy="50" r="30"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("e-rx")).rx, "auto");
+}, "negative rx presentation attribute computes to auto");
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("e-ry")).ry, "auto");
+}, "negative ry presentation attribute computes to auto");
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("c-r")).r, "0px");
+}, "negative r presentation attribute computes to 0px");
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById("c-cx")).cx, "-20px");
+}, "negative cx presentation attribute is accepted");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/reftests/circle-006-expected.svg
+++ b/svg/geometry/reftests/circle-006-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element is not rendered</title>
+</svg>

--- a/svg/geometry/reftests/circle-006.svg
+++ b/svg/geometry/reftests/circle-006.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>A negative r is invalid (computes to 0) so the circle is not rendered</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
+  <h:link rel="match" href="not-rendered-200-ref.svg"/>
+  <h:meta name="assert" content="A negative value for r is invalid and computes to 0; a circle with r=0 is not rendered."/>
+  <circle cx="100" cy="100" r="-40" fill="blue"/>
+</svg>

--- a/svg/geometry/reftests/ellipse-005.svg
+++ b/svg/geometry/reftests/ellipse-005.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
-  <title>A negative value for rx is invalid and must be ignored</title>
+  <title>A negative value for rx is invalid; rx computes to auto and the used radius mirrors ry</title>
   <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
   <html:link rel="match"  href="circle-ref.svg" />
   <ellipse cx="204" cy="56" rx="-65" ry="65" fill="blue"/>

--- a/svg/geometry/reftests/ellipse-006.svg
+++ b/svg/geometry/reftests/ellipse-006.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
-  <title>A negative value for ry is invalid and must be ignored</title>
+  <title>A negative value for ry is invalid; ry computes to auto and the used radius mirrors rx</title>
   <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
   <html:link rel="match"  href="circle-ref.svg" />
   <ellipse cx="204" cy="56" rx="65" ry="-65" fill="blue"/>

--- a/svg/geometry/reftests/ellipse-007-expected.svg
+++ b/svg/geometry/reftests/ellipse-007-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element is not rendered</title>
+</svg>

--- a/svg/geometry/reftests/ellipse-007.svg
+++ b/svg/geometry/reftests/ellipse-007.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>Both rx and ry negative: the ellipse is not rendered</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+  <h:link rel="match" href="not-rendered-200-ref.svg"/>
+  <h:meta name="assert" content="When both rx and ry are negative they are treated as auto with no counterpart, so the used radii are 0 and the ellipse is not rendered."/>
+  <ellipse cx="100" cy="100" rx="-40" ry="-40" fill="blue"/>
+</svg>

--- a/svg/geometry/reftests/not-rendered-200-ref.svg
+++ b/svg/geometry/reftests/not-rendered-200-ref.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element is not rendered</title>
+</svg>

--- a/svg/geometry/reftests/rect-005-expected.svg
+++ b/svg/geometry/reftests/rect-005-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element is not rendered</title>
+</svg>

--- a/svg/geometry/reftests/rect-005.svg
+++ b/svg/geometry/reftests/rect-005.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>A rect with negative width is not rendered</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+  <h:link rel="match" href="not-rendered-200-ref.svg"/>
+  <h:meta name="assert" content="A negative width is invalid; on a rect it is treated as auto and resolves to 0, so the rect is not rendered."/>
+  <rect x="20" y="20" width="-100" height="100" fill="blue"/>
+</svg>

--- a/svg/geometry/reftests/rect-006-expected.svg
+++ b/svg/geometry/reftests/rect-006-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference: the element is not rendered</title>
+</svg>

--- a/svg/geometry/reftests/rect-006.svg
+++ b/svg/geometry/reftests/rect-006.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="200" height="200">
+  <title>A rect with negative height is not rendered</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+  <h:link rel="match" href="not-rendered-200-ref.svg"/>
+  <h:meta name="assert" content="A negative height is invalid; on a rect it is treated as auto and resolves to 0, so the rect is not rendered."/>
+  <rect x="20" y="20" width="100" height="-100" fill="blue"/>
+</svg>

--- a/svg/geometry/reftests/rect-007-expected.svg
+++ b/svg/geometry/reftests/rect-007-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="120">
+  <title>Reference: mirrored radii render as rounded rects; both-negative renders square</title>
+  <rect x="10" y="10" width="100" height="100" rx="40" ry="40" fill="green"/>
+  <rect x="130" y="10" width="100" height="100" rx="40" ry="40" fill="green"/>
+  <rect x="250" y="10" width="100" height="100" fill="green"/>
+</svg>

--- a/svg/geometry/reftests/rect-007-ref.svg
+++ b/svg/geometry/reftests/rect-007-ref.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="120">
+  <title>Reference: mirrored radii render as rounded rects; both-negative renders square</title>
+  <rect x="10" y="10" width="100" height="100" rx="40" ry="40" fill="green"/>
+  <rect x="130" y="10" width="100" height="100" rx="40" ry="40" fill="green"/>
+  <rect x="250" y="10" width="100" height="100" fill="green"/>
+</svg>

--- a/svg/geometry/reftests/rect-007.svg
+++ b/svg/geometry/reftests/rect-007.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" width="360" height="120">
+  <title>Negative rect corner radii: a negative rx/ry computes to auto and mirrors the other radius; both negative gives square corners</title>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+  <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#RectElement"/>
+  <h:link rel="match" href="rect-007-ref.svg"/>
+  <h:meta name="assert" content="A negative rx (or ry) on a rect is invalid and computes to auto, so the used radius mirrors the other (valid) radius; when both rx and ry are negative both are auto and the used radii are 0 (square corners)."/>
+  <!-- rx negative, ry valid: rx mirrors ry=40 -->
+  <rect x="10" y="10" width="100" height="100" rx="-30" ry="40" fill="green"/>
+  <!-- rx valid, ry negative: ry mirrors rx=40 -->
+  <rect x="130" y="10" width="100" height="100" rx="40" ry="-30" fill="green"/>
+  <!-- both negative: both auto -> 0 -> square corners -->
+  <rect x="250" y="10" width="100" height="100" rx="-30" ry="-40" fill="green"/>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [Add WPT tests for SVG geometry negative-value handling and viewBox zero/negative rendering](https://bugs.webkit.org/show_bug.cgi?id=320095)