### PR TITLE
HTML parser: fix legacy PI parse errors

### DIFF
--- a/html/syntax/parsing/resources/comments01.dat
+++ b/html/syntax/parsing/resources/comments01.dat
@@ -155,10 +155,9 @@ FOO<!-->BAZ
 #data
 <?xml version="1.0">Hi
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,22): expected-doctype-but-got-chars
 #new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
+(1:6) disallowed-processing-instruction-target
 #document
 | <!-- ?xml version="1.0" -->
 | <html>
@@ -169,10 +168,9 @@ FOO<!-->BAZ
 #data
 <?xml version="1.0">
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,20): expected-doctype-but-got-eof
 #new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
+(1:6) disallowed-processing-instruction-target
 #document
 | <!-- ?xml version="1.0" -->
 | <html>
@@ -182,10 +180,9 @@ FOO<!-->BAZ
 #data
 <?xml version
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,13): expected-doctype-but-got-eof
 #new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
+(1:6) disallowed-processing-instruction-target
 #document
 | <!-- ?xml version -->
 | <html>

--- a/html/syntax/parsing/resources/html5test-com.dat
+++ b/html/syntax/parsing/resources/html5test-com.dat
@@ -129,10 +129,7 @@
 #data
 <?import namespace="foo" implementation="#bar">
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,47): expected-doctype-but-got-eof
-#new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
 #document
 | <?import namespace="foo" implementation="#bar"?>
 | <html>

--- a/html/syntax/parsing/resources/tests1.dat
+++ b/html/syntax/parsing/resources/tests1.dat
@@ -551,10 +551,9 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <?
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,2): expected-doctype-but-got-eof
 #new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
+(1:3) eof-in-processing-instruction
 #document
 | <html>
 |   <head>
@@ -563,10 +562,9 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <?#
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,3): expected-doctype-but-got-eof
 #new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
+(1:3) invalid-first-character-of-processing-instruction-target
 #document
 | <!-- ?# -->
 | <html>
@@ -602,10 +600,7 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <?COMMENT?>
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,11): expected-doctype-but-got-eof
-#new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
 #document
 | <?COMMENT ?>
 | <html>
@@ -641,10 +636,7 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <?COM--MENT?>
 #errors
-(1,1): expected-tag-name-but-got-question-mark
 (1,13): expected-doctype-but-got-eof
-#new-errors
-(1:2) unexpected-question-mark-instead-of-tag-name
 #document
 | <?COM--MENT ?>
 | <html>


### PR DESCRIPTION
PR #61083 corrected these processing-instruction trees but left their pre-PI tokenizer errors in place. The [tag open state](https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state) no longer reports `unexpected-question-mark-instead-of-tag-name` for `?`; it clears the temporary buffer and enters the [processing instruction open state](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state). Each changed fixture follows one of the normative paths below.

| Input | Normative path | Error change |
| --- | --- | --- |
| `<?xml version="1.0">Hi` | PI open reconsumes `x` in the [target state](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state). The following space completes the target `xml`, which is explicitly disallowed. The tokenizer reports the error at that space, converts `?xml` to a comment through [convert the temporary buffer to a comment](https://html.spec.whatwg.org/multipage/parsing.html#convert-the-temporary-buffer-to-a-comment), and reconsumes the space in the [bogus comment state](https://html.spec.whatwg.org/multipage/parsing.html#bogus-comment-state). | Replace the obsolete column-2 question-mark error with `disallowed-processing-instruction-target` at column 6. Keep the independent missing-doctype error raised when `Hi` is reprocessed by the [initial insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode). |
| `<?xml version="1.0">` | The tokenizer takes the same disallowed-`xml` target path and emits the same comment. | Replace the obsolete error with `disallowed-processing-instruction-target` at column 6. Keep the initial-mode missing-doctype error at EOF. |
| `<?xml version` | The space after `xml` triggers the disallowed-target branch before EOF. The bogus comment state emits the resulting `?xml version` comment at EOF. | Replace the obsolete error with `disallowed-processing-instruction-target` at column 6. Keep the initial-mode missing-doctype error at EOF. |
| `<?import namespace="foo" implementation="#bar">` | `import` contains only permitted target characters. The space creates a PI token, the [after-target state](https://html.spec.whatwg.org/multipage/parsing.html#after-processing-instruction-target-state) skips the separator, and `>` in the [PI data state](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-data-state) emits the token. The grammar does not require `?>`. | Remove both obsolete question-mark error entries. Keep the initial-mode missing-doctype error at EOF. |
| `<?` | After tag open consumes `?`, PI open immediately consumes EOF. Its EOF branch reports `eof-in-processing-instruction` and emits no comment or PI token. | Replace the column-2 question-mark error with `eof-in-processing-instruction` at column 3, the position after the two-character input. Keep the initial-mode missing-doctype error at EOF. |
| `<?#` | PI open rejects `#` as the first target character at column 3. It reports `invalid-first-character-of-processing-instruction-target`, converts the empty temporary buffer to a comment whose data starts with `?`, and reconsumes `#` in bogus comment, producing the existing `<!-- ?# -->` tree at EOF. | Replace the column-2 question-mark error with the PI-open error at column 3. Keep the initial-mode missing-doctype error at EOF. |
| `<?COMMENT?>` | ASCII letters are valid target characters. `?` completes the target and is reconsumed through after-target into PI data; the [PI questionable state](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-questionable-state) sees the following `>` and emits the PI without appending `?` or reporting an error. | Remove both obsolete question-mark error entries. Keep the initial-mode missing-doctype error at EOF. |
| `<?COM--MENT?>` | Hyphen-minus is explicitly permitted in the PI target state, so this follows the same `?>` path as `COMMENT`. | Remove both obsolete question-mark error entries. Keep the initial-mode missing-doctype error at EOF. |

The patch does not alter tree expectations. It changes only tokenizer errors that became stale when HTML processing instructions replaced the old bogus-comment handling, while preserving the separate tree-construction errors required by the initial insertion mode.

TurboHTML's consumer-side migration from the retired `html5lib-tests` tree-construction copy to the pinned WPT corpus is [tox-dev/turbohtml#748](https://github.com/tox-dev/turbohtml/pull/748).
