### PR TITLE
Test that `Response.redirect()` and `Response.json()` headers are mutable

### DIFF
--- a/fetch/api/response/response-static-json.any.js
+++ b/fetch/api/response/response-static-json.any.js
@@ -94,3 +94,22 @@ for (const [input, expected] of encodingChecks) {
     assert_array_equals(data, expected);
   }, `Check response returned by static json() with input ${input}`);
 }
+
+test(function () {
+  const headers = Response.json(null).headers;
+
+  headers.append("x-custom", "value");
+  assert_equals(headers.get("x-custom"), "value");
+
+  headers.set("x-custom", "value2");
+  assert_equals(headers.get("x-custom"), "value2");
+
+  headers.delete("x-custom");
+  assert_equals(headers.get("x-custom"), null);
+
+  assert_equals(headers.get("content-type"), APPLICATION_JSON);
+  headers.set("content-type", FOO_BAR);
+  assert_equals(headers.get("content-type"), FOO_BAR);
+  headers.delete("content-type");
+  assert_equals(headers.get("content-type"), null);
+}, "headers of Response.json() are mutable");

--- a/fetch/api/response/response-static-redirect.any.js
+++ b/fetch/api/response/response-static-redirect.any.js
@@ -38,3 +38,23 @@ invalidRedirectStatus.forEach(function(invalidStatus) {
         "Expect RangeError exception");
   }, "Check error returned when giving invalid status to redirect(), status = " + invalidStatus);
 });
+
+test(function() {
+  const response = Response.redirect(url);
+  const headers = response.headers;
+
+  headers.append("x-custom", "value");
+  assert_equals(headers.get("x-custom"), "value");
+
+  headers.set("x-custom", "value2");
+  assert_equals(headers.get("x-custom"), "value2");
+
+  headers.delete("x-custom");
+  assert_equals(headers.get("x-custom"), null);
+
+  assert_equals(headers.get("Location"), url);
+  headers.set("Location", "http://other.url/");
+  assert_equals(headers.get("Location"), "http://other.url/");
+  headers.delete("Location");
+  assert_equals(headers.get("Location"), null);
+}, "headers of Response.redirect() are mutable");


### PR DESCRIPTION
Align with the intended Fetch change to give `Response.redirect()` a `"response"` headers guard, matching `Response.json()` and `new Response()`.

upstream PR: https://github.com/whatwg/fetch/pull/1944