### PR TITLE
[testdriver] Add test_driver.create_window()

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -90,6 +90,7 @@ the global scope.
 
 ### Window State ###
 ```eval_rst
+.. js:autofunction:: test_driver.create_window
 .. js:autofunction:: test_driver.minimize_window
 .. js:autofunction:: test_driver.set_window_rect
 ```

--- a/infrastructure/testdriver/create_window.html
+++ b/infrastructure/testdriver/create_window.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver create_window method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+promise_test(async () => {
+    const handle = await test_driver.create_window();
+    assert_equals(typeof handle, "string", "handle expected to be a string");
+    assert_not_equals(handle, "", "handle should not be an empty string");
+}, "create_window returns a window handle");
+
+promise_test(async () => {
+    const first = await test_driver.create_window();
+    const second = await test_driver.create_window();
+    assert_not_equals(first, second, "each call should create a distinct window");
+}, "create_window returns a distinct handle for each created window");
+
+// Created windows are deliberately left open.
+// testdriver has no window close API.
+// wptrunner closes leftover windows between tests.
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1423,6 +1423,33 @@
         },
 
         /**
+         * Creates a new top-level browsing context, as if the user requested
+         * a new tab or window from the browser.
+         *
+         * Matches the behaviour of the `New Window
+         * <https://www.w3.org/TR/webdriver/#new-window>`_
+         * WebDriver command.
+         *
+         * The new window is opened with `about:blank`,
+         * the test does not get a ``WindowProxy`` for it,
+         * and the returned WebDriver window handle is its only identifier.
+         *
+         * @param {String} type - Type hint for the new browsing context,
+         *                        either "tab" or "window" or null for the
+         *                        implementation default.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null to use the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled with the WebDriver window handle
+         *                    (a string) of the new browsing context, or
+         *                    rejected if the WebDriver command errors.
+         */
+        create_window: function(type=null, context=null) {
+            return window.test_driver_internal.create_window(type, context);
+        },
+
+        /**
          * Minimizes the browser window.
          *
          * Matches the behaviour of the `Minimize
@@ -2616,6 +2643,10 @@
 
         async freeze(context=null) {
             throw new Error("freeze() is not implemented by testdriver-vendor.js");
+        },
+
+        async create_window(type=null, context=null) {
+            throw new Error("create_window() is not implemented by testdriver-vendor.js");
         },
 
         async minimize_window(context=null) {

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -153,6 +153,17 @@ class GetWindowRectAction:
     def __call__(self, payload):
         return self.protocol.window.get_rect()
 
+class CreateWindowAction:
+    name = "create_window"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        type = payload["type"]
+        return self.protocol.window.create(type)
+
 class ActionSequenceAction:
     name = "action_sequence"
 
@@ -633,6 +644,7 @@ actions = [ClickAction,
            MinimizeWindowAction,
            SetWindowRectAction,
            GetWindowRectAction,
+           CreateWindowAction,
            ActionSequenceAction,
            GenerateTestReportAction,
            SetPermissionAction,

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -468,6 +468,12 @@ class MarionetteWindowProtocolPart(WindowProtocolPart):
     def setup(self):
         self.marionette = self.parent.marionette
 
+    def create(self, type_hint=None):
+        # Unlike the New Window command, WebDriver:NewWindow rejects a null
+        # type, and the client always sends the key so the default is
+        # applied here. focus=False retains focus on the test window.
+        return self.marionette.open(type=type_hint or "tab", focus=False)["handle"]
+
     def minimize(self):
         return self.marionette.minimize_window()
 

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -216,6 +216,9 @@ class SeleniumWindowProtocolPart(WindowProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
+    def create(self, type_hint=None):
+        raise NotImplementedError()
+
     def minimize(self):
         self.previous_rect = self.webdriver.window.rect
         self.logger.info("Minimizing")

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -613,6 +613,10 @@ class WebDriverWindowProtocolPart(WindowProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
+    def create(self, type_hint=None):
+        self.logger.debug("Creating new window")
+        return self.webdriver.new_window(type_hint=type_hint)
+
     def minimize(self):
         self.logger.debug("Minimizing")
         return self.webdriver.window.minimize()

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -750,6 +750,15 @@ class WindowProtocolPart(ProtocolPart):
     name = "window"
 
     @abstractmethod
+    def create(self, type_hint=None):
+        """Create a new top-level browsing context without switching to it.
+
+        :param type_hint: Optional hint, either "tab" or "window", for the
+                          type of top-level browsing context to create.
+        :returns: A handle string identifying the new top-level browsing context."""
+        pass
+
+    @abstractmethod
     def set_rect(self, rect):
         """Restores the window to the given rect."""
         pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -542,6 +542,10 @@
         return create_context_action("get_named_cookie", context, {name});
     };
 
+    window.test_driver_internal.create_window = function(type=null, context=null) {
+        return create_context_action("create_window", context, {type});
+    };
+
     window.test_driver_internal.minimize_window = function(context=null) {
         return create_context_action("minimize_window", context, {});
     };


### PR DESCRIPTION
This adds `test_driver.create_window(type, context)` which gives test author access to [the New Window command](https://w3c.github.io/webdriver/#new-window) in WebDriver classic. The command creates a top-level browsing context as if the user had opened it and resolves with the new window's handle.

This is needed because `window.open` always creates the window with the 'is created by web content' flag set to true. This flag has bearing [on the session-history branch of HTML's script-closable.](https://html.spec.whatwg.org/#script-closable).

This is the first step to resolving #51933 . This is built on in #62198 which adds support for [Navigate To](https://w3c.github.io/webdriver/#navigate-to) to testdriver.

