### PR TITLE
aamtests: Fix _find_fully_loaded_tab

### DIFF
--- a/core-aam/aamtests/support/atspi_wrapper.py
+++ b/core-aam/aamtests/support/atspi_wrapper.py
@@ -113,8 +113,6 @@ class AtspiWrapper(ApiWrapper[Atspi.Accessible]):
                         tab = relation.get_target(0)
                         if self._is_ready(tab, self.test_url):
                             return tab
-                        else:
-                            return None
                 continue
 
             for i in range(Atspi.Accessible.get_child_count(node)):


### PR DESCRIPTION
Instead of returning, let's continue searching for other frames. This fixes running aamtests on desktop environment.