### PR TITLE
[WebCryptoAPI] Add tests for [EnforceRange] WebIDL attribute

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/derived_bits_length.js
+++ b/WebCryptoAPI/derive_bits_keys/derived_bits_length.js
@@ -17,16 +17,16 @@ function define_tests() {
                         derivedBits = await subtle.deriveBits(testData.deriveAlg, privateKey);
                     else
                         derivedBits = await subtle.deriveBits(testData.deriveAlg, privateKey, testParam.length);
-                    if (testParam.expected === undefined) {
-                        assert_unreached("deriveBits should have thrown an OperationError exception.");
+                    if (testParam.expected === "TypeError" || testParam.expected === "OperationError") {
+                        assert_unreached("deriveBits should have thrown an " + testParam.expected + " exception.");
                     }
                     assert_array_equals(new Uint8Array(derivedBits), testParam.expected, "Derived bits do not match the expected result.");
                 } catch (err) {
-                    if (err instanceof AssertionError || testParam.expected !== undefined) {
+                    if (err instanceof AssertionError || !(testParam.expected === "TypeError" || testParam.expected === "OperationError")) {
                         throw err;
                     }
                     assert_true(privateKey !== undefined, "Key should be valid.");
-                    assert_equals(err.name, "OperationError", "deriveBits correctly threw OperationError: " + err.message);
+                    assert_equals(err.name, testParam.expected, "deriveBits correctly threw " + testParam.expected + ": " + err.message);
                 }
             }, algorithm + " derivation with " + testParam.length + " as 'length' parameter");
         });

--- a/WebCryptoAPI/derive_bits_keys/derived_bits_length_testcases.js
+++ b/WebCryptoAPI/derive_bits_keys/derived_bits_length_testcases.js
@@ -1,38 +1,49 @@
+var enforceRangeTestCases = [
+    // These cases should throw an error in all algorithms due to [EnforceRange]
+    {length: NaN, expected: "TypeError"},
+    {length: Infinity, expected: "TypeError"},
+    {length: -8, expected: "TypeError"},
+    {length: 2**32 + 8, expected: "TypeError"},
+];
 var testCases = {
     "HKDF": [
         {length: 256, expected: algorithms["HKDF"].derivation},
         {length: 384, expected: algorithms["HKDF"].derivation384},
-        {length: 230, expected: undefined}, // should throw an exception, not multiple of 8
+        {length: 230, expected: "OperationError"}, // should throw an exception, not multiple of 8
         {length: 0, expected: emptyArray},
-        {length: null, expected: undefined }, // should throw an exception
-        {length: undefined, expected: undefined }, // should throw an exception
-        {length: "omitted", expected: undefined }, // default value is null, so should throw
+        {length: null, expected: "OperationError"}, // should throw an exception
+        {length: undefined, expected: "OperationError"}, // should throw an exception
+        {length: "omitted", expected: "OperationError"}, // default value is null, so should throw
+        ...enforceRangeTestCases,
     ],
     "PBKDF2": [
         {length: 256, expected: algorithms["PBKDF2"].derivation},
         {length: 384, expected: algorithms["PBKDF2"].derivation384},
-        {length: 230, expected: undefined}, // should throw an exception, not multiple of 8
+        {length: 230, expected: "OperationError"}, // should throw an exception, not multiple of 8
         {length: 0, expected: emptyArray},
-        {length: null, expected: undefined }, // should throw an exception
-        {length: undefined, expected: undefined }, // should throw an exception
-        {length: "omitted", expected: undefined }, // default value is null, so should throw
+        {length: null, expected: "OperationError"}, // should throw an exception
+        {length: undefined, expected: "OperationError"}, // should throw an exception
+        {length: "omitted", expected: "OperationError"}, // default value is null, so should throw
+        ...enforceRangeTestCases,
     ],
     "ECDH": [
         {length: 256, expected: algorithms["ECDH"].derivation},
-        {length: 384, expected: undefined}, // should throw an exception, bigger than the output size
+        {length: 384, expected: "OperationError"}, // should throw an exception, bigger than the output size
         {length: 230, expected: algorithms["ECDH"].derivation230},
         {length: 0, expected: emptyArray},
         {length: null, expected: algorithms["ECDH"].derivation},
         {length: undefined, expected: algorithms["ECDH"].derivation},
-        {length: "omitted", expected: algorithms["ECDH"].derivation }, // default value is null
+        {length: "omitted", expected: algorithms["ECDH"].derivation}, // default value is null
+        ...enforceRangeTestCases,
     ],
     "X25519": [
         {length: 256, expected: algorithms["X25519"].derivation},
-        {length: 384, expected: undefined}, // should throw an exception, bigger than the output size
+        {length: 384, expected: "OperationError"}, // should throw an exception, bigger than the output size
         {length: 230, expected: algorithms["X25519"].derivation230},
         {length: 0, expected: emptyArray},
         {length: null, expected: algorithms["X25519"].derivation},
         {length: undefined, expected: algorithms["X25519"].derivation},
-        {length: "omitted", expected: algorithms["X25519"].derivation }, // default value is null
+        {length: "omitted", expected: algorithms["X25519"].derivation}, // default value is null
+        ...enforceRangeTestCases,
     ],
 }

