### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321702

### DIFF
--- a/css/css-values/random-item-computed.html
+++ b/css/css-values/random-item-computed.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#random-caching">
 <link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -108,6 +109,56 @@ test(() => {
     assert_in_array(getComputedStyle(target).getPropertyValue('--p').trim(), set);
     assert_in_array(getComputedStyle(target).getPropertyValue('--q').trim(), set);
 }, 'Independent auto random-item() instances each resolve to a valid item');
+
+const ITEMS = ['rgb(1, 0, 0)', 'rgb(0, 1, 0)', 'rgb(0, 0, 1)', 'rgb(1, 1, 0)', 'rgb(0, 1, 1)', 'rgb(1, 0, 1)', 'rgb(1, 1, 1)', 'rgb(2, 0, 0)'];
+const ITEM_LIST = ITEMS.join(', ');
+
+function computedColorsForSiblings(key) {
+    const holder = document.createElement('div');
+    document.body.appendChild(holder);
+    try {
+        const colors = [];
+        for (let i = 0; i < 12; ++i) {
+            const element = document.createElement('div');
+            element.style.cssText = `color: random-item(${key}, ${ITEM_LIST})`;
+            holder.appendChild(element);
+            colors.push(getComputedStyle(element).color);
+        }
+        return colors;
+    } finally {
+        document.body.removeChild(holder);
+    }
+}
+
+// An element-scoped key gives each element an independent draw, so 12 elements agreeing across
+// 8 items is about 1 in 10^10.
+test(() => {
+    const colors = computedColorsForSiblings('auto');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_greater_than(new Set(colors).size, 1, 'every element selected the same item');
+}, 'random-item() with an auto <random-key> is element-scoped');
+
+test(() => {
+    const colors = computedColorsForSiblings('element-scoped');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_greater_than(new Set(colors).size, 1, 'every element selected the same item');
+}, 'random-item() with a bare element-scoped <random-key> is not shared between elements');
+
+test(() => {
+    const colors = computedColorsForSiblings('--per-element element-scoped');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_greater_than(new Set(colors).size, 1, 'every element selected the same item');
+}, 'random-item() with a <dashed-ident> element-scoped <random-key> is not shared between elements');
+
+test(() => {
+    const colors = computedColorsForSiblings('--across-elements');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_equals(new Set(colors).size, 1, 'elements selected different items');
+}, 'random-item() with a <dashed-ident> <random-key> is shared between elements');
 
 // Deterministic value-sharing: the same dashed-ident key selects the same item on two properties.
 test(() => {


### PR DESCRIPTION
WebKit export from bug: [\[css-values-5 random-item()\] auto <random-key> is not element-scoped, so every element shares one item](https://bugs.webkit.org/show_bug.cgi?id=321702)