### PR TITLE
layout: Map between pre-transformed and post-transformed selection offsets during display list construction

### DIFF
--- a/css/css-text/text-transform/reference/text-transform-upperlower-108-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-108-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Text, text transform in textarea element: German sharp S, uppercase and selection</title>
+<meta name="assert" content="text-transform: uppercase will uppercase the German sharp S as described in Unicode's SpecialCasing.txt .">
+<link rel='author' title='Martin Robinson' href='mailto:mrobinson@igalia.com'>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
+</head>
+
+<body>
+    <p class="instructions">Test passes if both characters below are selected.</p>
+    <textarea id="textarea" style="text-transform: uppercase">SS</textarea>
+    <script>
+        textarea.focus();
+        textarea.setSelectionRange(0, 2);
+    </script>
+</body>
+</html>

--- a/css/css-text/text-transform/text-transform-upperlower-108.html
+++ b/css/css-text/text-transform/text-transform-upperlower-108.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Text, text transform in textarea element: German sharp S, uppercase and selection</title>
+<meta name="assert" content="text-transform: uppercase will uppercase the German sharp S as described in Unicode's SpecialCasing.txt .">
+<link rel='author' title='Martin Robinson' href='mailto:mrobinson@igalia.com'>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
+<link rel="match" href="reference/text-transform-upperlower-108-ref.html">
+</head>
+
+<body>
+    <p class="instructions">Test passes if both characters below are selected.</p>
+    <textarea id="textarea" style="text-transform: uppercase">&#x00DF;</textarea>
+    <script>
+        textarea.focus();
+        textarea.setSelectionRange(0, 1);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
There are two types of DOM-node-relative text offsets to consider in
layout. One is pre-transformed, that is before any white space collapse
or `text-transform` is applied to the node's text content. This is how
selections are stored, so that they can be updated without triggering a
full layout. The other is post-transformed, that is after white space
collapse and `text-transform`. This is how glyph character advances are
measured. This changes moves the mapping from the first to the second to
display list construction, so that it is done also for form control
selections. This fixes the behavior of visual selections and
`text-transform` in form control elements and is also foundational for
ensuring that the reverse transform can happen during hit testing.

Testing: This change adds a new WPT test.

Reviewed in servo/servo#47022