### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321498

### DIFF
--- a/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist.html
+++ b/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div style="height: 200vh; width: 200vw;"></div>
+<div id="frag"></div>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await navigation.navigate("#frag").finished;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element after navigating to #frag");
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "manual" });
+  };
+  let promises = navigation.navigate("#does-not-exist");
+  await promises.committed;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element before scroll()");
+  navigate_event.scroll();
+  assert_equals(document.querySelector(":target"), null, "target element after scroll()");
+  intercept_resolve();
+  await promises.finished;
+  assert_equals(document.querySelector(":target"), null, "target element after finished");
+}, "scroll: scroll() should clear the CSS :target element when the fragment does not exist");
+</script>
+</body>

--- a/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment.html
+++ b/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div style="height: 200vh; width: 200vw;"></div>
+<div id="frag"></div>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  let start_url = location.href;
+  await navigation.navigate("#frag").finished;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element after navigating to #frag");
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "manual" });
+  };
+  let promises = navigation.navigate(start_url);
+  await promises.committed;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element before scroll()");
+  navigate_event.scroll();
+  assert_equals(document.querySelector(":target"), null, "target element after scroll()");
+  intercept_resolve();
+  await promises.finished;
+  assert_equals(document.querySelector(":target"), null, "target element after finished");
+}, "scroll: scroll() should clear the CSS :target element when the destination url contains no fragment");
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [\[Navigation API\] navigateEvent.scroll() does not scroll to the beginning of the document when the fragment does not exist](https://bugs.webkit.org/show_bug.cgi?id=321498)