### PR TITLE
Add test for strut insertion with block ellipsis

### DIFF
--- a/css/css-overflow/line-clamp/block-ellipsis-039.html
+++ b/css/css-overflow/line-clamp/block-ellipsis-039.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow: block-ellipsis root-inline strut</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#block-ellipsis">
+<link rel="match" href="reference/block-ellipsis-039-ref.html">
+<meta name="assert" content="The strut inserted by block-ellipsis is online styled after the root inline, not after any other interrupted inline box.">
+<style>
+.test, .ref {
+    width: min-content;
+    float: left;
+    border: solid 1px;
+    margin: 0 1ch;
+}
+.test {
+    line-clamp: 2;
+}
+.tall {
+    font-size: 2em;
+    line-height: 2;
+}
+</style>
+
+<p>This test passes if the two boxes below are identical, including having the same height.
+
+<div class=test>
+    <span class=tall>TEST TEST TEST</span>
+    <span></span>
+</div>
+<div class=ref>
+    <span class=tall>TEST</span>
+    …
+</div>

--- a/css/css-overflow/line-clamp/reference/block-ellipsis-039-ref.html
+++ b/css/css-overflow/line-clamp/reference/block-ellipsis-039-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<style>
+.ref {
+    width: min-content;
+    float: left;
+    border: solid 1px;
+    margin: 0 1ch;
+}
+.tall {
+    font-size: 2em;
+    line-height: 2;
+}
+</style>
+
+<p>This test passes if the two boxes below are identical, including having the same height.
+
+<div class=ref>
+    <span class=tall>TEST</span>
+    …
+</div>
+<div class=ref>
+    <span class=tall>TEST</span>
+    …
+</div>


### PR DESCRIPTION
We only insert a strut based on the root inline, not on any interrupted inline box that might be there otherwise.

See https://github.com/w3c/csswg-drafts/issues/13786