### PR TITLE
wpt: Ensure javascript: URL produces a load event.

### DIFF
--- a/fetch/fetch-later/new-window.https.window.js
+++ b/fetch/fetch-later/new-window.https.window.js
@@ -45,9 +45,12 @@ for (const target of ['', '_blank']) {
 
           // Opens a blank popup window that fires a fetchLater request.
           const w = window.open(
-              `javascript: fetchLater("${url}", {activateAfter: 0})`, target,
+              `javascript: fetchLater("${url}", {activateAfter: 0});''`, target,
               features);
-          await new Promise(resolve => w.addEventListener('load', resolve));
+          await new Promise((resolve, reject) => {
+            w.addEventListener('load', resolve);
+            w.addEventListener('error', reject);
+          });
 
           // The popup should have sent the request.
           await expectBeacon(uuid, {count: 1});


### PR DESCRIPTION
Per https://github.com/whatwg/html/issues/12788, the current test relies on Chrome-specific behaviour and causes timeouts in other browsers, even when fetchLater is supported.

https://wpt.fyi/results/fetch/fetch-later/new-window.https.window.html?label=experimental&label=master&aligned
Reviewed in servo/servo#47286