### PR TITLE
Wasm Proposals: Install JS files for proposal tests

### DIFF
--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ocaml-compiler: 5.04.x
       - name: Setup OCaml tools
-        run: opam install --yes ocamlfind js_of_ocaml js_of_ocaml-ppx
+        run: opam install --yes ocamlfind js_of_ocaml js_of_ocaml-ppx stdint.0.7.2
       - name: Build interpreter
         run: cd wasm-spec/interpreter && opam exec make
       - name: Convert WAST tests to WPT

--- a/wasm/proposals.json
+++ b/wasm/proposals.json
@@ -1,3 +1,3 @@
 [
-  "stack-switching"
+  "wide-arithmetic"
 ]

--- a/wasm/tools/update-proposals.py
+++ b/wasm/tools/update-proposals.py
@@ -107,20 +107,34 @@ def main():
             # 7. Create target directory in WPT proposals
             target_dir = os.path.join(wpt_root, "wasm", "proposals", name, "core")
             os.makedirs(target_dir, exist_ok=True)
+            os.makedirs(os.path.join(target_dir, "js"), exist_ok=True)
+
+            harness_dir = os.path.join(out_dir, "js", "harness")
 
             # 8. Copy only the files that were changed/added by the proposal
             copied_count = 0
             for rel_wast in changed_wast_files:
                 print(f"Changed wast file: {rel_wast}")
-                src_file = os.path.join(out_dir, rel_wast + ".js.html")
-                dst_file = os.path.join(target_dir, rel_wast +  ".js.tentative.html")
+                src_html = os.path.join(out_dir, rel_wast + ".js.html")
+                dst_html = os.path.join(target_dir, rel_wast +  ".js.tentative.html")
+                src_js = os.path.join(out_dir, "js", rel_wast + ".js")
+                dst_js = os.path.join(target_dir, "js", rel_wast + ".js")
+                print(f" {dst_html} {dst_js}")
 
-                assert os.path.exists(src_file)
-                os.makedirs(os.path.dirname(dst_file), exist_ok=True)
-                shutil.copy2(src_file, dst_file)
+                assert os.path.exists(src_html)
+                os.makedirs(os.path.dirname(dst_html), exist_ok=True)
+                os.makedirs(os.path.dirname(dst_js), exist_ok=True)
+                shutil.copy2(src_html, dst_html)
+                shutil.copy2(src_js, dst_js)
                 copied_count += 1
 
             if copied_count > 0:
+                # Copy the parts of the JS harness that come from the spec repo
+                os.makedirs(os.path.join(target_dir, "js", "harness"))
+                for harness_file in ("sync_index.js", "async_index.js"):
+                    shutil.copy2(os.path.join(harness_dir, harness_file),
+                                 os.path.join(target_dir, "js", "harness"))
+
                 proposal_repo = f"https://github.com/WebAssembly/{name}"
                 proposal_commit = run_cmd(["git", "rev-parse", "HEAD"], cwd=proposal_dir).strip()
                 updated_proposals.append((name, proposal_repo, proposal_commit))

--- a/wasm/tools/update-proposals.py
+++ b/wasm/tools/update-proposals.py
@@ -119,7 +119,6 @@ def main():
                 dst_html = os.path.join(target_dir, rel_wast +  ".js.tentative.html")
                 src_js = os.path.join(out_dir, "js", rel_wast + ".js")
                 dst_js = os.path.join(target_dir, "js", rel_wast + ".js")
-                print(f" {dst_html} {dst_js}")
 
                 assert os.path.exists(src_html)
                 os.makedirs(os.path.dirname(dst_html), exist_ok=True)


### PR DESCRIPTION
HTML tests converted from wasm come with a JS file for each. The updater script was failing to copy them into the wpt dir along with the HTMLs. This PR copies the per-test JS files along with the per-repo JS utility files (but not testharness.js; we use the harness built into wpt).

Also drop the stack-switching proposal for now, as it needs a merge from the upstream spec before it wil work correctly. Instead use wide-arithmetic, a phase 4 proposal with an up-to-date spec repo.