### PR TITLE
layout: Take `OffsetMap` into account when getting glyph character index

### DIFF
--- a/css/css-text/text-transform/reference/text-transform-upperlower-108-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-108-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Text, text transform in textarea element: German sharp S, uppercase and selection</title>
+<meta name="assert" content="text-transform: uppercase will uppercase the German sharp S as described in Unicode's SpecialCasing.txt .">
+<link rel='author' title='Martin Robinson' href='mailto:mrobinson@igalia.com'>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
+</head>
+
+<body>
+    <p class="instructions">Test passes if both characters below are selected.</p>
+    <textarea id="textarea" style="text-transform: uppercase">SS</textarea>
+    <script>
+        textarea.focus();
+        textarea.setSelectionRange(0, 2);
+    </script>
+</body>
+</html>

--- a/css/css-text/text-transform/text-transform-upperlower-108.html
+++ b/css/css-text/text-transform/text-transform-upperlower-108.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Text, text transform in textarea element: German sharp S, uppercase and selection</title>
+<meta name="assert" content="text-transform: uppercase will uppercase the German sharp S as described in Unicode's SpecialCasing.txt .">
+<link rel='author' title='Martin Robinson' href='mailto:mrobinson@igalia.com'>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
+<link rel="match" href="reference/text-transform-upperlower-108-ref.html">
+</head>
+
+<body>
+    <p class="instructions">Test passes if both characters below are selected.</p>
+    <textarea id="textarea" style="text-transform: uppercase">&#x00DF;</textarea>
+    <script>
+        textarea.focus();
+        textarea.setSelectionRange(0, 1);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
When text is transformed by `InlineFormattingContext` construction, we
keep an `OffsetMap` to map between indices pre-and-post-transform.
This change ensures the map is used when mapping back to
pre-transformed DOM indices, meaning that moving the edit point with
the mouse in `<textarea>` that has a CSS `text-transform` or is
subject to white space collapse works properly.

Testing: A Servo-specific WPT test is added for this change as it depends on mouse interaction behavior.

Reviewed in servo/servo#47025