### PR TITLE
CSP: Extend tests for wildcard host

### DIFF
--- a/content-security-policy/generic/wildcard-host-part-002.sub.window.js
+++ b/content-security-policy/generic/wildcard-host-part-002.sub.window.js
@@ -1,16 +1,9 @@
 setup(_ => {
   const meta = document.createElement("meta");
   meta.httpEquiv = "content-security-policy";
-  meta.content = "img-src http://*:{{ports[http][0]}}";
+  meta.content = "img-src http://*:{{ports[http][0]}}/content-security-policy/support/pass.png";
   document.head.appendChild(meta);
 });
-
-async_test((t) => {
-  const img = document.createElement("img");
-  img.onerror = t.step_func_done();
-  img.onload = t.unreached_func("`data:` image should have been blocked.");
-  img.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
-}, "Host wildcard doesn't affect scheme matching.");
 
 async_test((t) => {
   const img = document.createElement("img");
@@ -37,5 +30,12 @@ async_test((t) => {
   const img = document.createElement("img");
   img.onerror = t.step_func_done();
   img.onload = t.unreached_func("image from {{domains[]}}:{{ports[http][1]}} should have been blocked.");
-  img.src = "http://{{domains[]}}:{{ports[http][1]}}/content-security-policy/support/fail.png"
+  img.src = "http://{{domains[]}}:{{ports[http][1]}}/content-security-policy/support/pass.png"
 }, "Host wildcard doesn't affect port matching (port {{ports[http][1]}}).");
+
+async_test((t) => {
+  const img = document.createElement("img");
+  img.onerror = t.step_func_done();
+  img.onload = t.unreached_func("image fail.png should have been blocked.");
+  img.src = "http://{{domains[]}}:{{ports[http][0]}}/content-security-policy/support/fail.png"
+}, "Host wildcard doesn't affect path matching.");


### PR DESCRIPTION
Extend a bit the test for http://*:{{ports[http][0]}}, checking it matches the default host too and mismatches when port is different.

Add a similar test with an explicit path
http://*:{{ports[http][0]}}/content-security-policy/support/pass.png which works the same except that it also mismatches if path is different.

Tests for wildcard ports are a bit more tricky because the default port is not used by WPT server so they are not added in this simple PR where only image load/error is used as a check.