### PR TITLE
Wide-gamut screenshot reftests (RFC 242)

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -236,6 +236,10 @@ class RefTest(URLManifestItem):
         return self._extras.get("dpi")
 
     @property
+    def reftest_color_space(self) -> Optional[Text]:
+        return self._extras.get("reftest_color_space")
+
+    @property
     def fuzzy(self) -> Fuzzy:
         fuzzy: Union[Fuzzy, List[Tuple[Optional[Sequence[Text]], List[int]]]] = self._extras.get("fuzzy", {})
         if not isinstance(fuzzy, list):
@@ -268,6 +272,8 @@ class RefTest(URLManifestItem):
             extras["dpi"] = self.dpi
         if self.fuzzy:
             extras["fuzzy"] = list(self.fuzzy.items())
+        if self.reftest_color_space is not None:
+            extras["reftest_color_space"] = self.reftest_color_space
         if self.testdriver:
             extras["testdriver"] = self.testdriver
         return rv

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -4,8 +4,9 @@ import os
 from collections import deque
 from fnmatch import fnmatch
 from io import BytesIO
-from typing import (Any, BinaryIO, Callable, Deque, Dict, Iterable, List,
-                    Optional, Pattern, Set, Text, Tuple, TypedDict, Union)
+from typing import (Any, BinaryIO, Callable, ClassVar, Deque, Dict, FrozenSet,
+                    Iterable, List, Optional, Pattern, Set, Text, Tuple,
+                    TypedDict, Union)
 from urllib.parse import parse_qs, urlparse, urljoin
 
 try:
@@ -675,6 +676,45 @@ class SourceFile:
             assert len(arg_values) == 0 and len(positional_args) == 0
         return rv
 
