### PR TITLE
[wasm] Named import live bindings for ESM mutable globals

### DIFF
--- a/wasm/jsapi/esm-integration/WEB_FEATURES.yml
+++ b/wasm/jsapi/esm-integration/WEB_FEATURES.yml
@@ -1,5 +1,6 @@
 rules:
 - global-exports-live-bindings.tentative.any.js: [wasm-mutable-globals]
+- global-exports-named-import-live-bindings.tentative.any.js: [wasm-mutable-globals]
 - mutable-global-sharing.tentative.any.js: [wasm-mutable-globals]
 - source-phase-string-builtins.tentative.any.js: [wasm-string-builtins]
 - string-builtins.tentative.any.js: [wasm-string-builtins]

--- a/wasm/jsapi/esm-integration/global-exports-named-import-live-bindings.tentative.any.js
+++ b/wasm/jsapi/esm-integration/global-exports-named-import-live-bindings.tentative.any.js
@@ -1,0 +1,30 @@
+// META: global=window,dedicatedworker,jsshell
+
+promise_test(async () => {
+  const m = await import("./resources/named-import-mutable-value.js");
+  m.setGlobal(111);
+  assert_equals(m.getGlobal(), 111);
+  assert_equals(m.readNamed(), 111);
+
+  m.setGlobal(222);
+  assert_equals(m.getGlobal(), 222);
+  assert_equals(m.readNamed(), 222);
+}, "Named imports of wasm mutable globals should be live");
+
+promise_test(async () => {
+  const ns = await import("./resources/js-reexport-mutable-value.js");
+  ns.setGlobal(333);
+  assert_equals(ns.getGlobal(), 333);
+  assert_equals(ns.mutableValue, 333);
+
+  ns.setGlobal(444);
+  assert_equals(ns.getGlobal(), 444);
+  assert_equals(ns.mutableValue, 444);
+}, "JS re-export of a wasm mutable global should stay live");
+
+promise_test(async () => {
+  const ns = await import("./resources/js-reexport-mutable-value.js");
+  assert_throws_js(TypeError, () => {
+    ns.mutableValue = 1;
+  });
+}, "JS re-export of a wasm mutable global is not assignable");

--- a/wasm/jsapi/esm-integration/resources/js-reexport-mutable-value.js
+++ b/wasm/jsapi/esm-integration/resources/js-reexport-mutable-value.js
@@ -1,0 +1,5 @@
+export {
+  mutableValue,
+  setGlobal,
+  getGlobal,
+} from "./mutable-global-export.wasm";

--- a/wasm/jsapi/esm-integration/resources/named-import-mutable-value.js
+++ b/wasm/jsapi/esm-integration/resources/named-import-mutable-value.js
@@ -1,0 +1,11 @@
+import {
+  mutableValue,
+  setGlobal,
+  getGlobal,
+} from "./mutable-global-export.wasm";
+
+export function readNamed() {
+  return mutableValue;
+}
+
+export { setGlobal, getGlobal };


### PR DESCRIPTION
`global-exports-live-bindings` only checks namespace property access (`ns.g`). The ESM integration spec also makes a static named import live:

```js
import { mutableValue, setGlobal } from "./mod.wasm";
setGlobal(222);
assert_equals(mutableValue, 222);
```

This adds that, plus the JS re-export form (`export { mutableValue } from "./mod.wasm"`).

Uses the existing `mutable-global-export.wasm` fixture. Reuses `mutableValue` / `setGlobal` / `getGlobal`.