### PR TITLE
Add click test for auto popover nested inside hint

### DIFF
--- a/html/semantics/popovers/popover-light-dismiss-hint.html
+++ b/html/semantics/popovers/popover-light-dismiss-hint.html
@@ -37,7 +37,7 @@
   #improperlynestedauto1 {left:100px; top:500px;}
   #hint1        {left:200px; top:100px;}
   #hint2        {left:200px; top:200px;}
-  #improperlynestedauto1 {left:200px; top:400px;}
+  #improperlynestedauto2 {left:200px; top:300px;}
   #manual1      {left:300px; top:100px;}
   #outside {width:25px;height:25px}
 </style>

--- a/html/semantics/popovers/popover-light-dismiss-hint.html
+++ b/html/semantics/popovers/popover-light-dismiss-hint.html
@@ -95,6 +95,13 @@
   }
 
   promise_test(async (t) => {
+    const popovers = [hint1, hint2, improperlynestedauto2, manual1];
+    openall(popovers, t);
+    await clickOn(improperlynestedauto2);
+    assertState(popovers, [true, true, true, true]);
+  }, 'Clicking an auto nested inside a hint keeps the whole chain open');
+
+  promise_test(async (t) => {
     openall(setA, t);
     await clickOn(outside);
     assertState(setA, [false,false,false,false,true]);


### PR DESCRIPTION
This covers a case currently failing in Safari TP. It passes in Firefox and Chrome.