### PR TITLE
[css-cascade] Add reftests for @scope (custom-element) and @scope (custom-element) to (...)

### DIFF
--- a/css/css-cascade/scope-custom-element-descendant-ref.html
+++ b/css/css-cascade/scope-custom-element-descendant-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: @scope (custom-element) sole scope styles light-dom children</title>
+<link rel="match" href="scope-custom-element-descendant-ref.html">
+<link rel="author" title="Jack Holden" href="mailto:jack@holdhelm.com">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">
+
+<style>
+  @scope (my-menu .my-grid) {
+    :scope {
+      background: blue;
+      color: white;
+      padding: 1rem;
+    }
+  }
+</style>
+
+<p>The box below should have a blue background.</p>
+
+<my-menu>
+  <template shadowrootmode="open">
+    <style>
+      :host { display: block; }
+      ::slotted(.my-grid) { display: block; }
+    </style>
+    <slot></slot>
+  </template>
+
+  <div class="my-grid">Scoped content</div>
+</my-menu>

--- a/css/css-cascade/scope-custom-element-descendant-ref.html
+++ b/css/css-cascade/scope-custom-element-descendant-ref.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Reference: @scope (custom-element) sole scope styles light-dom children</title>
-<link rel="match" href="scope-custom-element-descendant-ref.html">
 <link rel="author" title="Jack Holden" href="mailto:jack@holdhelm.com">
 <link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
 <link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">

--- a/css/css-cascade/scope-custom-element-descendant.html
+++ b/css/css-cascade/scope-custom-element-descendant.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>@scope (custom-element) sole scope styles light-dom children</title>
+<link rel="match" href="scope-custom-element-descendant-ref.html">
+<link rel="author" title="Jack Holden" href="mailto:jack@holdhelm.com">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">
+
+<style>
+  @scope (my-menu) {
+    .my-grid {
+      background: blue;
+      color: white;
+      padding: 1rem;
+    }
+  }
+</style>
+
+<p>The box below should have a blue background.</p>
+
+<my-menu>
+  <template shadowrootmode="open">
+    <style>
+      :host { display: block; }
+      ::slotted(.my-grid) { display: block; }
+    </style>
+    <slot></slot>
+  </template>
+
+  <div class="my-grid">Scoped content</div>
+</my-menu>

--- a/css/css-cascade/scope-shadow-slotted-lower-bound-ref.html
+++ b/css/css-cascade/scope-shadow-slotted-lower-bound-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: @scope lower bound with slotted light-DOM elements</title>
+<link rel="author" title="Jack Holden" href="mailto:jack@holdhelm.com">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">
+
+<style>
+    /* red by default */
+    a {
+        color: red;
+    }
+
+    /* blue for light dom elements to be slotted in my-menu that are not special */
+    my-menu a:not([slot="special"]) {
+        color: blue;
+    }
+</style>
+
+<my-menu>
+  <template shadowrootmode="open">
+    <style>
+      :host { display: block; border: 1px solid #ccc; padding: 0.5rem; }
+      ::slotted(a) { display: inline-block; }
+    </style>
+    <nav>
+      <slot></slot>
+      <slot name="special"></slot>
+    </nav>
+  </template>
+
+  <a id="link1" href="#">Should be blue (in scope)</a>
+  <a id="link2" href="#">Should be blue (in scope)</a>
+  <a id="special" slot="special" href="#">Should be red (excluded from scope)</a>
+</my-menu>

--- a/css/css-cascade/scope-shadow-slotted-lower-bound.html
+++ b/css/css-cascade/scope-shadow-slotted-lower-bound.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>@scope lower bound with slotted light-DOM elements</title>
+<link rel="match" href="scope-shadow-slotted-lower-bound-ref.html">
+<link rel="author" title="Jack Holden" href="mailto:jack@holdhelm.com">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">
+
+<style>
+    /* red by default */
+    a {
+        color: red;
+    }
+
+    /* blue for light dom elements to be slotted in my-menu that are not special */
+    @scope (my-menu) to (a[slot="special"]) {
+        a {
+            color: blue;
+        }
+    }
+</style>
+
+<my-menu>
+  <template shadowrootmode="open">
+    <style>
+      :host { display: block; border: 1px solid #ccc; padding: 0.5rem; }
+      ::slotted(a) { display: inline-block; }
+    </style>
+    <nav>
+      <slot></slot>
+      <slot name="special"></slot>
+    </nav>
+  </template>
+
+  <a id="link1" href="#">Should be blue (in scope)</a>
+  <a id="link2" href="#">Should be blue (in scope)</a>
+  <a id="special" slot="special" href="#">Should be red (excluded from scope)</a>
+</my-menu>


### PR DESCRIPTION
### Description

This PR adds reftests for `@scope` when the scope root is a **custom element**. Currently both fail only in WebKit/Safari.

1. **With a lower bound**:
```css
@scope (my-menu) to (a[slot="special"]) {
  a { color: blue; }
}
```
2. **Sole custom element selector, no lower bound, style light dom children**:
```css
@scope (my-menu) {
  .my-grid {
    background: blue;
  }
}
```

### Tests added

- `css-cascade/scope-shadow-slotted-lower-bound.html`  
  Explicit `@scope` custom-element root + lower bound + slotted light-DOM elements.
- `css-cascade/scope-custom-element-descendant.html`
  Explicit `@scope` custom-element root styling a descendant (no lower bound).

### Notes

@Westbrook pointed out the implicit way works fine. https://codepen.io/editor/Westbrook/pen/019ff228-d468-73ab-8649-f75633707a52.

For the `css-cascade/scope-custom-element-descendant.html` test, I wanted to showcase `@scope` where it does work in all browsers but I am unsure if this is too much and I should just change to `my-menu .my-grid {}`? 

```css
  @scope (my-menu .my-grid) {
    :scope {
      background: blue;
      color: white;
      padding: 1rem;
    }
  }
```

Many thanks!