### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321588

### DIFF
--- a/css/CSS2/visufx/visibility-descendants-002-ref.html
+++ b/css/CSS2/visufx/visibility-descendants-002-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A visible descendant of a hidden element renders</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!-- The test without the overflow clip. Nothing overflows, so it renders the same. -->
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/css/CSS2/visufx/visibility-descendants-002.html
+++ b/css/CSS2/visufx/visibility-descendants-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: A visible descendant of a hidden element renders when it has non-visible overflow</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#valdef-visibility-hidden">
+<link rel="match" href="visibility-descendants-002-ref.html">
+<meta name="assert" content="A descendant of a hidden element with 'visibility' set to 'visible' is visible even when it establishes its own overflow clip and the hidden ancestor is positioned.">
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    overflow: hidden;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/css/CSS2/visufx/visibility-descendants-003-ref.html
+++ b/css/CSS2/visufx/visibility-descendants-003-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A visible descendant of a hidden element renders</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!-- The test's end state, unscripted and without the overflow clip. Nothing overflows. -->
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/css/CSS2/visufx/visibility-descendants-003.html
+++ b/css/CSS2/visufx/visibility-descendants-003.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: A visible descendant of a hidden element still renders after it stops painting itself</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#valdef-visibility-hidden">
+<link rel="match" href="visibility-descendants-003-ref.html">
+<meta name="assert" content="A descendant of a hidden element with 'visibility' set to 'visible' stays visible when it is changed from positioned to statically positioned, which changes whether the descendant or its hidden ancestor is responsible for painting it.">
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    overflow: hidden;
+    visibility: visible;
+    position: relative;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>
+<script>
+// Start positioned and go static. The reverse order cannot detect a stale cached answer.
+document.body.offsetHeight;
+document.getElementById("div3").style.position = "static";
+</script>


### PR DESCRIPTION
WebKit export from bug: [visibility: hidden is broken when overflow: hidden is used and parent has relative position](https://bugs.webkit.org/show_bug.cgi?id=321588)