### PR TITLE
[wasm] Match ESM worker tests to worker-helper message shape

### DIFF
--- a/wasm/webapi/esm-integration/worker-import.tentative.html
+++ b/wasm/webapi/esm-integration/worker-import.tentative.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 const worker = new Worker("resources/worker.js", { type: "module" });
 worker.onmessage = (msg) => {
-  assert_equals(msg.data, 42);
+  assert_equals(msg.data.value, 42);
   done();
 }
 </script>

--- a/wasm/webapi/esm-integration/worker.tentative.html
+++ b/wasm/webapi/esm-integration/worker.tentative.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 const worker = new Worker("resources/worker.wasm", { type: "module" });
 worker.onmessage = (msg) => {
-  assert_equals(msg, 42);
+  assert_equals(msg.data.value, 42);
   done();
 }
 worker.onerror = () => {


### PR DESCRIPTION
`resources/worker-helper.js` posts `{value, checks}` (since the source-phase import work). Two older tests were never updated:

- `worker-import.tentative.html` compared `msg.data` to `42`
- `worker.tentative.html` compared the `MessageEvent` itself to `42`

Both now assert `msg.data.value === 42`, same as `worker-import-source-phase.tentative.html`.