### PR TITLE
layout: Use a total order comparator when distributing extra space to rowspans

### DIFF
--- a/css/css-tables/crashtests/row-size-distribution-rowspan-sorting.html
+++ b/css/css-tables/crashtests/row-size-distribution-rowspan-sorting.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46806">
+<table>
+    <tr>
+        <td rowspan=6></td>
+        <td rowspan=2></td>
+        <td rowspan=4></td>
+        <td rowspan=4></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=2>XXXX</td>
+        <td rowspan=2></td>
+    </tr>
+    <tr></tr>
+    <tr>
+        <td rowspan=6></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=4></td>
+        <td rowspan=4></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr></tr>
+</table>


### PR DESCRIPTION
Extra space is distributed to rowspans in an order determined by the
specification. The sorting that was used to determine this order wasn't
total which meant that you could have a situation where:

 - rowspan_a == rowspan_b
 - rowspan_a > rowspan_c
 - rowspan_c > rowspan_b

This change makes the sorting total by properly ordering ranges even
when one side of their ranges overlap. The test included here
unfortunately has to be a bit noisy because the standard library only
detects a non-total ordering under a specific set and distribution of
elements.

Testing: This change includes a WPT crashtest.
Fixes: #<!-- nolink -->46806.

Reviewed in servo/servo#46841