### PR TITLE
Set Credential Properties WebDriver command

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/virtual_authenticator.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/virtual_authenticator.html.ini
@@ -18,3 +18,8 @@
   [Can set user verified]
     expected:
       if product == "safari": FAIL
+
+  [Can set credential properties]
+    expected:
+      if product == "chrome": PASS
+      FAIL

--- a/infrastructure/testdriver/virtual_authenticator.html
+++ b/infrastructure/testdriver/virtual_authenticator.html
@@ -57,6 +57,19 @@ promise_test(async t => {
 }, "Can get the credentials");
 
 promise_test(async t => {
+  await test_driver.set_credential_properties(authenticator_id, credential_id, {
+    backupEligibility: true,
+    backupState: true,
+    signCount: 10,
+  });
+  let credentials = await test_driver.get_credentials(authenticator_id);
+  assert_equals(credentials.length, 1);
+  assert_equals(credentials[0].backupEligibility, true);
+  assert_equals(credentials[0].backupState, true);
+  assert_equals(credentials[0].signCount, 10);
+}, "Can set credential properties");
+
+promise_test(async t => {
   await test_driver.remove_credential(authenticator_id, credential_id);
   let credentials = await test_driver.get_credentials(authenticator_id);
   assert_equals(credentials.length, 0);

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1733,6 +1733,24 @@
         },
 
         /**
+         * Sets credential properties on an authenticator.
+         *
+         * Matches the `Set Credential Properties
+         * <https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties>`_
+         * WebDriver command.
+         *
+         * @param {String} authenticator_id - the ID of the authenticator
+         * @param {String} credential_id - the ID of the credential (base64url encoded)
+         * @param {Object} props - the credential properties to set
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         */
+        set_credential_properties: function(authenticator_id, credential_id, props, context=null) {
+            return window.test_driver_internal.set_credential_properties(authenticator_id, credential_id, props, context);
+        },
+
+        /**
          * Sets the storage access rule for an origin when embedded
          * in a third-party context.
          *
@@ -2668,6 +2686,10 @@
 
         async set_user_verified(authenticator_id, uv, context=null) {
             throw new Error("set_user_verified() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_credential_properties(authenticator_id, credential_id, props, context=null) {
+            throw new Error("set_credential_properties() is not implemented by testdriver-vendor.js");
         },
 
         async set_storage_access(origin, embedding_origin, blocked, context=null) {

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -1007,6 +1007,14 @@ class WebAuthn:
             "POST", "webauthn/authenticator/%s/uv" % authenticator_id, uv
         )
 
+    def set_credential_properties(self, authenticator_id, credential_id, props):
+        return self.session.send_session_command(
+            "POST",
+            "webauthn/authenticator/%s/credentials/%s/props"
+            % (authenticator_id, credential_id),
+            props,
+        )
+
 
 class WebExtensions:
     def __init__(self, session):

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -325,6 +325,25 @@ class SetUserVerifiedAction:
             "Setting user verified flag on authenticator %s to %s" % (authenticator_id, uv["isUserVerified"]))
         return self.protocol.virtual_authenticator.set_user_verified(authenticator_id, uv)
 
+class SetCredentialPropertiesAction:
+    name = "set_credential_properties"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        authenticator_id = payload["authenticator_id"]
+        credential_id = payload["credential_id"]
+        props = payload["props"]
+        self.logger.debug(
+            "Setting credential properties on authenticator %s, credential %s"
+            % (authenticator_id, credential_id)
+        )
+        return self.protocol.virtual_authenticator.set_credential_properties(
+            authenticator_id, credential_id, props
+        )
+
 class SetSPCTransactionModeAction:
     name = "set_spc_transaction_mode"
 
@@ -643,6 +662,7 @@ actions = [ClickAction,
            RemoveCredentialAction,
            RemoveAllCredentialsAction,
            SetUserVerifiedAction,
+           SetCredentialPropertiesAction,
            SetSPCTransactionModeAction,
            SetRPHRegistrationModeAction,
            CancelFedCMDialogAction,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -887,6 +887,11 @@ class WebDriverVirtualAuthenticatorProtocolPart(VirtualAuthenticatorProtocolPart
     def set_user_verified(self, authenticator_id, uv):
         return self.webdriver.send_session_command("POST", "webauthn/authenticator/%s/uv" % authenticator_id, uv)
 
+    def set_credential_properties(self, authenticator_id, credential_id, props):
+        return self.webdriver.send_session_command(
+            "POST",
+            "webauthn/authenticator/%s/credentials/%s/props" % (authenticator_id, credential_id), props)
+
 
 class WebDriverSPCTransactionsProtocolPart(SPCTransactionsProtocolPart):
     def setup(self):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1065,6 +1065,15 @@ class VirtualAuthenticatorProtocolPart(ProtocolPart):
         :param bool uv: the user verified flag"""
         pass
 
+    @abstractmethod
+    def set_credential_properties(self, authenticator_id, credential_id, props):
+        """Sets credential properties on an authenticator
+
+        :param str authenticator_id: The ID of the authenticator
+        :param str credential_id: The ID of the credential
+        :param props: The credential properties to set"""
+        pass
+
 
 class SPCTransactionsProtocolPart(ProtocolPart):
     """Protocol part for Secure Payment Confirmation transactions"""

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -615,6 +615,10 @@
         return create_context_action("set_user_verified", context, {authenticator_id, uv});
     };
 
+    window.test_driver_internal.set_credential_properties = function(authenticator_id, credential_id, props, context=null) {
+        return create_context_action("set_credential_properties", context, {authenticator_id, credential_id, props});
+    };
+
     window.test_driver_internal.set_spc_transaction_mode = function(mode, context = null) {
         return create_context_action("set_spc_transaction_mode", context, {mode});
     };

--- a/webdriver/tests/classic/external/webauthn/set_credential_properties/__init__.py
+++ b/webdriver/tests/classic/external/webauthn/set_credential_properties/__init__.py
@@ -1,0 +1,8 @@
+def set_credential_properties(
+    session, authenticator_id, credential_id, properties
+):
+    return session.transport.send(
+        "POST",
+        f"/session/{session.session_id}/webauthn/authenticator/{authenticator_id}/credentials/{credential_id}/props",
+        properties,
+    )

--- a/webdriver/tests/classic/external/webauthn/set_credential_properties/invalid.py
+++ b/webdriver/tests/classic/external/webauthn/set_credential_properties/invalid.py
@@ -1,0 +1,64 @@
+import pytest
+from tests.support.classic.asserts import assert_error
+
+from .. import create_credential
+from . import set_credential_properties
+
+
+def test_authenticator_id_invalid_value(session):
+    response = set_credential_properties(
+        session, authenticator_id="invalid", credential_id="Y3JlZC0x", properties={}
+    )
+    assert_error(response, "invalid argument")
+
+
+def test_credential_id_invalid_value(session, authenticator):
+    response = set_credential_properties(
+        session,
+        authenticator_id=authenticator,
+        credential_id="invalid",
+        properties={},
+    )
+    assert_error(response, "invalid argument")
+
+
+@pytest.mark.parametrize("backup_eligibility", ["foo", 123, [], {}, None])
+def test_backup_eligibility_invalid_type(session, authenticator, backup_eligibility):
+    credential = create_credential(credential_id="Y3JlZC0x")
+    session.web_authn.add_credential(authenticator, credential)
+
+    response = set_credential_properties(
+        session,
+        authenticator,
+        "Y3JlZC0x",
+        {"backupEligibility": backup_eligibility},
+    )
+    assert_error(response, "invalid argument")
+
+
+@pytest.mark.parametrize("backup_state", ["foo", 123, [], {}, None])
+def test_backup_state_invalid_type(session, authenticator, backup_state):
+    credential = create_credential(credential_id="Y3JlZC0x")
+    session.web_authn.add_credential(authenticator, credential)
+
+    response = set_credential_properties(
+        session,
+        authenticator,
+        "Y3JlZC0x",
+        {"backupState": backup_state},
+    )
+    assert_error(response, "invalid argument")
+
+
+@pytest.mark.parametrize("sign_count", ["foo", True, [], {}, -1, 1.5, 2**32])
+def test_sign_count_invalid_type(session, authenticator, sign_count):
+    credential = create_credential(credential_id="Y3JlZC0x")
+    session.web_authn.add_credential(authenticator, credential)
+
+    response = set_credential_properties(
+        session,
+        authenticator,
+        "Y3JlZC0x",
+        {"signCount": sign_count},
+    )
+    assert_error(response, "invalid argument")

--- a/webdriver/tests/classic/external/webauthn/set_credential_properties/set.py
+++ b/webdriver/tests/classic/external/webauthn/set_credential_properties/set.py
@@ -1,0 +1,72 @@
+import pytest
+
+from tests.support.classic.asserts import assert_success
+
+from .. import create_credential
+from . import set_credential_properties
+
+
+@pytest.mark.parametrize("backup_eligibility", [True, False])
+def test_set_backup_eligibility(session, authenticator, backup_eligibility):
+    credential = create_credential(credential_id="cHJvcHMtMQ")
+    session.web_authn.add_credential(authenticator, credential)
+
+    response = set_credential_properties(
+        session, authenticator, "cHJvcHMtMQ", {"backupEligibility": backup_eligibility}
+    )
+    assert_success(response)
+
+    credentials = session.web_authn.get_credentials(authenticator)
+    assert len(credentials) == 1
+    assert credentials[0]["backupEligibility"] is backup_eligibility
+
+
+@pytest.mark.parametrize("backup_state", [True, False])
+def test_set_backup_state(session, authenticator, backup_state):
+    credential = create_credential(credential_id="cHJvcHMtMg")
+    session.web_authn.add_credential(authenticator, credential)
+
+    response = set_credential_properties(
+        session, authenticator, "cHJvcHMtMg", {"backupState": backup_state}
+    )
+    assert_success(response)
+
+    credentials = session.web_authn.get_credentials(authenticator)
+    assert len(credentials) == 1
+    assert credentials[0]["backupState"] is backup_state
+
+
+@pytest.mark.parametrize("sign_count", [0, 42, None, 2**32 - 1])
+def test_set_sign_count(session, authenticator, sign_count):
+    credential = create_credential(credential_id="cHJvcHMtMw", sign_count=1)
+    session.web_authn.add_credential(authenticator, credential)
+
+    response = set_credential_properties(
+        session, authenticator, "cHJvcHMtMw", {"signCount": sign_count}
+    )
+    assert_success(response)
+
+    credentials = session.web_authn.get_credentials(authenticator)
+    assert len(credentials) == 1
+    assert credentials[0]["signCount"] == sign_count
+
+
+def test_set_multiple_properties(session, authenticator):
+    credential = create_credential(credential_id="cHJvcHMtNA", sign_count=1)
+    session.web_authn.add_credential(authenticator, credential)
+
+    properties = {
+        "backupEligibility": True,
+        "backupState": True,
+        "signCount": 100,
+    }
+    response = set_credential_properties(
+        session, authenticator, "cHJvcHMtNA", properties
+    )
+    assert_success(response)
+
+    credentials = session.web_authn.get_credentials(authenticator)
+    assert len(credentials) == 1
+    assert credentials[0]["backupEligibility"] is True
+    assert credentials[0]["backupState"] is True
+    assert credentials[0]["signCount"] == 100


### PR DESCRIPTION
Add support for the WebAuthn WebDriver Set Credential Properties command.

https://w3c.github.io/webauthn/#sctn-automation-set-credential-properties

Upcoming Credential Manager Trust Group Keys tests will make use of this command.

See issue https://github.com/w3c/webauthn/issues/2338.