### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=318685

### DIFF
--- a/css/css-flexbox/flex-column-reverse-multiline-item-position-ref.html
+++ b/css/css-flexbox/flex-column-reverse-multiline-item-position-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: multi-line column-reverse item positions</title>
+<style>
+#target {
+    position: relative;
+    width: 200px;
+    height: 80px;
+}
+#target > div {
+    position: absolute;
+    width: 50px;
+    background: green;
+}
+.short { left: 0; top: 40px; height: 40px; }
+.tall { left: 50px; top: 0; height: 80px; }
+</style>
+<p>Test passes if there is a green step shape (a short block at the lower left, a taller block to its right) and no red.</p>
+<div id="target">
+    <div class="short"></div>
+    <div class="tall"></div>
+</div>

--- a/css/css-flexbox/flex-column-reverse-multiline-item-position.html
+++ b/css/css-flexbox/flex-column-reverse-multiline-item-position.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: multi-line column-reverse item positions</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#main-alignment">
+<link rel="match" href="flex-column-reverse-multiline-item-position-ref.html">
+<style>
+#target {
+    display: flex;
+    flex-flow: column-reverse wrap;
+    align-content: flex-start;
+    align-items: flex-start;
+    width: 200px;
+    max-height: 100px;
+    margin: 0;
+    border: 0;
+    padding: 0;
+}
+#target > div {
+    width: 50px;
+    background: green;
+}
+.short { height: 40px; }
+.tall { height: 80px; }
+</style>
+<p>Test passes if there is a green step shape (a short block at the lower left, a taller block to its right) and no red.</p>
+<!-- max-height forces a wrap: the 40px item fills line 1, the 80px item wraps to line 2, and the container's
+     auto height resolves to the taller line (80px). Each column-reverse line packs at the main-start (bottom)
+     against that finalized height, so the short line is bottom-aligned. -->
+<div id="target">
+    <div class="short"></div>
+    <div class="tall"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[cleanup\] Reverse column-reverse flex lines against the finalized container main size instead of reading it back mid-placement](https://bugs.webkit.org/show_bug.cgi?id=318685)