### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318324

### DIFF
--- a/svg/geometry/parsing/cx-attribute-invalid.svg
+++ b/svg/geometry/parsing/cx-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cx presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cx presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("cx", "auto", 0, "0px");
+test_invalid_attribute_value("cx", "none", 0, "0px");
+test_invalid_attribute_value("cx", "10px 20px", 0, "0px");
+test_invalid_attribute_value("cx", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/cx-attribute-valid.svg
+++ b/svg/geometry/parsing/cx-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cx presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cx presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;' (unlike the cx CSS property, which does not accept a bare number)."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("cx", "0", 0);
+test_valid_attribute_value("cx", "5", 5);
+test_valid_attribute_value("cx", "-10", -10);
+test_valid_attribute_value("cx", "5px", 5);
+test_valid_attribute_value("cx", "-10px", -10);
+test_valid_attribute_value("cx", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/cy-attribute-invalid.svg
+++ b/svg/geometry/parsing/cy-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cy presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cy presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("cy", "auto", 0, "0px");
+test_invalid_attribute_value("cy", "none", 0, "0px");
+test_invalid_attribute_value("cy", "10px 20px", 0, "0px");
+test_invalid_attribute_value("cy", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/cy-attribute-valid.svg
+++ b/svg/geometry/parsing/cy-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cy presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cy presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;' (unlike the cy CSS property, which does not accept a bare number)."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("cy", "0", 0);
+test_valid_attribute_value("cy", "5", 5);
+test_valid_attribute_value("cy", "-10", -10);
+test_valid_attribute_value("cy", "5px", 5);
+test_valid_attribute_value("cy", "-10px", -10);
+test_valid_attribute_value("cy", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/ellipse-rx-attribute-invalid.svg
+++ b/svg/geometry/parsing/ellipse-rx-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute on ellipse with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute on ellipse rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for rx is invalid and must be ignored per SVG2 geometry.html#RX."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("rx", "-10", 0, "auto");
+test_invalid_attribute_value("rx", "-10px", 0, "auto");
+test_invalid_attribute_value("rx", "-10%", 0, "auto");
+test_invalid_attribute_value("rx", "none", 0, "auto");
+test_invalid_attribute_value("rx", "10px 20px", 0, "auto");
+test_invalid_attribute_value("rx", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/ellipse-rx-attribute-valid.svg
+++ b/svg/geometry/parsing/ellipse-rx-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute on ellipse with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute on ellipse supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("rx", "auto", 0, "auto");
+test_valid_attribute_value("rx", "0", 0);
+test_valid_attribute_value("rx", "5", 5);
+test_valid_attribute_value("rx", "5px", 5);
+test_valid_attribute_value("rx", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/ellipse-ry-attribute-invalid.svg
+++ b/svg/geometry/parsing/ellipse-ry-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute on ellipse with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute on ellipse rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for ry is invalid and must be ignored per SVG2 geometry.html#RY."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("ry", "-10", 0, "auto");
+test_invalid_attribute_value("ry", "-10px", 0, "auto");
+test_invalid_attribute_value("ry", "-10%", 0, "auto");
+test_invalid_attribute_value("ry", "none", 0, "auto");
+test_invalid_attribute_value("ry", "10px 20px", 0, "auto");
+test_invalid_attribute_value("ry", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/ellipse-ry-attribute-valid.svg
+++ b/svg/geometry/parsing/ellipse-ry-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute on ellipse with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute on ellipse supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("ry", "auto", 0, "auto");
+test_valid_attribute_value("ry", "0", 0);
+test_valid_attribute_value("ry", "5", 5);
+test_valid_attribute_value("ry", "5px", 5);
+test_valid_attribute_value("ry", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/height-attribute-invalid.svg
+++ b/svg/geometry/parsing/height-attribute-invalid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the height presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the height presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt;', keeping the initial computed value of 0."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("height", "-10", 0, "0px");
+test_invalid_attribute_value("height", "-10px", 0, "0px");
+test_invalid_attribute_value("height", "-10%", 0, "0px");
+test_invalid_attribute_value("height", "auto", 0, "0px");
+test_invalid_attribute_value("height", "none", 0, "0px");
+test_invalid_attribute_value("height", "10px 20px", 0, "0px");
+test_invalid_attribute_value("height", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/height-attribute-valid.svg
+++ b/svg/geometry/parsing/height-attribute-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the height presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the height presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("height", "0", 0);
+test_valid_attribute_value("height", "5", 5);
+test_valid_attribute_value("height", "5px", 5);
+test_valid_attribute_value("height", "5%", 40, "40px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/r-attribute-invalid.svg
+++ b/svg/geometry/parsing/r-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the r presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the r presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt;', keeping the initial computed value of 0. A negative value for r is invalid and must be ignored per SVG2 geometry.html#R."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("r", "-10", 0, "0px");
+test_invalid_attribute_value("r", "-10px", 0, "0px");
+test_invalid_attribute_value("r", "-10%", 0, "0px");
+test_invalid_attribute_value("r", "auto", 0, "0px");
+test_invalid_attribute_value("r", "10px 20px", 0, "0px");
+test_invalid_attribute_value("r", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/r-attribute-valid.svg
+++ b/svg/geometry/parsing/r-attribute-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the r presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the r presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;'."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("r", "0", 0);
+test_valid_attribute_value("r", "5", 5);
+test_valid_attribute_value("r", "5px", 5);
+test_valid_attribute_value("r", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/rx-attribute-invalid.svg
+++ b/svg/geometry/parsing/rx-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for rx is invalid and must be ignored per SVG2 geometry.html#RX."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("rx", "-10", 0, "auto");
+test_invalid_attribute_value("rx", "-10px", 0, "auto");
+test_invalid_attribute_value("rx", "-10%", 0, "auto");
+test_invalid_attribute_value("rx", "none", 0, "auto");
+test_invalid_attribute_value("rx", "10px 20px", 0, "auto");
+test_invalid_attribute_value("rx", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/rx-attribute-valid.svg
+++ b/svg/geometry/parsing/rx-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("rx", "auto", 0, "auto");
+test_valid_attribute_value("rx", "0", 0);
+test_valid_attribute_value("rx", "5", 5);
+test_valid_attribute_value("rx", "5px", 5);
+test_valid_attribute_value("rx", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/ry-attribute-invalid.svg
+++ b/svg/geometry/parsing/ry-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for ry is invalid and must be ignored per SVG2 geometry.html#RY."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("ry", "-10", 0, "auto");
+test_invalid_attribute_value("ry", "-10px", 0, "auto");
+test_invalid_attribute_value("ry", "-10%", 0, "auto");
+test_invalid_attribute_value("ry", "none", 0, "auto");
+test_invalid_attribute_value("ry", "10px 20px", 0, "auto");
+test_invalid_attribute_value("ry", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/ry-attribute-valid.svg
+++ b/svg/geometry/parsing/ry-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("ry", "auto", 0, "auto");
+test_valid_attribute_value("ry", "0", 0);
+test_valid_attribute_value("ry", "5", 5);
+test_valid_attribute_value("ry", "5px", 5);
+test_valid_attribute_value("ry", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/support/attribute-testcommon.js
+++ b/svg/geometry/parsing/support/attribute-testcommon.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Create a test that a SVG geometry-property presentation attribute
+ * (https://w3c.github.io/svgwg/svg2-draft/geometry.html) parses a value
+ * correctly when set via the SVG-attribute syntax (setAttribute), as
+ * distinct from the CSS-property syntax already covered by
+ * /css/support/parsing-testcommon.js.
+ *
+ * Per https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value,
+ * presentation attributes for <length-percentage>-typed geometry properties
+ * also accept a bare unitless <number> (treated as a length in user units),
+ * which the CSS-property grammar rejects — so the two syntaxes need
+ * independent valid/invalid value sets, not a shared one.
+ *
+ * The document element #target is used to perform the test; it must be an
+ * element that supports the given attribute (e.g. <rect> for rx/ry,
+ * <circle> for r, <circle>/<ellipse> for cx/cy).
+ *
+ * @param {string} attribute  The name of the presentation attribute.
+ * @param {string} value      A specified attribute value.
+ * @param {number} expected   The expected SVGAnimatedLength.baseVal.value.
+ * @param {string} computed   The expected getComputedStyle() serialization.
+ *                            Defaults to `${expected}px` when omitted.
+ */
+function test_valid_attribute_value(attribute, value, expected, computed) {
+  if (computed === undefined)
+    computed = `${expected}px`;
+
+  test(() => {
+    const target = document.getElementById('target');
+    target.removeAttribute(attribute);
+    target.setAttribute(attribute, value);
+    assert_equals(target.getAttribute(attribute), value,
+      'attribute should round-trip in the DOM');
+    assert_equals(target[attribute].baseVal.value, expected,
+      'SVGAnimatedLength.baseVal.value');
+    assert_equals(getComputedStyle(target)[attribute], computed,
+      'getComputedStyle()');
+  }, `${attribute}="${value}" should be a valid attribute value`);
+}
+
+/**
+ * Create a test that an invalid presentation-attribute value for a SVG
+ * geometry property is ignored — the attribute keeps the initial computed
+ * value (per https://w3c.github.io/svgwg/svg2-draft/geometry.html, "invalid
+ * and must be ignored").
+ *
+ * @param {string} attribute       The name of the presentation attribute.
+ * @param {string} value           An invalid specified attribute value.
+ * @param {number} initialValue    The expected initial baseVal.value.
+ * @param {string} initialComputed The expected initial getComputedStyle()
+ *                                 serialization.
+ */
+function test_invalid_attribute_value(attribute, value, initialValue, initialComputed) {
+  test(() => {
+    const target = document.getElementById('target');
+    target.removeAttribute(attribute);
+    assert_equals(target[attribute].baseVal.value, initialValue,
+      'sanity check: initial baseVal.value before setAttribute');
+    target.setAttribute(attribute, value);
+    assert_equals(target.getAttribute(attribute), value,
+      'invalid value is still reflected in the DOM attribute string');
+    assert_equals(target[attribute].baseVal.value, initialValue,
+      'SVGAnimatedLength.baseVal.value should keep the initial value');
+    assert_equals(getComputedStyle(target)[attribute], initialComputed,
+      'getComputedStyle() should keep the initial value');
+  }, `${attribute}="${value}" should be an invalid attribute value (ignored)`);
+}

--- a/svg/geometry/parsing/width-attribute-invalid.svg
+++ b/svg/geometry/parsing/width-attribute-invalid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the width presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the width presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt;', keeping the initial computed value of 0."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("width", "-10", 0, "0px");
+test_invalid_attribute_value("width", "-10px", 0, "0px");
+test_invalid_attribute_value("width", "-10%", 0, "0px");
+test_invalid_attribute_value("width", "auto", 0, "0px");
+test_invalid_attribute_value("width", "none", 0, "0px");
+test_invalid_attribute_value("width", "10px 20px", 0, "0px");
+test_invalid_attribute_value("width", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/width-attribute-valid.svg
+++ b/svg/geometry/parsing/width-attribute-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the width presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the width presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("width", "0", 0);
+test_valid_attribute_value("width", "5", 5);
+test_valid_attribute_value("width", "5px", 5);
+test_valid_attribute_value("width", "5%", 40, "40px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/x-attribute-invalid.svg
+++ b/svg/geometry/parsing/x-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the x presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the x presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("x", "auto", 0, "0px");
+test_invalid_attribute_value("x", "none", 0, "0px");
+test_invalid_attribute_value("x", "10px 20px", 0, "0px");
+test_invalid_attribute_value("x", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/x-attribute-valid.svg
+++ b/svg/geometry/parsing/x-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the x presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the x presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("x", "0", 0);
+test_valid_attribute_value("x", "5", 5);
+test_valid_attribute_value("x", "-10", -10);
+test_valid_attribute_value("x", "5px", 5);
+test_valid_attribute_value("x", "-10px", -10);
+test_valid_attribute_value("x", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/y-attribute-invalid.svg
+++ b/svg/geometry/parsing/y-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the y presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the y presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("y", "auto", 0, "0px");
+test_invalid_attribute_value("y", "none", 0, "0px");
+test_invalid_attribute_value("y", "10px 20px", 0, "0px");
+test_invalid_attribute_value("y", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/svg/geometry/parsing/y-attribute-valid.svg
+++ b/svg/geometry/parsing/y-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the y presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the y presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("y", "0", 0);
+test_valid_attribute_value("y", "5", 5);
+test_valid_attribute_value("y", "-10", -10);
+test_valid_attribute_value("y", "5px", 5);
+test_valid_attribute_value("y", "-10px", -10);
+test_valid_attribute_value("y", "5%", 40, "5%");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [SVGLength.value returns raw negative numbers for r/rx/ry/width/height/textLength after setAttribute, disagreeing with getComputedStyle()](https://bugs.webkit.org/show_bug.cgi?id=318324)