### PR TITLE
Computed role -wip

### DIFF
--- a/webdriver/tests/classic/get_computed_role/get.py
+++ b/webdriver/tests/classic/get_computed_role/get.py
@@ -83,4 +83,5 @@ def test_computed_roles(session, inline, html, tag, expected):
     session.url = inline(html)
     element = session.find.css(tag, all=False)
     result = get_computed_role(session, element.id)
+#     print("RESULT:", result)
     assert_success(result, expected)

--- a/webdriver/tests/classic/get_computed_role/get.py
+++ b/webdriver/tests/classic/get_computed_role/get.py
@@ -83,5 +83,5 @@ def test_computed_roles(session, inline, html, tag, expected):
     session.url = inline(html)
     element = session.find.css(tag, all=False)
     result = get_computed_role(session, element.id)
-#     print("RESULT:", result)
+    print("RESULT:", result)
     assert_success(result, expected)


### PR DESCRIPTION
This is the first part to https://github.com/servo/servo/issues/43734, this allows the current tests to pass with the hashmap table.

We are now creating a relationship between a DOM node and an AccessKit node and querying the AK node for the role, which allow the current tests to pass. We still need to implement the AAM algorithms for computing the roles for each element.

cc @alice (I can't add reviewers so just drawing your attention to this)
Reviewed in servo/servo#47339