### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=320896

### DIFF
--- a/css/css-variables/var-parsing.html
+++ b/css/css-variables/var-parsing.html
@@ -12,10 +12,34 @@ test_valid_value('width', 'var(--x)');
 test_valid_value('width', 'var(--x,)');
 test_valid_value('width', 'var(--x, )');
 
-test_invalid_value('width', 'var(--x ())');
-test_invalid_value('width', 'var(--x () )');
-test_invalid_value('width', 'var(--x() )');
-test_invalid_value('width', 'var(--x (),)');
-test_invalid_value('width', 'var(--x(),)');
+// var()'s name argument is a <declaration-value> that is substituted and only then parsed as a
+// <custom-property-name>, so these are valid at parse time and round-trip as pending-substitution
+// values. They become invalid at computed-value time when the name fails to parse.
+// https://drafts.csswg.org/css-variables-2/#funcdef-var
+test_valid_value('width', 'var(--x ())');
+test_valid_value('width', 'var(--x () )');
+test_valid_value('width', 'var(--x() )');
+test_valid_value('width', 'var(--x (),)');
+test_valid_value('width', 'var(--x(),)');
+
+// The name argument is a free-form production, so it may be {}-wrapped: the braces are syntactic and
+// the argument is the block's contents.
+// https://drafts.csswg.org/css-values-5/#component-function-commas
+test_valid_value('width', 'var({--x})');
+test_valid_value('width', 'var({--x}, 10px)');
+test_valid_value('width', 'var({--x, --y})');
+
+// A free-form production that does not start with "{" matches neither top-level commas nor {} blocks,
+// so a {} block may not be mixed with other values in the name argument.
+test_invalid_value('width', 'var(--x {--y})');
+test_invalid_value('width', 'var({--x} --y)');
+test_invalid_value('width', 'var(--x {--y}, 10px)');
+
+// <declaration-value> is one or more tokens, so an empty name argument is invalid whether or not it
+// is {}-wrapped.
+test_invalid_value('width', 'var()');
+test_invalid_value('width', 'var({})');
+test_invalid_value('width', 'var({}, 10px)');
+test_invalid_value('width', 'var(, 10px)');
 
 </script>

--- a/css/css-variables/variable-declaration-29.html
+++ b/css/css-variables/variable-declaration-29.html
@@ -3,15 +3,18 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!DOCTYPE html>
-<title>CSS Test: Test declaring a variable with an invalid custom property name "--".</title>
+<title>CSS Test: An invalid custom property name "--" as a var() name argument triggers the fallback.</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="http://www.w3.org/TR/css-variables-1/#defining-variables">
 <link rel="match" href="support/color-green-ref.html">
 <style>
+/* "--" is not a valid <custom-property-name>, so "--: red" is dropped and the var() name argument
+   substitutes to "--", which fails to parse as a name. The reference is guaranteed-invalid, so the
+   fallback is used. https://drafts.csswg.org/css-variables-2/#funcdef-var */
 p {
-  color: green;
+  color: red;
   --: red;
-  color: var(--,crimson);
+  color: var(--, green);
 }
 </style>
 <p>This text must be green.</p>

