### PR TITLE
Fix typos in GPC docs

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -195,7 +195,7 @@ the global scope.
 ### Global Privacy Control ###
 
 ```eval_rst
-.. js:autofunction:: test_driver.set_global_privacy_control
+.. js:autofunction:: test_driver.get_global_privacy_control
 .. js:autofunction:: test_driver.set_global_privacy_control
 ```
 

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -2358,6 +2358,10 @@
 
         /**
          * Gets the current globally-applied privacy control status
+         * 
+         * Matches the `Get Global Privacy Control
+         * <https://www.w3.org/TR/gpc/#get-global-privacy-control>`_
+         * WebDriver command.
          *
          * @returns {Promise} Fulfils with an object with boolean property `gpc`
          *                    that encodes the current "do not sell or share"
@@ -2369,6 +2373,10 @@
 
         /**
          * Sets and then gets the current globally-applied privacy control status
+         * 
+         * Matches the `Set Global Privacy Control
+         * <https://www.w3.org/TR/gpc/#set-global-privacy-control>`_
+         * WebDriver command.
          *
          * @param {boolean} newValue - A boolean that is true if the browser
          *                             should convey a "do not sell or share" signal

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -2370,7 +2370,7 @@
         /**
          * Gets the current globally-applied privacy control status
          *
-         * @param {bool} newValue - The a boolean that is true if the browers
+         * @param {bool} newValue - The a boolean that is true if the browsers
          *                          should convey a "do not sell or share" signal
          *                          and false otherwise
          *

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -2368,9 +2368,9 @@
         },
 
         /**
-         * Gets the current globally-applied privacy control status
+         * Sets and then gets the current globally-applied privacy control status
          *
-         * @param {bool} newValue - The a boolean that is true if the browsers
+         * @param {bool} newValue - The a boolean that is true if the browser
          *                          should convey a "do not sell or share" signal
          *                          and false otherwise
          *

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -2370,9 +2370,9 @@
         /**
          * Sets and then gets the current globally-applied privacy control status
          *
-         * @param {bool} newValue - The a boolean that is true if the browser
-         *                          should convey a "do not sell or share" signal
-         *                          and false otherwise
+         * @param {boolean} newValue - A boolean that is true if the browser
+         *                             should convey a "do not sell or share" signal
+         *                             and false otherwise
          *
          * @returns {Promise} Fulfils with an object with boolean property `gpc`
          *                    that encodes the new "do not sell or share"

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -2358,7 +2358,7 @@
 
         /**
          * Gets the current globally-applied privacy control status
-         * 
+         *
          * Matches the `Get Global Privacy Control
          * <https://www.w3.org/TR/gpc/#get-global-privacy-control>`_
          * WebDriver command.
@@ -2373,7 +2373,7 @@
 
         /**
          * Sets and then gets the current globally-applied privacy control status
-         * 
+         *
          * Matches the `Set Global Privacy Control
          * <https://www.w3.org/TR/gpc/#set-global-privacy-control>`_
          * WebDriver command.


### PR DESCRIPTION
I was implementing the WPT facing parts of GPC for Chrome (https://crrev.com/c/8186637) and noticed these errors as well as a spec inconsistency (https://github.com/w3c/gpc/issues/151)