### PR TITLE
Update tests to not assume multiplications by 1 can be simplified away 

### DIFF
--- a/css/css-values/calc-infinity-nan-serialize-length.html
+++ b/css/css-values/calc-infinity-nan-serialize-length.html
@@ -57,8 +57,8 @@ var test_map = {
 
     "1 * min(NaN * 1pt, NaN * 1cm)"                 :"calc(NaN * 1px)",
     "1 * max(NaN * 1cm, NaN * 2Q)"                  :"calc(NaN * 1px)",
-    "1 * min(NaN * 2px, NaN * 4em)"                 :"calc(NaN * 1px)",
-    "1 * clamp(NaN * 2em, NaN * 4px, NaN * 8pt)"    :"clamp(NaN * 1em, NaN * 1px, NaN * 1px)",
+    "1 * min(NaN * 2px, NaN * 4em)"                 :"calc(1 * min(NaN * 1px, NaN * 1em))",
+    "1 * clamp(NaN * 2em, NaN * 4px, NaN * 8pt)"    :"calc(1 * clamp(NaN * 1em, NaN * 1px, NaN * 1px))",
 };
 
 for (var exp in test_map) {

--- a/css/css-values/calc-nesting-002.html
+++ b/css/css-values/calc-nesting-002.html
@@ -66,7 +66,7 @@
 
     verifySerialization("calc(calc(300px - 1 * (0% - 100px)))", "calc(0% + 400px)", "testing calc(calc(300px - 1 * (0% - 100px)))");
 
-    verifySerialization("calc(0px - 1 * (min(20%, 20px) - 10px))", "calc(10px - min(20%, 20px))", "testing simplification with nested sum");
+    verifySerialization("calc(0px - 1 * (min(20%, 20px) - 10px))", "calc(0px - (1 * (-10px + min(20%, 20px))))", "testing simplification with nested sum");
 
   /*
 


### PR DESCRIPTION
css/css-values/calc-infinity-nan-serialize-length.html and css/css-values/calc-nesting-002.html incorrectly assert that a calc() expression of the form `1 * math-function()` can be simplified to be just `math-function()`.
