### PR TITLE
[css-values-5] Add coverage for the random() caching key in custom properties

### DIFF
--- a/css/css-values/random-computed.tentative.html
+++ b/css/css-values/random-computed.tentative.html
@@ -38,6 +38,26 @@
     inherits: true;
     initial-value: 3%;
   }
+  @property --len-a {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 3px;
+  }
+  @property --len-b {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 3px;
+  }
+  @property --len-list {
+    syntax: "<length>+";
+    inherits: true;
+    initial-value: 3px;
+  }
+  @property --len-scoped {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 3px;
+  }
   @property --transform-function {
     syntax: "<transform-function>";
     inherits: true;
@@ -60,6 +80,13 @@
   .randomNoIdentifierPercent {
     left: random(0%, 100%);
     top: random(0%, 100%);
+  }
+  .randomCustomLength {
+    width: random(0px, 300000px);
+    --len-a: random(0px, 300000px);
+    --len-b: random(0px, 300000px);
+    --len-list: random(0px, 300000px) random(0px, 300000px);
+    --len-scoped: random(property-scoped, 0px, 300000px);
   }
   .randomMatchElement {
     width: random(property-index-scoped, 0px, 300000px);
@@ -629,6 +656,131 @@ test(() => {
 
   try {
     const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const computedA = getComputedStyle(el).getPropertyValue('--len-a');
+    const computedB = getComputedStyle(el).getPropertyValue('--len-b');
+
+    test_random_not_equals(computedA, computedB,
+                          "Different registered <length> custom properties on the same element should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() in different registered <length> custom properties on the same element should not be shared`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const other = document.createElement('div');
+    other.className = 'randomCustomLength';
+    holder.appendChild(other);
+
+    const elComputed = getComputedStyle(el).getPropertyValue('--len-a');
+    const otherComputed = getComputedStyle(other).getPropertyValue('--len-a');
+
+    test_random_not_equals(elComputed, otherComputed,
+                          "The same custom property on different elements should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() in a custom property should be element-scoped by default`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    // Both are the first random() in their own property, so these only differ if the caching key
+    // distinguishes a custom property from a non-custom one.
+    const computedWidth = getComputedStyle(el)['width'];
+    const computedLength = getComputedStyle(el).getPropertyValue('--len-a');
+
+    test_random_not_equals(computedWidth, computedLength,
+                          "A custom property and a non-custom property should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() in a custom property should not be shared with a non-custom property at the same index`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const other = document.createElement('div');
+    other.className = 'randomCustomLength';
+    holder.appendChild(other);
+
+    const elComputed = getComputedStyle(el).getPropertyValue('--len-scoped');
+    const otherComputed = getComputedStyle(other).getPropertyValue('--len-scoped');
+
+    test_random_equals(elComputed, otherComputed);
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random(property-scoped, ...) in a custom property should be equal between elements`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const [first, second] = getComputedStyle(el).getPropertyValue('--len-list').split(' ');
+
+    test_random_not_equals(first, second,
+                          "Two random() functions in one custom property should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `two random() functions in the same custom property should not be shared`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.style.setProperty('--len-a', 'random(0px, 300000px)');
+    // The author-supplied <dashed-ident> happens to name the other property. It is a separate
+    // namespace from the property a key is implicitly scoped to, so these must not collide.
+    el.style.setProperty('--len-b', 'random(--len-a, 0px, 300000px)');
+    holder.appendChild(el);
+
+    const computedA = getComputedStyle(el).getPropertyValue('--len-a');
+    const computedB = getComputedStyle(el).getPropertyValue('--len-b');
+
+    test_random_not_equals(computedA, computedB,
+                          "An implicit property scope should not collide with an author <dashed-ident> of the same name");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() keyed on a custom property should not collide with an author <dashed-ident> naming it`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
     el.className = 'randomIdentifier';
     holder.appendChild(el);
 
@@ -958,8 +1110,10 @@ test(() => {
     const el = document.createElement('div');
     el.className = 'randomNoIdentifier';
     holder.appendChild(el);
-    const computedValue = getComputedStyle(el)['--random-in-initial'];
-    test_random_equals(computedValue, undefined);
+    // The initial-value is invalid, so the @property rule registers nothing and the property is
+    // left unregistered, which reads back as the empty string.
+    const computedValue = getComputedStyle(el).getPropertyValue('--random-in-initial');
+    test_random_equals(computedValue, '');
   } finally {
     document.body.removeChild(holder);
   }


### PR DESCRIPTION
Adds cases pinning which `random()` usages share a base value inside custom properties: two registered `<length>` custom properties on one element, the same custom property on two elements, a custom property against a non-custom one at the same index, `property-scoped` equality across elements, two `random()` functions within one custom property, and an author `<dashed-ident>` that happens to name the property an implicit key is scoped to.

Per https://drafts.csswg.org/css-values-5/#random-caching, `property-index-scoped` "adds the property name and the index of the random function among all the random functions used in the same property value to the random key". Custom properties can share a single internal property identifier in an implementation, so these pin that the name participates in the key.

The `@property` `initial-value` case read the computed value with bracket access on the `CSSStyleDeclaration`, which never resolves a custom property, so it compared `undefined` to `undefined` and could not fail. It now reads with `getPropertyValue()` and asserts the property is left unregistered.

Corresponding WebKit change: https://github.com/WebKit/WebKit/pull/71477