### PR TITLE
script: Align live range update steps with specification

### DIFF
--- a/dom/ranges/Range-mutations-normalize.html
+++ b/dom/ranges/Range-mutations-normalize.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<title>Range mutation tests - normalize</title>
+ <link rel="help" href="https://dom.spec.whatwg.org/#dom-node-normalize">;
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<div id=log></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+    function createTestNode(t) {
+        // Create a node with adjacent 4 text children.
+        const parentNode = document.createElement("div");
+        parentNode.append(document.createElement("span"), "A", "BB", "CCC", "DDDD", document.createElement("span"));
+        document.body.append(parentNode);
+        t.add_cleanup(() => parentNode.remove());
+        return parentNode;
+    }
+
+    function normalizeTestNode(testNode) {
+        testNode.normalize();
+        assert_equals(testNode.childNodes.length, 3);
+        assert_equals(testNode.childNodes[1].data, "ABBCCCDDDD");
+    }
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range = document.createRange();
+        range.setStart(testNode.childNodes[1], 0);
+        range.setEnd(testNode.childNodes[4], 4);
+        normalizeTestNode(testNode);
+        assert_equals(range.startContainer, testNode.childNodes[1]);
+        assert_equals(range.startOffset, 0);
+        assert_equals(range.endContainer, testNode.childNodes[1]);
+        assert_equals(range.endOffset, 10);
+    }, "Live range updates properly when its boundaries span multiple merged text nodes");
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range = document.createRange();
+        range.setStart(testNode.childNodes[3], 2);
+        range.setEnd(testNode.childNodes[3], 2);
+
+        normalizeTestNode(testNode);
+
+        assert_equals(range.startContainer, testNode.childNodes[1]);
+        assert_equals(range.startOffset, 5);
+        assert_equals(range.endContainer, testNode.childNodes[1]);
+        assert_equals(range.endOffset, 5);
+    }, "Live range updates properly when collapsed into single merged text node in range of multiple")
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range = document.createRange();
+        range.setStart(testNode, 3);
+        range.setEnd(testNode, 4);
+
+        normalizeTestNode(testNode);
+
+        assert_equals(range.startContainer, testNode.childNodes[1]);
+        assert_equals(range.startOffset, 3);
+        assert_equals(range.endContainer, testNode.childNodes[1]);
+        assert_equals(range.endOffset, 6);
+    }, "Live range updates properly when its boundaries are initially indices to merged nodes")
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range1 = document.createRange();
+        let range2 = document.createRange();
+
+        range1.setStart(testNode, 0);
+        range1.setEnd(testNode, 0);
+        range2.setStart(testNode, 5);
+        range2.setEnd(testNode, 5);
+
+        normalizeTestNode(testNode);
+
+        assert_equals(range1.startContainer, testNode);
+        assert_equals(range1.startOffset, 0);
+        assert_equals(range1.endContainer, testNode);
+        assert_equals(range1.endOffset, 0);
+
+        assert_equals(range2.startContainer, testNode);
+        assert_equals(range2.startOffset, 2);
+        assert_equals(range2.endContainer, testNode);
+        assert_equals(range2.endOffset, 2);
+    }, "Live range updates properly when text nodes merged before and after them")
+</script>


### PR DESCRIPTION
This change reworks the live range update steps that show up in various
places in the specification so that they match what the specification
says. Now updates to live ranges use the existing `set_start` and
`set_end` APIs which simplify the code greatly as they already handle
updating the `Node`'s live range list. This is preparation work for
adding a new live-ish range type for selections (which will have a few
different requirements than a real DOM live range).

Improvements to spec compliance of `Node#normalize()`:
 - Instead of issuing one mutation record per merged node only issue a
   single one.
 - The change to the preserved node's data happens before the merged
   nodes' removal.
 - Indices for live range updates would be stale when merging more
   than two nodes.

Notes on performance:
 - This switches to accessing a rooted `SmallVec` of live ranges
   per-node. In cases where a node has 4 or fewer live ranges, this will
   not allocate, otherwise this adds a new vector allocation for an
   edge case.
 - The amount of rooting should be unchanged as the old code had to
   root all accessed `Range`'s anyway.
 - In some cases we avoid calculating node indices where they were
   before using `LazyCell`.

Testing: This change adds a new WPT test.

Reviewed in servo/servo#47425