### PR TITLE
Add a test deleting the WebDriver session from a different HTTP connection

### DIFF
--- a/webdriver/tests/classic/delete_session/delete.py
+++ b/webdriver/tests/classic/delete_session/delete.py
@@ -1,5 +1,6 @@
 import pytest
 from webdriver import error
+from webdriver.transport import HTTPWireProtocol
 
 from tests.support.classic.asserts import assert_success
 
@@ -29,6 +30,23 @@ def test_accepted_beforeunload_prompt(session, url):
     # A beforeunload prompt has to be automatically accepted, and the session deleted
     with pytest.raises(error.InvalidSessionIdException):
         session.alert.text
+
+    # Need an explicit call to session.end() to notify the test harness
+    # that a new session needs to be created for subsequent tests.
+    session.end()
+
+
+def test_delete_session_with_different_connection(session, configuration):
+    # The session ID should remain valid on any HTTP connection to the
+    # remote end, not just the one that created it. Close the original
+    # connection first to prove it doesn't need to stay open.
+    session.transport.close()
+
+    other_transport = HTTPWireProtocol(configuration["host"], configuration["port"])
+
+    response = other_transport.send("DELETE", f"session/{session.session_id}")
+    value = assert_success(response)
+    assert value is None
 
     # Need an explicit call to session.end() to notify the test harness
     # that a new session needs to be created for subsequent tests.


### PR DESCRIPTION
Closing the connection doesn't close the session per spec, so this should work.
