### PR TITLE
[css-view-transitions] Remove references to non-existent scripts

### DIFF
--- a/css/css-transitions/transitionevent-interface.html
+++ b/css/css-transitions/transitionevent-interface.html
@@ -5,7 +5,6 @@
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="transitionevent-interface.js"></script>
 
 <div id="test"></div>
 

--- a/css/css-view-transitions/document-active-view-transition.html
+++ b/css/css-view-transitions/document-active-view-transition.html
@@ -6,7 +6,6 @@
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="support/utils.js"></script>
 
 <style>
 #target {

--- a/css/css-view-transitions/scoped/element-active-view-transition.html
+++ b/css/css-view-transitions/scoped/element-active-view-transition.html
@@ -6,7 +6,6 @@
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="support/utils.js"></script>
 
 <style>
 #target {


### PR DESCRIPTION
`support/utils.js` didn't exist at the point `document-active-view-transition.html` was added in 7f9e7d2d3b.

Similarly, `transitionevent-interface.js` didn't exist at the point `transitionevent-interface.html` was added in b040cb2a07.