### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321526

### DIFF
--- a/navigation-api/navigate-event/navigate-multiple-nested-navigateerror.html
+++ b/navigation-api/navigate-event/navigate-multiple-nested-navigateerror.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(t => {
+  const expected = [
+    "navigate #1",
+    "navigateerror #1",
+    "navigate #3",
+    "navigateerror #3",
+    "navigate #4",
+    "navigateerror #4",
+    "navigate #5",
+    "navigateerror #5",
+    "navigate #2",
+    "navigatesuccess #2"
+  ];
+
+  // Each navigateerror handler starts a navigation of its own, so aborting the ongoing navigate
+  // event leaves behind a new one that must be aborted in turn.
+  const nextHash = { "#1": "#3", "#3": "#4", "#4": "#5" };
+
+  const result = [];
+  navigation.onnavigate = t.step_func(e => {
+    result.push(`${e.type} ${new URL(e.destination.url).hash}`);
+  });
+
+  navigation.onnavigateerror = t.step_func(e => {
+    const hash = new URL(navigation.currentEntry.url).hash;
+    result.push(`${e.type} ${hash}`);
+
+    if (nextHash[hash])
+      navigation.navigate(nextHash[hash]);
+  });
+
+  navigation.onnavigatesuccess = t.step_func_done(e => {
+    result.push(`${e.type} ${new URL(navigation.currentEntry.url).hash}`);
+    assert_array_equals(result, expected);
+  });
+
+  navigation.navigate("#1");
+  navigation.navigate("#2");
+
+}, "aborting a navigation repeatedly aborts navigations started from navigateerror handlers");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[Navigation API\] navigateerror is not fired for a navigation started from a navigateerror handler](https://bugs.webkit.org/show_bug.cgi?id=321526)