### PR TITLE
[webdriver] Add suggested reviewers for the WebDriver WebAuthn folder

### DIFF
--- a/webdriver/tests/classic/external/webauthn/META.yml
+++ b/webdriver/tests/classic/external/webauthn/META.yml
@@ -1,0 +1,4 @@
+spec: https://w3c.github.io/webauthn/
+suggested_reviewers:
+  - nsatragno
+  - whimboo


### PR DESCRIPTION
Add nsatragno (myself) and whimboo as suggested reviewers for the WebAuthn webdriver tests.

@whimboo wrote these tests, and I wrote (most of) the webauthn automation part of the spec and own the chromium implementation.

Related to issue #20684