### PR TITLE
layout: Use `f64` when blending table content sizes

### DIFF
--- a/css/css-tables/crashtests/table-content-size-blending-crash.html
+++ b/css/css-tables/crashtests/table-content-size-blending-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/46774">
+<style>
+    span {
+        display: inline-block;
+        width: 2000000px;
+    }
+    table {
+        border-collapse: collapse;
+        width: 2060000px
+    }
+    td {
+        padding: 0;
+    }
+</style>
+<table><td><span></span><span></span></td></table>
+


### PR DESCRIPTION
It seems that `f32` doesn't have enough precision to prevent hitting our
floating point error limit when blending content sizes during table
layout. This change makes more calculations use `f64` preventing a debug
assertion from firing.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->46774.

Reviewed in servo/servo#46775