### PR TITLE
Update several WebVTT tests to use shared css files and fix tests that do not match spec

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50-ref.html
@@ -1,30 +1,7 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center, position greater than 50%</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    right: 0px;
-    width: 64px;
-    text-align: center;
-    font: 20px/1 Ahem;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-    color: green;
-}
-</style>
-<div class=video>
-    <div class="cue">
-        <span class="cueText">foo</span>
-    </div>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue" style="width:20%; left:80%;"><span class="cue-background">foo</span></div>
 </div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:center, position greater than 50%</title>
 <link rel="match" href="align_center_position_gt_50-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font: 20px/1 Ahem;
-    color: green;
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_gt_50.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size-ref.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center, position greater than 50%, size greater than maximum size</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-}
-.cue {
-    position: absolute;
-    bottom: 0px;
-    right: 0px;
-    width: 64px;
-    text-align: center;
-    font: 20px/1 Ahem;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-    color: green;
-}
-</style>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<link rel="stylesheet" href="support/webvtt-ref.css">
 <div class=video>
-    <div class="cue">
-        <div><span class="cueText">Awe</span></div>
-        <div><span class="cueText">som</span></div>
-        <div><span class="cueText">e!!</span></div>
-        <div><span class="cueText">!</span></div>
-    </div>
+    <div class="cue" style="width:20%; left:80%; font-size:20px;"><span class="cue-background">Awesome!!!</span></div>
 </div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_gt_50_size_gt_maximum_size.html
@@ -3,15 +3,13 @@
 <title>WebVTT rendering, align:center, position greater than 50%, size greater than maximum size</title>
 <link rel="match" href="align_center_position_gt_50_size_gt_maximum_size-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font: 20px/1 Ahem;
-    color: green;
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
+<style>
+    ::cue {
+        font-size: 20px;
+    }
+</style>
 <video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50-ref.html
@@ -1,31 +1,7 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center, position less than 50%</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0px;
-    right: 0;
-    width: 64px;
-    text-align: center;
-    font: 20px/1 Ahem;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-    color: green;
-}
-</style>
-<div class=video>
-    <div class="cue">
-        <span class="cueText">foo</span>
-    </div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video">
+    <div class="cue" style="width:20%;"><span class="cue-background">foo</span></div>
 </div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:center, position less than 50%</title>
 <link rel="match" href="align_center_position_lt_50-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font: 20px/1 Ahem;
