### PR TITLE
Make document named property exposure tests deterministic

### DIFF
--- a/html/dom/documents/dom-tree-accessors/nameditem-names.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-names.html
@@ -6,19 +6,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <embed name="exposed_embed">
-  <embed name="not_exposed_embed">
-  </embed>
-</embed>
 <form name="form">
 </form>
 <iframe name="iframe">
 </iframe>
 <img name="img">
-<object name="exposed_object_with_name">
+<object data="/common/blank.html" type="text/html" name="exposed_object_with_name">
+  <embed name="not_exposed_embed">
   <object name="not_exposed_object_with_name">
   </object>
 </object>
-<object id="exposed_object_with_id">
+<object data="/common/blank.html" type="text/html" id="exposed_object_with_id">
   <object id="not_exposed_object_with_id">
   </object>
 </object>
@@ -29,73 +27,83 @@
 </template>
 <img name="42">
 <script>
-var names = Object.getOwnPropertyNames(document);
+setup({ explicit_done: true });
 
-test(function() {
-  assert_true(names.includes("exposed_embed"))
-}, "An embed name appears in a document's property names if the embed is exposed.");
+window.addEventListener("load", function() {
+  var names = Object.getOwnPropertyNames(document);
 
-test(function() {
-  assert_false(names.includes("not_exposed_embed"))
-}, "An embed name does not appears in a document's property names if the embed is inside another embed.");
+  test(function() {
+    assert_true(names.includes("exposed_embed"))
+  }, "An embed name appears in a document's property names if the embed is exposed.");
 
-test(function() {
-  assert_true(names.includes("form"))
-}, "A form name appears in a document's property names.");
+  test(function() {
+    assert_false(names.includes("not_exposed_embed"))
+  }, "An embed name does not appear in a document's property names if the embed has an exposed object ancestor.");
 
-test(function() {
-  assert_true(names.includes("iframe"))
-}, "An iframe name appears in a document's property names.");
+  test(function() {
+    assert_true(names.includes("form"))
+  }, "A form name appears in a document's property names.");
 
-test(function() {
-  assert_true(names.includes("img"))
-}, "An img name appears in a document's property names when the img has no id.");
+  test(function() {
+    assert_true(names.includes("iframe"))
+  }, "An iframe name appears in a document's property names.");
 
-test(function() {
-  assert_true(names.includes("exposed_object_with_name"))
-}, "An object name appears in a document's property names if the object is exposed.");
+  test(function() {
+    assert_true(names.includes("img"))
+  }, "An img name appears in a document's property names when the img has no id.");
 
-test(function() {
-  assert_true(names.includes("exposed_object_with_id"))
-}, "An object id appears in a document's property names if the object is exposed.");
+  test(function() {
+    assert_not_equals(document.querySelector('[name="exposed_object_with_name"]').contentDocument, null,
+                      "The object must successfully load its data resource");
+    assert_true(names.includes("exposed_object_with_name"))
+  }, "An object name appears in a document's property names if the object is exposed.");
 
-test(function() {
-  assert_false(names.includes("not_exposed_object_with_name"))
-}, "An object name does not appear in a document's property names if the object is inside another object.");
+  test(function() {
+    assert_not_equals(document.querySelector("#exposed_object_with_id").contentDocument, null,
+                      "The object must successfully load its data resource");
+    assert_true(names.includes("exposed_object_with_id"))
+  }, "An object id appears in a document's property names if the object is exposed.");
 
-test(function() {
-  assert_false(names.includes("not_exposed_object_with_id"))
-}, "An object id does not appear in a document's property names if the object is inside another object.");
+  test(function() {
+    assert_false(names.includes("not_exposed_object_with_name"))
+  }, "An object name does not appear in a document's property names if the object has an exposed object ancestor.");
 
-test(function() {
-  assert_true(names.includes("img_with_id"))
-}, "An img name appears in a document's property names when the img has an id.");
+  test(function() {
+    assert_false(names.includes("not_exposed_object_with_id"))
+  }, "An object id does not appear in a document's property names if the object has an exposed object ancestor.");
 
-test(function() {
-  assert_true(names.includes("img_id"))
-}, "An img id appears in a document's property names when the img has a name.");
+  test(function() {
+    assert_true(names.includes("img_with_id"))
+  }, "An img name appears in a document's property names when the img has an id.");
 
-test(function() {
-  assert_false(names.includes("img_with_just_id"))
-}, "An img id does not appear in a document's property names when the img has no name.");
+  test(function() {
+    assert_true(names.includes("img_id"))
+  }, "An img id appears in a document's property names when the img has a name.");
 
-test(function() {
-  assert_true(names.includes("42"))
-}, "A document's property names can include integer strings.");
+  test(function() {
+    assert_false(names.includes("img_with_just_id"))
+  }, "An img id does not appear in a document's property names when the img has no name.");
 
-test(function() {
-  assert_false(names.includes("template"))
-}, "A template name does not appear in a document's property names.");
+  test(function() {
+    assert_true(names.includes("42"))
+  }, "A document's property names can include integer strings.");
 
-test(function() {
-  assert_false(names.includes("img_in_template"))
-}, "An img name does not appear in a document's property names when the img is in a template's document fragment.");
+  test(function() {
+    assert_false(names.includes("template"))
+  }, "A template name does not appear in a document's property names.");
 
-test(function() {
-  var form_index = names.indexOf("form");
-  assert_equals(names.indexOf("iframe"), form_index + 1);
-  assert_equals(names.indexOf("img"), form_index + 2);
-  assert_greater_than(names.indexOf("img_id"), names.indexOf("img"));
-  assert_greater_than(names.indexOf("42"), names.indexOf("img_id"));
-}, "A document's property names appear in tree order.");
+  test(function() {
+    assert_false(names.includes("img_in_template"))
+  }, "An img name does not appear in a document's property names when the img is in a template's document fragment.");
+
+  test(function() {
+    var form_index = names.indexOf("form");
+    assert_equals(names.indexOf("iframe"), form_index + 1);
+    assert_equals(names.indexOf("img"), form_index + 2);
+    assert_greater_than(names.indexOf("img_id"), names.indexOf("img"));
+    assert_greater_than(names.indexOf("42"), names.indexOf("img_id"));
+  }, "A document's property names appear in tree order.");
+
+  done();
+});
 </script>


### PR DESCRIPTION
Load supported HTML resources in the outer object elements and wait for the document load event before checking supported property names. This guarantees that the outer objects are exposed and that their nested object and embed elements have an exposed object ancestor.

Replace the impossible parsed embed-inside-embed fixture with an embed inside an exposed object.