### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320716

### DIFF
--- a/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change.html
+++ b/css/css-pseudo/highlight-cascade/highlight-cascade-parent-style-change.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight cascade: inheritance after a parent style change</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade">
+<meta name="assert" content="This test verifies that a highlight pseudo-element inherits from the current style of the corresponding highlight pseudo-element of its parent element, not from a previously resolved one.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #parent { font-size: 10px; }
+  #parent::selection { text-shadow: green 1em 0; }
+</style>
+<div id="parent"><span id="child">text</span></div>
+<script>
+test(() => {
+    const parent = document.getElementById("parent");
+    const child = document.getElementById("child");
+    const shadow = element => getComputedStyle(element, "::selection").textShadow;
+
+    // Resolves and caches the highlight styles of both, the child inheriting from the parent.
+    assert_equals(shadow(parent), "rgb(0, 128, 0) 10px 0px 0px", "parent");
+    assert_equals(shadow(child), "rgb(0, 128, 0) 10px 0px 0px", "child");
+
+    // The parent's own highlight text-shadow is in em, so this changes it, and the child inherits
+    // that computed value through the highlight chain.
+    parent.style.fontSize = "40px";
+
+    assert_equals(shadow(parent), "rgb(0, 128, 0) 40px 0px 0px", "parent after the change");
+    assert_equals(shadow(child), "rgb(0, 128, 0) 40px 0px 0px", "child after the change");
+}, "A highlight pseudo-element inherits from the parent's new style, not its previous one");
+</script>

--- a/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary.html
+++ b/css/css-pseudo/highlight-cascade/highlight-cascade-shadow-boundary.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight cascade: inheritance across a shadow boundary</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade">
+<meta name="assert" content="This test verifies that highlight inheritance follows the flat tree, so that a highlight pseudo-element in a shadow tree inherits from the corresponding highlight pseudo-element of the shadow host, and slotted content inherits through the slot.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #host::selection { background-color: rgb(1, 2, 3); }
+  #slotHost::selection { background-color: rgb(4, 5, 6); }
+</style>
+<div id="host"></div>
+<div id="slotHost"><span id="slotted">text</span></div>
+<script>
+const host = document.getElementById("host");
+const slotHost = document.getElementById("slotHost");
+host.attachShadow({ mode: "open" }).innerHTML = "<span id='inner'>text</span>";
+slotHost.attachShadow({ mode: "open" }).innerHTML = "<slot></slot>";
+
+const background = element => getComputedStyle(element, "::selection").backgroundColor;
+
+test(() => {
+    assert_equals(background(host.shadowRoot.getElementById("inner")), "rgb(1, 2, 3)");
+}, "A highlight pseudo-element in a shadow tree inherits from the shadow host's");
+
+test(() => {
+    assert_equals(background(document.getElementById("slotted")), "rgb(4, 5, 6)");
+}, "A highlight pseudo-element of slotted content inherits through the slot");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[Custom Highlight\] ::highlight() pseudo-elements should inherit from the parent element's highlight.](https://bugs.webkit.org/show_bug.cgi?id=320716)