### PR TITLE
[webdriver] Fix test_get_credentials_resident

### DIFF
--- a/webdriver/tests/classic/external/webauthn/get_credentials/get.py
+++ b/webdriver/tests/classic/external/webauthn/get_credentials/get.py
@@ -48,6 +48,7 @@ def test_get_credentials_resident(session, authenticator):
     credential = create_credential(
         credential_id="cmVzaWRlbnQ",
         is_resident_credential=True,
+        user_handle="dXNlcjE",
         sign_count=10,
     )
     session.web_authn.add_credential(authenticator, credential)


### PR DESCRIPTION
According to the WebAuthn spec, userHandle is mandatory when isResidentCredential is true.

Fixes #61546