### PR TITLE
[wasm] Await TestSandwich in js-promise-integration

### DIFF
--- a/wasm/jsapi/jspi/js-promise-integration.any.js
+++ b/wasm/jsapi/jspi/js-promise-integration.any.js
@@ -321,11 +321,11 @@ async function TestSandwich(suspend) {
 }
 
 promise_test(async () => {
-  TestSandwich(true);
+  await TestSandwich(true);
 }, "Test sandwich with suspension");
 
 promise_test(async () => {
-  TestSandwich(false);
+  await TestSandwich(false);
 }, "Test sandwich with no suspension");
 
 test(() => {


### PR DESCRIPTION
The sandwich `promise_test`s call async `TestSandwich()` and discard the promise. testharness can treat the test as done while JSPI is still suspended. A later assertion or exception becomes an unhandled rejection instead of a test FAIL.

Await the helper so the tests wait for resume.