### PR TITLE
script: More carefully handle dirty root and descendant damage marking

### DIFF
--- a/shadow-dom/crashtests/modify-sibling-of-shadowroot-after-attach.html
+++ b/shadow-dom/crashtests/modify-sibling-of-shadowroot-after-attach.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46024">
+
+<div id="shadowroot">
+    <span id="insideshadowroot"></span>
+</div>
+<script>
+  onload = _ => {
+    document.body.offsetTop;
+    insideshadowroot.innerText = "Changed";
+    shadowroot.attachShadow({mode: "open"});
+    document.body.appendChild(document.createElement("div"));
+  }
+</script>


### PR DESCRIPTION
Script passes a dirty root to layout along with setting the
HAS_DIRTY_DESCENDANTS flag on elements at or below that root indicating
that children need to be traversed. There was an undocumented invariant
that no nodes above that dirty root were marked with
HAS_DIRTY_DESCENDANTS, as the flag itself was used to determine
when the dirty root is raised to some common ancestor of the old dirty
root and a damaged node.

There were some problems with the old implementation and this change
fixes them by hewing closer to Gecko (from which we took this design).
Notably:

- In the complex situation where we cannot trivially calculate the dirty
  root, we now calculate it by walking up from the old dirty root and
  finding the first element which already has the flag set.
- When removing nodes from the flat tree, if they were the previous
  dirty root, the dirty root is cleared.
- Ensure that all marking traversals for the HAS_DIRTY_DESCENDANTS flag
  marking happen in the flat tree.
- When slotting nodes into `<slot>` elements, the style and layout data
  of fallback content is cleared, and the dirty root is potentially reset.
- Comments are added everywhere in this tricky algorithm explaining what
  the heck is going on.
- The new debug assertion for the invariant found a case where we were
  triggering restyles too late before a relayout -- when setting selection flags.
  This is moved earlier in the method.

Testing: This change adds a new WPT crash test.
Fixes: #<!-- nolink -->46024.
Fixes: #<!-- nolink -->46883.

Reviewed in servo/servo#46906