### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320791

### DIFF
--- a/xhr/send-usp.any.js
+++ b/xhr/send-usp.any.js
@@ -43,4 +43,72 @@ function encode(n) {
   for (var i = 0; i < NUM_TESTS; i++) {
     usp.append("a" + i, String.fromCharCode(i));
   }
-  x.send(usp)
+  x.send(usp);
+
+// Content-Type and request body handling for send(URLSearchParams).
+// https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send
+[
+  {
+    method: "POST",
+    authorContentType: null,
+    expectedContentType: "application/x-www-form-urlencoded;charset=UTF-8",
+    expectedBody: "a=b",
+    description: "POST uses the URLSearchParams MIME type when no Content-Type was set"
+  },
+  {
+    method: "POST",
+    authorContentType: "text/plain",
+    expectedContentType: "text/plain",
+    expectedBody: "a=b",
+    description: "POST keeps an author-set Content-Type"
+  },
+  {
+    // The spec only reconciles the charset parameter when the body is a Document or a string, but
+    // Blink, Gecko and WebKit all do it for URLSearchParams too, and the body is always UTF-8 here.
+    method: "POST",
+    authorContentType: "text/plain;charset=windows-1252",
+    expectedContentType: "text/plain;charset=UTF-8",
+    expectedBody: "a=b",
+    description: "POST replaces the charset parameter of an author-set Content-Type"
+  },
+  {
+    method: "GET",
+    authorContentType: null,
+    expectedContentType: "NO",
+    expectedBody: "",
+    description: "GET sends neither a body nor a Content-Type"
+  },
+  {
+    method: "HEAD",
+    authorContentType: null,
+    expectedContentType: "NO",
+    expectedBody: null,
+    description: "HEAD sends neither a body nor a Content-Type"
+  },
+  {
+    method: "GET",
+    authorContentType: "text/plain",
+    expectedContentType: "text/plain",
+    expectedBody: "",
+    description: "GET keeps an author-set Content-Type"
+  }
+].forEach(({ method, authorContentType, expectedContentType, expectedBody, description }) => {
+  promise_test(t => {
+    const client = new XMLHttpRequest();
+    client.open(method, "resources/content.py");
+    if (authorContentType !== null)
+      client.setRequestHeader("Content-Type", authorContentType);
+    client.send(new URLSearchParams("a=b"));
+    return new Promise((resolve, reject) => {
+      client.onload = resolve;
+      client.onerror = () => reject(new Error("Network error"));
+    }).then(() => {
+      assert_equals(client.getResponseHeader("X-Request-Method"), method, "request method");
+      assert_equals(client.getResponseHeader("X-Request-Content-Type"), expectedContentType, "Content-Type request header");
+      if (expectedBody !== null)
+        assert_equals(client.response, expectedBody, "request body");
+      if (expectedBody === "")
+        assert_equals(client.getResponseHeader("X-Request-Content-Length"), "NO", "Content-Length request header");
+    });
+  }, `XMLHttpRequest.send(URLSearchParams): ${description}`);
+});


### PR DESCRIPTION
WebKit export from bug: [XMLHttpRequest.send(URLSearchParams) sets a Content-Type request header on GET and HEAD requests](https://bugs.webkit.org/show_bug.cgi?id=320791)