### PR TITLE
Match cross-origin Range requests to the test scheme

### DIFF
--- a/fetch/range/general.any.js
+++ b/fetch/range/general.any.js
@@ -93,7 +93,7 @@ promise_test(async () => {
 }, `Fetch with range header will be sent with Accept-Encoding: identity`);
 
 promise_test(async () => {
-  const wavURL = new URL(get_host_info().HTTP_REMOTE_ORIGIN + '/fetch/range/resources/long-wav.py');
+  const wavURL = new URL(get_host_info().REMOTE_ORIGIN + '/fetch/range/resources/long-wav.py');
   const stashTakeURL = new URL('resources/stash-take.py', location);
 
   function changeToken() {
@@ -115,7 +115,7 @@ promise_test(async () => {
 }, `Cross Origin Fetch with non safe range header`);
 
 promise_test(async () => {
-  const wavURL = new URL(get_host_info().HTTP_REMOTE_ORIGIN + '/fetch/range/resources/long-wav.py');
+  const wavURL = new URL(get_host_info().REMOTE_ORIGIN + '/fetch/range/resources/long-wav.py');
   const stashTakeURL = new URL('resources/stash-take.py', location);
 
   function changeToken() {


### PR DESCRIPTION
The service-worker variant of `fetch/range/general.any.js` runs in a
secure context, but its cross-origin tests hard-code `HTTP_REMOTE_ORIGIN`.

This causes the safe Range request to fail as mixed content before the
Range-header behavior under test is reached.

Use `REMOTE_ORIGIN` so the request remains cross-origin while matching
the scheme of the initiating context.

This fixes the `Cross Origin Fetch with safe range header` subtest in
`general.any.serviceworker.html`.

The service-worked variant previously failed in Chromium, Gecko 
and WebKit due to this test bug. After this patch, it now passes in
all.