### PR TITLE
 Add more cases for shadow root scoped registries  

### DIFF
--- a/custom-elements/registries/Document-importNode-cross-document.window.js
+++ b/custom-elements/registries/Document-importNode-cross-document.window.js
@@ -114,3 +114,39 @@ test(t => {
   const clone = contentDocument.importNode(element);
   assert_equals(clone.shadowRoot.customElementRegistry, scoped);
 }, "Cloning including shadow tree with scoped registry (null registry target)");
+
+test(t => {
+  const contentDocument = document.implementation.createHTMLDocument();
+  const scopedDocRegistry = new CustomElementRegistry();
+  scopedDocRegistry.initialize(contentDocument);
+  assert_equals(contentDocument.customElementRegistry, scopedDocRegistry);
+
+  const element = document.createElement("div");
+  const clone = contentDocument.importNode(element);
+  assert_equals(clone.customElementRegistry, null);
+}, "Cloning with global registry (scoped registry target)");
+
+test(t => {
+  const contentDocument = document.implementation.createHTMLDocument();
+  const scopedDocRegistry = new CustomElementRegistry();
+  scopedDocRegistry.initialize(contentDocument);
+  assert_equals(contentDocument.customElementRegistry, scopedDocRegistry);
+
+  const element = document.createElement("div");
+  const elementShadow = element.attachShadow({ mode: "open", clonable: true });
+  const clone = contentDocument.importNode(element);
+  assert_equals(clone.shadowRoot.customElementRegistry, null);
+}, "Cloning including shadow tree with global registry (scoped registry target)");
+
+test(t => {
+  const contentDocument = document.implementation.createHTMLDocument();
+  const scopedDocRegistry = new CustomElementRegistry();
+  scopedDocRegistry.initialize(contentDocument);
+  assert_equals(contentDocument.customElementRegistry, scopedDocRegistry);
+
+  const scoped = new CustomElementRegistry();
+  const element = document.createElement("div");
+  const elementShadow = element.attachShadow({ mode: "open", clonable: true, customElementRegistry: scoped });
+  const clone = contentDocument.importNode(element);
+  assert_equals(clone.shadowRoot.customElementRegistry, scoped);
+}, "Cloning including shadow tree with scoped registry (scoped registry target)");


### PR DESCRIPTION
This adds a few more cases for scoped registries.

1 failure in Chrome, 2 failures in Safari. These seem to follow per-spec though, so either spec is wrong or implementations are.

## Test 1: "Cloning with global registry (scoped registry target)"
- clone a single node (https://dom.spec.whatwg.org/#clone-a-single-node) step 2.1: registry = element's registry = global
- step 2.2: not null -> skip fallback
- step 2.3: global is-global -> set to document's registry's effectiveGlobal = effectiveGlobal(scopedDocRegistry) = null
- step 2.4: create element (https://dom.spec.whatwg.org/#concept-create-element) with registry = null
- result: clone.customElementRegistry === null

Chrome: ✅, Safari: ✅ 


## Test 2: "Cloning including shadow tree with global registry (scoped registry target)"
- attachShadow (https://dom.spec.whatwg.org/#dom-element-attachshadow) step 1: no override -> shadow root registry = main doc registry = global
- clone a node (https://dom.spec.whatwg.org/#concept-node-clone) step 6.2: shadowRootRegistry = global
- step 6.3: global is-global -> set to effectiveGlobal(scopedDocRegistry) = null
- step 6.4: attach a shadow root (https://dom.spec.whatwg.org/#concept-attach-a-shadow-root) with null
- result: clone.shadowRoot.customElementRegistry === null

Chrome: ❌, Safari: ❌ 

## Test 3: "Cloning including shadow tree with scoped registry (scoped registry target)"
- attachShadow (https://dom.spec.whatwg.org/#dom-element-attachshadow) step 2: customElementRegistry: scoped present -> shadow root registry = scoped
- clone a node (https://dom.spec.whatwg.org/#concept-node-clone) step 6.2: shadowRootRegistry = scoped
- step 6.3: scoped NOT is-global -> skip, unchanged
- step 6.4: attach shadow root with scoped
- result: clone.shadowRoot.customElementRegistry === scoped

Chrome: ❌, Safari: ✅

/cc @annevk @ja-y-son