### PR TITLE
Add AI policy to docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ The way to contribute is just as usual:
 * Commit locally and push that to your repo.
 * Create a pull request based on the above.
 
+AI Policy
+=========
+
+Use of LLMs to help author tests is generally acceptable, but every
+change must be attributable to a human who understands and can take
+responsibility for the proposed change.
+
+Use of LLMs to participate in discussions is generally not acceptable;
+any LLM-generated content must either be from a bot account or
+contained inside a `<blockquote>` (for short contributions of at most
+one paragraph) or `<details>` element.
+
+For full details see the [Policy for LLM
+Use](https://web-platform-tests.org/writing-tests/ai-policy.html)
+
 Issues with web-platform-tests
 ------------------------------
 

--- a/docs/writing-tests/ai-policy.md
+++ b/docs/writing-tests/ai-policy.md
@@ -1,0 +1,30 @@
+# Policy for LLM (AI) Use
+
+The use of large language models (LLMs) as tools to help author commits to
+this repository is allowed with the stipulations described below.
+Contributors who repeatedly fail to adhere to these guidelines may be banned
+from contributing to this project.
+
+## Disclosure
+
+If LLMs are used as a significant input to a commit, authors are encouraged
+to include details about how they were used as part of the commit message in
+order to help review and future understanding of the code.
+
+Human-authored code discourse (e.g. issue descriptions, pull request
+descriptions, and responses to discussion threads) should not include
+LLM-generated content in the main text; any such content must be clearly
+labelled and placed inside a `<details>` element. A `<blockquote>` element
+may instead be used to designate text if it is no longer than one paragraph
+in length.
+
+## Attribution
+
+All commits must be attributed to the human who is taking responsibility for
+them, regardless of LLM use.
+
+## Understanding
+
+Every pull request must be initiated by one human. That person must author
+the pull request description, understand every change proposed, and be
+prepared to engage in technical discussion regarding those changes.

--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -8,6 +8,8 @@ testing plan](making-a-testing-plan) will help you decide what to write.
 
 There's also a load of [general guidelines](general-guidelines) that apply to all tests.
 
+Before using an LLM to contribute tests please read the [Policy for LLM Use](ai-policy).
+
 ## Test Types
 
 There are various different ways of writing tests:
@@ -62,6 +64,7 @@ make sure you run the [`lint` script](lint-tool) before opening a pull request!
    :maxdepth: 1
 
    general-guidelines
+   ai-policy
    making-a-testing-plan
    testharness
    testharness-tutorial


### PR DESCRIPTION
As agreed in [RFC 239](https://github.com/web-platform-tests/rfcs/blob/main/rfcs/llm_policy.md).