### PR TITLE
script: Use `is_in_a_document_tree()` to check if a node is in a tree

### DIFF
--- a/html/semantics/forms/resetting-a-form/form-attribute-detach-crash.html
+++ b/html/semantics/forms/resetting-a-form/form-attribute-detach-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Crash found by DOM fuzzing</title>
+<link rel="help" href="https://github.com/servo/servo/issues/46790">
+<body>
+    <input form="form2">
+    <div id="div">
+        <form id="form2">
+            <button form="div"> </button>
+        </form>
+    </div>
+
+    <script>
+        document.createElement("ct").appendChild(div);
+    </script>
+</body>


### PR DESCRIPTION
… instead of `.has_parent()`. Being in a tree is a pre-condition of `insert_pre_order()` for its call to `compare_dom_tree_position()`. Failing to uphold that pre-condition caused a panic in some case found by a DOM fuzzer.

Fixes: https://github.com/servo/servo/issues/46790
Testing: adding a new crashtest to WPT, manually checked to crash before the code change
Reviewed in servo/servo#46866