### PR TITLE
Fix non-ASCII ident code point test coverage

### DIFF
--- a/css/css-syntax/non-ascii-codepoints.html
+++ b/css/css-syntax/non-ascii-codepoints.html
@@ -5,6 +5,7 @@
 
 <meta name="author" title="Tab Atkins-Bittner">
 <link rel=help href="https://drafts.csswg.org/css-syntax/#non-ascii-ident-code-point">
+<link rel=help href="https://drafts.csswg.org/css-syntax/#input-preprocessing">
 
 <script>
 function validIdentChar(cp) {
@@ -23,8 +24,9 @@ function testValid(cp) {
 }
 
 function testInvalid(cp) {
-  // Just skip if the codepoint is outside the possible range.
-  if(cp > 0x1ffff) return;
+  // Skip values beyond Unicode's maximum and surrogates, which input
+  // preprocessing replaces with U+FFFD.
+  if(cp > 0x10ffff || (cp >= 0xd800 && cp <= 0xdfff)) return;
   test(()=>{
     assert_false(validIdentChar(cp));
   }, `Codepoint U+${cp.toString(16)} is not a 'non-ASCII ident codepoint'.`)
@@ -70,12 +72,16 @@ testValidRanges([
   [0xf8, 0x37d],
   [0x37f, 0x1fff],
   [0x200c, 0x200d],
-  [0x203f, 0x2040]
+  [0x203f, 0x2040],
   [0x2070, 0x218f],
   [0x2c00, 0x2fef],
   [0x3001, 0xd7ff],
   [0xf900, 0xfdcf],
   [0xfdf0, 0xfffd],
-  [0x10000, 0x1ffff],
+  [0x10000, 0x10ffff],
 ]);
+
+// Test representative whitespace and bidi-control codepoints excluded by the spec.
+testInvalid(0x00a0); // NO-BREAK SPACE
+testInvalid(0x202e); // RIGHT-TO-LEFT OVERRIDE
 </script>


### PR DESCRIPTION
This fixes a missing comma that caused the test to stop early. While here, it aligns the tested range and surrogate handling with the current spec, and adds two representative invalid code points.