### PR TITLE
Document named properties: drop object/embed exposedness

### DIFF
--- a/html/dom/documents/dom-tree-accessors/nameditem-07.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-07.html
@@ -31,6 +31,24 @@
 <object name=test10a></object>
 
 <object name=test11a id=test11b></object>
+
+<div id=nested1>
+  <object name=test12>
+    <object name=test12></object>
+  </object>
+</div>
+
+<div id=nested2>
+  <object id=test13>
+    <object id=test13></object>
+  </object>
+</div>
+
+<div id=nested3>
+  <object name=test14>
+    <embed name=test14>
+  </object>
+</div>
 </div>
 <script>
 test(function() {
@@ -209,4 +227,37 @@ test(function() {
   assert_equals(document["test11b"], undefined);
   assert_equals(document.test11b, undefined);
 }, "object elements that is removed, should not be accessible.");
+
+test(function() {
+  var objects = document.querySelectorAll("#nested1 object");
+  assert_equals(objects.length, 2);
+  assert_equals(objects[1].parentNode, objects[0]);
+
+  assert_true("test12" in document, '"test12" in document should be true');
+  var collection = document.test12;
+  assert_class_string(collection, "HTMLCollection", "collection should be an HTMLCollection");
+  assert_array_equals(collection, [objects[0], objects[1]]);
+}, "If an object is nested inside an object with the same name, a collection should be returned. (name)");
+
+test(function() {
+  var objects = document.querySelectorAll("#nested2 object");
+  assert_equals(objects.length, 2);
+  assert_equals(objects[1].parentNode, objects[0]);
+
+  assert_true("test13" in document, '"test13" in document should be true');
+  var collection = document.test13;
+  assert_class_string(collection, "HTMLCollection", "collection should be an HTMLCollection");
+  assert_array_equals(collection, [objects[0], objects[1]]);
+}, "If an object is nested inside an object with the same id, a collection should be returned. (id)");
+
+test(function() {
+  var object = document.querySelector("#nested3 object");
+  var embed = document.querySelector("#nested3 embed");
+  assert_equals(embed.parentNode, object);
+
+  assert_true("test14" in document, '"test14" in document should be true');
+  var collection = document.test14;
+  assert_class_string(collection, "HTMLCollection", "collection should be an HTMLCollection");
+  assert_array_equals(collection, [object, embed]);
+}, "If an embed is nested inside an object with the same name, a collection should be returned. (name)");
 </script>

--- a/html/dom/documents/dom-tree-accessors/nameditem-names.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-names.html
@@ -5,19 +5,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
-<embed name="exposed_embed">
+<embed name="embed">
 <form name="form">
 </form>
 <iframe name="iframe">
 </iframe>
 <img name="img">
-<object data="/common/blank.html" type="text/html" name="exposed_object_with_name">
-  <embed name="not_exposed_embed">
-  <object name="not_exposed_object_with_name">
+<object data="/common/blank.html" type="text/html" name="object_with_name">
+  <embed name="embed_in_object">
+  <object name="object_in_object_with_name">
   </object>
 </object>
-<object data="/common/blank.html" type="text/html" id="exposed_object_with_id">
-  <object id="not_exposed_object_with_id">
+<object data="/common/blank.html" type="text/html" id="object_with_id">
+  <object id="object_in_object_with_id">
   </object>
 </object>
 <img name="img_with_id" id="img_id">
@@ -33,12 +33,8 @@ window.addEventListener("load", function() {
   var names = Object.getOwnPropertyNames(document);
 
   test(function() {
-    assert_true(names.includes("exposed_embed"))
-  }, "An embed name appears in a document's property names if the embed is exposed.");
-
-  test(function() {
-    assert_false(names.includes("not_exposed_embed"))
-  }, "An embed name does not appear in a document's property names if the embed has an exposed object ancestor.");
+    assert_true(names.includes("embed"))
+  }, "An embed name appears in a document's property names.");
 
   test(function() {
     assert_true(names.includes("form"))
@@ -53,24 +49,57 @@ window.addEventListener("load", function() {
   }, "An img name appears in a document's property names when the img has no id.");
 
   test(function() {
-    assert_not_equals(document.querySelector('[name="exposed_object_with_name"]').contentDocument, null,
+    assert_true(names.includes("object_with_name"))
+  }, "An object name appears in a document's property names.");
+
+  test(function() {
+    assert_true(names.includes("object_with_id"))
+  }, "An object id appears in a document's property names.");
+
+  test(function() {
+    assert_not_equals(document.querySelector('[name="object_with_name"]').contentDocument, null,
                       "The object must successfully load its data resource");
-    assert_true(names.includes("exposed_object_with_name"))
-  }, "An object name appears in a document's property names if the object is exposed.");
+    assert_true(names.includes("embed_in_object"))
+  }, "An embed name appears in a document's property names when the embed is inside an object that is not showing its fallback content.");
 
   test(function() {
-    assert_not_equals(document.querySelector("#exposed_object_with_id").contentDocument, null,
+    assert_not_equals(document.querySelector('[name="object_with_name"]').contentDocument, null,
                       "The object must successfully load its data resource");
-    assert_true(names.includes("exposed_object_with_id"))
-  }, "An object id appears in a document's property names if the object is exposed.");
+    assert_true(names.includes("object_in_object_with_name"))
+  }, "An object name appears in a document's property names when the object is inside an object that is not showing its fallback content.");
 
   test(function() {
-    assert_false(names.includes("not_exposed_object_with_name"))
-  }, "An object name does not appear in a document's property names if the object has an exposed object ancestor.");
+    assert_not_equals(document.querySelector("#object_with_id").contentDocument, null,
+                      "The object must successfully load its data resource");
+    assert_true(names.includes("object_in_object_with_id"))
+  }, "An object id appears in a document's property names when the object is inside an object that is not showing its fallback content.");
+
+  // A name is only useful if the named getter resolves it, so check that the
+  // two algorithms agree for object elements and their descendants.
+  test(function() {
+    var object = document.querySelector('[name="object_with_name"]');
+    assert_equals(document.object_with_name, object);
+  }, "An object with object and embed descendants is returned by the named getter (name).");
 
   test(function() {
-    assert_false(names.includes("not_exposed_object_with_id"))
-  }, "An object id does not appear in a document's property names if the object has an exposed object ancestor.");
+    var object = document.querySelector("#object_with_id");
+    assert_equals(document.object_with_id, object);
+  }, "An object with an object descendant is returned by the named getter (id).");
+
+  test(function() {
+    var object = document.querySelector('[name="object_with_name"]');
+    assert_equals(document.embed_in_object, object.querySelector("embed"));
+  }, "An embed inside an object that is not showing its fallback content is returned by the named getter.");
+
+  test(function() {
+    var object = document.querySelector('[name="object_with_name"]');
+    assert_equals(document.object_in_object_with_name, object.querySelector("object"));
+  }, "An object inside an object that is not showing its fallback content is returned by the named getter (name).");
+
+  test(function() {
+    var object = document.querySelector("#object_with_id");
+    assert_equals(document.object_in_object_with_id, object.querySelector("object"));
+  }, "An object inside an object that is not showing its fallback content is returned by the named getter (id).");
 
   test(function() {
     assert_true(names.includes("img_with_id"))


### PR DESCRIPTION
Per the proposal in https://github.com/whatwg/html/issues/12787, stop filtering `<object>`/`<embed>` elements by exposedness for document named properties, matching Gecko.