--- a/css/css-variables/variable-reference-name-substitution-attr-taint.html
+++ b/css/css-variables/variable-reference-name-substitution-attr-taint.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>attr()-taint propagates through the var() name argument</title>
+    <link rel="help" href="https://drafts.csswg.org/css-values-5/#attr-security">
+    <link rel="help" href="https://drafts.csswg.org/css-variables-2/#replace-a-var-function">
+    <link rel="author" title="Apple Inc." href="https://apple.com">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        @property --registered-url {
+            syntax: "<url>";
+            inherits: false;
+            initial-value: url("https://does-not-exist.test/initial.png");
+        }
+    </style>
+</head>
+<body>
+<div id="target" data-image-name="--image" data-length-name="--length" data-not-a-name="10px" data-none="none"></div>
+<script>
+    "use strict";
+
+    // The substitution value of an arbitrary substitution function is attr()-tainted as a whole if any
+    // attr()-tainted values were involved in creating it, and using an attr()-tainted value as or in a
+    // <url> makes a declaration invalid at computed-value time. Resolving a var() name argument from an
+    // attribute therefore taints the substituted value, even though the value itself comes from a
+    // custom property rather than from the attribute.
+
+    const target = document.getElementById("target");
+    const url = "https://does-not-exist.test/404.png";
+    const initialURL = "https://does-not-exist.test/initial.png";
+
+    function computed(declaration, property) {
+        target.setAttribute("style", declaration);
+        const value = getComputedStyle(target).getPropertyValue(property);
+        target.removeAttribute("style");
+        return value;
+    }
+
+    test(() => {
+        assert_equals(computed(`--image: image-set("${url}"); background-image: var(attr(data-image-name type(*)));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument makes an image-set() declaration invalid at computed-value time");
+
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); background-image: var(attr(data-image-name type(*)));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument taints a url() value");
+
+    test(() => {
+        assert_equals(computed(`--name: attr(data-image-name type(*)); --image: url("${url}"); background-image: var(var(--name));`,
+                              "background-image"), "none");
+    }, "attr()-taint reaches the name argument through another custom property");
+
+    // The name is tainted and does not parse, so the taint carries into the fallback that gets used.
+    test(() => {
+        assert_equals(computed(`background-image: var(attr(data-not-a-name type(*)), url("${url}"));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument taints the fallback");
+
+    // A registered property with <url> syntax resolved from tainted data is invalid at computed-value
+    // time, so it computes to its initial value.
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); --registered-url: var(attr(data-image-name type(*)));`,
+                              "--registered-url"), `url("${initialURL}")`);
+    }, "attr()-tainted name argument taints a registered <url> property");
+
+    // Taint only matters for URLs.
+    test(() => {
+        assert_equals(computed("--length: 10px; width: var(attr(data-length-name type(*)));", "width"), "10px");
+    }, "attr()-tainted name argument does not invalidate values that are not URLs");
+
+    // Custom properties are not URL contexts, so the tainted value is still observable there.
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); --result: var(attr(data-image-name type(*)));`, "--result"),
+                      `url("${url}")`);
+    }, "attr()-tainted name argument substitutes normally into a custom property");
+
+    // Taint from the name argument must be detected per var(), not from the state of the value so far.
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); --name: attr(data-image-name type(*)); --tainted-none: attr(data-none type(*)); background-image: var(--tainted-none), var(var(--name));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument taints the value even when an earlier value was already tainted");
+
+    // A name argument with no attr() involved is not tainted.
+    test(() => {
+        assert_equals(computed(`--image: image-set("${url}"); --name: --image; background-image: var(var(--name));`,
+                              "background-image"), `image-set(url("${url}") 1dppx)`);
+    }, "untainted substituted name argument does not taint the value");
+</script>
+</body>
+</html>