--- a/WebCryptoAPI/generateKey/failures.js
+++ b/WebCryptoAPI/generateKey/failures.js
@@ -101,13 +101,19 @@ function run_test(algorithmNames) {
 
         if (algorithmName.toUpperCase().substring(0, 3) === "AES") {
             // Specifier properties are name and length
-            [64, 127, 129, 255, 257, 512].forEach(function(length) {
+            [64, 127, 129, 255, 257, 512, 128 + 2**32, 128 - 2**32].forEach(function(length) {
                 results.push({name: algorithmName, length: length});
+            });
+        } else if (algorithmName.toUpperCase() === "HMAC") {
+            [128 + 2**32, 128 - 2**32].forEach(function(length) {
+                results.push({name: algorithmName, hash: "SHA-256", length: length});
             });
         } else if (algorithmName.toUpperCase().substring(0, 3) === "RSA") {
             [new Uint8Array([1]), new Uint8Array([1,0,0])].forEach(function(publicExponent) {
                 results.push({name: algorithmName, hash: "SHA-256", modulusLength: 1024, publicExponent: publicExponent});
             });
+            results.push({name: algorithmName, hash: "SHA-256", modulusLength: 1024 + 2 ** 32, publicExponent: new Uint8Array([1,0,1])});
+            results.push({name: algorithmName, hash: "SHA-256", modulusLength: 1024 - 2 ** 32, publicExponent: new Uint8Array([1,0,1])});
         } else if (algorithmName.toUpperCase().substring(0, 2) === "EC") {
             ["P-512", "Curve25519"].forEach(function(curveName) {
                 results.push({name: algorithmName, namedCurve: curveName});
@@ -177,6 +183,9 @@ function run_test(algorithmNames) {
                 [false, true].forEach(function(extractable) {
                     if (name.substring(0,2) === "EC") {
                         testError(algorithm, extractable, usages, "NotSupportedError", "Bad algorithm property");
+                    } else if (name.substring(0,3) === "RSA" && (algorithm.modulusLength < 0 || algorithm.modulusLength > 2**32) ||
+                        (name.substring(0,3) === "AES" || name === "HMAC") && (algorithm.length < 0 || algorithm.length > 2**32)) {
+                        testError(algorithm, extractable, usages, "TypeError", "Bad algorithm property");
                     } else {
                         testError(algorithm, extractable, usages, "OperationError", "Bad algorithm property");
                     }


### PR DESCRIPTION
The `[EnforceRange]` attribute of the `length` parameter of `deriveBits` was added in https://github.com/w3c/webcrypto/pull/555.

The `[EnforceRange]` attribute of the `length` and `modulusLength` properties of the `{Aes,Hmac,Rsa}KeyGenParams` dictionaries was already there.

This change adds tests for both.