-    color: green;
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_lt_50.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size-ref.html
@@ -1,33 +1,7 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center, position less than 50%, size greater than maximum size</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-}
-.cue {
-    position: absolute;
-    bottom: 0px;
-    left: 0px;
-    width: 64px;
-    text-align: center;
-    font: 20px/1 Ahem;
-}
-.cueText {
-    background: rgba(0,0,0,0.8);
-    color: green;
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <div class=video>
-    <div class="cue">
-        <div><span class="cueText">Awe</span></div>
-        <div><span class="cueText">som</span></div>
-        <div><span class="cueText">e!!</span></div>
-        <div><span class="cueText">!</span></div>
-    </div>
+    <div class="cue" style="width:20%; font-size:20px;"><span class="cue-background">Awesome!!!</span></div>
 </div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_position_lt_50_size_gt_maximum_size.html
@@ -2,17 +2,15 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:center, position less than 50%, size greater than maximum size</title>
 <link rel="match" href="align_center_position_lt_50_size_gt_maximum_size-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font: 20px/1 Ahem;
-    color: green;
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<style>
+    ::cue {
+        font-size: 20px;
+    }
+</style>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_position_lt_50_size_gt_maximum_size.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html
@@ -1,27 +1,7 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:center with long cues</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video">
+<div class="cue" style="width:100%;"><span class="cue-background">This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></div>
+</div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:center with long cues</title>
 <link rel="match" href="align_center_wrapped-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_center_long.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
@@ -1,27 +1,5 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:end</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: right;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test</span></span></div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video"><div class="cue" style="width:50%; text-align:end;"><span class="cue-background">This is a test</span></div></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_end.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:end</title>
 <link rel="match" href="align_end-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_end.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
@@ -1,27 +1,5 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:end with long cues</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: right;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video"><div class="cue" style="width:50%; text-align:end;"><span class="cue-background">This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></div></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped.html
@@ -2,15 +2,8 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:end with long cues</title>
 <link rel="match" href="align_end_wrapped-ref.html">
+<link rel="stylesheet" href="support/webvtt-test.css">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
 <script src="/common/reftest-wait.js"></script>
 <video width="320" height="180" autoplay>
     <source src="/media/white.webm" type="video/webm">

--- a/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
@@ -1,27 +1,8 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:start</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: left;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test</span></span></div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video">
+    <div class="cue" style="width:50%; left:50%; text-align:start;"><span class="cue-background">This is a test</span>
+    </div>
+</div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_start.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:start</title>
 <link rel="match" href="align_start-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_start.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
@@ -1,27 +1,5 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, align:start with long cues</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: left;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video"><div class="cue" style="width:50%; left:50%; text-align:start;"><span class="cue-background">This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></div></div>

--- a/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, align:start with long cues</title>
 <link rel="match" href="align_start_wrapped-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/align_start_long.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles-ref.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <title>Reference for WebVTT rendering, &lt;audio&gt; should not have subtitles</title>
+<link rel="stylesheet" href="support/webvtt-ref.css">
 <style>
 audio {
     width: 320px;

--- a/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html
+++ b/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html
@@ -2,16 +2,13 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, &lt;audio&gt; should not have subtitles</title>
 <link rel="match" href="audio_has_no_subtitles-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <style>
 audio {
     width: 320px;
     height: 180px;
     outline: solid
-}
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/webvtt/rendering/cues-with-video/processing-model/cue_too_long-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/cue_too_long-ref.html
@@ -1,15 +1,5 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, size:50%, cue too long - should be hidden</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-</style>
-<div class="video"><span class="cue"></span></span></div>
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<div class="video"><div class="cue"><span class="cue-background"></span></div></div>

--- a/webvtt/rendering/cues-with-video/processing-model/cue_too_long.html
+++ b/webvtt/rendering/cues-with-video/processing-model/cue_too_long.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, size:50%, cue too long - should be hidden</title>
 <link rel="match" href="cue_too_long-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="support/webvtt-test.css">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/very_long_cue.vtt">

--- a/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css
+++ b/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css
@@ -24,7 +24,7 @@ body { margin: 0 }
     text-decoration: none;
     text-shadow: none;
     outline: none;
-    font: 9px Ahem, sans-serif; /* Use Ahem because it improves test reliability. */
+    font: 9px/1 Ahem, sans-serif;
     bottom: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
Update several WebVTT tests to use shared css files and fix tests that do not match spec.

Tests in PR:
align_center_position_gt_50
align_center_position_gt_50_size_gt_maximum_size
align_center_position_lt_50
align_center_position_lt_50_size_gt_maximum_size
align_center_wrapped
align_end
align_end_wrapped
align_start
align_start_wrapped
audio_has_no_subtitles
cue_too_long

Also modify webvtt-ref.css to have style `font: 9px/1 Ahem, sans-serif;` instead of `font: 9px Ahem, sans-serif;` The line height of 1 is necessary to have a consistent rendering, since the default line height differs across browsers.

This change causes Safari to regress on align_start and align_end, but the WebKit bug causing this has just been [fixed](https://github.com/WebKit/WebKit/pull/70876).

It also causes Firefox to regress on align_center_position_gt_50, align_center_position_gt_50_size_gt_maximum_size, align_center_position_lt_50, and align_center_position_lt_50_size_gt_maximum_size. This is due to a [firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=2060917).

These tests were discussed and approved at the WebVTT interop meetings on [Aug. 5 2026](https://github.com/web-platform-tests/interop-webvtt/issues/22) and [Aug. 19 2026](https://github.com/web-platform-tests/interop-webvtt/issues/23)