### PR TITLE
Use the standard wpt_report.json filename for infrastructure tests

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -11,7 +11,7 @@ CHANNEL="$2"
 
 run_infra_test() {
     echo "### Running Infrastructure Tests for $1 ###"
-    ./tools/ci/taskcluster-run.py "$1" "$2" -- --log-tbpl=- --log-wptreport="../artifacts/wptreport-$1.json" --logcat-dir="../artifacts/" --metadata=infrastructure/metadata/ --include=infrastructure/
+    ./tools/ci/taskcluster-run.py "$1" "$2" -- --log-tbpl=- --log-wptreport=../artifacts/wpt_report.json --logcat-dir="../artifacts/" --metadata=infrastructure/metadata/ --include=infrastructure/
 }
 
 main() {


### PR DESCRIPTION
The per-browser suffix dates from when a single task ran all three
browsers, so each browser needed a distinct filename to avoid
overwriting the others' report. 644c18e758 (TC: run infrastructure/
separately per browser) split each browser into its own task with its
own artifact upload, removing that collision risk and making it safe
to drop the suffix.

By using wpt_report.json, the same filename the regular test tasks
already pass, we now automatically gzip the report file.

Additionally, the non-standard filename meant that wpt.fyi did not
find the infrastructure results, and thus did not consume them.