--- a/css/css-variables/variable-reference-name-substitution.html
+++ b/css/css-variables/variable-reference-name-substitution.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>var() name argument is an arbitrary substitution value</title>
+    <link rel="help" href="https://drafts.csswg.org/css-variables-2/#replace-a-var-function">
+    <link rel="help" href="https://drafts.csswg.org/css-values-5/#component-function-commas">
+    <link rel="author" title="Apple Inc." href="https://apple.com">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        #target { --other: 10px; }
+        @property --registered-length {
+            syntax: "<length>";
+            inherits: false;
+            initial-value: 7px;
+        }
+        @property --registered-universal {
+            syntax: "*";
+            inherits: false;
+        }
+    </style>
+</head>
+<body>
+<div id="target" data-name="--other" data-not-a-name="10px"></div>
+<script>
+    "use strict";
+
+    const target = document.getElementById("target");
+
+    function computed(declaration, property) {
+        target.setAttribute("style", declaration);
+        const value = getComputedStyle(target).getPropertyValue(property || "width");
+        target.removeAttribute("style");
+        return value;
+    }
+
+    const initialWidth = computed("width: initial;");
+
+    // The inner var() resolves to `--other`, which becomes the name looked up by the outer var().
+    // https://drafts.csswg.org/css-variables-2/#replace-a-var-function example.
+    test(() => {
+        assert_equals(computed("--myvar: --other; width: var(var(--myvar));"), "10px");
+    }, "var() name comes from another var()");
+
+    test(() => {
+        assert_equals(computed("--myvar: --other; --indirect: --myvar; width: var(var(var(--indirect)));"), "10px");
+    }, "var() name comes from a chain of var()s");
+
+    // A substituted name that does not parse as a <custom-property-name> makes the reference
+    // guaranteed-invalid, so the fallback is used.
+    test(() => {
+        assert_equals(computed("--myvar: not-a-custom-prop; width: var(var(--myvar), 20px);"), "20px");
+    }, "invalid substituted name falls back");
+
+    // The name-providing var() is itself unset, so the name is guaranteed-invalid: fallback is used.
+    test(() => {
+        assert_equals(computed("width: var(var(--unset), 30px);"), "30px");
+    }, "unset name-providing var() falls back");
+
+    // Whitespace around the substituted name is allowed.
+    test(() => {
+        assert_equals(computed("--myvar: --other; width: var( var(--myvar) );"), "10px");
+    }, "whitespace around substituted name");
+
+    // A substituted name that is not itself a custom-property name (bad prefix) and no fallback:
+    // the property is invalid at computed-value time and falls back to initial (auto).
+    test(() => {
+        assert_equals(computed("--myvar: other; width: var(var(--myvar));"), initialWidth);
+    }, "invalid substituted name without fallback is invalid at computed-value time");
+
+    // A name argument that substitutes to nothing does not parse as a <custom-property-name>.
+    test(() => {
+        assert_equals(computed("--empty: ; width: var(var(--empty), 40px);"), "40px");
+    }, "name argument substituting to nothing falls back");
+
+    // A <custom-property-name> is a single ident, so a multi-token name never parses.
+    test(() => {
+        assert_equals(computed("--two: --other --other; width: var(var(--two), 50px);"), "50px");
+    }, "multi-token substituted name falls back");
+
+    test(() => {
+        assert_equals(computed("--dimension: 10px; width: var(var(--dimension), 60px);"), "60px");
+    }, "dimension-token substituted name falls back");
+
+    test(() => {
+        assert_equals(computed('--string: "--other"; width: var(var(--string), 70px);'), "70px");
+    }, "string substituted name falls back");
+
+    // "--" is not a valid <custom-property-name>.
+    test(() => {
+        assert_equals(computed("--dashes: --; width: var(var(--dashes), 80px);"), "80px");
+    }, "-- as substituted name falls back");
+
+    // https://drafts.csswg.org/css-values-5/#component-function-commas
+    // A {}-wrapped free-form production represents the contents of the block, so the braces are
+    // stripped before the name is parsed. They are allowed even when not required.
+    test(() => {
+        assert_equals(computed("width: var({--other});"), "10px");
+    }, "{}-wrapped literal name argument");
+
+    test(() => {
+        assert_equals(computed("--myvar: --other; width: var({var(--myvar)});"), "10px");
+    }, "{}-wrapped substituted name argument");
+
+    test(() => {
+        assert_equals(computed("width: var( { --other } );"), "10px");
+    }, "{}-wrapped name argument with whitespace");
+
+    test(() => {
+        assert_equals(computed("width: var({--unset}, 90px);"), "90px");
+    }, "{}-wrapped name argument with fallback");
+
+    // Other arbitrary substitution functions can produce the name.
+    test(() => {
+        assert_equals(computed("width: var(attr(data-name type(*)));"), "10px");
+    }, "var() name comes from attr()");
+
+    test(() => {
+        assert_equals(computed("width: var(attr(data-not-a-name type(*)), 100px);"), "100px");
+    }, "var() name from attr() that is not a name falls back");
+
+    test(() => {
+        assert_equals(computed("width: var(if(style(--other: 10px): --other; else: --unset));"), "10px");
+    }, "var() name comes from if()");
+
+    test(() => {
+        assert_equals(computed("width: var(random-item(--key, --other, --other));"), "10px");
+    }, "var() name comes from random-item()");
+
+    // Cycles are detected through the name argument, since looking up the referenced property
+    // implies property replacement. https://drafts.csswg.org/css-variables-2/#replace-a-var-function
+    test(() => {
+        assert_equals(computed("--self: var(var(--self)); width: var(--self, 110px);"), "110px");
+    }, "direct cycle through the name argument");
+
+    test(() => {
+        assert_equals(computed("--name: --cyclic; --cyclic: var(var(--name)); width: var(--cyclic, 120px);"), "120px");
+    }, "indirect cycle through the name argument");
+
+    // Registered properties: a substituted name resolves them like a literal name does.
+    test(() => {
+        assert_equals(computed("--name: --registered-length; width: var(var(--name));"), "7px");
+    }, "substituted name resolves a registered property");
+
+    // A universal registration without an initial value is guaranteed-invalid, so the fallback is used.
+    test(() => {
+        assert_equals(computed("--name: --registered-universal; width: var(var(--name), 130px);"), "130px");
+    }, "substituted name of a guaranteed-invalid registered property uses the fallback");
+
+    // A name that does not parse has no referenced property, so there is no registered syntax to
+    // check the fallback against.
+    // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
+    test(() => {
+        assert_equals(computed("--name: not-a-name; width: var(var(--name), 140px);"), "140px");
+    }, "fallback of an unparsed name is not syntax checked");
+</script>
+</body>
+</html>

