### PR TITLE
Cookies: test Path attribute encoding and segment boundary matching

### DIFF
--- a/cookies/path/match-percent-encoded.https.window.js
+++ b/cookies/path/match-percent-encoded.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testdriver.js
-// META: script=/resources/testdriver-vendor.js
 // META: title=Cookie Path attribute matching against percent-encoded URL paths
 
 'use strict';
@@ -16,6 +14,7 @@
 // https://github.com/whatwg/url/issues/814
 
 const SCOPE = '/cookies/path/resources/probe/';
+const NAME_PREFIX = 'match-percent-encoded-';
 
 // Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
 // as percent-escapes. wptserve percent-decodes the query into bytes and cookie.py
@@ -28,6 +27,16 @@ async function setCookieViaHTTP(cookie, rawEscape) {
   }
   const response = await fetch(`/cookies/resources/cookie.py?set=${query}`);
   assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
 }
 
 // Loads a synthesized document at `path` and returns what it reported.
@@ -70,30 +79,34 @@ promise_setup(async () => {
   }
 });
 
-function cookieTest(name, body) {
+// Sets the cookie under test, then expires it again through the same Path, which
+// is what removes it.
+function cookieTest(description, {suffix, pathSegment, raw}, body) {
+  const name = NAME_PREFIX + suffix;
   promise_test(async t => {
-    await test_driver.delete_all_cookies();
-    t.add_cleanup(test_driver.delete_all_cookies);
-    await body(t);
-  }, name);
+    t.add_cleanup(() => setCookieViaHTTP(
+        `${name}=; Max-Age=0; Path=${SCOPE}${pathSegment}`, raw));
+
+    await setCookieViaHTTP(`${name}=1; Path=${SCOPE}${pathSegment}`, raw);
+    await body(t, name);
+  }, description);
 }
 
 // Controls: the service worker synthesizes a document at the probed path and
 // cookies for that path are visible in it, so the apparatus reports what it
 // claims to.
