### PR TITLE
Align <area> with no href but js event attached with <a> with no href but js event attached

### DIFF
--- a/html-aam/area-role-tentative.html
+++ b/html-aam/area-role-tentative.html
@@ -13,6 +13,7 @@
 
 <map name="areamap">
   <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex">
+  <area shape="rect" coords="0,15,15,31" alt="x" data-testname="el-area-no-href[onclick]" data-expectedrole="link" class="ex" onclick="alert('test')">
   <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
 </map>
 <img usemap="#areamap" style="width: 32px; height: 32px;" alt="x" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">

--- a/html-aam/area-role-tentative.html
+++ b/html-aam/area-role-tentative.html
@@ -19,7 +19,7 @@
     - https://github.com/w3c/aria/issues/2867
     - https://github.com/web-platform-tests/interop-accessibility/issues/245
   -->
-  <area shape="rect" coords="0,15,15,31" alt="x" data-testname="el-area-no-href[onclick]" data-expectedrole="link" class="ex" onclick="alert('test')">
+  <area shape="rect" coords="0,15,15,31" alt="x" data-testname="el-area-no-href[onclick]" data-expectedrole="link" class="ex" onclick="console.log('WPT test');">
   <!-- GP end tentative -->
   <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
 </map>

--- a/html-aam/area-role-tentative.html
+++ b/html-aam/area-role-tentative.html
@@ -13,7 +13,14 @@
 
 <map name="areamap">
   <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex">
+  <!-- 
+    GP start tentative, trying to align <area> with no href but js event associated to <a> behaviour:
+    - https://github.com/w3c/aria/pull/2863
+    - https://github.com/w3c/aria/issues/2867
+    - https://github.com/web-platform-tests/interop-accessibility/issues/245
+  -->
   <area shape="rect" coords="0,15,15,31" alt="x" data-testname="el-area-no-href[onclick]" data-expectedrole="link" class="ex" onclick="alert('test')">
+  <!-- GP end tentative -->
   <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
 </map>
 <img usemap="#areamap" style="width: 32px; height: 32px;" alt="x" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">

--- a/html-aam/area-role.html
+++ b/html-aam/area-role.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTMLAreaElement Role Verification Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<map name="areamap">
+  <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex">
+  <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
+</map>
+<img usemap="#areamap" style="width: 32px; height: 32px;" alt="x" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Closes: https://github.com/web-platform-tests/interop-accessibility/issues/245

Relates to:
- https://github.com/w3c/aria/pull/2863
- https://github.com/w3c/html-aam/issues/610

This PR adds tests for the `area` element without an `href` attribute but with a JS event handler attached.
It assumes that its behavior should be consistent with an `a` element without an `href` attribute but with a JS event handler attached.