### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321424

### DIFF
--- a/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-ref.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG container (reference)</title>
+<svg width="300" height="300">
+  <g transform="rotate(90 100 100)">
+    <rect x="50" y="50" width="100" height="100" fill="green"/>
+  </g>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-rotated-container.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-rotated-container.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG container</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-rotated-container-ref.html">
+<meta name="assert" content="The reference box of a rotated container is its own bounding box in its own user space, so inset() trims 100 user units from its right edge and the result rotates with the container.">
+<svg width="300" height="300">
+  <g transform="rotate(90 100 100)" style="clip-path: inset(0 100px 0 0)">
+    <rect x="50" y="50" width="200" height="100" fill="green"/>
+  </g>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-ref.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG shape (reference)</title>
+<svg width="300" height="300">
+  <rect x="50" y="50" width="100" height="100" transform="rotate(90 100 100)" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-rotated-shape-ref.html">
+<meta name="assert" content="The reference box is the shape's own bounding box in its own user space, so inset() trims 100 user units from its right edge and the result rotates with the shape.">
+<svg width="300" height="300">
+  <rect x="50" y="50" width="200" height="100" transform="rotate(90 100 100)" style="clip-path: inset(0 100px 0 0)" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-ref.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape lengths on a scaled SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect x="50" y="50" width="100" height="100" transform="scale(2)" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape lengths on a scaled SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-scaled-shape-ref.html">
+<meta name="assert" content="An absolute length in a basic shape resolves in the shape's own user space, so inset() on a scale(2) shape trims 100 user units rather than 100 units of the parent's space.">
+<svg width="400" height="400">
+  <rect x="50" y="50" width="200" height="100" transform="scale(2)" style="clip-path: inset(0 100px 0 0)" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-ref.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a rotated SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect x="0" y="0" width="100" height="100" transform="rotate(90 100 100)" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a rotated SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-view-box-rotated-shape-ref.html">
+<meta name="assert" content="The view-box reference box is sized from the nearest SVG viewport but positioned in the rotated shape's own user space.">
+<svg width="400" height="400">
+  <rect x="0" y="0" width="200" height="100" transform="rotate(90 100 100)" style="clip-path: inset(0 300px 0 0) view-box" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-ref.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a scaled SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect width="100" height="200" transform="scale(2)" fill="green"/>
+</svg>

--- a/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape.html
+++ b/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a scaled SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-view-box-scaled-shape-ref.html">
+<meta name="assert" content="The view-box reference box is sized from the nearest SVG viewport but positioned in the scaled shape's own user space.">
+<svg width="400" height="400">
+  <rect width="200" height="200" transform="scale(2)" style="clip-path: inset(0 300px 0 0) view-box" fill="green"/>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [\[Legacy SVG\] CSS clip-path basic-shape is mispositioned on a rotated or scaled SVG element](https://bugs.webkit.org/show_bug.cgi?id=321424)