### PR TITLE
script: Fix iframe name for initial navigation

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/window-name-after-cross-origin-sub-frame-navigation.sub.html
+++ b/html/browsers/browsing-the-web/history-traversal/window-name-after-cross-origin-sub-frame-navigation.sub.html
@@ -12,7 +12,7 @@
             assert_equals(e.data, true);
         }));
     </script>
-    <iframe src="support/window-name-navigation.sub.html?hostname={{domains[www1]}}&shouldhavename=true&sendmessage=true";
+    <iframe src="support/window-name-navigation.sub.html?hostname={{domains[www1]}}&shouldhavename=true&sendmessage=true">
     </iframe>
 </body>
 </html>

--- a/html/browsers/browsing-the-web/history-traversal/window-name-after-same-origin-sub-frame-navigation.sub.html
+++ b/html/browsers/browsing-the-web/history-traversal/window-name-after-same-origin-sub-frame-navigation.sub.html
@@ -12,7 +12,7 @@
             assert_equals(e.data, true);
         }));
     </script>
-    <iframe src="support/window-name-navigation.sub.html?hostname={{host}}&shouldhavename=true&sendmessage=true";
+    <iframe src="support/window-name-navigation.sub.html?hostname={{host}}&shouldhavename=true&sendmessage=true">
     </iframe>
 </body>
 </html>


### PR DESCRIPTION
During the initial load of an iframe, the name wasn't available yet. Now, we set the name immediately when creating the child navigable, following the spec.

Fixes #<!-- nolink -->47259

Testing: new WPT passes

Reviewed in servo/servo#47270