### PR TITLE
wpt: Add tests for LCP element removed after paint

### DIFF
--- a/largest-contentful-paint/image-element-when-fully-active.html
+++ b/largest-contentful-paint/image-element-when-fully-active.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>Largest Contentful Paint: element is null after iframe removal.</title>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe src="resources/iframe-stores-image-entry.html" id="ifr"></iframe>
+<link rel="author" title="Shubham Gupta" href="mailto:shubhamg13.work@gmail.com">
+<script>
+  setup({"hide_test_state": true});
+  let t = async_test('Element is null after iframe with LCP image is removed');
+  window.triggerTest = t.step_func_done(entry => {
+    assert_not_equals(entry.element, null);
+    const iframe = document.getElementById('ifr');
+    iframe.remove();
+    assert_equals(entry.element, null);
+  });
+</script>
+</body>
+</html>

--- a/largest-contentful-paint/image-removed-after-paint.html
+++ b/largest-contentful-paint/image-removed-after-paint.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>LCP: element removed after image paints</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/largest-contentful-paint-helpers.js"></script>
+<link rel="author" title="Shubham Gupta" href="mailto:shubhamg13.work@gmail.com">
+<body>
+<script>
+promise_test(async (t) => {
+  const img = document.createElement('img');
+  img.src = '/images/blue.png';
+  img.id = 'test-image';
+  document.body.appendChild(img);
+
+  const { promise, resolve } = Promise.withResolvers();
+  const observer = new PerformanceObserver((list) => {
+    resolve(list.getEntries()[0]);
+  });
+  observer.observe({ type: 'largest-contentful-paint', buffered: true });
+
+  const entry = await promise;
+
+  assert_not_equals(entry.element, null,
+    'entry.element should be non-null when element is in DOM');
+
+  img.remove();
+  await raf();
+  await raf();
+
+  assert_equals(entry.element, null,
+    'entry.element should be null after element is removed');
+}, 'Element removed after LCP entry should reflect in entry.element');
+</script>
+</body>
+</html>

--- a/largest-contentful-paint/resources/iframe-stores-image-entry.html
+++ b/largest-contentful-paint/resources/iframe-stores-image-entry.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img src="/images/blue.png" width="100" height="50" id="iframe-image">
+<script>
+  const observer = new PerformanceObserver(entryList => {
+    window.parent.triggerTest(entryList.getEntries()[0]);
+  });
+  observer.observe({type: 'largest-contentful-paint', buffered: true});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adding new WPT tests for LCP element removed. 

There is one existing test [element-only-when-fully-active.html](https://github.com/web-platform-tests/wpt/blob/master/largest-contentful-paint/element-only-when-fully-active.html). But contains `Text` (missing support in Servo yet) inside iframe.

So, adding simpler version with image. 

Testing: No Code changes.

Reviewed in servo/servo#46851