### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320709

### DIFF
--- a/mathml/relations/html5-tree/tabindex-003.html
+++ b/mathml/relations/html5-tree/tabindex-003.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>MathML tabIndex attribute: resetting an explicitly set value</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#attributes-common-to-html-and-mathml-elements">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex">
+<meta name="assert" content="Verify that an explicitly set tabIndex is reset to the default value when the tabindex attribute is changed to a value that is not a valid integer, or removed">
+
+<script src="/mathml/support/mathml-fragments.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <math>
+  </math>
+  <script>
+    // tabindex is defined by HTML, which parses the attribute as an integer and
+    // falls back to the default tab index for any value that fails to parse.
+    // That includes the empty string, garbage, and out-of-range integers.
+    const invalidValues = ["", "invalid", " ", "9999999999", "-9999999999"];
+
+    // The HTML rules for parsing integers stop at the first non-digit and keep
+    // the digits collected so far, so these are valid despite the trailing junk.
+    const valuesWithTrailingGarbage = [["1.5", 1], ["4abc", 4], ["-2 ", -2]];
+
+    Object.keys(MathMLFragments).forEach(elName => {
+        const mathEl = document.querySelector('math');
+
+        // <a> needs an href to be focusable by default, and so to have a
+        // default tab index of 0 rather than -1.
+        const href = elName == 'a' ? ' href="#"' : '';
+        mathEl.innerHTML = `<${elName} id="el"${href}></${elName}>`;
+        const el = mathEl.querySelector('#el');
+        const expectedDefault = elName == 'a' ? 0 : -1;
+
+        invalidValues.forEach(invalidValue => {
+            test(() => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", invalidValue);
+                assert_equals(el.getAttribute("tabindex"), invalidValue);
+                assert_equals(el.tabIndex, expectedDefault, "invalid value");
+            }, `changing tabindex from "3" to "${invalidValue}" resets ${elName}.tabIndex`);
+        });
+
+        test(() => {
+            valuesWithTrailingGarbage.forEach(([value, expectedTabIndex]) => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", value);
+                assert_equals(el.tabIndex, expectedTabIndex, `"${value}"`);
+            });
+            el.removeAttribute("tabindex");
+        }, `trailing garbage after the digits of ${elName}'s tabindex is ignored`);
+
+        test(() => {
+            el.setAttribute("tabindex", "3");
+            assert_equals(el.tabIndex, 3, "valid value");
+
+            el.removeAttribute("tabindex");
+            assert_equals(el.tabIndex, expectedDefault, "attribute removed");
+        }, `removing tabindex resets ${elName}.tabIndex`);
+    });
+  </script>
+</body>
+</html>

--- a/svg/interact/scripted/focus-tabindex-invalid-value.svg
+++ b/svg/interact/scripted/focus-tabindex-invalid-value.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+    <title>SVG Test: focus - resetting an explicitly set tabindex</title>
+    <metadata>
+        <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#Focus"/>
+        <h:link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex"/>
+        <h:meta name="assert" content="Verify that an explicitly set tabIndex is reset to the default value when the tabindex attribute is changed to a value that is not a valid integer, or removed"/>
+    </metadata>
+    <a id="anchor" href="#"></a>
+    <rect id="rect"></rect>
+    <g id="g"></g>
+    <circle id="circle"></circle>
+    <text id="text"></text>
+    <svg id="nested"></svg>
+    <h:script src="/resources/testharness.js"/>
+    <h:script src="/resources/testharnessreport.js"/>
+    <script><![CDATA[
+    // tabindex is defined by HTML, which parses the attribute as an integer and
+    // falls back to the default tab index for any value that fails to parse.
+    // That includes the empty string, garbage, and out-of-range integers.
+    const invalidValues = ["", "invalid", " ", "9999999999", "-9999999999"];
+
+    // The HTML rules for parsing integers stop at the first non-digit and keep
+    // the digits collected so far, so these are valid despite the trailing junk.
+    const valuesWithTrailingGarbage = [["1.5", 1], ["4abc", 4], ["-2 ", -2]];
+
+    // [id, default tabIndex]
+    const elements = [
+        ["anchor", 0],
+        ["rect", -1],
+        ["g", -1],
+        ["circle", -1],
+        ["text", -1],
+        ["nested", -1],
+    ];
+
+    for (const [id, expectedDefault] of elements) {
+        const el = document.getElementById(id);
+
+        test(() => {
+            assert_equals(el.tabIndex, expectedDefault);
+        }, `default value of ${id}.tabIndex`);
+
+        for (const invalidValue of invalidValues) {
+            test(() => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", invalidValue);
+                assert_equals(el.getAttribute("tabindex"), invalidValue);
+                assert_equals(el.tabIndex, expectedDefault, "invalid value");
+
+                el.removeAttribute("tabindex");
+            }, `changing tabindex from "3" to "${invalidValue}" resets ${id}.tabIndex`);
+        }
+
+        test(() => {
+            valuesWithTrailingGarbage.forEach(([value, expectedTabIndex]) => {
+                el.setAttribute("tabindex", "3");
+                assert_equals(el.tabIndex, 3, "valid value");
+
+                el.setAttribute("tabindex", value);
+                assert_equals(el.tabIndex, expectedTabIndex, `"${value}"`);
+            });
+            el.removeAttribute("tabindex");
+        }, `trailing garbage after the digits of ${id}'s tabindex is ignored`);
+
+        test(() => {
+            el.setAttribute("tabindex", "3");
+            assert_equals(el.tabIndex, 3, "valid value");
+
+            el.removeAttribute("tabindex");
+            assert_equals(el.tabIndex, expectedDefault, "attribute removed");
+        }, `removing tabindex resets ${id}.tabIndex`);
+    }
+    ]]></script>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [MathML and SVG elements do not reset tabIndex when tabindex is changed to an invalid value](https://bugs.webkit.org/show_bug.cgi?id=320709)