### PR TITLE
jpegxl: test image rendering using CSS

### DIFF
--- a/jpegxl/css-background-image-ref.html
+++ b/jpegxl/css-background-image-ref.html
@@ -1,0 +1,10 @@
+<html>
+<title>JPEG XL CSS background-image reference</title>
+<style>
+  img {
+    image-rendering: pixelated;
+    width: 120px; height: 120px;
+  }
+</style>
+<img src="resources/3x3_srgb_lossless.png">
+</html>

--- a/jpegxl/css-background-image.html
+++ b/jpegxl/css-background-image.html
@@ -1,0 +1,23 @@
+<html class="reftest-wait">
+<title>JPEG XL CSS background-image</title>
+<link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
+<link rel="match" href="css-background-image-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+  #bg {
+    background-image: url(resources/3x3_srgb_lossless.jxl);
+    background-size: cover;
+    image-rendering: pixelated;
+    width: 120px; height: 120px;
+  }
+</style>
+<div id="bg"></div>
+<script>
+  new Promise(r => {
+    const img = new Image();
+    img.onload = r;
+    img.onerror = r;
+    img.src = "resources/3x3_srgb_lossless.jxl";
+  }).then(takeScreenshot);
+</script>
+</html>

--- a/jpegxl/css-before-content-ref.html
+++ b/jpegxl/css-before-content-ref.html
@@ -1,0 +1,10 @@
+<html>
+<title>JPEG XL CSS ::before content reference</title>
+<style>
+  img {
+    image-rendering: pixelated;
+    width: 120px; height: 120px;
+  }
+</style>
+<img src="resources/3x3_srgb_lossless.png">
+</html>

--- a/jpegxl/css-before-content.html
+++ b/jpegxl/css-before-content.html
@@ -1,0 +1,23 @@
+<html class="reftest-wait">
+<title>JPEG XL CSS ::before content</title>
+<link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
+<link rel="match" href="css-before-content-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+  #content::before {
+    content: url(resources/3x3_srgb_lossless.jxl);
+    display: block;
+    image-rendering: pixelated;
+    width: 120px; height: 120px;
+  }
+</style>
+<div id="content"></div>
+<script>
+  new Promise(r => {
+    const img = new Image();
+    img.onload = r;
+    img.onerror = r;
+    img.src = "resources/3x3_srgb_lossless.jxl";
+  }).then(takeScreenshot);
+</script>
+</html>

--- a/jpegxl/css-image-set-ref.html
+++ b/jpegxl/css-image-set-ref.html
@@ -1,0 +1,10 @@
+<html>
+<title>JPEG XL CSS image-set() reference</title>
+<style>
+  img {
+    image-rendering: pixelated;
+    width: 120px; height: 120px;
+  }
+</style>
+<img src="resources/3x3_srgb_lossless.png">
+</html>

--- a/jpegxl/css-image-set.html
+++ b/jpegxl/css-image-set.html
@@ -1,0 +1,23 @@
+<html class="reftest-wait">
+<title>JPEG XL CSS image-set()</title>
+<link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
+<link rel="match" href="css-image-set-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+  #set {
+    background-image: image-set(url(resources/3x3_srgb_lossless.jxl) 1x);
+    background-size: cover;
+    image-rendering: pixelated;
+    width: 120px; height: 120px;
+  }
+</style>
+<div id="set"></div>
+<script>
+  new Promise(r => {
+    const img = new Image();
+    img.onload = r;
+    img.onerror = r;
+    img.src = "resources/3x3_srgb_lossless.jxl";
+  }).then(takeScreenshot);
+</script>
+</html>

--- a/jpegxl/css-list-style-image-ref.html
+++ b/jpegxl/css-list-style-image-ref.html
@@ -1,0 +1,9 @@
+<html>
+<title>JPEG XL CSS list-style-image reference</title>
+<style>
+  li {
+    list-style-image: url(resources/3x3_srgb_lossless.png);
+  }
+</style>
+<ul><li>item</li></ul>
+</html>

--- a/jpegxl/css-list-style-image.html
+++ b/jpegxl/css-list-style-image.html
@@ -1,0 +1,20 @@
+<html class="reftest-wait">
+<title>JPEG XL CSS list-style-image</title>
+<link rel="help" href="https://github.com/web-platform-tests/interop-jpegxl">
+<link rel="match" href="css-list-style-image-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+  li {
+    list-style-image: url(resources/3x3_srgb_lossless.jxl);
+  }
+</style>
+<ul><li>item</li></ul>
+<script>
+  new Promise(r => {
+    const img = new Image();
+    img.onload = r;
+    img.onerror = r;
+    img.src = "resources/3x3_srgb_lossless.jxl";
+  }).then(takeScreenshot);
+</script>
+</html>


### PR DESCRIPTION
Includes tests for `background-image`, `content`, `image-set()` and `list-style-image`.

Fixes https://github.com/web-platform-tests/interop-jpegxl/issues/8