### PR TITLE
CSP: Extend tests for wildcard host and port.

### DIFF
--- a/content-security-policy/generic/wildcard-host-and-port-parts-001.sub.window.js
+++ b/content-security-policy/generic/wildcard-host-and-port-parts-001.sub.window.js
@@ -1,0 +1,28 @@
+// META: script=/content-security-policy/support/testharness-helper.js
+
+setup(_ => {
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "content-security-policy";
+  meta.content = "connect-src http://*:*/images/green-100x100.png";
+  document.head.appendChild(meta);
+});
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}:{{ports[http][0]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "host+port wildcard allows arbitrary host:port (www1, {{ports[http][0]}}).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}:{{ports[http][1]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "host+port wildcard allows arbitrary host:port (www2, {{ports[http][1]}}).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}:{{ports[http][0]}}/images/red-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url))
+  ]);
+}, "host+port wildcard doesn't affect path matching.");

--- a/content-security-policy/generic/wildcard-host-and-port-parts-002.sub.window.js
+++ b/content-security-policy/generic/wildcard-host-and-port-parts-002.sub.window.js
@@ -1,0 +1,26 @@
+// META: script=/content-security-policy/support/testharness-helper.js
+
+setup(_ => {
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "content-security-policy";
+  meta.content = "connect-src http://*:*";
+  document.head.appendChild(meta);
+});
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}:{{ports[http][0]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "host+port wildcard allows arbitrary host:port (www1, {{ports[http][0]}}).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}:{{ports[http][1]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "host+port wildcard allows arbitrary host:port (www2, {{ports[http][1]}}).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}:{{ports[http][0]}}/images/green-256x256.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Path matching does not apply for empty path-part.");

--- a/content-security-policy/generic/wildcard-host-part-003.sub.window.js
+++ b/content-security-policy/generic/wildcard-host-part-003.sub.window.js
@@ -1,0 +1,37 @@
+// META: script=/content-security-policy/support/testharness-helper.js
+
+setup(_ => {
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "content-security-policy";
+  // Default http port is 80.
+  meta.content = "connect-src http://*/images/green-100x100.png";
+  document.head.appendChild(meta);
+});
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Host wildcard allows arbitrary hosts (www1).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Host wildcard allows arbitrary hosts (www2).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}:{{ports[http][0]}}/images/green-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url)),
+  ]);
+}, "Host wildcard doesn't affect port matching.");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}/images/red-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url))
+  ]);
+}, "Host wildcard doesn't affect path matching.");

--- a/content-security-policy/generic/wildcard-host-part-004.sub.window.js
+++ b/content-security-policy/generic/wildcard-host-part-004.sub.window.js
@@ -1,0 +1,35 @@
+// META: script=/content-security-policy/support/testharness-helper.js
+
+setup(_ => {
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "content-security-policy";
+  // Default http port is 80.
+  meta.content = "connect-src http://*";
+  document.head.appendChild(meta);
+});
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Host wildcard allows arbitrary hosts (www1).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Host wildcard allows arbitrary hosts (www2).");
+
+promise_test(async t => {
+  const url = "http://{{domains[www1]}}:{{ports[http][0]}}/images/green-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url)),
+  ]);
+}, "Host wildcard doesn't affect port matching.");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}/images/green-256x256.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Path matching does not apply for empty path-part.");

--- a/content-security-policy/generic/wildcard-port-part-001.sub.window.js
+++ b/content-security-policy/generic/wildcard-port-part-001.sub.window.js
@@ -1,0 +1,36 @@
+// META: script=/content-security-policy/support/testharness-helper.js
+
+setup(_ => {
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "content-security-policy";
+  meta.content = "connect-src http://{{host}}:*/images/green-100x100.png";
+  document.head.appendChild(meta);
+});
+
+promise_test(async t => {
+  const url = "http://{{host}}:{{ports[http][0]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await fetch(url);
+}, "Port wildcard allows arbitrary port {{ports[http][0]}}.");
+
+promise_test(async t => {
+  const url = "http://{{host}}:{{ports[http][1]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Port wildcard allows arbitrary port {{ports[http][1]}}.");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}:{{ports[http][0]}}/images/green-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url)),
+  ]);
+}, "Port wildcard does not affect host matching.");
+
+promise_test(async t => {
+  const url = "http://{{host}}:{{ports[http][0]}}/images/red-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url)),
+  ]);
+}, "Port wildcard does not affect path matching.");

