### PR TITLE
Add tests for lazy-loading cross-site iframes

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-cross-site.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-cross-site.sub.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<head>
+  <title>Iframes with loading='lazy' load when in the viewport</title>
+  <link rel="author" title="Scott Little" href="mailto:sclittle@chromium.org">
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t_in_viewport =
+    async_test('In-viewport iframes load eagerly');
+  const t_below_viewport =
+    async_test('Below-viewport iframes load lazily');
+
+  const expected_url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport";
+
+  let has_window_loaded = false;
+
+  const in_viewport_iframe_onload = t_in_viewport.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The in_viewport iframe should not block the load event");
+  });
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport").scrollIntoView();
+  });
+
+  window.addEventListener("message", t_below_viewport.step_func_done(event => {
+    assert_equals(event.data, expected_url,
+                  "The below-viewport iframe should have loaded its cross-site document");
+    assert_true(has_window_loaded,
+                "The window load event should have fired before the below-viewport iframe loads");
+  }));
+
+</script>
+
+<body>
+  <iframe id="in_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="in_viewport_iframe_onload();"></iframe>
+
+
+ <div style="height:2000vh;"></div>
+  <iframe id="below_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport"
+          loading="lazy" width="200px" height="100px"></iframe>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-in-scroller-cross-site.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-in-scroller-cross-site.sub.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #spacer {
+    width: 100px;
+    height: 100px;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <iframe
+    id="target"
+    src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+    loading="lazy"
+    onload="iframe_onload();"
+  ></iframe>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes load when near viewport."
+  );
+
+  function iframe_onload() {
+    t.done();
+  }
+
+  t.step_timeout(() => {
+    t.unreached_func(
+      "Timed out while waiting for iframe to load."
+    )();
+  }, 2000);
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-in-scroller-far-cross-site.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-in-scroller-far-cross-site.sub.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#lazy-load-root-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    background-color: gray;
+  }
+
+  #spacer {
+    width: 130px;
+    height: 10000vh;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <iframe
+    id="target"
+    src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html"
+    loading="lazy"
+    onload="iframe_onload();"
+  ></iframe>
+</div>
+
+<script>
+  const t = async_test(
+    "Test that lazy-loaded iframes do not load when far from viewport."
+  );
+
+  function iframe_onload() {
+    t.unreached_func(
+      "Lazy-loading iframe far from viewport should not load."
+    )();
+  }
+
+  t.step_timeout(() => {
+    t.done();
+  }, 2000);
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-multiple-queued-navigations-cross-site.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-multiple-queued-navigations-cross-site.sub.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<head>
+  <title>A below-viewport lazy cross-site iframe navigates only to the latest src mutation</title>
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t = async_test('A below-viewport lazy cross-site iframe navigates only to the latest src mutation');
+
+  const new_src = 'http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?new-src';
+
+  let has_below_viewport_loaded = false;
+
+  window.addEventListener("load", t.step_func(() => {
+    assert_false(has_below_viewport_loaded,
+                "The below_viewport element should not have loaded before " +
+                "window.load().");
+
+    // Queue another lazy load navigation on the iframe. This should not result
+    // in multiple internal intersection observers being created for the iframe
+    // element, but instead should result in only one intersection observer
+    // associated with the iframe element, and the resulting navigation should
+    // be for the latest `src` attribute mutation.
+    const target = document.querySelector('#below_viewport');
+    target.src = new_src;
+    target.scrollIntoView();
+  }));
+
+  window.addEventListener("message", t.step_func_done(event => {
+    assert_equals(document.querySelector('#below_viewport').src, new_src,
+      "The iframe's src should reflect the latest `src` mutation");
+    assert_equals(event.data, new_src,
+      'The iframe should be navigated to the resource provided by the latest `src` mutation');
+  }));
+
+
+</script>
+
+<body>
+  <div style="height:3000vh;"></div>
+  <iframe id="below_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?old-src"
+          loading="lazy" onload="has_below_viewport_loaded = true;"
+          width="200px" height="100px"></iframe>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<head>
+  <title>Nested cross-site iframes with loading='lazy' load when in the viewport</title>
+  <meta name="timeout" content="long">
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t_in_viewport =
+    async_test('In-viewport iframes load eagerly');
+  const t_below_viewport =
+    async_test('Below-viewport iframes load lazily');
+  const t_nested_in_viewport =
+    async_test('In-viewport iframe nested in a cross-site frame loads eagerly');
+  const t_nested_below_viewport =
+    async_test('Below-viewport iframe nested in a cross-site frame loads lazily');
+
+  const expected_subframe_url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html?below-viewport";
+  const expected_nested_subframe_url = "https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport";
+
+  let has_window_loaded = false;
+
+  const in_viewport_iframe_onload = t_in_viewport.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The outer in_viewport iframe should not block the load event");
+  });
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport").scrollIntoView();
+  });
+
+  const below_viewport_iframe_onload = t_below_viewport.step_func_done(() => {
+    assert_true(has_window_loaded,
+                "The outer window load event should have fired before the outer below-viewport iframe loads");
+  });
+
+  window.addEventListener("message", event => {
+    if (event.data?.info === "nested-in-viewport-loaded") {
+      t_nested_in_viewport.step_func_done(() => {
+        assert_false(event.data.hasWindowLoaded,
+                     "The nested in-viewport iframe should not block its own load event");
+      })();
+    } else if (event.data?.info === "nested-below-viewport-loaded") {
+      t_nested_below_viewport.step_func_done(() => {
+        assert_equals(event.data.subframeSrc, expected_subframe_url,
+                      "The below-viewport iframe should have loaded its cross-site document");
+        assert_equals(event.data.nestedSubframeSrc, expected_nested_subframe_url,
+                      "The nested below-viewport iframe should have loaded its cross-site document");
+        assert_true(event.data.hasWindowLoaded,
+                    "The nested window load event should have fired before the nested below-viewport iframe loads");
+      })();
+    }
+  });
+
+</script>
+
+<body>
+  <iframe id="in_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="in_viewport_iframe_onload();"></iframe>
+
+
+ <div style="height:2000vh;"></div>
+  <iframe id="below_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html?below-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="below_viewport_iframe_onload();"></iframe>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<head>
+  <title>Side-by-side cross-site iframes with loading='lazy' load when in the viewport</title>
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t_in_viewport_left =
+    async_test('In-viewport left iframe loads eagerly');
+  const t_below_viewport_left =
+    async_test('Below-viewport left iframe loads lazily');
+  const t_in_viewport_right =
+    async_test('In-viewport right iframe loads eagerly');
+  const t_below_viewport_right =
+    async_test('Below-viewport right iframe loads lazily');
+
+  const expected_left_url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-left";
+  const expected_right_url = "https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-right";
+
+  let has_window_loaded = false;
+
+  const in_viewport_left_iframe_onload = t_in_viewport_left.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The left in_viewport iframe should not block the load event");
+  });
+
+  const in_viewport_right_iframe_onload = t_in_viewport_right.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The right in_viewport iframe should not block the load event");
+  });
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport_left").scrollIntoView();
+  });
+
+  window.addEventListener("message", event => {
+    if (event.source === document.getElementById("below_viewport_left").contentWindow) {
+      t_below_viewport_left.step_func_done(() => {
+        assert_equals(event.data, expected_left_url,
+                      "The left below-viewport iframe should have loaded its cross-site document");
+        assert_true(has_window_loaded,
+                    "The window load event should have fired before the left below-viewport iframe loads");
+      })();
+    } else if (event.source === document.getElementById("below_viewport_right").contentWindow) {
+      t_below_viewport_right.step_func_done(() => {
+        assert_equals(event.data, expected_right_url,
+                      "The right below-viewport iframe should have loaded its cross-site document");
+        assert_true(has_window_loaded,
+                    "The window load event should have fired before the right below-viewport iframe loads");
+      })();
+    }
+  });
+
+</script>
+
+<body>
+  <div style="display: flex; gap: 10px;">
+    <iframe id="in_viewport_left"
+            src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+            loading="lazy" width="200px" height="100px"
+            onload="in_viewport_left_iframe_onload();"></iframe>
+    <iframe id="in_viewport_right"
+            src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+            loading="lazy" width="200px" height="100px"
+            onload="in_viewport_right_iframe_onload();"></iframe>
+  </div>
+
+
+ <div style="height:2000vh;"></div>
+  <div style="display: flex; gap: 10px;">
+    <iframe id="below_viewport_left"
+            src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-left"
+            loading="lazy" width="200px" height="100px"></iframe>
+    <iframe id="below_viewport_right"
+            src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-right"
+            loading="lazy" width="200px" height="100px"></iframe>
+  </div>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+
+<script>
+  let has_window_loaded = false;
+
+  function in_viewport_iframe_onload() {
+    parent.postMessage({ info: "nested-in-viewport-loaded",
+                         hasWindowLoaded: has_window_loaded }, "*");
+  }
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport").scrollIntoView();
+  });
+
+  window.addEventListener("message", event => {
+    parent.postMessage({ info: "nested-below-viewport-loaded",
+                         hasWindowLoaded: has_window_loaded,
+                         nestedSubframeSrc: event.data,
+                         subframeSrc: location.href }, "*");
+  });
+
+</script>
+
+<body>
+  <iframe id="in_viewport"
+          src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="in_viewport_iframe_onload();"></iframe>
+
+
+ <div style="height:2000vh;"></div>
+  <iframe id="below_viewport"
+          src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport"
+          loading="lazy" width="200px" height="100px"></iframe>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<body>
+  <p>Subframe</p>
+</body>
+<script>
+parent.postMessage(location.href, '*');
+</script>


### PR DESCRIPTION
This change adds cross-site variants of several of existing iframe-loading-lazy tests, along with two new tests that involve more than onecross-site frame.