+    # Valid identifiers for <meta name="reftest-color-space">.
+    _VALID_COLOR_SPACES: ClassVar[FrozenSet[Text]] = frozenset({
+        "srgb",
+        "display-p3",
+        "rec2020",
+        "rec2100-pq",
+        "rec2100-hlg",
+        # TODO: Add an Adobe RGB-compatible identifier if standardized
+    })
+
+    @cached_property
+    def reftest_color_space_nodes(self) -> List[ElementTree.Element]:
+        """List of ElementTree Elements corresponding to nodes in a test that
+        specify the target color space for screenshot capture."""
+        assert self.root is not None
+        return self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='reftest-color-space']")
+
+    @cached_property
+    def reftest_color_space(self) -> Optional[Text]:
+        if self.root is None:
+            return None
+
+        nodes = self.reftest_color_space_nodes
+        if not nodes:
+            return None
+
+        if len(nodes) > 1:
+            raise ValueError("%s has multiple reftest-color-space meta tags" % self.rel_url)
+
+        value = nodes[0].attrib.get("content", "").strip()
+        if value not in self._VALID_COLOR_SPACES:
+            raise ValueError(
+                "%s has an invalid reftest-color-space value %r\n"
+                "valid values are: %s"
+                % (self.rel_url, value, ", ".join(sorted(self._VALID_COLOR_SPACES)))
+            )
+
+        return value
+
     @cached_property
     def page_ranges_nodes(self) -> List[ElementTree.Element]:
         """List of ElementTree Elements corresponding to nodes in a test that
@@ -1086,6 +1126,7 @@ class SourceFile:
                     viewport_size=self.viewport_size,
                     fuzzy=self.fuzzy,
                     page_ranges=self.page_ranges,
+                    reftest_color_space=self.reftest_color_space,
                     testdriver=self.has_testdriver,
                 )]
 
@@ -1240,6 +1281,9 @@ class SourceFile:
                     viewport_size=self.viewport_size,
                     dpi=self.dpi,
                     fuzzy=self.fuzzy,
+                    reftest_color_space=(
+                        None if self.name_is_reference else self.reftest_color_space
+                    ),
                     testdriver=self.has_testdriver,
                 ))
 

--- a/tools/manifest/tests/test_item.py
+++ b/tools/manifest/tests/test_item.py
@@ -132,6 +132,44 @@ def test_reftest_fuzzy_multi(fuzzy):
     assert fuzzy == t3.fuzzy
 
 
+@pytest.mark.parametrize("content", [
+    "srgb",
+    "display-p3",
+    "rec2020",
+    "rec2100-pq",
+    "rec2100-hlg",
+])
+def test_reftest_color_space(content):
+    t = RefTest('/',
+                'foo/test.html',
+                '/',
+                'foo/test.html',
+                [('/foo/ref.html', '==')],
+                reftest_color_space=content)
+    assert content == t.reftest_color_space
+
+    json_obj = t.to_json()
+
+    m = Manifest("/", "/")
+    t2 = RefTest.from_json(m, t.path, json_obj)
+    assert content == t2.reftest_color_space
+
+    roundtrip = json.loads(json.dumps(json_obj))
+    t3 = RefTest.from_json(m, t.path, roundtrip)
+    assert content == t3.reftest_color_space
+
+def test_reftest_color_space_none():
+    t = RefTest('/',
+                'foo/test.html',
+                '/',
+                'foo/test.html',
+                [('/foo/ref.html', '==')])
+    assert t.reftest_color_space is None
+
+    json_obj = t.to_json()
+    assert "reftest_color_space" not in json_obj[-1]
+
+
 def test_item_types():
     for key, value in item_types.items():
         assert isinstance(key, str)

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -951,6 +951,40 @@ def test_reftest_fuzzy_duplicate_key(fuzzy):
         s.fuzzy
 
 
+@pytest.mark.parametrize("content, expected", [
+    (b"srgb", "srgb"),
+    (b"display-p3", "display-p3"),
+    (b"rec2020", "rec2020"),
+    (b"rec2100-pq", "rec2100-pq"),
+    (b"rec2100-hlg", "rec2100-hlg"),
+])
+def test_reftest_color_space_valid(content, expected):
+    html = b"""<link rel=match href=ref.html>
+<meta name="reftest-color-space" content="%s">""" % content
+    s = create("foo/test.html", html)
+    assert s.reftest_color_space == expected
+
+def test_reftest_color_space_absent():
+    html = b"""<link rel=match href=ref.html>"""
+    s = create("foo/test.html", html)
+    assert s.reftest_color_space is None
+
+def test_reftest_color_space_invalid():
+    html = b"""<link rel=match href=ref.html>
+<meta name="reftest-color-space" content="invalid">"""
+    s = create("foo/test.html", html)
+    with pytest.raises(ValueError, match="invalid reftest-color-space"):
+        s.reftest_color_space
+
+def test_reftest_color_space_duplicate():
+    html = b"""<link rel=match href=ref.html>
+<meta name="reftest-color-space" content="srgb">
+<meta name="reftest-color-space" content="display-p3">"""
+    s = create("foo/test.html", html)
+    with pytest.raises(ValueError, match="multiple reftest-color-space"):
+        s.reftest_color_space
+
+
 @pytest.mark.parametrize("pac, expected", [
     (b"proxy.pac", "proxy.pac")])
 def test_pac(pac, expected):

--- a/tools/webdriver/webdriver/bidi/modules/browsing_context.py
+++ b/tools/webdriver/webdriver/bidi/modules/browsing_context.py
@@ -65,6 +65,7 @@ class BrowsingContext(BidiModule):
         clip: Optional[ClipOptions] = None,
         origin: Optional[OriginOptions] = None,
         format: Optional[FormatOptions] = None,
+        colorSpace: Optional[str] = None,
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {"context": context}
 
@@ -74,6 +75,8 @@ class BrowsingContext(BidiModule):
             params["clip"] = clip
         if origin is not None:
             params["origin"] = origin
+        if colorSpace is not None:
+            params["colorSpace"] = colorSpace
 
         return params
 

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -496,11 +496,20 @@ class RefTestImplementation:
                                                           rhs_screenshots)):
             comparison_screenshots = (lhs_screenshot, rhs_screenshot)
 
+            bit_depth = None
             if contract is not None:
                 for screenshot, url in zip(comparison_screenshots, urls):
                     try:
                         info = parse_png(base64.b64decode(screenshot))
                         validate_contract(info, contract)
+                        if bit_depth is None:
+                            bit_depth = info.bit_depth
+                        elif bit_depth != info.bit_depth:
+                            self.logger.error(
+                                f"Bit depth mismatch between screenshots: "
+                                f"{bit_depth} vs {info.bit_depth}"
+                            )
+                            return (None, page_idx)
                     except InvalidPNGError as e:
                         self.logger.error(f"Invalid PNG for {url}: {e}")
                         return (None, page_idx)
@@ -525,6 +534,10 @@ class RefTestImplementation:
 
                 if max_per_channel is None:
                     return (None, page_idx)
+
+            if fuzzy and bit_depth and bit_depth != 8:
+                self.logger.error("Fuzzy comparison is not yet supported for screenshots above 8 bits per channel")
+                return (None, page_idx)
 
             if not fuzzy or fuzzy == ((0, 0), (0, 0)):
                 equal = pixels_different == 0 and max_per_channel == 0

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -426,11 +426,11 @@ class RefTestImplementation:
     def logger(self):
         return self.executor.logger
 
-    def get_hash(self, test, viewport_size, dpi, page_ranges):
-        key = (test.url, viewport_size, dpi)
+    def get_hash(self, test, viewport_size, dpi, page_ranges, color_space=None):
+        key = (test.url, viewport_size, dpi, color_space)
 
         if key not in self.screenshot_cache:
-            success, data = self.get_screenshot_list(test, viewport_size, dpi, page_ranges)
+            success, data = self.get_screenshot_list(test, viewport_size, dpi, page_ranges, color_space=color_space)
 
             if not success:
                 return False, data
@@ -532,6 +532,7 @@ class RefTestImplementation:
         viewport_size = test.viewport_size
         dpi = test.dpi
         page_ranges = test.page_ranges
+        color_space = test.color_space
         self.message = []
 
 
@@ -549,7 +550,7 @@ class RefTestImplementation:
             fuzzy = self.get_fuzzy(test, nodes, relation)
 
             for i, node in enumerate(nodes):
-                success, data = self.get_hash(node, viewport_size, dpi, page_ranges)
+                success, data = self.get_hash(node, viewport_size, dpi, page_ranges, color_space=color_space)
                 if success is False:
                     return {"status": data[0], "message": data[1]}
 
@@ -583,7 +584,7 @@ class RefTestImplementation:
 
         for i, (node, screenshot) in enumerate(zip(nodes, screenshots)):
             if screenshot is None:
-                success, screenshot = self.retake_screenshot(node, viewport_size, dpi, page_ranges)
+                success, screenshot = self.retake_screenshot(node, viewport_size, dpi, page_ranges, color_space=color_space)
                 if success:
                     screenshots[i] = screenshot
 
@@ -614,15 +615,12 @@ class RefTestImplementation:
                 break
         return value
 
-    def retake_screenshot(self, node, viewport_size, dpi, page_ranges):
-        success, data = self.get_screenshot_list(node,
-                                                 viewport_size,
-                                                 dpi,
-                                                 page_ranges)
+    def retake_screenshot(self, node, viewport_size, dpi, page_ranges, color_space=None):
+        success, data = self.get_screenshot_list(node, viewport_size, dpi, page_ranges, color_space=color_space)
         if not success:
             return False, data
 
-        key = (node.url, viewport_size, dpi)
+        key = (node.url, viewport_size, dpi, color_space)
         hash_val, _ = self.screenshot_cache[key]
         self.screenshot_cache[key] = hash_val, data
         return True, data
@@ -649,8 +647,8 @@ class RefTestImplementation:
 
         return struct.unpack(">LL", image_data[16:24])
 
-    def get_screenshot_list(self, node, viewport_size, dpi, page_ranges):
-        success, data = self.executor.screenshot(node, viewport_size, dpi, page_ranges)
+    def get_screenshot_list(self, node, viewport_size, dpi, page_ranges, color_space=None):
+        success, data = self.executor.screenshot(node, viewport_size, dpi, page_ranges, color_space=color_space)
         viewport_size = (800, 600) if viewport_size is None else viewport_size
         dpi = 96 if dpi is None else dpi
         dpcm = dpi / 2.54

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -2,7 +2,6 @@
 
 import base64
 import hashlib
-import io
 import json
 import os
 import socket
@@ -17,6 +16,14 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 from . import pytestrunner
 from .actions import actions
 from .asyncactions import async_actions
+from .png_validator import (
+    InvalidPNGError,
+    MalformedCaptureError,
+    decode_pixels_stdlib,
+    get_contract,
+    parse_png,
+    validate_contract,
+)
 from .protocol import Protocol, PytestProtocol, merge_dicts
 
 
@@ -403,6 +410,18 @@ class PrintRefTestExecutor(TestExecutor):
     is_print = True
 
 
+def _composite_rgba_row(row: list) -> list:
+    out = []
+    for i in range(0, len(row), 4):
+        r, g, b, a = row[i], row[i + 1], row[i + 2], row[i + 3]
+        out.extend([r * a // 255, g * a // 255, b * a // 255])
+    return out
+
+
+def _drop_alpha(row: list) -> list:
+    return [v for i, v in enumerate(row) if i % 4 != 3]
+
+
 class RefTestImplementation:
     def __init__(self, executor):
         self.timeout_multiplier = executor.timeout_multiplier
@@ -449,7 +468,7 @@ class RefTestImplementation:
     def reset(self):
         self.screenshot_cache.clear()
 
-    def check_pass(self, hashes, screenshots, urls, relation, fuzzy):
+    def check_pass(self, hashes, screenshots, urls, relation, fuzzy, color_space=None):
         """Check if a test passes, and return a tuple of (pass, page_idx),
         where page_idx is the zero-based index of the first page on which a
         difference occurs if any, or None if there are no differences"""
@@ -464,6 +483,10 @@ class RefTestImplementation:
 
         assert len(lhs_screenshots) == len(lhs_hashes) == len(rhs_screenshots) == len(rhs_hashes)
 
+        contract = None
+        if color_space is not None:
+            contract = get_contract(color_space)
+
         for (page_idx, (lhs_hash,
                         rhs_hash,
                         lhs_screenshot,
@@ -472,15 +495,36 @@ class RefTestImplementation:
                                                           lhs_screenshots,
                                                           rhs_screenshots)):
             comparison_screenshots = (lhs_screenshot, rhs_screenshot)
+
+            if contract is not None:
+                for screenshot, url in zip(comparison_screenshots, urls):
+                    try:
+                        info = parse_png(base64.b64decode(screenshot))
+                        validate_contract(info, contract)
+                    except InvalidPNGError as e:
+                        self.logger.error(f"Invalid PNG for {url}: {e}")
+                        return (None, page_idx)
+                    except MalformedCaptureError as e:
+                        self.logger.error(
+                            f"Capture contract violation for {url}: {e}"
+                        )
+                        return (None, page_idx)
+
             if lhs_hash == rhs_hash:
                 max_per_channel, pixels_different = 0, 0
             else:
                 # sometimes images can have different hashes, but pixels can be identical.
                 self.logger.info("Image hashes didn't match%s, checking pixel differences" %
                                  ("" if len(hashes) == 1 else " on page %i" % (page_idx + 1)))
-                max_per_channel, pixels_different = self.get_differences(comparison_screenshots,
-                                                                         urls,
-                                                                         page_idx if len(hashes) > 1 else None)
+                max_per_channel, pixels_different = self.get_differences(
+                    comparison_screenshots,
+                    urls,
+                    page_idx if len(hashes) > 1 else None,
+                    contract=contract,
+                )
+
+                if max_per_channel is None:
+                    return (None, page_idx)
 
             if not fuzzy or fuzzy == ((0, 0), (0, 0)):
                 equal = pixels_different == 0 and max_per_channel == 0
@@ -498,43 +542,97 @@ class RefTestImplementation:
         # All screenshots were equal within the fuzziness
         return (True if relation == "==" else False, -1)
 
-    def get_differences(self, screenshots, urls, page_idx=None):
-        from PIL import Image, ImageChops, ImageStat
+    def get_differences(self, screenshots, urls, page_idx=None, contract=None):
+        try:
+            left_png = base64.b64decode(screenshots[0])
+            right_png = base64.b64decode(screenshots[1])
+        except Exception as e:
+            self.logger.error(f"Failed to decode base64 screenshot: {e}")
+            return None, None
 
-        lhs = Image.open(io.BytesIO(base64.b64decode(screenshots[0]))).convert("RGB")
-        rhs = Image.open(io.BytesIO(base64.b64decode(screenshots[1]))).convert("RGB")
-        if lhs.size != rhs.size:
+        try:
+            left_info = parse_png(left_png)
+            right_info = parse_png(right_png)
+        except InvalidPNGError as e:
+            self.logger.error(f"Failed to parse PNG: {e}")
+            return None, None
+
+        if left_info.width != right_info.width or left_info.height != right_info.height:
             self.logger.info(
-                f"Images differ in size; {urls[0]} is {lhs.size}, {urls[1]} is {rhs.size}" +
-                ("" if page_idx is None else f" on page {page_idx + 1}")
+                f"Images differ in size; {urls[0]} is {left_info.width}x{left_info.height}, "
+                f"{urls[1]} is {right_info.width}x{right_info.height}"
+                + ("" if page_idx is None else f" on page {page_idx + 1}")
             )
-        self.check_if_solid_color(lhs, urls[0])
-        self.check_if_solid_color(rhs, urls[1])
-        diff = ImageChops.difference(lhs, rhs)
-        minimal_diff = diff.crop(diff.getbbox())
-        mask = minimal_diff.convert("L", dither=None)
-        stat = ImageStat.Stat(minimal_diff, mask)
-        per_channel = max(item[1] for item in stat.extrema)
-        count = stat.count[0]
-        self.logger.info("Found %s pixels different, maximum difference per channel %s%s" %
-                         (count,
-                          per_channel,
-                          "" if page_idx is None else " on page %i" % (page_idx + 1)))
-        return per_channel, count
+            max_pixels = max(left_info.width * left_info.height, right_info.width * right_info.height)
+            return 0, max_pixels
 
-    def check_if_solid_color(self, image, url):
-        extrema = image.getextrema()
-        if all(min == max for min, max in extrema):
-            color = ''.join('%02X' % value for value, _ in extrema)
-            self.message.append(f"Screenshot is solid color 0x{color} for {url}\n")
+        try:
+            left_rows, _lw, _lh, _lch = decode_pixels_stdlib(left_png, left_info)
+            right_rows, _rw, _rh, _rch = decode_pixels_stdlib(right_png, right_info)
+        except Exception as e:
+            self.logger.error(f"Failed to decode PNG pixels: {e}")
+            return None, None
+
+        # Only RGB (2) and RGBA (6) colour types are supported.
+        if left_info.color_type not in (2, 6) or right_info.color_type not in (2, 6):
+            self.logger.error(
+                f"Unsupported PNG colour type: "
+                f"{urls[0]} type={left_info.color_type}, "
+                f"{urls[1]} type={right_info.color_type}"
+            )
+            return None, None
+
+        pixels_different = 0
+        max_per_channel = 0
+
+        # Composite alpha against black to match old PIL .convert("RGB") behaviour.
+        if left_info.alpha:
+            if contract is None:
+                left_rows = [_composite_rgba_row(r) for r in left_rows]
+                right_rows = [_composite_rgba_row(r) for r in right_rows]
+            else:
+                left_rows = [_drop_alpha(r) for r in left_rows]
+                right_rows = [_drop_alpha(r) for r in right_rows]
+
+        self._check_solid_colour(left_rows, urls[0])
+        self._check_solid_colour(right_rows, urls[1])
+
+        for y in range(left_info.height):
+            lr = left_rows[y]
+            rr = right_rows[y]
+            # Count pixels (groups of 3 channel values), matching PIL stat.count[0].
+            for p in range(0, len(lr), 3):
+                pixel_diff = 0
+                for c in range(3):
+                    idx = p + c
+                    pixel_diff = max(pixel_diff, abs(lr[idx] - rr[idx]))
+                if pixel_diff > 0:
+                    pixels_different += 1
+                    if pixel_diff > max_per_channel:
+                        max_per_channel = pixel_diff
+
+        self.logger.info(
+            "Found %s pixels different, maximum difference per channel %s%s"
+            % (pixels_different, max_per_channel,
+               "" if page_idx is None else " on page %i" % (page_idx + 1))
+        )
+        return max_per_channel, pixels_different
+
+    def _check_solid_colour(self, rows, url):
+        if not rows or not rows[0]:
+            return
+        first = rows[0]
+        if all(row == first for row in rows):
+            colour = "".join(f"{v:02X}" for v in first[:3])
+            if self.message is not None:
+                self.message.append(f"Screenshot is solid colour 0x{colour} for {url}\n")
 
     def run_test(self, test):
         viewport_size = test.viewport_size
         dpi = test.dpi
         page_ranges = test.page_ranges
-        color_space = test.color_space
+        color_space = getattr(test, "color_space", None)
         self.message = []
-
 
         # Depth-first search of reference tree, with the goal
         # of reachings a leaf node with only pass results
@@ -557,7 +655,16 @@ class RefTestImplementation:
                 hashes[i], screenshots[i] = data
                 urls[i] = node.url
 
-            is_pass, page_idx = self.check_pass(hashes, screenshots, urls, relation, fuzzy)
+            is_pass, page_idx = self.check_pass(hashes, screenshots, urls, relation, fuzzy, color_space=color_space)
+
+            if is_pass is None:
+                return {
+                    "status": "ERROR",
+                    "message": (
+                        f"Screenshot for {urls[0]} / {urls[1]} did not satisfy "
+                        f"the capture contract for color_space={color_space}"
+                    ),
+                }
             log_data = [
                 {"url": urls[0], "screenshot": screenshots[0][page_idx],
                  "hash": hashes[0][page_idx]},

--- a/tools/wptrunner/wptrunner/executors/executoredge.py
+++ b/tools/wptrunner/wptrunner/executors/executoredge.py
@@ -35,9 +35,12 @@ class EdgeDriverPrintRefTestExecutor(EdgeDriverRefTestExecutor):
         with open(os.path.join(here, "reftest.js")) as f:
             self.script = f.read()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         # https://github.com/web-platform-tests/wpt/issues/7140
         assert dpi is None
+
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the Edge executor")
 
         if not self.has_window:
             self.protocol.base.execute_script(self.script)

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -1233,10 +1233,13 @@ class MarionetteRefTestExecutor(RefTestExecutor):
 
         return self.convert_result(test, result)
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         # https://github.com/web-platform-tests/wpt/issues/7135
         assert viewport_size is None
         assert dpi is None
+
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the Marionette executor")
 
         timeout = self.timeout_multiplier * test.timeout if self.debug_info is None else None
 
@@ -1446,9 +1449,12 @@ class MarionettePrintRefTestExecutor(MarionetteRefTestExecutor):
         if not isinstance(self.implementation, InternalRefTestImplementation):
             self.protocol.pdf_print.load_runner()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         # https://github.com/web-platform-tests/wpt/issues/7140
         assert dpi is None
+
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the Marionette print reftest executor")
 
         self.viewport_size = viewport_size
         timeout = self.timeout_multiplier * test.timeout if self.debug_info is None else None

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -442,10 +442,13 @@ class SeleniumRefTestExecutor(RefTestExecutor):
 
         return self.convert_result(test, result)
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         # https://github.com/web-platform-tests/wpt/issues/7135
         assert viewport_size is None
         assert dpi is None
+
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the Selenium executor")
 
         return SeleniumRun(self.logger,
                            self._screenshot,

--- a/tools/wptrunner/wptrunner/executors/executorservolegacy.py
+++ b/tools/wptrunner/wptrunner/executors/executorservolegacy.py
@@ -244,7 +244,10 @@ class ServoLegacyRefTestExecutor(ServoExecutorMixin, RefTestExecutor):
         os.rmdir(self.tempdir)
         super().teardown()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the Servo executor")
+
         with TempFilename(self.tempdir) as output_path:
             extra_args = ["--exit",
                           "--output=%s" % output_path,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1407,24 +1407,30 @@ class WebDriverRefTestExecutor(RefTestExecutor):
 
         return self.convert_result(test, result)
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         # https://github.com/web-platform-tests/wpt/issues/7135
         assert viewport_size is None
         assert dpi is None
 
         timeout = self.timeout_multiplier * test.timeout if self.debug_info is None else None
 
+        def _do_screenshot(protocol, url, timeout):
+            return self._screenshot(protocol, url, timeout, color_space=color_space)
+
         return WebDriverRun(self.logger,
-                            self._screenshot,
+                            _do_screenshot,
                             self.protocol,
                             self.test_url(test),
                             timeout,
                             self.extra_timeout).run()
 
-    def _screenshot(self, protocol, url, timeout):
+    def _screenshot(self, protocol, url, timeout, color_space=None):
         # There's nothing we want from the "complete" message, so discard the
         # return value.
         protocol.testdriver.run(url, self.wait_script)
+
+        if color_space is not None:
+            return self._bidi_screenshot(color_space)
 
         screenshot = self.protocol.webdriver.screenshot()
         if screenshot is None:
@@ -1435,6 +1441,33 @@ class WebDriverRefTestExecutor(RefTestExecutor):
             screenshot = screenshot.split(",", 1)[1]
 
         return screenshot
+
+    def _bidi_screenshot(self, color_space):
+        bidi_session = getattr(self.protocol.webdriver, "bidi_session", None)
+        if bidi_session is None:
+            raise ValueError("reftest-color-space requires a WebDriver BiDi session")
+
+        capture_screenshot = getattr(bidi_session.browsing_context, "capture_screenshot", None)
+        if capture_screenshot is None:
+            raise ValueError("browsingContext.captureScreenshot is not available in the WebDriver BiDi client library")
+
+        try:
+            result = self.protocol.loop.run_until_complete(
+                capture_screenshot(
+                    context=self.protocol.base.current_window,
+                    format={"type": "image/png"},
+                    colorSpace=color_space,
+                    raw_result=True,
+                )
+            )
+        except Exception as e:
+            raise ValueError(f"BiDi captureScreenshot failed for color_space={color_space}: {e}") from e
+
+        data = result.get("data")
+        if data is None:
+            raise ValueError("BiDi captureScreenshot returned no data")
+
+        return data
 
 
 class WebDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
@@ -1447,9 +1480,12 @@ class WebDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
         with open(os.path.join(here, "reftest.js")) as f:
             self.script = f.read()
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         # https://github.com/web-platform-tests/wpt/issues/7140
         assert dpi is None
+
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the WebDriver print reftest executor")
 
         if not self.has_window:
             self.protocol.base.execute_script(self.script)

--- a/tools/wptrunner/wptrunner/executors/executorwktr.py
+++ b/tools/wptrunner/wptrunner/executors/executorwktr.py
@@ -197,8 +197,12 @@ class WKTRRefTestExecutor(RefTestExecutor):
         except BaseException as exception:
             return _convert_exception(test, exception, self.protocol.wktr_errors.read_errors())
 
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
+    def screenshot(self, test, viewport_size, dpi, page_ranges, color_space=None):
         assert dpi is None
+
+        if color_space is not None:
+            raise ValueError("reftest-color-space is not supported by the WebKit executor")
+
         command = self.test_url(test)
         command += "'--pixel-test'"
         assert not self.is_print

--- a/tools/wptrunner/wptrunner/executors/png_validator.py
+++ b/tools/wptrunner/wptrunner/executors/png_validator.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import enum
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+
+class ColorSpace(enum.Enum):
+    """Colour spaces matching the `colorSpace` BiDi parameter."""
+    SRGB = "srgb"
+    DISPLAY_P3 = "display-p3"
+    REC2020 = "rec2020"
+    REC2100_PQ = "rec2100-pq"
+    REC2100_HLG = "rec2100-hlg"
+
+
+class MalformedCaptureError(Exception):
+    """PNG payload violates the capture contract."""
+
+
+class InvalidPNGError(Exception):
+    """Bytestream is not a valid PNG."""
+
+
+@dataclass
+class PngInfo:
+    """Parsed PNG metadata for contract validation and comparison."""
+    width: int
+    height: int
+    bit_depth: int
+    color_type: int
+    color_space: ColorSpace
+    has_srgb: bool = False
+    has_iccp: bool = False
+    has_cicp: bool = False
+    iccp_profile_name: Optional[str] = None
+    cicp_primaries: Optional[int] = None
+    cicp_transfer_function: Optional[int] = None
+    interlaced: bool = False
+    alpha: bool = False
+
+
+@dataclass
+class CaptureContract:
+    """Expected PNG properties for a given requested colour space."""
+    color_space: ColorSpace
+    min_bit_depth: int = 8
+    max_bit_depth: int = 16
+    require_alpha: bool = False
+    allow_alpha: bool = True
+
+
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+_CT_GRAY = 0
+_CT_RGB = 2
+_CT_INDEXED = 3
+_CT_GRAY_ALPHA = 4
+_CT_RGBA = 6
+
+
+def _chunk_crc(chunk_type: bytes, data: bytes) -> int:
+    return zlib.crc32(chunk_type + data) & 0xFFFFFFFF
+
+
+def _parse_ihdr(data: bytes) -> Tuple[int, int, int, int, int]:
+    width, height, bit_depth, color_type, _compression, _filter_m, interlace = \
+        struct.unpack(">LLBBBBB", data[:13])
+    return width, height, bit_depth, color_type, interlace
+
+
+def _parse_cicp(data: bytes) -> Tuple[int, int]:
+    if len(data) < 4:
+        return (0, 0)
+    return data[0], data[1]
+
+
+def _resolve_color_space_from_chunks(
+    has_srgb: bool,
+    iccp_name: Optional[str],
+    cicp_primaries: Optional[int],
+    cicp_transfer: Optional[int],
+) -> ColorSpace:
+    if has_srgb:
+        return ColorSpace.SRGB
+
+    if cicp_primaries is not None and cicp_transfer is not None:
+        # Display-P3 primaries (12) + sRGB transfer (13)
+        if cicp_primaries == 12 and cicp_transfer == 13:
+            return ColorSpace.DISPLAY_P3
+        # Rec.2020 primaries (9) + sRGB/bt709 transfer
+        if cicp_primaries == 9 and cicp_transfer in (1, 13, 14, 15):
+            return ColorSpace.REC2020
+        # Rec.2020 primaries (9) + PQ transfer (16)
+        if cicp_primaries == 9 and cicp_transfer == 16:
+            return ColorSpace.REC2100_PQ
+        # Rec.2020 primaries (9) + HLG transfer (18)
+        if cicp_primaries == 9 and cicp_transfer == 18:
+            return ColorSpace.REC2100_HLG
+        # sRGB primaries (1) + sRGB transfer (13)
+        if cicp_primaries == 1 and cicp_transfer == 13:
+            return ColorSpace.SRGB
+
+    if iccp_name is not None:
+        name_lower = iccp_name.lower()
+        if "display p3" in name_lower or "display-p3" in name_lower:
+            return ColorSpace.DISPLAY_P3
+        if "rec2020" in name_lower or "rec.2020" in name_lower:
+            return ColorSpace.REC2020
+        if "rec2100" in name_lower or "rec.2100" in name_lower:
+            if "pq" in name_lower or "smpte2084" in name_lower:
+                return ColorSpace.REC2100_PQ
+            if "hlg" in name_lower:
+                return ColorSpace.REC2100_HLG
+
+    return ColorSpace.SRGB
+
+
+def parse_png(png_bytes: bytes) -> PngInfo:
+    if not png_bytes.startswith(_PNG_SIGNATURE):
+        raise InvalidPNGError("Data does not start with PNG signature")
+
+    pos = len(_PNG_SIGNATURE)
+    ihdr_found = False
+    iend_found = False
+    width = height = bit_depth = color_type = interlace = 0
+    has_srgb = False
+    iccp_name: Optional[str] = None
+    has_iccp = False
+    cicp_primaries: Optional[int] = None
+    cicp_transfer: Optional[int] = None
+    has_cicp = False
+
+    while pos < len(png_bytes) and not iend_found:
+        if pos + 8 > len(png_bytes):
+            raise InvalidPNGError("Truncated PNG: cannot read chunk header")
+
+        length, chunk_type = struct.unpack(">L4s", png_bytes[pos : pos + 8])
+        pos += 8
+        chunk_end = pos + length
+
+        if chunk_end + 4 > len(png_bytes):
+            raise InvalidPNGError(
+                f"Truncated PNG: chunk {chunk_type!r} extends past end of data"
+            )
+
+        chunk_data = png_bytes[pos:chunk_end]
+        pos = chunk_end
+        crc = struct.unpack(">L", png_bytes[pos : pos + 4])[0]
+        pos += 4
+
+        expected_crc = _chunk_crc(chunk_type, chunk_data)
+        if crc != expected_crc:
+            raise InvalidPNGError(f"CRC mismatch in chunk {chunk_type!r}")
+
+        if chunk_type == b"IHDR":
+            width, height, bit_depth, color_type, interlace = _parse_ihdr(chunk_data)
+            ihdr_found = True
+        elif chunk_type == b"sRGB":
+            has_srgb = True
+        elif chunk_type == b"iCCP":
+            has_iccp = True
+            null_pos = chunk_data.find(b"\x00")
+            if null_pos > 0:
+                iccp_name = chunk_data[:null_pos].decode("ascii", errors="replace")
+        elif chunk_type == b"cICP":
+            has_cicp = True
+            cicp_primaries, cicp_transfer = _parse_cicp(chunk_data)
+        elif chunk_type == b"IEND":
+            iend_found = True
+
+    if not ihdr_found:
+        raise InvalidPNGError("No IHDR chunk found")
+    if not iend_found:
+        raise InvalidPNGError("No IEND chunk found")
+
+    color_space = _resolve_color_space_from_chunks(
+        has_srgb, iccp_name, cicp_primaries, cicp_transfer
+    )
+
+    return PngInfo(
+        width=width,
+        height=height,
+        bit_depth=bit_depth,
+        color_type=color_type,
+        color_space=color_space,
+        has_srgb=has_srgb,
+        has_iccp=has_iccp,
+        has_cicp=has_cicp,
+        iccp_profile_name=iccp_name,
+        cicp_primaries=cicp_primaries,
+        cicp_transfer_function=cicp_transfer,
+        interlaced=interlace != 0,
+        alpha=color_type in (_CT_GRAY_ALPHA, _CT_RGBA),
+    )
+
+
+def validate_contract(png_info: PngInfo, contract: CaptureContract) -> None:
+    if png_info.color_space != contract.color_space:
+        raise MalformedCaptureError(
+            f"Colour space mismatch: PNG reports {png_info.color_space.value}, "
+            f"expected {contract.color_space.value}"
+        )
+
+    if not (contract.min_bit_depth <= png_info.bit_depth <= contract.max_bit_depth):
+        raise MalformedCaptureError(
+            f"Bit depth {png_info.bit_depth} is not in accepted range "
+            f"[{contract.min_bit_depth}, {contract.max_bit_depth}]"
+        )
+
+    if png_info.color_type not in (_CT_RGB, _CT_RGBA):
+        raise MalformedCaptureError(
+            f"Unexpected PNG colour type {png_info.color_type} (expected RGB or RGBA)"
+        )
+
+    if png_info.interlaced:
+        raise MalformedCaptureError("Interlaced PNG is not supported")
+    if png_info.color_type == _CT_RGBA and not contract.allow_alpha:
+        raise MalformedCaptureError("Alpha channel present but not allowed by contract")
+    if png_info.color_type == _CT_RGB and contract.require_alpha:
+        raise MalformedCaptureError("Alpha channel required but not present")
+
+
+def decode_pixels_stdlib(
+    png_bytes: bytes, info: PngInfo
+) -> Tuple[List[List[int]], int, int, int]:
+    """Returns (rows, width, height, channels) where *rows* is a list of rows,
+    each row is a flat list of channel values (R, G, B[, A])."""
+    pos = len(_PNG_SIGNATURE)
+    idat_chunks: List[bytes] = []
+
+    while pos < len(png_bytes):
+        length, chunk_type = struct.unpack(">L4s", png_bytes[pos : pos + 8])
+        pos += 8
+        chunk_data = png_bytes[pos : pos + length]
+        pos += length + 4  # skip CRC
+
+        if chunk_type == b"IDAT":
+            idat_chunks.append(chunk_data)
+        elif chunk_type == b"IEND":
+            break
+
+    raw = zlib.decompress(b"".join(idat_chunks))
+
+    _CT_TO_CHANNELS = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}
+    channels = _CT_TO_CHANNELS.get(info.color_type, 3)
+    bytes_per_channel = info.bit_depth // 8
+    pixel_bytes = channels * bytes_per_channel
+    stride = info.width * pixel_bytes + 1  # +1 for filter byte
+
+    rows: List[List[int]] = []
+    prev_recon: Optional[List[int]] = None
+
+    for y in range(info.height):
+        row_start = y * stride
+        filter_byte = raw[row_start]
+        row_data = list(raw[row_start + 1 : row_start + stride])
+
+        if filter_byte == 0:  # None
+            pass
+        elif filter_byte == 1:  # Sub
+            for i in range(pixel_bytes, len(row_data)):
+                row_data[i] = (row_data[i] + row_data[i - pixel_bytes]) & 0xFF
+        elif filter_byte == 2:  # Up
+            for i in range(len(row_data)):
+                up = prev_recon[i] if prev_recon is not None else 0
+                row_data[i] = (row_data[i] + up) & 0xFF
+        elif filter_byte == 3:  # Average
+            for i in range(len(row_data)):
+                left = row_data[i - pixel_bytes] if i >= pixel_bytes else 0
+                up = prev_recon[i] if prev_recon is not None else 0
+                row_data[i] = (row_data[i] + (left + up) // 2) & 0xFF
+        elif filter_byte == 4:  # Paeth
+            for i in range(len(row_data)):
+                left = row_data[i - pixel_bytes] if i >= pixel_bytes else 0
+                up = prev_recon[i] if prev_recon is not None else 0
+                up_left = (
+                    prev_recon[i - pixel_bytes]
+                    if prev_recon is not None and i >= pixel_bytes
+                    else 0
+                )
+                row_data[i] = (row_data[i] + _paeth_predictor(left, up, up_left)) & 0xFF
+        else:
+            raise InvalidPNGError(f"Unknown PNG filter byte: {filter_byte}")
+
+        prev_recon = row_data
+
+        if info.interlaced:
+            raise InvalidPNGError("Interlaced PNG is not supported")
+
+        if bytes_per_channel == 1:
+            rows.append(list(row_data))
+        else:
+            row_channels = []
+            for i in range(0, len(row_data), 2):
+                val = struct.unpack(">H", bytes(row_data[i : i + 2]))[0]
+                row_channels.append(val)
+            rows.append(row_channels)
+
+    return rows, info.width, info.height, channels
+
+
+def _paeth_predictor(a: int, b: int, c: int) -> int:
+    p = a + b - c
+    pa = abs(p - a)
+    pb = abs(p - b)
+    pc = abs(p - c)
+    if pa <= pb and pa <= pc:
+        return a
+    if pb <= pc:
+        return b
+    return c
+
+
+_DEFAULT_CONTRACTS: Dict[str, CaptureContract] = {
+    "srgb": CaptureContract(ColorSpace.SRGB, min_bit_depth=8, max_bit_depth=8),
+    "display-p3": CaptureContract(ColorSpace.DISPLAY_P3, min_bit_depth=8, max_bit_depth=16),
+    "rec2020": CaptureContract(ColorSpace.REC2020, min_bit_depth=8, max_bit_depth=16),
+    "rec2100-pq": CaptureContract(ColorSpace.REC2100_PQ, min_bit_depth=10, max_bit_depth=16),
+    "rec2100-hlg": CaptureContract(ColorSpace.REC2100_HLG, min_bit_depth=10, max_bit_depth=16),
+}
+
+
+def get_contract(color_space_id: str) -> Optional[CaptureContract]:
+    return _DEFAULT_CONTRACTS.get(color_space_id)

--- a/tools/wptrunner/wptrunner/tests/test_png_validator.py
+++ b/tools/wptrunner/wptrunner/tests/test_png_validator.py
@@ -417,3 +417,15 @@ class TestCheckPass:
         )
         assert result is True
         assert page == -1
+
+
+    def test_fuzzy_with_high_bit_depth_fails(self, impl):
+        png = _make_png(bit_depth=16, extra_chunks=(_chunk(b"cICP", bytes([12, 13, 0, 1])),))
+        b64 = _b64(png)
+        screenshots = ([b64], [b64])
+        hashes = (["h1"], ["h1"])
+        result, page = impl.check_pass(
+            hashes, screenshots, ["test", "ref"], "==", ([10, 10], [100, 100]),
+            color_space="display-p3",
+        )
+        assert result is None

--- a/tools/wptrunner/wptrunner/tests/test_png_validator.py
+++ b/tools/wptrunner/wptrunner/tests/test_png_validator.py
@@ -1,0 +1,419 @@
+import base64
+import io
+import logging
+import struct
+import zlib
+
+import pytest
+
+from ..executors.base import RefTestImplementation
+from ..executors.png_validator import (
+    CaptureContract,
+    ColorSpace,
+    InvalidPNGError,
+    MalformedCaptureError,
+    PngInfo,
+    decode_pixels_stdlib,
+    get_contract,
+    parse_png,
+    validate_contract,
+)
+
+
+def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+    c = chunk_type + data
+    crc = zlib.crc32(c) & 0xFFFFFFFF
+    return struct.pack(">I", len(data)) + c + struct.pack(">I", crc)
+
+
+_PNG_SIG = b"\x89PNG\r\n\x1a\n"
+
+
+def _make_png(
+    width: int = 4,
+    height: int = 4,
+    bit_depth: int = 8,
+    color_type: int = 2,  # RGB
+    extra_chunks: tuple = (),
+    idat: bytes | None = None,
+) -> bytes:
+    ihdr = struct.pack(">IIBBBBB", width, height, bit_depth, color_type, 0, 0, 0)
+    parts = [_PNG_SIG, _chunk(b"IHDR", ihdr)]
+    parts.extend(extra_chunks)
+    if idat is None:
+        channels_map = {0: 1, 2: 3, 4: 2, 6: 4}
+        ch_count = channels_map.get(color_type, 3)
+        bps = bit_depth // 8
+        row = b"\x00" + b"\x00" * width * ch_count * bps
+        raw = row * height
+        idat = zlib.compress(raw)
+    parts.append(_chunk(b"IDAT", idat))
+    parts.append(_chunk(b"IEND", b""))
+    return b"".join(parts)
+
+
+class TestParsePng:
+    def test_basic_8bit_rgb(self):
+        png = _make_png()
+        info = parse_png(png)
+        assert info.width == 4
+        assert info.height == 4
+        assert info.bit_depth == 8
+        assert info.color_type == 2
+        assert info.color_space == ColorSpace.SRGB
+        assert not info.alpha
+
+    def test_8bit_rgba(self):
+        png = _make_png(color_type=6)
+        info = parse_png(png)
+        assert info.color_type == 6
+        assert info.alpha
+
+    def test_16bit_rgb(self):
+        png = _make_png(bit_depth=16)
+        info = parse_png(png)
+        assert info.bit_depth == 16
+
+    def test_srgb_chunk(self):
+        png = _make_png(extra_chunks=(_chunk(b"sRGB", b"\x00"),))
+        info = parse_png(png)
+        assert info.has_srgb
+        assert info.color_space == ColorSpace.SRGB
+
+    def test_cicp_display_p3(self):
+        png = _make_png(extra_chunks=(_chunk(b"cICP", bytes([12, 13, 0, 1])),))
+        info = parse_png(png)
+        assert info.has_cicp
+        assert info.cicp_primaries == 12
+        assert info.cicp_transfer_function == 13
+        assert info.color_space == ColorSpace.DISPLAY_P3
+
+    def test_cicp_rec2100_pq(self):
+        png = _make_png(extra_chunks=(_chunk(b"cICP", bytes([9, 16, 0, 1])),))
+        info = parse_png(png)
+        assert info.color_space == ColorSpace.REC2100_PQ
+
+    def test_cicp_rec2100_hlg(self):
+        png = _make_png(extra_chunks=(_chunk(b"cICP", bytes([9, 18, 0, 1])),))
+        info = parse_png(png)
+        assert info.color_space == ColorSpace.REC2100_HLG
+
+    def test_iccp_display_p3(self):
+        name = b"Display P3\x00"
+        compressed = zlib.compress(b"fake icc profile data")
+        chunk_data = name + b"\x00" + compressed
+        png = _make_png(extra_chunks=(_chunk(b"iCCP", chunk_data),))
+        info = parse_png(png)
+        assert info.has_iccp
+        assert "display p3" in (info.iccp_profile_name or "").lower()
+        assert info.color_space == ColorSpace.DISPLAY_P3
+
+    def test_not_png(self):
+        with pytest.raises(InvalidPNGError, match="signature"):
+            parse_png(b"not a png file")
+
+    def test_truncated(self):
+        with pytest.raises(InvalidPNGError):
+            parse_png(_PNG_SIG + b"\x00\x00\x00\x00")
+
+    def test_no_ihdr(self):
+        buf = _PNG_SIG + _chunk(b"sRGB", b"\x00") + _chunk(b"IEND", b"")
+        with pytest.raises(InvalidPNGError, match="IHDR"):
+            parse_png(buf)
+
+    def test_bad_crc(self):
+        ihdr = struct.pack(">IIBBBBB", 4, 4, 8, 2, 0, 0, 0)
+        c = b"IHDR" + ihdr
+        crc = struct.pack(">I", 0xDEADBEEF)
+        buf = _PNG_SIG + struct.pack(">I", len(ihdr)) + c + crc + _chunk(b"IEND", b"")
+        with pytest.raises(InvalidPNGError, match="CRC"):
+            parse_png(buf)
+
+
+class TestValidateContract:
+    def test_ok_8bit_srgb(self):
+        info = PngInfo(4, 4, 8, 2, ColorSpace.SRGB)
+        contract = CaptureContract(ColorSpace.SRGB)
+        validate_contract(info, contract)
+
+    def test_wrong_color_space(self):
+        info = PngInfo(4, 4, 8, 2, ColorSpace.DISPLAY_P3)
+        contract = CaptureContract(ColorSpace.SRGB)
+        with pytest.raises(MalformedCaptureError, match="Colour space mismatch"):
+            validate_contract(info, contract)
+
+    def test_bit_depth_too_low(self):
+        info = PngInfo(4, 4, 8, 2, ColorSpace.REC2100_PQ)
+        contract = CaptureContract(ColorSpace.REC2100_PQ, min_bit_depth=10)
+        with pytest.raises(MalformedCaptureError, match="Bit depth"):
+            validate_contract(info, contract)
+
+    def test_bit_depth_too_high(self):
+        info = PngInfo(4, 4, 16, 2, ColorSpace.SRGB)
+        contract = CaptureContract(ColorSpace.SRGB, max_bit_depth=8)
+        with pytest.raises(MalformedCaptureError, match="Bit depth"):
+            validate_contract(info, contract)
+
+    def test_wrong_color_type(self):
+        info = PngInfo(4, 4, 8, 0, ColorSpace.SRGB)  # grayscale
+        contract = CaptureContract(ColorSpace.SRGB)
+        with pytest.raises(MalformedCaptureError, match="colour type"):
+            validate_contract(info, contract)
+
+
+class TestDecodePixelsStdlib:
+    def test_8bit_rgb_roundtrip(self):
+        from PIL import Image as PILImage
+
+        for mode, color_type in [("RGB", 2), ("RGBA", 6)]:
+            img = PILImage.new(mode, (7, 3))
+            for y in range(3):
+                for x in range(7):
+                    v = (x * 36 + 3, y * 80 + 5, 127)
+                    if mode == "RGBA":
+                        v = v + (200 - x * 10,)
+                    img.putpixel((x, y), v)
+
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            png_bytes = buf.getvalue()
+
+            info = parse_png(png_bytes)
+            rows, _w, _h, _ch = decode_pixels_stdlib(png_bytes, info)
+
+            flat = []
+            for row in rows:
+                flat.extend(row)
+
+            img2 = PILImage.open(io.BytesIO(png_bytes))
+            pil_flat = []
+            for p in img2.get_flattened_data():
+                pil_flat.extend(p)
+
+            assert flat == pil_flat, f"{mode}: stdlib != PIL"
+
+    def test_16bit_grayscale_roundtrip(self):
+        from PIL import Image as PILImage
+
+        img = PILImage.new("I;16", (5, 3))
+        for y in range(3):
+            for x in range(5):
+                img.putpixel((x, y), x * 10000 + y * 1000)
+
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        info = parse_png(png_bytes)
+        rows, _w, _h, _ch = decode_pixels_stdlib(png_bytes, info)
+
+        flat = []
+        for row in rows:
+            flat.extend(row)
+
+        img2 = PILImage.open(io.BytesIO(png_bytes))
+        pil_flat = list(img2.get_flattened_data())
+
+        assert flat == pil_flat, f"16-bit gray: stdlib={flat} != PIL={pil_flat}"
+
+    def test_16bit_rgb_filter0(self):
+        row = b"\x00"
+        row += struct.pack(">HHH", 0x0000, 0x0000, 0x0000)
+        row += struct.pack(">HHH", 0xFFFF, 0xFFFF, 0xFFFF)
+        row += struct.pack(">HHH", 0x8000, 0x4000, 0x2000)
+        idat = zlib.compress(row)
+        png = _make_png(width=3, height=1, bit_depth=16, idat=idat)
+        info = parse_png(png)
+        rows, _w, _h, _ch = decode_pixels_stdlib(png, info)
+        assert rows[0] == [0, 0, 0, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x4000, 0x2000]
+
+    def test_16bit_rgba_filter0(self):
+        row = b"\x00"
+        row += struct.pack(">HHHH", 0x0000, 0xFFFF, 0x8000, 0x4000)
+        row += struct.pack(">HHHH", 0x1234, 0x5678, 0x9ABC, 0xDEF0)
+        idat = zlib.compress(row)
+        png = _make_png(width=2, height=1, bit_depth=16, color_type=6, idat=idat)
+        info = parse_png(png)
+        rows, _w, _h, _ch = decode_pixels_stdlib(png, info)
+        assert rows[0] == [0, 0xFFFF, 0x8000, 0x4000, 0x1234, 0x5678, 0x9ABC, 0xDEF0]
+
+
+class TestGetContract:
+    def test_known(self):
+        c = get_contract("display-p3")
+        assert c is not None
+        assert c.color_space == ColorSpace.DISPLAY_P3
+
+    def test_unknown(self):
+        assert get_contract("nonexistent") is None
+
+    def test_srgb_limits_8bit(self):
+        c = get_contract("srgb")
+        assert c.max_bit_depth == 8
+
+    def test_hdr_requires_more_than_8bit(self):
+        for cs in ("rec2100-pq", "rec2100-hlg"):
+            c = get_contract(cs)
+            assert c is not None
+            assert c.min_bit_depth >= 10
+
+
+class _FakeExecutor:
+    """Minimal mock so RefTestImplementation can be instantiated."""
+    timeout_multiplier = 1
+    subsuite = ""
+    screenshot_cache = {}
+    reftest_screenshot = "fail"
+    logger = logging.getLogger("test")
+
+
+def _b64(png_bytes: bytes) -> str:
+    return base64.b64encode(png_bytes).decode()
+
+
+@pytest.fixture
+def impl():
+    return RefTestImplementation(_FakeExecutor())
+
+
+class TestGetDifferences:
+    def test_identical(self, impl):
+        png = _make_png(width=3, height=2)
+        screenshots = (_b64(png), _b64(png))
+        max_diff, count = impl.get_differences(screenshots, urls=["a", "b"])
+        assert max_diff == 0
+        assert count == 0
+
+    def test_one_pixel_diff(self, impl):
+        # Two 2×1 RGB PNGs differing by one channel value.
+        row = b"\x00" + b"\xff\x00\x00" + b"\x00\xff\x00"
+        png_a = _make_png(width=2, height=1, idat=zlib.compress(row))
+        row2 = b"\x00" + b"\xfe\x00\x00" + b"\x00\xff\x00"
+        png_b = _make_png(width=2, height=1, idat=zlib.compress(row2))
+        screenshots = (_b64(png_a), _b64(png_b))
+        max_diff, count = impl.get_differences(screenshots, urls=["a", "b"])
+        assert max_diff == 1  # 0xff - 0xfe
+        assert count == 1
+
+    def test_size_mismatch(self, impl):
+        png_a = _make_png(width=3, height=2)
+        png_b = _make_png(width=4, height=2)
+        screenshots = (_b64(png_a), _b64(png_b))
+        max_diff, count = impl.get_differences(screenshots, urls=["a", "b"])
+        assert max_diff == 0
+        assert count > 0  # triggers failure
+
+    def test_16bit(self, impl):
+        row = b"\x00"
+        row += struct.pack(">HHH", 0x0000, 0x0000, 0x0000)
+        row += struct.pack(">HHH", 0xFFFF, 0xFFFF, 0xFFFF)
+        png_a = _make_png(width=2, height=1, bit_depth=16, idat=zlib.compress(row))
+        row2 = b"\x00"
+        row2 += struct.pack(">HHH", 0x0000, 0x0000, 0x0000)
+        row2 += struct.pack(">HHH", 0xFFFE, 0xFFFF, 0xFFFF)
+        png_b = _make_png(width=2, height=1, bit_depth=16, idat=zlib.compress(row2))
+        screenshots = (_b64(png_a), _b64(png_b))
+        max_diff, count = impl.get_differences(screenshots, urls=["a", "b"])
+        assert max_diff == 1
+        assert count == 1
+
+    def test_invalid_base64(self, impl):
+        max_diff, count = impl.get_differences(("not base64", "also bad"), urls=["a", "b"])
+        assert max_diff is None
+        assert count is None
+
+    def test_alpha_skipped(self, impl):
+        # Two 2×1 RGBA PNGs with same RGB but different alpha.
+        row_a = b"\x00" + b"\x80\x40\x20\xff" + b"\x10\x20\x30\x80"
+        png_a = _make_png(width=2, height=1, color_type=6, idat=zlib.compress(row_a))
+        row_b = b"\x00" + b"\x80\x40\x20\x00" + b"\x10\x20\x30\x00"
+        png_b = _make_png(width=2, height=1, color_type=6, idat=zlib.compress(row_b))
+        screenshots = (_b64(png_a), _b64(png_b))
+
+        # Without contract: composited against black → alpha matters.
+        max_diff, count = impl.get_differences(screenshots, urls=["a", "b"])
+        assert max_diff == 128  # 0x80*255//255 vs 0x80*0//255
+        assert count == 2  # both pixels differ
+
+        # With contract: alpha dropped, raw RGB compared → identical.
+        from ..executors.png_validator import CaptureContract, ColorSpace
+        contract = CaptureContract(ColorSpace.SRGB)
+        max_diff2, count2 = impl.get_differences(
+            screenshots, urls=["a", "b"], contract=contract
+        )
+        assert max_diff2 == 0
+        assert count2 == 0
+
+    def test_solid_colour_warns(self, impl):
+        row = b"\x00" + b"\xFF\x00\x00" * 2
+        png = _make_png(width=2, height=2, idat=zlib.compress(row * 2))
+        impl.message = []
+        impl.get_differences((_b64(png), _b64(png)), urls=["a", "b"])
+        assert any("solid colour" in m for m in impl.message)
+        assert any("FF0000" in m for m in impl.message)
+
+
+class TestCheckPass:
+    def _hash(self, screenshots):
+        h = ["a", "b"]
+        return (h[:len(screenshots[0])], h[:len(screenshots[1])])
+
+    def test_pass_identical(self, impl):
+        png = _make_png()
+        b64 = _b64(png)
+        screenshots = ([b64], [b64])
+        hashes = (["h1"], ["h1"])
+        result, page = impl.check_pass(
+            hashes, screenshots, ["test", "ref"], "==", None
+        )
+        assert result is True
+        assert page == -1
+
+    def test_fail_different(self, impl):
+        png_a = _make_png()
+        # Make a different PNG by changing a pixel.
+        row = b"\x00" + b"\x80\x80\x80" * 4
+        png_b = _make_png(width=4, height=1, idat=zlib.compress(row))
+        screenshots = ([_b64(png_a)], [_b64(png_b)])
+        hashes = (["h1"], ["h2"])
+        result, _page = impl.check_pass(
+            hashes, screenshots, ["test", "ref"], "==", None
+        )
+        assert result is False
+
+    def test_contract_valid(self, impl):
+        png = _make_png(extra_chunks=(_chunk(b"cICP", bytes([12, 13, 0, 1])),))
+        b64 = _b64(png)
+        screenshots = ([b64], [b64])
+        hashes = (["h1"], ["h1"])
+        result, page = impl.check_pass(
+            hashes, screenshots, ["test", "ref"], "==", None,
+            color_space="display-p3",
+        )
+        assert result is True
+        assert page == -1
+
+    def test_contract_violation_wrong_space(self, impl):
+        # PNG is sRGB but contract expects Display-P3.
+        png = _make_png()
+        b64 = _b64(png)
+        screenshots = ([b64], [b64])
+        hashes = (["h1"], ["h1"])
+        result, _page = impl.check_pass(
+            hashes, screenshots, ["test", "ref"], "==", None,
+            color_space="display-p3",
+        )
+        # Contract violation → (None, page_idx)
+        assert result is None
+
+    def test_no_contract_no_validation(self, impl):
+        # Without color_space, even a Display-P3 PNG is compared without error.
+        png = _make_png(extra_chunks=(_chunk(b"cICP", bytes([12, 13, 0, 1])),))
+        b64 = _b64(png)
+        screenshots = ([b64], [b64])
+        hashes = (["h1"], ["h1"])
+        result, page = impl.check_pass(
+            hashes, screenshots, ["test", "ref"], "==", None
+        )
+        assert result is True
+        assert page == -1

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -557,7 +557,7 @@ class ReftestTest(Test):
 
     def __init__(self, url_base, tests_root, url, inherit_metadata, test_metadata, references,
                  timeout=None, path=None, viewport_size=None, dpi=None, fuzzy=None,
-                 protocol="http", subdomain=False, testdriver=False):
+                 protocol="http", subdomain=False, testdriver=False, color_space=None):
         Test.__init__(self, url_base, tests_root, url, inherit_metadata, test_metadata, timeout,
                       path, protocol, subdomain)
 
@@ -570,6 +570,7 @@ class ReftestTest(Test):
         self.dpi = dpi
         self.testdriver = testdriver
         self._fuzzy = fuzzy or {}
+        self.color_space = color_space
 
     @classmethod
     def cls_kwargs(cls, manifest_test):
@@ -577,6 +578,7 @@ class ReftestTest(Test):
                 "dpi": manifest_test.dpi,
                 "protocol": server_protocol(manifest_test),
                 "fuzzy": manifest_test.fuzzy,
+                "color_space": getattr(manifest_test, "reftest_color_space", None),
                 "testdriver": bool(getattr(manifest_test, "testdriver", False))}
 
     @classmethod


### PR DESCRIPTION
This patch is a draft implementation of RFC 242 (web-platform-tests/rfcs#242).

It implements support for the `reftest-color-space` metadata, which is passed to WebDriver BiDi `captureScreenshot`. Before, we were using PIL to decode and compare PNGs. This was limited, since it only supported 8-bits. Instead, we now have a custom PNG comparison that preserves samples and bit depth.

Limitations and follow up work:

- Fuzzy high bit tests are still unspecified, so we reject them for now.
- Adobe RGB is not added as a color space since an identifier is not yet standardized.
- We need browser support for captures to be able to test these changes properly.

Relevant issues:

web-platform-tests/rfcs#242
web-platform-tests/wpt#44320
w3c/webdriver-bidi#1114