### PR TITLE
[compression-dictionary] Add dummy end points when ReportingObserver is used

### DIFF
--- a/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src-nonce.tentative.https.html.headers
+++ b/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src-nonce.tentative.https.html.headers
@@ -1,2 +1,3 @@
-Content-Security-Policy: connect-src 'nonce-abc'
+Reporting-Endpoints: dummy-endpoint="/reporting/resources/report.py?reportID=6d7c97ca-8fe0-11f1-ad1d-47a790fa3ab2"
+Content-Security-Policy: connect-src 'none'; report-to dummy-endpoint
 Link: </registration?missingNonceFromHeader> ; rel="compression-dictionary"

--- a/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src.tentative.https.html.headers
+++ b/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src.tentative.https.html.headers
@@ -1,3 +1,4 @@
-Content-Security-Policy: connect-src *:*/allowedRegistration
+Reporting-Endpoints: dummy-endpoint="/reporting/resources/report.py?reportID=6d7c5a9e-8fe0-11f1-930d-5f24093adacc"
+Content-Security-Policy: connect-src *:*/allowedRegistration; report-to dummy-endpoint
 Link: </blockedRegistration?blockedFromHeader> ; rel="compression-dictionary"
 Link: </allowedRegistration?allowedFromHeader> ; rel="compression-dictionary"


### PR DESCRIPTION
Per the CSP specification, 'csp-violation' reports are only generated when there is a 'report-to' directive. See https://github.com/w3c/webappsec-csp/issues/819