### PR TITLE
Add test for nested slot fallback matching between `:has-slotted` and `assignedNodes({flatten:true})`

### DIFF
--- a/css/css-shadow/has-slotted-nested-slot-fallback.html
+++ b/css/css-shadow/has-slotted-nested-slot-fallback.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>:has-slotted and the fallback content of a nested slot</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="ancestor"><template shadowrootmode="open"><div id="host"><template shadowrootmode="open"><style>
+  slot {
+    color: rgb(0, 0, 0);
+  }
+  :has-slotted {
+    color: rgb(0, 255, 0);
+  }
+</style><slot id="slot"></slot></template><slot id="nested-slot"><div id="nested-fallback">test</div></slot></div></template></div>
+<script>
+  const host = ancestor.shadowRoot.querySelector("#host");
+  const slot = host.shadowRoot.querySelector("#slot");
+  const nestedSlot = ancestor.shadowRoot.querySelector("#nested-slot");
+  const nestedFallback = ancestor.shadowRoot.querySelector("#nested-fallback");
+
+  test(function () {
+    assert_array_equals(slot.assignedNodes(), [nestedSlot], "the nested slot is assigned to the slot");
+    assert_array_equals(slot.assignedNodes({flatten: true}), [nestedFallback], "flattening finds the nested slot's fallback content, not a whitespace text node");
+    assert_true(slot.matches(":has-slotted"), "slot element should match :has-slotted");
+    assert_equals(getComputedStyle(slot).color, "rgb(0, 255, 0)", "slot element should match :has-slotted");
+    assert_equals(host.shadowRoot.querySelectorAll(":has-slotted").length, 1, "slot element should match :has-slotted");
+  }, ":has-slotted must match when the flattened assigned nodes come from a nested slot's fallback content");
+</script>

--- a/css/css-shadow/has-slotted-nested-slot-fallback.html
+++ b/css/css-shadow/has-slotted-nested-slot-fallback.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <meta charset="utf-8" />
 <title>:has-slotted and the fallback content of a nested slot</title>
-<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586" />
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/14307" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="ancestor"><template shadowrootmode="open"><div id="host"><template shadowrootmode="open"><style>
   slot {
-    color: rgb(0, 0, 0);
+    color: rgb(255, 0, 0);
   }
   :has-slotted {
     color: rgb(0, 255, 0);


### PR DESCRIPTION
This is very similar to https://github.com/web-platform-tests/wpt/blob/5e7e05030f/css/css-shadow/has-slotted-flattened-001.html except that this does NOT have whitespaces in the HTML, which materially changes the outcome!

I did this using the JS harness to ensure that the whitespace is not picked up as the assignedNodes (note the assertion on line 23) so that a formatting change that introduces whitespace would trigger a failure and closer look.

Keeping as draft for a minute, as I believe the resolution [in CSSWG here](https://github.com/w3c/csswg-drafts/issues/14307) should happen first, for validation.

Firefox 154.0b9 fails this test currently, despite passing all other `:has-slotted` tests. 