### PR TITLE
[scroll-animations] Make it parse errors if using relative units for rangeStart and rangeEnd

### DIFF
--- a/scroll-animations/scroll-timelines/scroll-timeline-range.html
+++ b/scroll-animations/scroll-timelines/scroll-timeline-range.html
@@ -108,23 +108,36 @@
     });
   }, 'Scroll timeline with calculated range [JavaScript API]');
 
-promise_test(async t => {
+  promise_test(async t => {
     t.add_cleanup(() => {
       target.style.fontSize = '';
     });
-    await test_range_waapi(t, {
-      rangeStart: "5em",
-      rangeEnd: "calc(100% - 5em)",
-      startOffset: 50,
-      endOffset: 950
-    });
-    target.style.fontSize =  '20px';
-    await waitForNextFrame();
-    const anim = target.getAnimations()[0];
-    const expectedProgress = (600 - 100) / (900 - 100);
-    assert_approx_equals(anim.effect.getComputedTiming().progress,
-                         expectedProgress, 0.001);
-  }, 'Scroll timeline with EM range [JavaScript API]');
+
+    const timeline = new ScrollTimeline({source: scroller, axis: 'block'});
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "5em",
+          rangeEnd: "calc(100% - 5em)",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid font-relative units');
+
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "2vh",
+          rangeEnd: "calc(100% - 2vw)",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid viewport units');
+  }, 'Scroll timeline with relative units range [JavaScript API]');
 
   // Test via CSS.
   async function test_range_css(t, options) {
@@ -167,7 +180,7 @@ promise_test(async t => {
     });
   }, 'Scroll timeline with calculated range [CSS]');
 
-promise_test(async t => {
+  promise_test(async t => {
     t.add_cleanup(() => {
       target.style.fontSize = '';
     });

--- a/scroll-animations/view-timelines/view-timeline-range.html
+++ b/scroll-animations/view-timelines/view-timeline-range.html
@@ -179,7 +179,7 @@
     });
 
     await runTimelineRangeTest(t, {
-      rangeStart: "contain calc(sign(100em - 1px) * 20px)",
+      rangeStart: "contain calc(sign(1000px - 1px) * 20px)",
       rangeEnd: "contain calc(100%)",
       startOffset: 720,
       endOffset: 800
@@ -193,13 +193,38 @@
     });
 
     await runTimelineRangeTest(t, {
-      rangeStart: "exit 2em",
-      rangeEnd: "exit 8em",
+      rangeStart: "exit 20px",
+      rangeEnd: "exit 80px",
       startOffset: 820,
       endOffset: 880
     });
-
-
   }, 'View timeline with range as strings.');
+
+  promise_test(async t => {
+    const timeline = new ViewTimeline({subject: target, axis: 'block'});
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "exit 2em",
+          rangeEnd: "exit 8em",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid font-relative units');
+
+    assert_throws_js(TypeError, () => {
+      let anim = target.animate(
+        null,
+        {
+          timeline: timeline,
+          rangeStart: "cover 2vh",
+          rangeEnd: "cover calc(100% - 2vw)",
+        },
+      );
+      t.add_cleanup(() => { anim?.cancel(); });
+    }, 'Invalid viewport units');
+  }, 'View timeline with range as strings with relative units.');
 
 </script>


### PR DESCRIPTION
Per https://github.com/w3c/csswg-drafts/issues/13853, we shouldn't allow relative units for rangeStart and rangeEnd.