### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320623

### DIFF
--- a/FileAPI/reading-data-section/filereader_abort.any.js
+++ b/FileAPI/reading-data-section/filereader_abort.any.js
@@ -36,3 +36,32 @@
               assert_equals(readerAbort.readyState, readerAbort.DONE);
             });
       }, "Aborting after read");
+
+    promise_test(t => {
+        var reader = new FileReader();
+
+        var eventWatcher = new EventWatcher(t, reader,
+            ['abort', 'loadstart', 'loadend', 'error', 'load']);
+
+        // First read: run to completion so the reader reaches the DONE state.
+        reader.readAsText(new Blob(["first read"]));
+        return eventWatcher.wait_for('loadstart')
+          .then(() => eventWatcher.wait_for('load'))
+          .then(() => eventWatcher.wait_for('loadend'))
+          .then(() => {
+              assert_equals(reader.readyState, reader.DONE);
+
+              // Reuse the same reader for a second read and abort it while it is
+              // still LOADING. 'abort' and 'loadend' are dispatched synchronously,
+              // so call wait_for before calling abort.
+              reader.readAsText(new Blob(["second read"]));
+              assert_equals(reader.readyState, reader.LOADING);
+              var nextEvent = eventWatcher.wait_for(['abort', 'loadend']);
+              reader.abort();
+              return nextEvent;
+            })
+          .then(() => {
+              assert_equals(reader.result, null);
+              assert_equals(reader.readyState, reader.DONE);
+            });
+      }, "Aborting a reused reader after a previous read completed");


### PR DESCRIPTION
WebKit export from bug: [FileReader.abort() is silently ignored on a reused reader after a prior read completes](https://bugs.webkit.org/show_bug.cgi?id=320623)