### PR TITLE
script: Avoid double adjustment of Selection ranges during `contenteditable` node movement

### DIFF
--- a/editing/crashtests/updating-selection-offsets-after-insertHorizontalRule.html
+++ b/editing/crashtests/updating-selection-offsets-after-insertHorizontalRule.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/47333">
+<script>
+function main() {
+  window.getSelection().selectAllChildren(div);
+  document.execCommand("removeFormat");
+  document.execCommand("insertHorizontalRule");
+}
+</script>
+<body onload="main()" contenteditable="">
+<div id="div"><b>


### PR DESCRIPTION
The editing specification has a different way of updating selection
ranges than the typical live range update method in the `insert` and
`remove` algorithms. Because selections are currently represented as
live ranges (something that will change soon), this means that the
adjustment was being applied twice: once by the live range update and
then once by the `contenteditable` code's range fixup. This change makes
it so that the `contenteditable` fixup runs against the original
selection boundaries, meaning that the final fixup is done only once.

Testing: This change adds a WPT crash test.
Fixes: #<!-- nolink -->47333.

Reviewed in servo/servo#47393