### PR TITLE
Clarify wording in README

### DIFF
--- a/editing/README
+++ b/editing/README
@@ -1,12 +1,9 @@
-Most of this directory tests conformance to the editing spec written long ago
-by Aryeh Gregor.  Nobody actually implements the spec, but the tests are still
-useful for regression testing.  The files in data/ were generated from a
-JavaScript implementation of the specification using a complex procedure that
-can't actually be replicated right now as-is.  Editing them manually is
-possible, but they're not really meant to be human-readable.  If anyone is
-interested, it would be possible for Aryeh to get the test generation procedure
-working again.  Or you could look into the repository history and figure out
-how to do it yourself, if you're brave.
+Most of this directory tests conformance to the editing spec written long ago by Aryeh Gregor.
+None of the major browsers actually implement the spec, but the tests are still useful for regression testing.
+The files in data/ were generated from a JavaScript implementation of the specification using a complex procedure that can't actually be replicated right now as-is.
+Editing them manually is possible, but they're not really meant to be human-readable.
+If anyone is interested, it would be possible for Aryeh to get the test generation procedure working again.
+Or you could look into the repository history and figure out how to do it yourself, if you're brave.
 
 There is also a directory other/ that contains additional editor-related tests.
 They aren't necessarily based on any specification, but try to specify sensible


### PR DESCRIPTION
Both Ladybird and Servo largely follow the draft specification for their implementations, albeit with some modifications for compatibility, as well as some fixes in places where the spec as written runs into nonsensical behavior. (such as trying to walk out of the DOM tree entirely or inserting content into HTML comment nodes, etc.)

Beyond that, I un-wrapped the line breaks for this paragraph since that just makes editing it easier.