### PR TITLE
layout: Consider Text as LCP candidate

### DIFF
--- a/largest-contentful-paint/larger-text.html
+++ b/largest-contentful-paint/larger-text.html
@@ -47,7 +47,7 @@
 
       await new Promise(resolve => {
         new PerformanceObserver(
-          (entryList, observer) => {
+          t.step_func((entryList, observer) => {
             entryList.getEntries().forEach(entry => {
               // The tiny images or text1 could be reported as LCP if it is rendered before text2.
               if (entry.id !== 'text2')
@@ -85,8 +85,9 @@
               observer.disconnect();
 
               resolve();
+              })
             })
-          }).observe({ type: 'largest-contentful-paint', buffered: true });
+          ).observe({ type: 'largest-contentful-paint', buffered: true });
       });
     }, 'Largest Contentful Paint: largest text is reported.');
   </script>

--- a/largest-contentful-paint/observe-text.html
+++ b/largest-contentful-paint/observe-text.html
@@ -24,13 +24,15 @@ p {
           'startTime should be equal to renderTime to the precision of 1 millisecond.');
 
         // PaintTimingMixin
-        assert_greater_than_equal(entry.paintTime, beforeRender, 'paintTime should represent the time when the UA started painting');
+        if ("paintTime" in entry && entry.paintTime !== null) {
+          assert_greater_than_equal(entry.paintTime, beforeRender, 'paintTime should represent the time when the UA started painting');
 
-        if ("presentationTime" in entry && entry.presentationTime !== null) {
-          assert_greater_than(entry.presentationTime, entry.paintTime);
-          assert_equals(entry.presentationTime, entry.renderTime);
-        } else {
-          assert_equals(entry.renderTime, entry.paintTime);
+          if ("presentationTime" in entry && entry.presentationTime !== null) {
+            assert_greater_than(entry.presentationTime, entry.paintTime);
+            assert_equals(entry.presentationTime, entry.renderTime);
+          } else {
+            assert_equals(entry.renderTime, entry.paintTime);
+          }
         }
         assert_equals(entry.duration, 0);
         // Some lower bound: height of at least 12 px.

--- a/largest-contentful-paint/text-fragment-union.html
+++ b/largest-contentful-paint/text-fragment-union.html
@@ -21,7 +21,8 @@
     document.body.appendChild(div);
 
     await new Promise(resolve => {
-      new PerformanceObserver((entryList, observer) => {
+      new PerformanceObserver(
+        t.step_func((entryList, observer) => {
         for (const entry of entryList.getEntries()) {
           if (entry.id !== 'multi-line-text') continue;
 
@@ -47,7 +48,7 @@
           observer.disconnect();
           resolve();
         }
-      }).observe({type: 'largest-contentful-paint', buffered: true});
+      })).observe({type: 'largest-contentful-paint', buffered: true});
     });
   }, 'Text fragment union: wrapped text LCP size reflects the union of all line boxes.');
 </script>


### PR DESCRIPTION
Since the spec says, for text nodes we need to do union of border box per element.

-  Adding `containing_element_tag` for making this union.
 - Adding `TextRecord` to store `TextNodes` related to an `Element`.
 

> Note: Please view using `Hide whitespace` option.

Testing: More WPT Passed
- Added a specific test to verify union logic of rect - size calculation is correct in WPT 
  - `tests/wpt/tests/largest-contentful-paint/text-fragment-union.html`- web-platform-tests/wpt#61873
  - (_TODO: set loadTime to zero for text, other failing tests will also pass #<!-- nolink -->47315_)



Fixes: Part of #<!-- nolink -->42000
Reviewed in servo/servo#47212