### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320102

### DIFF
--- a/webtransport/resources/webtransport-test-helpers.sub.js
+++ b/webtransport/resources/webtransport-test-helpers.sub.js
@@ -88,6 +88,18 @@ async function query(token) {
   }
 }
 
+// Polls the server until the stream close info for |token| is recorded, then
+// returns it. Avoids racing on a fixed delay for the close signal to arrive.
+async function query_stream_close_info(token) {
+  while (true) {
+    const data = await query(token);
+    if ('stream-close-info' in data) {
+      return data['stream-close-info'];
+    }
+    await wait(10);
+  }
+}
+
 async function readInto(reader, buffer) {
   let offset = 0;
 

--- a/webtransport/streams-close.https.any.js
+++ b/webtransport/streams-close.https.any.js
@@ -17,11 +17,7 @@ promise_test(async t => {
   const writable = bidi_stream.writable;
   writable.close();
 
-  await wait(10);
-  const data = await query(id);
-
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
+  const info = await query_stream_close_info(id);
 
   assert_equals(info.source, 'FIN', 'source');
 }, 'Close outgoing stream / bidi-1');
@@ -38,11 +34,7 @@ promise_test(async t => {
   const writable = bidi.writable;
   writable.close();
 
-  await wait(10);
-  const data = await query(id);
-
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
+  const info = await query_stream_close_info(id);
 
   assert_equals(info.source, 'FIN', 'source');
 }, 'Close outgoing stream / bidi-2');
@@ -56,11 +48,7 @@ promise_test(async t => {
   const writable = await wt.createUnidirectionalStream();
   writable.close();
 
-  await wait(10);
-  const data = await query(id);
-
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
+  const info = await query_stream_close_info(id);
 
   assert_equals(info.source, 'FIN', 'source');
 }, 'Close outgoing stream / uni');
@@ -80,13 +68,9 @@ promise_test(async t => {
   await writable.abort(
       new WebTransportError({streamErrorCode: WT_CODE}));
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Abort client-created bidirectional stream');
@@ -108,13 +92,9 @@ promise_test(async t => {
   await writer.abort(
       new WebTransportError({streamErrorCode: WT_CODE}));
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Abort server-initiated bidirectional stream');
@@ -132,13 +112,9 @@ promise_test(async t => {
   await writable.abort(
       new WebTransportError({streamErrorCode: WT_CODE}));
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Abort unidirectional stream with WebTransportError');
@@ -171,13 +147,9 @@ promise_test(async t => {
   await promise_rejects_exactly(t, e, abort_promise, 'abort_promise');
   writer.releaseLock();
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, HTTP_CODE, 'code');
 }, 'Close and abort unidirectional stream');
@@ -191,13 +163,9 @@ promise_test(async t => {
   const writable = await wt.createUnidirectionalStream();
   await writable.abort();
 
-  await wait(10);
-  const data = await query(id);
+  const info = await query_stream_close_info(id);
 
   // Check that stream is aborted with RESET_STREAM with the code and reason
-  assert_own_property(data, 'stream-close-info');
-  const info = data['stream-close-info'];
-
   assert_equals(info.source, 'reset', 'reset_stream');
   assert_equals(info.code, webtransport_code_to_http_code(0), 'code');
 }, 'Abort unidirectional stream with default error code');


### PR DESCRIPTION
WebKit export from bug: [\[WebTransport\] WPT failure: Close and abort unidirectional stream](https://bugs.webkit.org/show_bug.cgi?id=320102)