### PR TITLE
script: Prevent text editing commands from running in uneditable nodes.

### DIFF
--- a/editing/crashtests/insert-rich-content-in-comment.html
+++ b/editing/crashtests/insert-rich-content-in-comment.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<div id="div" contenteditable="true"><!-- This is a comment. --></div>
+<script>
+  document.getSelection().setPosition(div.firstChild)
+  document.execCommand("insertImage", false, "foo");
+</script>

--- a/editing/crashtests/insert-rich-content-in-processing-instruction.html
+++ b/editing/crashtests/insert-rich-content-in-processing-instruction.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<div id="div" contenteditable="true"></div>
+<script>
+  div.appendChild(document.createProcessingInstruction("foo", "bar"));
+  document.getSelection().setPosition(div.firstChild)
+  document.execCommand("insertImage", false, "foo");
+</script>


### PR DESCRIPTION
Nothing good can come of trying to run editing commands when the selection boundaries are inside of HTML comment or processing instruction nodes, so this bumps the selection out of those problematic nodes before trying.

Testing: Added 2 new web platform tests
Fixes: #<!-- nolink -->47336

Reviewed in servo/servo#47362