### PR TITLE
jpegxl: fix css-before-content comparing a 3x3 image to a 120x120 reference

### DIFF
--- a/jpegxl/css-before-content-ref.html
+++ b/jpegxl/css-before-content-ref.html
@@ -1,10 +1,10 @@
 <html>
 <title>JPEG XL CSS ::before content reference</title>
 <style>
-  img {
-    image-rendering: pixelated;
-    width: 120px; height: 120px;
+  #content::before {
+    content: url(resources/3x3_srgb_lossless.png);
+    display: block;
   }
 </style>
-<img src="resources/3x3_srgb_lossless.png">
+<div id="content"></div>
 </html>

--- a/jpegxl/css-before-content.html
+++ b/jpegxl/css-before-content.html
@@ -7,8 +7,6 @@
   #content::before {
     content: url(resources/3x3_srgb_lossless.jxl);
     display: block;
-    image-rendering: pixelated;
-    width: 120px; height: 120px;
   }
 </style>
 <div id="content"></div>


### PR DESCRIPTION
The image renders at 3x3 even though the test asks for 120x120, so it can't
match the 120x120 reference. width and height on a ::before with an image don't
size the image in any browser yet, so a jxl test shouldn't depend on it.

Just make the reference a copy of the test with a png instead of a jxl.
