### PR TITLE
Route web app origin association handlers

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -967,6 +967,7 @@ class RoutesBuilder:
             ("*", "/.well-known/interest-group/real-time-report", handlers.PythonScriptHandler),
             ("*", "/.well-known/private-aggregation/*", handlers.PythonScriptHandler),
             ("GET", "/.well-known/shared-storage/trusted-origins", handlers.PythonScriptHandler),
+            ("GET", "/.well-known/web-app-origin-association", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
             ("*", "/.well-known/device-bound-sessions", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),


### PR DESCRIPTION
The Web App Manifest `scope_extensions` feature validates an extended origin by fetching `/.well-known/web-app-origin-association`. Tests need this fixed, extensionless endpoint to return a dynamic response containing the runtime-resolved app ID and virtual host.

Route the endpoint through `PythonScriptHandler`, consistent with the other dynamic `.well-known` resources. Without this route, wptserve returns the handler source as a static `application/octet-stream` response.

Chromium issue: https://issues.chromium.org/issues/422382413

Validation:
- `python wpt lint tools/serve/serve.py`
- Started wptserve with a temporary handler at the endpoint and verified a request on an alternate WPT host returned host-specific JSON with `Content-Type: application/json`.