### PR TITLE
script: Make inserttext handle surrogate pairs correctly.

### DIFF
--- a/editing/other/insert-text-with-surrogate-pairs.html
+++ b/editing/other/insert-text-with-surrogate-pairs.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+</head>
+<body>
+  <div contenteditable="true" id="editable"></div>
+  <script>
+    test(() => {
+      document.getSelection().selectAllChildren(editable);
+      document.execCommand("inserttext", false, "🏆");
+      assert_equals(editable.textContent, "🏆", "Surrogate pair should survive insertText");
+    }, "Surrogate pair should survive insertText");
+  </script>
+</body>


### PR DESCRIPTION
Any characters that are longer than one UTF-16 code unit weren't inserted correctly before this. Now they are.

The note about MutationObserver in my comment is referring to other browsers specifically, because we do generate one mutation event per character here. I'm not sure if that's just because no browser implements this spec verbatim or if maybe mutation events need to or could be aggregated somehow somewhere, but it's a discrepancy to be aware of, I guess. I would say that this could have performance implications if any JavaScript wants to act upon these events in some major way, but Firefox generates exactly 0 characterData mutation events from `insertText`, so I'd hope that there's no websites that depend on any of this behavior.
Edit: Firefox actually only generates 0 characterData mutation events when `inserttext` has to create a new text node.

Also, Ladybird, as the only other browser to implement this spec somewhat verbatim, ends up emitting mutation events per character as well (or rather per UTF-16 code unit), but they generate 2 for each character for some reason. No idea why.

Testing: Added a new WPT tests that verifies that this works.

Reviewed in servo/servo#47306