### PR TITLE
script: Claim blob URLs before fetching script sources.

### DIFF
--- a/FileAPI/url/url-in-tags-revoke.window.js
+++ b/FileAPI/url/url-in-tags-revoke.window.js
@@ -94,10 +94,29 @@ async_test(t => {
   e.onload = t.step_func_done(() => {
     assert_equals(window.script_test_result, run_result);
   });
+  e.onerror = t.unreached_func();
 
   document.body.appendChild(e);
   URL.revokeObjectURL(url);
 }, 'Fetching a blob URL immediately before revoking it works in <script> tags.');
+
+async_test(t => {
+  const run_result = 'test_script_OK';
+  const blob_contents = 'window.script_test_result = "' + run_result + '";';
+  const blob = new Blob([blob_contents], {type: "application/javascript"});
+  const url = URL.createObjectURL(blob);
+
+  const e = document.createElement('script');
+  e.setAttribute('src', url);
+  e.setAttribute('type', 'module');
+  e.onload = t.step_func_done(() => {
+    assert_equals(window.script_test_result, run_result);
+  });
+  e.onerror = t.unreached_func();
+
+  document.body.appendChild(e);
+  URL.revokeObjectURL(url);
+}, 'Fetching a blob URL immediately before revoking it works in module <script> tags.');
 
 async_test(t => {
   const channel_name = 'a-click-test';

--- a/FileAPI/url/url-in-tags.window.js
+++ b/FileAPI/url/url-in-tags.window.js
@@ -16,9 +16,27 @@ async_test(t => {
   e.onload = t.step_func_done(() => {
     assert_equals(window.test_result, run_result);
   });
+  e.onerror = t.unreached_func();
 
   document.body.appendChild(e);
 }, 'Blob URLs can be used in <script> tags');
+
+async_test(t => {
+  const run_result = 'test_script_OK';
+  const blob_contents = 'window.test_result = "' + run_result + '";';
+  const blob = new Blob([blob_contents], {type: 'application/javascript'});
+  const url = URL.createObjectURL(blob);
+
+  const e = document.createElement('script');
+  e.setAttribute('src', url);
+  e.setAttribute('type', 'module');
+  e.onload = t.step_func_done(() => {
+    assert_equals(window.test_result, run_result);
+  });
+  e.onerror = t.unreached_func();
+
+  document.body.appendChild(e);
+}, 'Blob URLs can be used in module <script> tags');
 
 async_test(t => {
   const run_result = 'test_frame_OK';


### PR DESCRIPTION
These changes push forward the blob URL claim migration a bit further, now making it possible for other callers of create_potential_cors_request to be migrated incrementally. The UrlWithBlobClaim type ensures that any blob URL referenced remains valid while the value is alive, even if the blob is revoked.

Testing: Previously intermittent test now passes consistently. Added new module-specific tests as well.
Part of #<!-- nolink -->25226
Fixes: #<!-- nolink -->19978

Reviewed in servo/servo#46881