### PR TITLE
Cookies: test overwriting a cookie with a new value or attributes

### DIFF
--- a/cookies/attributes/httponly-overwrite.https.window.js
+++ b/cookies/attributes/httponly-overwrite.https.window.js
@@ -1,0 +1,122 @@
+// META: title=Overwriting a cookie's HttpOnly attribute while its value stays the same
+
+'use strict';
+
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#store-a-cookie
+// https://github.com/httpwg/http-extensions/issues/3501
+
+async function setCookieViaHTTP(cookie) {
+  const set = encodeURIComponent(JSON.stringify(cookie));
+  const response = await fetch(`/cookies/resources/cookie.py?set=${set}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// The raw Cookie request header, which unlike document.cookie also observes
+// HttpOnly cookies.
+async function getCookieHeader() {
+  const response = await fetch('/cookiestore/resources/cookie_helper.py',
+                               {credentials: 'include'});
+  assert_true(response.ok, 'Reading the Cookie header succeeded');
+  const text = await response.text();
+  return decodeURIComponent(text.replace(/^cookie=/, ''));
+}
+
+// Whether a cookie's http-only is true, observed without reading
+// document.cookie: a cookie can only be overwritten through a non-HTTP API if
+// its http-only is false, so if a write from script does not land the cookie's
+// http-only is true.
+async function isHttpOnly(name) {
+  document.cookie = `${name}=overwritten; Path=/`;
+  return !(await getCookieHeader()).includes(`${name}=overwritten`);
+}
+
+function cookieTest(name, cookieName, body) {
+  promise_test(async t => {
+    t.add_cleanup(() => setCookieViaHTTP(`${cookieName}=; Path=/; Max-Age=0`));
+    t.add_cleanup(() => setCookieViaHTTP(`${cookieName}=; Path=/; Max-Age=0; HttpOnly`));
+    await body(t);
+  }, name);
+}
+
+// These two establish that isHttpOnly() reports what it claims to.
+cookieTest('A cookie set without HttpOnly is not http-only', 'control1', async t => {
+  await setCookieViaHTTP('control1=1; Path=/');
+  assert_false(await isHttpOnly('control1'));
+});
+
+cookieTest('A cookie set with HttpOnly is http-only', 'control2', async t => {
+  await setCookieViaHTTP('control2=1; Path=/; HttpOnly');
+  assert_true(await isHttpOnly('control2'));
+});
+
+// A cookie's http-only has to be updated even when nothing else about the cookie
+// changes. Failing to do so leaves the cookie writable by the non-HTTP APIs the
+// server just asked to have it protected from.
+cookieTest('Adding HttpOnly to a cookie with an unchanged value makes it http-only',
+           'test1', async t => {
+  await setCookieViaHTTP('test1=1; Path=/');
+  assert_false(await isHttpOnly('test1'), 'The cookie starts out not http-only');
+
+  await setCookieViaHTTP('test1=1; Path=/; HttpOnly');
+  assert_equals(await getCookieHeader(), 'test1=1',
+                'The cookie is still in the cookie store with its value');
+  assert_true(await isHttpOnly('test1'), 'The cookie is now http-only');
+});
+
+cookieTest('Removing HttpOnly from a cookie with an unchanged value makes it not http-only',
+           'test2', async t => {
+  await setCookieViaHTTP('test2=1; Path=/; HttpOnly');
+  assert_true(await isHttpOnly('test2'), 'The cookie starts out http-only');
+
+  await setCookieViaHTTP('test2=1; Path=/');
+  assert_equals(await getCookieHeader(), 'test2=1',
+                'The cookie is still in the cookie store with its value');
+  assert_false(await isHttpOnly('test2'), 'The cookie is no longer http-only');
+});
+
+// As above, but with both cookies in a single response, so that they also have
+// an identical creation time.
+cookieTest('Adding HttpOnly through a second Set-Cookie in the same response',
+           'test3', async t => {
+  await setCookieViaHTTP(['test3=1; Path=/', 'test3=1; Path=/; HttpOnly']);
+  assert_equals(await getCookieHeader(), 'test3=1',
+                'There is exactly one cookie, with its value');
+  assert_true(await isHttpOnly('test3'), 'The cookie is http-only');
+});
+
+cookieTest('Removing HttpOnly through a second Set-Cookie in the same response',
+           'test4', async t => {
+  await setCookieViaHTTP(['test4=1; Path=/; HttpOnly', 'test4=1; Path=/']);
+  assert_equals(await getCookieHeader(), 'test4=1',
+                'There is exactly one cookie, with its value');
+  assert_false(await isHttpOnly('test4'), 'The cookie is not http-only');
+});
+
+// An http-only cookie also has to stop being exposed to non-HTTP APIs. This is
+// separate from the tests above so that a user agent that protects the cookie
+// from being overwritten but keeps exposing its value fails only here.
+cookieTest('Adding HttpOnly to a cookie with an unchanged value hides it from document.cookie',
+           'test5', async t => {
+  await setCookieViaHTTP('test5=1; Path=/');
+  assert_equals(document.cookie, 'test5=1',
+                'The cookie is exposed to document.cookie');
+
+  await setCookieViaHTTP('test5=1; Path=/; HttpOnly');
+  assert_equals(await getCookieHeader(), 'test5=1',
+                'The cookie is still in the cookie store with its value');
+  assert_equals(document.cookie, '',
+                'The cookie is no longer exposed to document.cookie');
+});
+
+cookieTest('Removing HttpOnly from a cookie with an unchanged value exposes it to document.cookie',
+           'test6', async t => {
+  await setCookieViaHTTP('test6=1; Path=/; HttpOnly');
+  assert_equals(document.cookie, '',
+                'The cookie is not exposed to document.cookie');
+
+  await setCookieViaHTTP('test6=1; Path=/');
+  assert_equals(await getCookieHeader(), 'test6=1',
+                'The cookie is still in the cookie store with its value');
+  assert_equals(document.cookie, 'test6=1',
+                'The cookie is now exposed to document.cookie');
+});

--- a/cookies/attributes/httponly-overwrite.https.window.js
+++ b/cookies/attributes/httponly-overwrite.https.window.js
@@ -21,102 +21,116 @@ async function getCookieHeader() {
   return decodeURIComponent(text.replace(/^cookie=/, ''));
 }
 
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
 // Whether a cookie's http-only is true, observed without reading
 // document.cookie: a cookie can only be overwritten through a non-HTTP API if
 // its http-only is false, so if a write from script does not land the cookie's
 // http-only is true.
 async function isHttpOnly(name) {
   document.cookie = `${name}=overwritten; Path=/`;
-  return !(await getCookieHeader()).includes(`${name}=overwritten`);
+  return cookieValue(await getCookieHeader(), name) !== 'overwritten';
 }
 
-function cookieTest(name, cookieName, body) {
+function cookieTest(description, suffix, body) {
+  const name = `httponly-overwrite-${suffix}`;
   promise_test(async t => {
-    t.add_cleanup(() => setCookieViaHTTP(`${cookieName}=; Path=/; Max-Age=0`));
-    t.add_cleanup(() => setCookieViaHTTP(`${cookieName}=; Path=/; Max-Age=0; HttpOnly`));
-    await body(t);
-  }, name);
+    t.add_cleanup(() => setCookieViaHTTP(`${name}=; Path=/; Max-Age=0`));
+    t.add_cleanup(
+        () => setCookieViaHTTP(`${name}=; Path=/; Max-Age=0; HttpOnly`));
+    await body(t, name);
+  }, description);
 }
 
 // These two establish that isHttpOnly() reports what it claims to.
-cookieTest('A cookie set without HttpOnly is not http-only', 'control1', async t => {
-  await setCookieViaHTTP('control1=1; Path=/');
-  assert_false(await isHttpOnly('control1'));
+cookieTest('A cookie set without HttpOnly is not http-only', 'control1',
+           async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_false(await isHttpOnly(name));
 });
 
-cookieTest('A cookie set with HttpOnly is http-only', 'control2', async t => {
-  await setCookieViaHTTP('control2=1; Path=/; HttpOnly');
-  assert_true(await isHttpOnly('control2'));
+cookieTest('A cookie set with HttpOnly is http-only', 'control2',
+           async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_true(await isHttpOnly(name));
 });
 
 // A cookie's http-only has to be updated even when nothing else about the cookie
 // changes. Failing to do so leaves the cookie writable by the non-HTTP APIs the
 // server just asked to have it protected from.
 cookieTest('Adding HttpOnly to a cookie with an unchanged value makes it http-only',
-           'test1', async t => {
-  await setCookieViaHTTP('test1=1; Path=/');
-  assert_false(await isHttpOnly('test1'), 'The cookie starts out not http-only');
+           'test1', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_false(await isHttpOnly(name), 'The cookie starts out not http-only');
 
-  await setCookieViaHTTP('test1=1; Path=/; HttpOnly');
-  assert_equals(await getCookieHeader(), 'test1=1',
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
                 'The cookie is still in the cookie store with its value');
-  assert_true(await isHttpOnly('test1'), 'The cookie is now http-only');
+  assert_true(await isHttpOnly(name), 'The cookie is now http-only');
 });
 
 cookieTest('Removing HttpOnly from a cookie with an unchanged value makes it not http-only',
-           'test2', async t => {
-  await setCookieViaHTTP('test2=1; Path=/; HttpOnly');
-  assert_true(await isHttpOnly('test2'), 'The cookie starts out http-only');
+           'test2', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_true(await isHttpOnly(name), 'The cookie starts out http-only');
 
-  await setCookieViaHTTP('test2=1; Path=/');
-  assert_equals(await getCookieHeader(), 'test2=1',
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
                 'The cookie is still in the cookie store with its value');
-  assert_false(await isHttpOnly('test2'), 'The cookie is no longer http-only');
+  assert_false(await isHttpOnly(name), 'The cookie is no longer http-only');
 });
 
 // As above, but with both cookies in a single response, so that they also have
 // an identical creation time.
 cookieTest('Adding HttpOnly through a second Set-Cookie in the same response',
-           'test3', async t => {
-  await setCookieViaHTTP(['test3=1; Path=/', 'test3=1; Path=/; HttpOnly']);
-  assert_equals(await getCookieHeader(), 'test3=1',
-                'There is exactly one cookie, with its value');
-  assert_true(await isHttpOnly('test3'), 'The cookie is http-only');
+           'test3', async (t, name) => {
+  await setCookieViaHTTP([`${name}=1; Path=/`, `${name}=1; Path=/; HttpOnly`]);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is in the cookie store with its value');
+  assert_true(await isHttpOnly(name), 'The cookie is http-only');
 });
 
 cookieTest('Removing HttpOnly through a second Set-Cookie in the same response',
-           'test4', async t => {
-  await setCookieViaHTTP(['test4=1; Path=/; HttpOnly', 'test4=1; Path=/']);
-  assert_equals(await getCookieHeader(), 'test4=1',
-                'There is exactly one cookie, with its value');
-  assert_false(await isHttpOnly('test4'), 'The cookie is not http-only');
+           'test4', async (t, name) => {
+  await setCookieViaHTTP([`${name}=1; Path=/; HttpOnly`, `${name}=1; Path=/`]);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is in the cookie store with its value');
+  assert_false(await isHttpOnly(name), 'The cookie is not http-only');
 });
 
 // An http-only cookie also has to stop being exposed to non-HTTP APIs. This is
 // separate from the tests above so that a user agent that protects the cookie
 // from being overwritten but keeps exposing its value fails only here.
 cookieTest('Adding HttpOnly to a cookie with an unchanged value hides it from document.cookie',
-           'test5', async t => {
-  await setCookieViaHTTP('test5=1; Path=/');
-  assert_equals(document.cookie, 'test5=1',
+           'test5', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_equals(cookieValue(document.cookie, name), '1',
                 'The cookie is exposed to document.cookie');
 
-  await setCookieViaHTTP('test5=1; Path=/; HttpOnly');
-  assert_equals(await getCookieHeader(), 'test5=1',
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
                 'The cookie is still in the cookie store with its value');
-  assert_equals(document.cookie, '',
+  assert_equals(cookieValue(document.cookie, name), null,
                 'The cookie is no longer exposed to document.cookie');
 });
 
 cookieTest('Removing HttpOnly from a cookie with an unchanged value exposes it to document.cookie',
-           'test6', async t => {
-  await setCookieViaHTTP('test6=1; Path=/; HttpOnly');
-  assert_equals(document.cookie, '',
+           'test6', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_equals(cookieValue(document.cookie, name), null,
                 'The cookie is not exposed to document.cookie');
 
-  await setCookieViaHTTP('test6=1; Path=/');
-  assert_equals(await getCookieHeader(), 'test6=1',
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
                 'The cookie is still in the cookie store with its value');
-  assert_equals(document.cookie, 'test6=1',
+  assert_equals(cookieValue(document.cookie, name), '1',
                 'The cookie is now exposed to document.cookie');
 });

--- a/cookies/value/value-overwrite.https.window.js
+++ b/cookies/value/value-overwrite.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testdriver.js
-// META: script=/resources/testdriver-vendor.js
 // META: title=Overwriting a cookie's value while its attributes stay the same
 // META: timeout=long
 
@@ -10,7 +8,9 @@
 
 // A fixed expiry date, so that a cookie and the cookie overwriting it have an
 // identical expiry time no matter when they are set.
-const kExpires = 'Expires=Fri, 01 Jan 2100 00:00:00 GMT';
+const EXPIRES = 'Expires=Fri, 01 Jan 2100 00:00:00 GMT';
+
+const COOKIE_NAME = 'value-overwrite';
 
 async function setCookiesViaHTTP(cookies) {
   const set = encodeURIComponent(JSON.stringify(cookies));
@@ -26,15 +26,24 @@ async function getCookiesViaHTTP() {
   return response.json();
 }
 
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
 // Sets each cookie of `cookies` in order and then asserts that the server
-// observes `expected`, a name to value mapping.
+// observes the cookie with `expected` as its value.
 //
 // `separateResponses` controls whether each cookie is sent in a response of its
 // own, as opposed to all of them being sent in a single response.
 function overwriteTest({cookies, expected, name, separateResponses = true}) {
   promise_test(async t => {
-    await test_driver.delete_all_cookies();
-    t.add_cleanup(test_driver.delete_all_cookies);
+    t.add_cleanup(() => setCookiesViaHTTP([`${COOKIE_NAME}=; Path=/; Max-Age=0`]));
 
     if (separateResponses) {
       for (const cookie of cookies) {
@@ -44,7 +53,7 @@ function overwriteTest({cookies, expected, name, separateResponses = true}) {
       await setCookiesViaHTTP(cookies);
     }
 
-    assert_object_equals(await getCookiesViaHTTP(), expected);
+    assert_equals((await getCookiesViaHTTP())[COOKIE_NAME], expected);
   }, name);
 }
 
@@ -58,20 +67,20 @@ const attributeSets = [
   'Path=/; SameSite=Strict',
   'Path=/; SameSite=Lax',
   'Path=/; SameSite=None; Secure',
-  `Path=/; ${kExpires}`,
-  `Path=/; Secure; HttpOnly; SameSite=Strict; ${kExpires}`,
+  `Path=/; ${EXPIRES}`,
+  `Path=/; Secure; HttpOnly; SameSite=Strict; ${EXPIRES}`,
 ];
 
 for (const attributes of attributeSets) {
   overwriteTest({
-    cookies: [`test=1; ${attributes}`, `test=2; ${attributes}`],
-    expected: {test: '2'},
+    cookies: [`${COOKIE_NAME}=1; ${attributes}`, `${COOKIE_NAME}=2; ${attributes}`],
+    expected: '2',
     name: `Overwrite value via separate responses with '${attributes}'`,
   });
 
   overwriteTest({
-    cookies: [`test=1; ${attributes}`, `test=2; ${attributes}`],
-    expected: {test: '2'},
+    cookies: [`${COOKIE_NAME}=1; ${attributes}`, `${COOKIE_NAME}=2; ${attributes}`],
+    expected: '2',
     name: `Overwrite value via a single response with '${attributes}'`,
     separateResponses: false,
   });
@@ -80,23 +89,24 @@ for (const attributes of attributeSets) {
 // Max-Age is relative to when the cookie is received, so only cookies received
 // in the same response are guaranteed an identical expiry time.
 overwriteTest({
-  cookies: ['test=1; Path=/; Max-Age=1000', 'test=2; Path=/; Max-Age=1000'],
-  expected: {test: '2'},
+  cookies: [`${COOKIE_NAME}=1; Path=/; Max-Age=1000`,
+            `${COOKIE_NAME}=2; Path=/; Max-Age=1000`],
+  expected: '2',
   name: "Overwrite value via a single response with 'Path=/; Max-Age=1000'",
   separateResponses: false,
 });
 
 // Overwriting a value with the empty value is a change as well.
 overwriteTest({
-  cookies: ['test=1; Path=/', 'test=; Path=/'],
-  expected: {test: ''},
+  cookies: [`${COOKIE_NAME}=1; Path=/`, `${COOKIE_NAME}=; Path=/`],
+  expected: '',
   name: 'Overwrite value with the empty value',
 });
 
 // And so is overwriting the empty value with a value.
 overwriteTest({
-  cookies: ['test=; Path=/', 'test=1; Path=/'],
-  expected: {test: '1'},
+  cookies: [`${COOKIE_NAME}=; Path=/`, `${COOKIE_NAME}=1; Path=/`],
+  expected: '1',
   name: 'Overwrite the empty value with a value',
 });
 
@@ -104,12 +114,11 @@ overwriteTest({
 // cannot be set through document.cookie.
 for (const attributes of attributeSets.filter(a => !a.includes('HttpOnly'))) {
   promise_test(async t => {
-    await test_driver.delete_all_cookies();
-    t.add_cleanup(test_driver.delete_all_cookies);
+    t.add_cleanup(() => setCookiesViaHTTP([`${COOKIE_NAME}=; Path=/; Max-Age=0`]));
 
-    document.cookie = `test=1; ${attributes}`;
-    document.cookie = `test=2; ${attributes}`;
+    document.cookie = `${COOKIE_NAME}=1; ${attributes}`;
+    document.cookie = `${COOKIE_NAME}=2; ${attributes}`;
 
-    assert_equals(document.cookie, 'test=2');
+    assert_equals(cookieValue(document.cookie, COOKIE_NAME), '2');
   }, `Overwrite value via document.cookie with '${attributes}'`);
 }

--- a/cookies/value/value-overwrite.https.window.js
+++ b/cookies/value/value-overwrite.https.window.js
@@ -1,0 +1,115 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: title=Overwriting a cookie's value while its attributes stay the same
+// META: timeout=long
+
+'use strict';
+
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#store-a-cookie
+// https://github.com/httpwg/http-extensions/issues/3501
+
+// A fixed expiry date, so that a cookie and the cookie overwriting it have an
+// identical expiry time no matter when they are set.
+const kExpires = 'Expires=Fri, 01 Jan 2100 00:00:00 GMT';
+
+async function setCookiesViaHTTP(cookies) {
+  const set = encodeURIComponent(JSON.stringify(cookies));
+  const response = await fetch(`/cookies/resources/cookie.py?set=${set}`);
+  assert_true(response.ok, 'Setting cookies via HTTP succeeded');
+}
+
+// Reads the cookie store from the server's point of view, which unlike
+// document.cookie also observes HttpOnly cookies.
+async function getCookiesViaHTTP() {
+  const response = await fetch('/cookies/resources/list.py');
+  assert_true(response.ok, 'Reading cookies via HTTP succeeded');
+  return response.json();
+}
+
+// Sets each cookie of `cookies` in order and then asserts that the server
+// observes `expected`, a name to value mapping.
+//
+// `separateResponses` controls whether each cookie is sent in a response of its
+// own, as opposed to all of them being sent in a single response.
+function overwriteTest({cookies, expected, name, separateResponses = true}) {
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+    t.add_cleanup(test_driver.delete_all_cookies);
+
+    if (separateResponses) {
+      for (const cookie of cookies) {
+        await setCookiesViaHTTP([cookie]);
+      }
+    } else {
+      await setCookiesViaHTTP(cookies);
+    }
+
+    assert_object_equals(await getCookiesViaHTTP(), expected);
+  }, name);
+}
+
+// Each of these attribute strings results in a cookie whose secure, same-site,
+// expiry-time, and http-only are identical to those of the cookie it overwrites,
+// leaving the value as the only difference.
+const attributeSets = [
+  'Path=/',
+  'Path=/; Secure',
+  'Path=/; HttpOnly',
+  'Path=/; SameSite=Strict',
+  'Path=/; SameSite=Lax',
+  'Path=/; SameSite=None; Secure',
+  `Path=/; ${kExpires}`,
+  `Path=/; Secure; HttpOnly; SameSite=Strict; ${kExpires}`,
+];
+
+for (const attributes of attributeSets) {
+  overwriteTest({
+    cookies: [`test=1; ${attributes}`, `test=2; ${attributes}`],
+    expected: {test: '2'},
+    name: `Overwrite value via separate responses with '${attributes}'`,
+  });
+
+  overwriteTest({
+    cookies: [`test=1; ${attributes}`, `test=2; ${attributes}`],
+    expected: {test: '2'},
+    name: `Overwrite value via a single response with '${attributes}'`,
+    separateResponses: false,
+  });
+}
+
+// Max-Age is relative to when the cookie is received, so only cookies received
+// in the same response are guaranteed an identical expiry time.
+overwriteTest({
+  cookies: ['test=1; Path=/; Max-Age=1000', 'test=2; Path=/; Max-Age=1000'],
+  expected: {test: '2'},
+  name: "Overwrite value via a single response with 'Path=/; Max-Age=1000'",
+  separateResponses: false,
+});
+
+// Overwriting a value with the empty value is a change as well.
+overwriteTest({
+  cookies: ['test=1; Path=/', 'test=; Path=/'],
+  expected: {test: ''},
+  name: 'Overwrite value with the empty value',
+});
+
+// And so is overwriting the empty value with a value.
+overwriteTest({
+  cookies: ['test=; Path=/', 'test=1; Path=/'],
+  expected: {test: '1'},
+  name: 'Overwrite the empty value with a value',
+});
+
+// The equivalent of the above via a non-HTTP API. HttpOnly is excluded as it
+// cannot be set through document.cookie.
+for (const attributes of attributeSets.filter(a => !a.includes('HttpOnly'))) {
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+    t.add_cleanup(test_driver.delete_all_cookies);
+
+    document.cookie = `test=1; ${attributes}`;
+    document.cookie = `test=2; ${attributes}`;
+
+    assert_equals(document.cookie, 'test=2');
+  }, `Overwrite value via document.cookie with '${attributes}'`);
+}

--- a/cookiestore/change_eventhandler_for_attribute_change.https.window.js
+++ b/cookiestore/change_eventhandler_for_attribute_change.https.window.js
@@ -1,0 +1,83 @@
+// META: title=Cookie Store API: Test that changing only a cookie's attributes fires an event.
+// META: script=resources/cookie-test-helpers.js
+
+'use strict';
+
+// Changing a cookie is web-observable even when its value stays the same. These
+// complement change_eventhandler_for_no_change.https.window.js, which covers a
+// cookie whose value and attributes are all unchanged.
+//
+// See https://github.com/httpwg/http-extensions/issues/3501.
+//
+// HttpOnly is not covered here as it cannot be set through CookieStore or
+// document.cookie; cookies/attributes/httponly-overwrite.https.html covers it
+// at the level of the cookie store instead.
+
+cookie_test(async t => {
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'VALUE',
+    expires: new Date(Date.now() + 100_000_000),
+  });
+
+  const eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'VALUE',
+    expires: new Date(Date.now() + 200_000_000),
+  });
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'cookie', value: 'VALUE'}]},
+    'Change of expiry time is observed');
+}, 'CookieStore change of expires only should be observed');
+
+cookie_test(async t => {
+  await cookieStore.set({name: 'cookie', value: 'VALUE', sameSite: 'strict'});
+
+  const eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({name: 'cookie', value: 'VALUE', sameSite: 'lax'});
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'cookie', value: 'VALUE'}]},
+    'Change of same-site is observed');
+}, 'CookieStore change of sameSite only should be observed');
+
+// CookieStore always sets Secure, so document.cookie is used to vary it.
+cookie_test(async t => {
+  await setCookieStringDocument('cookie=VALUE; path=/; secure');
+
+  const eventPromise = observeNextCookieChangeEvent();
+  await setCookieStringDocument('cookie=VALUE; path=/');
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'cookie', value: 'VALUE'}]},
+    'Change of secure is observed');
+}, 'document.cookie change of Secure only should be observed');
+
+// An expiry time of null (a session cookie) and an expiry time in the future
+// are distinct, in both directions.
+cookie_test(async t => {
+  await cookieStore.set({name: 'cookie', value: 'VALUE'});
+
+  const eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'VALUE',
+    expires: new Date(Date.now() + 100_000_000),
+  });
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'cookie', value: 'VALUE'}]},
+    'Gaining an expiry time is observed');
+}, 'CookieStore change from no expires to expires should be observed');
+
+cookie_test(async t => {
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'VALUE',
+    expires: new Date(Date.now() + 100_000_000),
+  });
+
+  const eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({name: 'cookie', value: 'VALUE'});
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'cookie', value: 'VALUE'}]},
+    'Losing an expiry time is observed');
+}, 'CookieStore change from expires to no expires should be observed');


### PR DESCRIPTION
A cookie set again with the same name, host and path has to replace the existing one whenever its value or any attribute differs, and be observable when it does.

The layered cookies draft currently skips storing the new cookie when its secure, same-site and expiry-time match the existing cookie, without comparing value or http-only. That drops value updates and silently ignores a newly added `HttpOnly` attribute. See https://github.com/httpwg/http-extensions/issues/3501.

* `cookies/value/value-overwrite.https.window.js` covers value changes across the attribute combinations that leave secure, same-site, expiry-time and http-only identical, over HTTP (both in a single response and in separate responses) and through `document.cookie`.
* `cookies/attributes/httponly-overwrite.https.window.js` covers adding and removing `HttpOnly` while the value stays the same. It observes http-only by whether script can overwrite the cookie, with two control subtests establishing that this reports what it claims to, and asserts `document.cookie` exposure in separate subtests.
* `cookiestore/change_eventhandler_for_attribute_change.https.window.js` covers change events for a cookie whose value is unchanged but whose expiry time, same-site or `Secure` differs, complementing `change_eventhandler_for_no_change.https.window.js`.