--- a/css/css-variables/variable-reference.html
+++ b/css/css-variables/variable-reference.html
@@ -37,13 +37,13 @@
         { cssText: "width: var(--prop,);",                  expectedPropertyValue: "var(--prop,)" },
 
         { cssText: "width: var();",                         expectedPropertyValue: "" },
-        { cssText: "width: var(prop);",                     expectedPropertyValue: "" },
-        { cssText: "width: var(-prop);",                    expectedPropertyValue: "" },
-        { cssText: "width: var(--prop 20px);",              expectedPropertyValue: "" },
-        { cssText: "width: var(--prop, var(prop));",        expectedPropertyValue: "" },
-        { cssText: "width: var(--prop, var(-prop));",       expectedPropertyValue: "" },
-        { cssText: "width: var(20px);",                     expectedPropertyValue: "" },
-        { cssText: "width: var(var(--prop));",              expectedPropertyValue: "" },
+        { cssText: "width: var(prop);",                     expectedPropertyValue: "var(prop)" },
+        { cssText: "width: var(-prop);",                    expectedPropertyValue: "var(-prop)" },
+        { cssText: "width: var(--prop 20px);",              expectedPropertyValue: "var(--prop 20px)" },
+        { cssText: "width: var(--prop, var(prop));",        expectedPropertyValue: "var(--prop, var(prop))" },
+        { cssText: "width: var(--prop, var(-prop));",       expectedPropertyValue: "var(--prop, var(-prop))" },
+        { cssText: "width: var(20px);",                     expectedPropertyValue: "var(20px)" },
+        { cssText: "width: var(var(--prop));",              expectedPropertyValue: "var(var(--prop))" },
     ];
 
     testcases.forEach(function (testcase) {

--- a/css/css-variables/variable-supports-30.html
+++ b/css/css-variables/variable-supports-30.html
@@ -3,13 +3,16 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!DOCTYPE html>
-<title>CSS Test: Test a passing non-custom property declaration in an @supports rule whose value contains a variable reference with a dimension token as the variable name.</title>
+<title>CSS Test: A non-custom property declaration in an @supports rule whose value is a var() reference with a dimension token as the name argument is supported.</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="http://www.w3.org/TR/css-variables-1/#using-variables">
 <link rel="match" href="support/color-green-ref.html">
 <style>
 body { color: red; }
-@supports (color: var(--a)) and (not (color: var(1px))) {
+/* var()'s name argument is a <declaration-value>, so var(1px) is valid at parse time; the name
+   fails to parse as a <custom-property-name> only at computed-value time, so the declaration is
+   supported. https://drafts.csswg.org/css-variables-2/#funcdef-var */
+@supports (color: var(--a)) and (color: var(1px)) {
   p { color: green; }
 }
 </style>

--- a/css/css-variables/variable-supports-64.html
+++ b/css/css-variables/variable-supports-64.html
@@ -3,13 +3,16 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!DOCTYPE html>
-<title>CSS Test: Test a failing custom property declaration in an @supports rule whose value is a variable reference with a dimension token as the variable name.</title>
+<title>CSS Test: A custom property declaration in an @supports rule whose value is a var() reference with a dimension token as the name argument is supported.</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="http://www.w3.org/TR/css-variables-1/#using-variables">
 <link rel="match" href="support/color-green-ref.html">
 <style>
 body { color: red; }
-@supports (--a: a) and (not (--a: var(1px))) {
+/* var()'s name argument is a <declaration-value>, so var(1px) is valid at parse time; the name
+   fails to parse as a <custom-property-name> only at computed-value time, so the declaration is
+   supported. https://drafts.csswg.org/css-variables-2/#funcdef-var */
+@supports (--a: a) and (--a: var(1px)) {
   p { color: green; }
 }
 </style>


### PR DESCRIPTION
WebKit export from bug: [\[css-variables-2\] var() should be an arbitrary substitution function](https://bugs.webkit.org/show_bug.cgi?id=320896)