### PR TITLE
[screen-orientation] Test exiting fullscreen unlocks the orientation

### DIFF
--- a/screen-orientation/fullscreen-exit-unlocks-orientation.html
+++ b/screen-orientation/fullscreen-exit-unlocks-orientation.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Screen Orientation: exiting fullscreen unlocks the orientation and aborts a pending lock</title>
+<link rel="help" href="https://w3c.github.io/screen-orientation/#fullscreen-interaction" />
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#fully-exit-fullscreen" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+<script type="module">
+  import {
+    getOppositeOrientation,
+    attachIframe,
+  } from "./resources/orientation-utils.js";
+
+  // A throwing cleanup becomes a harness error, so guard each step.
+  function cleanup(t, iframe) {
+    t.add_cleanup(async () => {
+      if (iframe) iframe.remove();
+      try { screen.orientation.unlock(); } catch (e) {}
+      try {
+        if (document.fullscreenElement) await document.exitFullscreen();
+      } catch (e) {}
+    });
+  }
+
+  async function lockToOpposite() {
+    // false when locking is unsupported (e.g. desktop: lock() rejects NotSupportedError).
+    try {
+      await screen.orientation.lock(getOppositeOrientation());
+      return true;
+    } catch (e) {
+      if (e.name === "NotSupportedError") return false;
+      throw e;
+    }
+  }
+
+  promise_test(async (t) => {
+    cleanup(t);
+    await test_driver.bless("enter fullscreen");
+    await document.documentElement.requestFullscreen();
+    // Do not await the lock: it must still be pending when fullscreen exits.
+    const lockPromise = screen.orientation.lock(getOppositeOrientation());
+    await document.exitFullscreen();
+    let outcome;
+    try {
+      await lockPromise;
+      outcome = "resolved";
+    } catch (e) {
+      outcome = e.name;
+    }
+    assert_implements_optional(
+      outcome !== "NotSupportedError",
+      "screen.orientation.lock() is supported on this device"
+    );
+    assert_equals(
+      outcome,
+      "AbortError",
+      "a pending lock() is rejected with AbortError when the document exits fullscreen"
+    );
+  }, "Exiting fullscreen aborts a pending screen.orientation.lock() with AbortError");
+
+  promise_test(async (t) => {
+    cleanup(t);
+    const initial = {
+      type: screen.orientation.type,
+      angle: screen.orientation.angle,
+    };
+    await test_driver.bless("enter fullscreen");
+    await document.documentElement.requestFullscreen();
+    assert_implements_optional(
+      await lockToOpposite(),
+      "screen.orientation.lock() is supported on this device"
+    );
+    assert_not_equals(
+      screen.orientation.type,
+      initial.type,
+      "precondition: the lock changed the orientation"
+    );
+    const reverted = new Promise((resolve) =>
+      screen.orientation.addEventListener("change", resolve, { once: true })
+    );
+    await document.exitFullscreen();
+    await reverted;
+    assert_equals(screen.orientation.type, initial.type,
+      "orientation type reverts after exiting fullscreen");
+    assert_equals(screen.orientation.angle, initial.angle,
+      "orientation angle reverts after exiting fullscreen");
+  }, "Exiting fullscreen releases the screen orientation lock");
+
+  // The lock applies to the top-level document, so a subframe that locks and then
+  // exits fullscreen must release the top document's lock.
+  promise_test(async (t) => {
+    const iframe = await attachIframe();
+    cleanup(t, iframe);
+    const initial = {
+      type: screen.orientation.type,
+      angle: screen.orientation.angle,
+    };
+    await test_driver.bless("enter fullscreen", null, iframe.contentWindow);
+    await iframe.contentDocument.documentElement.requestFullscreen();
+    let supported = true;
+    try {
+      await iframe.contentWindow.screen.orientation.lock(getOppositeOrientation());
+    } catch (e) {
+      if (e.name === "NotSupportedError") supported = false;
+      else throw e;
+    }
+    assert_implements_optional(
+      supported,
+      "screen.orientation.lock() is supported on this device"
+    );
+    assert_not_equals(
+      screen.orientation.type,
+      initial.type,
+      "precondition: the subframe's lock changed the top orientation"
+    );
+    const reverted = new Promise((resolve) =>
+      screen.orientation.addEventListener("change", resolve, { once: true })
+    );
+    await iframe.contentDocument.exitFullscreen();
+    await reverted;
+    assert_equals(screen.orientation.type, initial.type,
+      "top orientation type reverts after the subframe exits fullscreen");
+    assert_equals(screen.orientation.angle, initial.angle,
+      "top orientation angle reverts after the subframe exits fullscreen");
+  }, "Exiting fullscreen in a subframe releases the top document's orientation lock");
+</script>
+</body>


### PR DESCRIPTION
Adds coverage for the Fullscreen and Screen Orientation interaction on the exit path: when a document or a subframe exits fullscreen, the orientation lock is released so the orientation reverts, and a still-pending lock() promise is rejected with AbortError. fullscreen-interactions.html only covers other cases, and the tests skip via assert_implements_optional where orientation locking is unsupported (e.g. desktop).

The abort-on-exit assertion depends on a pending Screen Orientation spec clarification to make the exit-versus-resolve ordering deterministic; the release assertions match the current spec. Context: https://bugs.webkit.org/show_bug.cgi?id=247250