### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321555

### DIFF
--- a/css/css-anchor-position/long-anchor-chain-crash.html
+++ b/css/css-anchor-position/long-anchor-chain-crash.html
@@ -4,6 +4,7 @@
 
 <title>Long chained anchor crash</title>
 <link rel="help" href="https://drafts.csswg.org/css-anchor-position/">
+<meta name="timeout" content="long">
 
 <style>
   .box {


### PR DESCRIPTION
WebKit export from bug: [Unreviewed, mark imported/w3c/web-platform-tests/css/css-anchor-position/long-anchor-chain-crash.html as slow](https://bugs.webkit.org/show_bug.cgi?id=321555)