### PR TITLE
Test sizes=auto with object-fit

### DIFF
--- a/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-object-fit.html
+++ b/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-object-fit.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<title>sizes=auto uses the concrete object width with object-fit</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#sizes-attributes">
+<link rel="help" href="https://drafts.csswg.org/css-images/#the-object-fit">
+<meta name="assert" content="sizes=auto uses the width of the concrete object size, including the effects of object-fit">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+img {
+  width: 200px;
+  height: 200px;
+}
+
+#cover {
+  object-fit: cover;
+}
+
+#contain {
+  object-fit: contain;
+}
+</style>
+
+<img id="cover" loading="lazy" sizes="auto"
+     srcset="support/wide-400x200.svg 400w"
+     width="800" height="400" alt="">
+<img id="contain" loading="lazy" sizes="auto"
+     srcset="support/tall-200x400.svg 200w"
+     width="400" height="800" alt="">
+
+<script>
+function loadPromise(img) {
+  if (img.complete) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    img.addEventListener("load", resolve, {once: true});
+    img.addEventListener("error", reject, {once: true});
+  });
+}
+
+promise_test(async () => {
+  await loadPromise(cover);
+  assert_equals(cover.naturalWidth, 400);
+}, "sizes=auto uses the 400px concrete object width for object-fit: cover");
+
+promise_test(async () => {
+  await loadPromise(contain);
+  assert_equals(contain.naturalWidth, 100);
+}, "sizes=auto uses the 100px concrete object width for object-fit: contain");
+</script>

--- a/html/semantics/embedded-content/the-img-element/sizes/support/tall-200x400.svg
+++ b/html/semantics/embedded-content/the-img-element/sizes/support/tall-200x400.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="400" viewBox="0 0 200 400">
+  <rect width="200" height="400" fill="green"/>
+</svg>

--- a/html/semantics/embedded-content/the-img-element/sizes/support/wide-400x200.svg
+++ b/html/semantics/embedded-content/the-img-element/sizes/support/wide-400x200.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200">
+  <rect width="400" height="200" fill="green"/>
+</svg>


### PR DESCRIPTION
This adds testharness coverage for the requirement that `sizes="auto"` uses
the width of an image's concrete object size, including the effects of
`object-fit`.

The test covers two cases in a 200px by 200px content box:

- a 2:1 image with `object-fit: cover`, whose concrete object width is 400px
- a 1:2 image with `object-fit: contain`, whose concrete object width is 100px

Each case uses a single width-descriptor candidate with matching intrinsic
dimensions. Its density-corrected `naturalWidth` therefore exposes the source
size without depending on DPR or candidate-selection discretion.

Current Chrome 151 incorrectly reports 200px for both cases.

Checks:

- `./wpt lint html/semantics/embedded-content/the-img-element/sizes/sizes-auto-object-fit.html html/semantics/embedded-content/the-img-element/sizes/support/wide-400x200.svg html/semantics/embedded-content/the-img-element/sizes/support/tall-200x400.svg`
- Local testharness run: harness status OK; both assertions fail in Chrome 151
  with the expected incorrect 200px result