-cookieTest('CONTROL a cookie for the probed path is visible in it', async t => {
-  await setCookieViaHTTP(`control=1; Path=${SCOPE}zzx`);
+cookieTest('CONTROL a cookie for the probed path is visible in it',
+           {suffix: 'control', pathSegment: 'zzx'}, async (t, name) => {
   const result = await probeAtPath(`${SCOPE}zzx/probe.html`);
   assert_equals(result.path, `${SCOPE}zzx/probe.html`,
                 'The document was synthesized at the probed path');
-  assert_equals(result.cookie, 'control=1');
+  assert_equals(cookieValue(result.cookie, name), '1');
 });
 
 cookieTest('CONTROL a cookie for a prefix of the probed path is visible in it',
-           async t => {
-  await setCookieViaHTTP(`prefix=1; Path=${SCOPE}`);
+           {suffix: 'prefix', pathSegment: ''}, async (t, name) => {
   const result = await probeAtPath(`${SCOPE}zzx/probe.html`);
-  assert_equals(result.cookie, 'prefix=1');
+  assert_equals(cookieValue(result.cookie, name), '1');
 });
 
 // Each case sets one cookie whose Path ends in `pathSegment`, with "ZZ" replaced
@@ -155,12 +168,14 @@ const CASES = [
   },
 ];
 
-for (const testCase of CASES) {
-  cookieTest(`A Path attribute where ${testCase.name}`, async t => {
-    await setCookieViaHTTP(
-        `t=1; Path=${SCOPE}${testCase.pathSegment}`, testCase.raw);
-    const result = await probeAtPath(`${SCOPE}${testCase.probeSegment}/probe.html`);
-    assert_equals(result.cookie, testCase.sent ? 't=1' : '');
+for (const [index, testCase] of CASES.entries()) {
+  cookieTest(`A Path attribute where ${testCase.name}`,
+             {suffix: `case${index}`, pathSegment: testCase.pathSegment,
+              raw: testCase.raw},
+             async (t, name) => {
+    const result =
+        await probeAtPath(`${SCOPE}${testCase.probeSegment}/probe.html`);
+    assert_equals(cookieValue(result.cookie, name), testCase.sent ? '1' : null);
   });
 }
 

--- a/cookies/path/match-percent-encoded.https.window.js
+++ b/cookies/path/match-percent-encoded.https.window.js
@@ -1,0 +1,169 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: title=Cookie Path attribute matching against percent-encoded URL paths
+
+'use strict';
+
+// A cookie's path is compared against the request URL's path, whose segments are
+// percent-encoded. So a byte written literally in a Path attribute does not match
+// its percent-encoded form in a URL, and a non-ASCII byte, which makes the cookie
+// fail to parse, is not reachable at any encoding of it.
+//
+// Observing this needs paths with no file behind them, so a service worker
+// synthesizes a document at whichever path is probed. The document reads
+// document.cookie, because a service worker cannot see a request's Cookie header.
+//
+// https://github.com/whatwg/url/issues/814
+
+const SCOPE = '/cookies/path/resources/probe/';
+
+// Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
+// as percent-escapes. wptserve percent-decodes the query into bytes and cookie.py
+// passes those bytes to the header unchanged, which is how a byte that a URL path
+// would percent-encode reaches the Path attribute as itself.
+async function setCookieViaHTTP(cookie, rawEscape) {
+  let query = encodeURIComponent(JSON.stringify([cookie]));
+  if (rawEscape !== undefined) {
+    query = query.replace('ZZ', rawEscape);
+  }
+  const response = await fetch(`/cookies/resources/cookie.py?set=${query}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// Loads a synthesized document at `path` and returns what it reported.
+function probeAtPath(path) {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.style = 'display: none';
+    const onMessage = event => {
+      if (event.source !== iframe.contentWindow) {
+        return;
+      }
+      window.removeEventListener('message', onMessage);
+      iframe.remove();
+      resolve(event.data);
+    };
+    window.addEventListener('message', onMessage);
+    iframe.src = path;
+    document.body.appendChild(iframe);
+  });
+}
+
+let registration;
+
+promise_setup(async () => {
+  registration = await navigator.serviceWorker.register(
+      'resources/probe/sw.js', {scope: SCOPE});
+  // navigator.serviceWorker.ready is not usable here: it waits for a worker
+  // controlling this document, and this document is outside the scope the probe
+  // paths need. Wait on the registration's own worker instead.
+  const worker =
+      registration.installing || registration.waiting || registration.active;
+  if (worker.state !== 'activated') {
+    await new Promise(resolve => {
+      worker.addEventListener('statechange', () => {
+        if (worker.state === 'activated') {
+          resolve();
+        }
+      });
+    });
+  }
+});
+
+function cookieTest(name, body) {
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+    t.add_cleanup(test_driver.delete_all_cookies);
+    await body(t);
+  }, name);
+}
+
+// Controls: the service worker synthesizes a document at the probed path and
+// cookies for that path are visible in it, so the apparatus reports what it
+// claims to.
+cookieTest('CONTROL a cookie for the probed path is visible in it', async t => {
+  await setCookieViaHTTP(`control=1; Path=${SCOPE}zzx`);
+  const result = await probeAtPath(`${SCOPE}zzx/probe.html`);
+  assert_equals(result.path, `${SCOPE}zzx/probe.html`,
+                'The document was synthesized at the probed path');
+  assert_equals(result.cookie, 'control=1');
+});
+
+cookieTest('CONTROL a cookie for a prefix of the probed path is visible in it',
+           async t => {
+  await setCookieViaHTTP(`prefix=1; Path=${SCOPE}`);
+  const result = await probeAtPath(`${SCOPE}zzx/probe.html`);
+  assert_equals(result.cookie, 'prefix=1');
+});
+
+// Each case sets one cookie whose Path ends in `pathSegment`, with "ZZ" replaced
+// by the raw bytes `raw` when given, then probes the URL path segment
+// `probeSegment`.
+const CASES = [
+  // A byte that is ASCII but that a URL path percent-encodes. The cookie is
+  // stored, but its path does not match the encoded segment.
+  {
+    name: 'a literal space does not match a percent-encoded space',
+    pathSegment: 'zzZZa',
+    raw: '%20',
+    probeSegment: 'zz%20a',
+    sent: false,
+  },
+  {
+    name: 'a percent-encoded space matches a percent-encoded space',
+    pathSegment: 'zz%20a',
+    probeSegment: 'zz%20a',
+    sent: true,
+  },
+
+  // A non-ASCII byte cannot be a URL path segment, so the cookie fails to parse
+  // and is reachable nowhere: neither at the percent-encoding of the byte, nor at
+  // the percent-encoding of its isomorphic decoding.
+  {
+    name: 'a non-ASCII byte is not reachable at the percent-encoding of that byte',
+    pathSegment: 'zzZZ',
+    raw: '%B8',
+    probeSegment: 'zz%B8',
+    sent: false,
+  },
+  {
+    name: 'a non-ASCII byte is not reachable at the percent-encoding of its isomorphic decoding',
+    pathSegment: 'zzZZ',
+    raw: '%B8',
+    probeSegment: 'zz%C2%B8',
+    sent: false,
+  },
+  {
+    name: 'a multi-byte non-ASCII sequence is not reachable at the percent-encoding of those bytes',
+    pathSegment: 'zzZZ',
+    raw: '%E4%B8%AD',
+    probeSegment: 'zz%E4%B8%AD',
+    sent: false,
+  },
+  {
+    name: 'a multi-byte non-ASCII sequence is not reachable at the percent-encoding of its isomorphic decoding',
+    pathSegment: 'zzZZ',
+    raw: '%E4%B8%AD',
+    probeSegment: 'zz%C3%A4%C2%B8%C2%AD',
+    sent: false,
+  },
+  {
+    name: 'an already percent-encoded non-ASCII byte matches, being ASCII itself',
+    pathSegment: 'zz%C2%B8',
+    probeSegment: 'zz%C2%B8',
+    sent: true,
+  },
+];
+
+for (const testCase of CASES) {
+  cookieTest(`A Path attribute where ${testCase.name}`, async t => {
+    await setCookieViaHTTP(
+        `t=1; Path=${SCOPE}${testCase.pathSegment}`, testCase.raw);
+    const result = await probeAtPath(`${SCOPE}${testCase.probeSegment}/probe.html`);
+    assert_equals(result.cookie, testCase.sent ? 't=1' : '');
+  });
+}
+
+promise_test(async t => {
+  await registration.unregister();
+}, 'cleanup: unregister the service worker');

--- a/cookies/path/match-percent-encoded.https.window.js
+++ b/cookies/path/match-percent-encoded.https.window.js
@@ -13,7 +13,7 @@
 //
 // https://github.com/whatwg/url/issues/814
 
-const SCOPE = '/cookies/path/resources/probe/';
+const PROBE_DIR = '/cookies/path/resources/probe';
 const NAME_PREFIX = 'match-percent-encoded-';
 
 // Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
@@ -62,7 +62,7 @@ let registration;
 
 promise_setup(async () => {
   registration = await navigator.serviceWorker.register(
-      'resources/probe/sw.js', {scope: SCOPE});
+      'resources/probe/sw.js', {scope: `${PROBE_DIR}/`});
   // navigator.serviceWorker.ready is not usable here: it waits for a worker
   // controlling this document, and this document is outside the scope the probe
   // paths need. Wait on the registration's own worker instead.
@@ -85,9 +85,9 @@ function cookieTest(description, {suffix, pathSegment, raw}, body) {
   const name = NAME_PREFIX + suffix;
   promise_test(async t => {
     t.add_cleanup(() => setCookieViaHTTP(
-        `${name}=; Max-Age=0; Path=${SCOPE}${pathSegment}`, raw));
+        `${name}=; Max-Age=0; Path=${PROBE_DIR}/${pathSegment}`, raw));
 
-    await setCookieViaHTTP(`${name}=1; Path=${SCOPE}${pathSegment}`, raw);
+    await setCookieViaHTTP(`${name}=1; Path=${PROBE_DIR}/${pathSegment}`, raw);
     await body(t, name);
   }, description);
 }
@@ -97,15 +97,15 @@ function cookieTest(description, {suffix, pathSegment, raw}, body) {
 // claims to.
 cookieTest('CONTROL a cookie for the probed path is visible in it',
            {suffix: 'control', pathSegment: 'zzx'}, async (t, name) => {
-  const result = await probeAtPath(`${SCOPE}zzx/probe.html`);
-  assert_equals(result.path, `${SCOPE}zzx/probe.html`,
+  const result = await probeAtPath(`${PROBE_DIR}/zzx/probe.html`);
+  assert_equals(result.path, `${PROBE_DIR}/zzx/probe.html`,
                 'The document was synthesized at the probed path');
   assert_equals(cookieValue(result.cookie, name), '1');
 });
 
 cookieTest('CONTROL a cookie for a prefix of the probed path is visible in it',
            {suffix: 'prefix', pathSegment: ''}, async (t, name) => {
-  const result = await probeAtPath(`${SCOPE}zzx/probe.html`);
+  const result = await probeAtPath(`${PROBE_DIR}/zzx/probe.html`);
   assert_equals(cookieValue(result.cookie, name), '1');
 });
 
@@ -174,7 +174,7 @@ for (const [index, testCase] of CASES.entries()) {
               raw: testCase.raw},
              async (t, name) => {
     const result =
-        await probeAtPath(`${SCOPE}${testCase.probeSegment}/probe.html`);
+        await probeAtPath(`${PROBE_DIR}/${testCase.probeSegment}/probe.html`);
     assert_equals(cookieValue(result.cookie, name), testCase.sent ? '1' : null);
   });
 }

--- a/cookies/path/match-segment-boundaries.https.window.js
+++ b/cookies/path/match-segment-boundaries.https.window.js
@@ -1,0 +1,86 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: title=Cookie Path attribute matching only at path segment boundaries
+
+'use strict';
+
+// A cookie is only sent when its path is the request URL's path, or a prefix of
+// it that ends at a path segment boundary. In particular a cookie path that is
+// longer than the request URL's path never matches, even when the request URL's
+// path is a prefix of it.
+//
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#store-a-cookie
+
+const DIR = '/cookies/path/resources';
+const TARGET = `${DIR}/echo.py`;
+
+async function setCookieViaHTTP(cookie) {
+  const set = encodeURIComponent(JSON.stringify([cookie]));
+  const response = await fetch(`/cookies/resources/cookie.py?set=${set}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// The Cookie header the server receives for a request to TARGET.
+async function cookieHeaderAtTarget() {
+  const response = await fetch(TARGET, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the Cookie header succeeded');
+  return (await response.text()).trim();
+}
+
+// Each test uses a cookie name of its own and clears the whole jar, so a cookie
+// stored under an unexpected path cannot leak into the next test.
+function pathTest({name, cookieName, path, expected}) {
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+    t.add_cleanup(test_driver.delete_all_cookies);
+
+    await setCookieViaHTTP(`${cookieName}=1; Path=${path}`);
+    assert_equals(await cookieHeaderAtTarget(), expected);
+  }, name);
+}
+
+pathTest({
+  name: 'A Path equal to the request path matches',
+  cookieName: 'exact',
+  path: TARGET,
+  expected: 'exact=1',
+});
+
+pathTest({
+  name: 'A Path that is a prefix ending at a segment boundary matches',
+  cookieName: 'prefix',
+  path: DIR,
+  expected: 'prefix=1',
+});
+
+pathTest({
+  name: 'A Path that is a prefix ending in a slash matches',
+  cookieName: 'trailingslash',
+  path: `${DIR}/`,
+  expected: 'trailingslash=1',
+});
+
+// The request path continues with ".py" rather than a "/", so the cookie path is
+// not a prefix ending at a segment boundary.
+pathTest({
+  name: 'A Path that is a prefix not ending at a segment boundary does not match',
+  cookieName: 'midsegment',
+  path: `${DIR}/echo`,
+  expected: '',
+});
+
+// The request path is a prefix of the cookie path rather than the other way
+// around. A cookie path longer than the request path can never match.
+pathTest({
+  name: 'A Path that is the request path followed by a slash does not match',
+  cookieName: 'longerslash',
+  path: `${TARGET}/`,
+  expected: '',
+});
+
+pathTest({
+  name: 'A Path that is the request path followed by a segment does not match',
+  cookieName: 'longersegment',
+  path: `${TARGET}/sub`,
+  expected: '',
+});

--- a/cookies/path/match-segment-boundaries.https.window.js
+++ b/cookies/path/match-segment-boundaries.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testdriver.js
-// META: script=/resources/testdriver-vendor.js
 // META: title=Cookie Path attribute matching only at path segment boundaries
 
 'use strict';
@@ -13,6 +11,7 @@
 
 const DIR = '/cookies/path/resources';
 const TARGET = `${DIR}/echo.py`;
+const NAME_PREFIX = 'segment-boundaries-';
 
 async function setCookieViaHTTP(cookie) {
   const set = encodeURIComponent(JSON.stringify([cookie]));
@@ -27,60 +26,72 @@ async function cookieHeaderAtTarget() {
   return (await response.text()).trim();
 }
 
-// Each test uses a cookie name of its own and clears the whole jar, so a cookie
-// stored under an unexpected path cannot leak into the next test.
-function pathTest({name, cookieName, path, expected}) {
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// Sets the cookie under test, then expires it again through the same Path, which
+// is what removes it.
+function pathTest({name, suffix, path, sent}) {
+  const cookieName = NAME_PREFIX + suffix;
   promise_test(async t => {
-    await test_driver.delete_all_cookies();
-    t.add_cleanup(test_driver.delete_all_cookies);
+    t.add_cleanup(
+        () => setCookieViaHTTP(`${cookieName}=; Path=${path}; Max-Age=0`));
 
     await setCookieViaHTTP(`${cookieName}=1; Path=${path}`);
-    assert_equals(await cookieHeaderAtTarget(), expected);
+    assert_equals(cookieValue(await cookieHeaderAtTarget(), cookieName),
+                  sent ? '1' : null);
   }, name);
 }
 
 pathTest({
   name: 'A Path equal to the request path matches',
-  cookieName: 'exact',
+  suffix: 'exact',
   path: TARGET,
-  expected: 'exact=1',
+  sent: true,
 });
 
 pathTest({
   name: 'A Path that is a prefix ending at a segment boundary matches',
-  cookieName: 'prefix',
+  suffix: 'prefix',
   path: DIR,
-  expected: 'prefix=1',
+  sent: true,
 });
 
 pathTest({
   name: 'A Path that is a prefix ending in a slash matches',
-  cookieName: 'trailingslash',
+  suffix: 'trailingslash',
   path: `${DIR}/`,
-  expected: 'trailingslash=1',
+  sent: true,
 });
 
 // The request path continues with ".py" rather than a "/", so the cookie path is
 // not a prefix ending at a segment boundary.
 pathTest({
   name: 'A Path that is a prefix not ending at a segment boundary does not match',
-  cookieName: 'midsegment',
+  suffix: 'midsegment',
   path: `${DIR}/echo`,
-  expected: '',
+  sent: false,
 });
 
 // The request path is a prefix of the cookie path rather than the other way
 // around. A cookie path longer than the request path can never match.
 pathTest({
   name: 'A Path that is the request path followed by a slash does not match',
-  cookieName: 'longerslash',
+  suffix: 'longerslash',
   path: `${TARGET}/`,
-  expected: '',
+  sent: false,
 });
 
 pathTest({
   name: 'A Path that is the request path followed by a segment does not match',
-  cookieName: 'longersegment',
+  suffix: 'longersegment',
   path: `${TARGET}/sub`,
-  expected: '',
+  sent: false,
 });

--- a/cookies/path/non-ascii-path-attribute.https.window.js
+++ b/cookies/path/non-ascii-path-attribute.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testdriver.js
-// META: script=/resources/testdriver-vendor.js
 // META: title=A non-ASCII byte in the winning Path attribute makes the cookie fail to parse
 
 'use strict';
@@ -16,6 +14,7 @@ const DIR = '/cookies/path/resources';
 const TARGET = `${DIR}/echo.py`;
 // The default path for a cookie set through /cookies/resources/cookie.py.
 const DEFAULT_PATH_TARGET = '/cookies/resources/list.py';
+const NAME_PREFIX = 'non-ascii-path-';
 
 // Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
 // as percent-escapes. wptserve percent-decodes the query into bytes and
@@ -30,73 +29,97 @@ async function setCookieViaHTTP(cookie, rawEscape) {
   assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
 }
 
-// The Cookie header the server receives for a request to `url`.
-async function cookieHeaderAt(url) {
-  const response = await fetch(url, {credentials: 'include'});
-  assert_true(response.ok, 'Reading the cookies succeeded');
-  return (await response.text()).trim();
+// The value of `name` in the Cookie header the server receives for a request to
+// TARGET, or null if it is not there.
+async function cookieValueAtTarget(name) {
+  const response = await fetch(TARGET, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the Cookie header succeeded');
+  for (const pair of (await response.text()).trim().split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
 }
 
-function cookieTest(name, body) {
+// The same for a request to the default path, which answers with JSON.
+async function cookieValueAtDefaultPath(name) {
+  const response = await fetch(DEFAULT_PATH_TARGET, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the cookies succeeded');
+  const cookies = await response.json();
+  return name in cookies ? cookies[name] : null;
+}
+
+// Cookies are expired through every Path they could have been stored under,
+// since only a matching Path removes them.
+function cookieTest(description, suffix, paths, body) {
+  const name = NAME_PREFIX + suffix;
   promise_test(async t => {
-    await test_driver.delete_all_cookies();
-    t.add_cleanup(test_driver.delete_all_cookies);
-    await body(t);
-  }, name);
+    for (const path of paths) {
+      t.add_cleanup(
+          () => setCookieViaHTTP(`${name}=; Path=${path}; Max-Age=0`));
+    }
+    await body(t, name);
+  }, description);
 }
 
 // Control: a later Path attribute overrides an earlier one, which the tests
 // below depend on.
-cookieTest('A later Path attribute overrides an earlier one', async t => {
-  await setCookieViaHTTP(`later=1; Path=${DIR}/nomatch; Path=${DIR}`);
-  assert_equals(await cookieHeaderAt(TARGET), 'later=1');
+cookieTest('A later Path attribute overrides an earlier one', 'later',
+           [DIR, `${DIR}/nomatch`], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/nomatch; Path=${DIR}`);
+  assert_equals(await cookieValueAtTarget(name), '1');
 });
 
 // Control: a non-ASCII byte outside the Path attribute is not a parse failure,
 // so it is specifically the path that cannot hold one.
-cookieTest('A non-ASCII byte in the value is not a parse failure', async t => {
-  await setCookieViaHTTP(`value=ZZ; Path=${DIR}`, '%E4%B8%AD');
-  assert_true((await cookieHeaderAt(TARGET)).startsWith('value='),
-              'The cookie was stored and sent');
+cookieTest('A non-ASCII byte in the value is not a parse failure', 'value',
+           [DIR], async (t, name) => {
+  await setCookieViaHTTP(`${name}=ZZ; Path=${DIR}`, '%E4%B8%AD');
+  assert_not_equals(await cookieValueAtTarget(name), null,
+                    'The cookie was stored and sent');
 });
 
 // A non-ASCII byte in a Path attribute that loses to a later one does not matter,
 // because only the winning Path attribute is validated.
 cookieTest('A non-ASCII Path attribute followed by a valid one is not a parse failure',
-           async t => {
-  await setCookieViaHTTP(`losing=1; Path=${DIR}/zzZZ; Path=${DIR}`, '%E4%B8%AD');
-  assert_equals(await cookieHeaderAt(TARGET), 'losing=1');
+           'losing', [DIR], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/zzZZ; Path=${DIR}`,
+                         '%E4%B8%AD');
+  assert_equals(await cookieValueAtTarget(name), '1');
 });
 
 // When the non-ASCII Path attribute is the one that wins, the cookie fails to
 // parse and nothing is stored.
 cookieTest('A non-ASCII byte in the winning Path attribute is a parse failure',
-           async t => {
-  await setCookieViaHTTP(`winning=1; Path=${DIR}; Path=${DIR}/zzZZ`, '%E4%B8%AD');
-  assert_equals(await cookieHeaderAt(TARGET), '');
+           'winning', [DIR], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}; Path=${DIR}/zzZZ`,
+                         '%E4%B8%AD');
+  assert_equals(await cookieValueAtTarget(name), null);
 });
 
 // The cookie must not be sent for a path the non-ASCII bytes were appended to.
 // A user agent that truncated the Path at the first non-ASCII byte, or dropped
 // the attribute so that the path became "/", would send it here.
 cookieTest('A Path attribute with non-ASCII bytes appended does not match that path',
-           async t => {
-  await setCookieViaHTTP(`appended=1; Path=${DIR}ZZ`, '%E4%B8%AD');
-  assert_equals(await cookieHeaderAt(TARGET), '');
+           'appended', [DIR, '/'], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}ZZ`, '%E4%B8%AD');
+  assert_equals(await cookieValueAtTarget(name), null);
 });
 
 // Nor may it fall back to the default path, which is what an ignored Path
 // attribute would produce.
 cookieTest('A non-ASCII Path attribute does not fall back to the default path',
-           async t => {
-  await setCookieViaHTTP(`fallback=1; Path=${DIR}/zzZZ`, '%E4%B8%AD');
-  assert_equals(await cookieHeaderAt(DEFAULT_PATH_TARGET), '{}');
+           'fallback', ['/cookies/resources'], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/zzZZ`, '%E4%B8%AD');
+  assert_equals(await cookieValueAtDefaultPath(name), null);
 });
 
 // A lone non-ASCII byte is not valid UTF-8 on its own, and is equally rejected.
 cookieTest('A lone non-ASCII byte in the winning Path attribute is a parse failure',
-           async t => {
-  await setCookieViaHTTP(`lone=1; Path=${DIR}/zzZZ`, '%B8');
-  assert_equals(await cookieHeaderAt(TARGET), '');
-  assert_equals(await cookieHeaderAt(DEFAULT_PATH_TARGET), '{}');
+           'lone', [DIR, '/cookies/resources'], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/zzZZ`, '%B8');
+  assert_equals(await cookieValueAtTarget(name), null);
+  assert_equals(await cookieValueAtDefaultPath(name), null);
 });

--- a/cookies/path/non-ascii-path-attribute.https.window.js
+++ b/cookies/path/non-ascii-path-attribute.https.window.js
@@ -1,0 +1,102 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: title=A non-ASCII byte in the winning Path attribute makes the cookie fail to parse
+
+'use strict';
+
+// A cookie's path is a URL path, whose segments are ASCII strings, so a Path
+// attribute holding a non-ASCII byte cannot be represented and the cookie fails
+// to parse. The check applies to the Path attribute that wins, not to every Path
+// attribute seen, matching how the rest of a cookie is validated once parsing
+// has settled on its final values.
+//
+// https://github.com/whatwg/url/issues/814
+
+const DIR = '/cookies/path/resources';
+const TARGET = `${DIR}/echo.py`;
+// The default path for a cookie set through /cookies/resources/cookie.py.
+const DEFAULT_PATH_TARGET = '/cookies/resources/list.py';
+
+// Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
+// as percent-escapes. wptserve percent-decodes the query into bytes and
+// cookie.py passes those bytes to the header unchanged, which is how a raw
+// non-ASCII byte reaches the Path attribute.
+async function setCookieViaHTTP(cookie, rawEscape) {
+  let query = encodeURIComponent(JSON.stringify([cookie]));
+  if (rawEscape !== undefined) {
+    query = query.replace('ZZ', rawEscape);
+  }
+  const response = await fetch(`/cookies/resources/cookie.py?set=${query}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// The Cookie header the server receives for a request to `url`.
+async function cookieHeaderAt(url) {
+  const response = await fetch(url, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the cookies succeeded');
+  return (await response.text()).trim();
+}
+
+function cookieTest(name, body) {
+  promise_test(async t => {
+    await test_driver.delete_all_cookies();
+    t.add_cleanup(test_driver.delete_all_cookies);
+    await body(t);
+  }, name);
+}
+
+// Control: a later Path attribute overrides an earlier one, which the tests
+// below depend on.
+cookieTest('A later Path attribute overrides an earlier one', async t => {
+  await setCookieViaHTTP(`later=1; Path=${DIR}/nomatch; Path=${DIR}`);
+  assert_equals(await cookieHeaderAt(TARGET), 'later=1');
+});
+
+// Control: a non-ASCII byte outside the Path attribute is not a parse failure,
+// so it is specifically the path that cannot hold one.
+cookieTest('A non-ASCII byte in the value is not a parse failure', async t => {
+  await setCookieViaHTTP(`value=ZZ; Path=${DIR}`, '%E4%B8%AD');
+  assert_true((await cookieHeaderAt(TARGET)).startsWith('value='),
+              'The cookie was stored and sent');
+});
+
+// A non-ASCII byte in a Path attribute that loses to a later one does not matter,
+// because only the winning Path attribute is validated.
+cookieTest('A non-ASCII Path attribute followed by a valid one is not a parse failure',
+           async t => {
+  await setCookieViaHTTP(`losing=1; Path=${DIR}/zzZZ; Path=${DIR}`, '%E4%B8%AD');
+  assert_equals(await cookieHeaderAt(TARGET), 'losing=1');
+});
+
+// When the non-ASCII Path attribute is the one that wins, the cookie fails to
+// parse and nothing is stored.
+cookieTest('A non-ASCII byte in the winning Path attribute is a parse failure',
+           async t => {
+  await setCookieViaHTTP(`winning=1; Path=${DIR}; Path=${DIR}/zzZZ`, '%E4%B8%AD');
+  assert_equals(await cookieHeaderAt(TARGET), '');
+});
+
+// The cookie must not be sent for a path the non-ASCII bytes were appended to.
+// A user agent that truncated the Path at the first non-ASCII byte, or dropped
+// the attribute so that the path became "/", would send it here.
+cookieTest('A Path attribute with non-ASCII bytes appended does not match that path',
+           async t => {
+  await setCookieViaHTTP(`appended=1; Path=${DIR}ZZ`, '%E4%B8%AD');
+  assert_equals(await cookieHeaderAt(TARGET), '');
+});
+
+// Nor may it fall back to the default path, which is what an ignored Path
+// attribute would produce.
+cookieTest('A non-ASCII Path attribute does not fall back to the default path',
+           async t => {
+  await setCookieViaHTTP(`fallback=1; Path=${DIR}/zzZZ`, '%E4%B8%AD');
+  assert_equals(await cookieHeaderAt(DEFAULT_PATH_TARGET), '{}');
+});
+
+// A lone non-ASCII byte is not valid UTF-8 on its own, and is equally rejected.
+cookieTest('A lone non-ASCII byte in the winning Path attribute is a parse failure',
+           async t => {
+  await setCookieViaHTTP(`lone=1; Path=${DIR}/zzZZ`, '%B8');
+  assert_equals(await cookieHeaderAt(TARGET), '');
+  assert_equals(await cookieHeaderAt(DEFAULT_PATH_TARGET), '{}');
+});

--- a/cookies/path/resources/echo.py
+++ b/cookies/path/resources/echo.py
@@ -1,0 +1,5 @@
+def main(request, response):
+    headers = [(b"Content-Type", b"text/plain"),
+               (b"Cache-Control", b"no-store"),
+               (b"Access-Control-Allow-Origin", b"*")]
+    return headers, request.headers.get(b"cookie", b"")

--- a/cookies/path/resources/probe/sw.js
+++ b/cookies/path/resources/probe/sw.js
@@ -1,0 +1,22 @@
+// Synthesizes a document at any path under this scope ending in "/probe.html",
+// so that a test can observe which cookies match a path that has no
+// corresponding file. Anything else is left to the network.
+//
+// Note a service worker cannot inspect the Cookie header of a request, as it is
+// a forbidden header name and cookies are attached after the fetch event, so the
+// synthesized document reads document.cookie instead.
+self.addEventListener('install', event => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', event => event.waitUntil(self.clients.claim()));
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (!url.pathname.endsWith('/probe.html')) {
+    return;
+  }
+  event.respondWith(new Response(
+      `<!doctype html><meta charset=utf-8><script>
+         parent.postMessage(
+             {path: location.pathname, cookie: document.cookie}, "*");
+       </script>`,
+      {headers: {'Content-Type': 'text/html; charset=utf-8'}}));
+});


### PR DESCRIPTION
A cookie's path is compared against the request URL's path, which is
percent-encoded, and matches only at a path segment boundary.

match-percent-encoded: a byte written literally in a Path attribute does not
match its percent-encoded form in a URL path, and a non-ASCII byte, which makes
the cookie fail to parse, is not reachable at any encoding of it. A service
worker synthesizes a document at whichever path is probed, so paths with no file
behind them can be observed without adding specially named files to the tree.

match-segment-boundaries: a cookie path longer than the request path never
matches, including when it is the request path followed by a slash.

non-ascii-path-attribute: the non-ASCII check applies to the Path attribute that
wins, not to every one seen, matching how the rest of a cookie is validated once
parsing has settled, and such a cookie does not fall back to the default path.

See https://github.com/whatwg/url/issues/814.