--- a/content-security-policy/generic/wildcard-port-part-002.sub.window.js
+++ b/content-security-policy/generic/wildcard-port-part-002.sub.window.js
@@ -1,0 +1,34 @@
+// META: script=/content-security-policy/support/testharness-helper.js
+
+setup(_ => {
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "content-security-policy";
+  meta.content = "connect-src http://{{host}}:*";
+  document.head.appendChild(meta);
+});
+
+promise_test(async t => {
+  const url = "http://{{host}}:{{ports[http][0]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await fetch(url);
+}, "Port wildcard allows arbitrary port {{ports[http][0]}}.");
+
+promise_test(async t => {
+  const url = "http://{{host}}:{{ports[http][1]}}/images/green-100x100.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await promise_rejects_js(t, TypeError, fetch(url));
+}, "Port wildcard allows arbitrary port {{ports[http][1]}}.");
+
+promise_test(async t => {
+  const url = "http://{{domains[www2]}}:{{ports[http][0]}}/images/green-100x100.png";
+  await Promise.all([
+    waitUntilCSPEventForURL(t, url, "connect-src"),
+    promise_rejects_js(t, TypeError, fetch(url)),
+  ]);
+}, "Port wildcard does not affect host matching.");
+
+promise_test(async t => {
+  const url = "http://{{host}}:{{ports[http][0]}}/images/green-256x256.png";
+  assert_no_csp_event_for_url(t, url, "connect-src");
+  await fetch(url);
+}, "Path matching does not apply for empty path-part.");

--- a/content-security-policy/support/testharness-helper.js
+++ b/content-security-policy/support/testharness-helper.js
@@ -1,6 +1,8 @@
-function assert_no_csp_event_for_url(test, url) {
+function assert_no_csp_event_for_url(test, url, effectiveDirective) {
   self.addEventListener("securitypolicyviolation", test.step_func(e => {
     if (e.blockedURI !== url)
+      return;
+    if (effectiveDirective && e.effectiveDirective != effectiveDirective)
       return;
     assert_unreached("SecurityPolicyViolation event fired for " + url);
   }));
@@ -10,17 +12,18 @@ function assert_no_event(test, obj, name) {
   obj.addEventListener(name, test.unreached_func("The '" + name + "' event should not have fired."));
 }
 
-function waitUntilCSPEventForURLOrLine(test, url, line) {
+function waitUntilCSPEventForURLOrLine(test, url, line, effectiveDirective) {
   return new Promise((resolve, reject) => {
     self.addEventListener("securitypolicyviolation", test.step_func(e => {
-      if (e.blockedURI == url && (!line || line == e.lineNumber))
+      if (e.blockedURI == url && (!line || line == e.lineNumber) &&
+          (!effectiveDirective || effectiveDirective == e.effectiveDirective))
         resolve(e);
     }));
   });
 }
 
-function waitUntilCSPEventForURL(test, url) {
-  return waitUntilCSPEventForURLOrLine(test, url);
+function waitUntilCSPEventForURL(test, url, directive) {
+  return waitUntilCSPEventForURLOrLine(test, url, undefined, directive);
 }
 
 function waitUntilCSPEventForEval(test, line) {


### PR DESCRIPTION
wildcard-host-part and wildcard-host-part-002 currently tests CSP host-source *:port-part (host wildcard) with empty and non-empty path-part respectively.

This PR adds tests for * (host wildcard without port-part) and for host-part:* (port wildcard) and for *:* (host and port wildcards) again with empty and non-empty path-part.

To make tests a bit more robust, testharness-helper.js is tweaked a bit so we can ensure expected/non-expected CSP violation are for a specific CSP directive.