### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=322178

### DIFF
--- a/svg/linking/reftests/svgview-and-xywh-ref.html
+++ b/svg/linking/reftests/svgview-and-xywh-ref.html
@@ -8,7 +8,7 @@
   .ref {
     width: 200px;
     height: 200px;
-    background-image: url("sprite4.svg");
+    background-image: url("support/squares.svg");
     background-size: 100% 100%;
     background-repeat: no-repeat;
   }

--- a/svg/linking/reftests/svgview-and-xywh.html
+++ b/svg/linking/reftests/svgview-and-xywh.html
@@ -12,7 +12,7 @@
   .test {
     width: 200px;
     height: 200px;
-    background-image: url("sprite4.svg#svgView(viewBox(0,0,100,100))&xywh=100,0,100,100");
+    background-image: url("support/squares.svg#svgView(viewBox(0,0,100,100))&xywh=100,0,100,100");
     background-size: 100% 100%;
     background-repeat: no-repeat;
   }

--- a/svg/linking/reftests/svgview-attribute-order.html
+++ b/svg/linking/reftests/svgview-attribute-order.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: svgView() attributes may appear in any order</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-teal-100x50-ref.html">
+<meta name="assert" content="The types of SVGViewAttribute may occur in any order, so preserveAspectRatio() before viewBox() must render identically to viewBox() before preserveAspectRatio().">
+
+<!--
+support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  Same fragment as svgview-preserveaspectratio.html with the two attributes swapped,
+  and the same reference. If an implementation required a fixed order, one of the two
+  would fail while the other passed.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(preserveAspectRatio(none);viewBox(100,0,100,100))" width="100" height="50" alt="">

--- a/svg/linking/reftests/svgview-escaped-semicolon.html
+++ b/svg/linking/reftests/svgview-escaped-semicolon.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: a semicolon in svgView() may be percent-encoded</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-teal-100x50-ref.html">
+<meta name="assert" content="Fragment identifiers may be url-escaped, and a semicolon separating svgView() attributes may therefore be written %3B. The escaped form must render identically to the literal semicolon.">
+
+<!--
+support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  Same fragment as svgview-preserveaspectratio.html with the separating semicolon
+  written %3B, and the same reference. The specification calls this form out
+  explicitly, because an unescaped semicolon would otherwise be read as a list
+  separator in a context such as an animated list of URLs.
+
+  FIXME: this file covers the escaping mechanism, not the situation that motivates
+  it. In an img src there is no list separator, so an unescaped semicolon works here
+  too and this test would pass either way. The case the specification describes is a
+  semicolon-separated list of URLs being animated, where the list is split on the
+  semicolon before the fragment is ever parsed: only %3B survives that split. No
+  test anywhere exercises it, and a search of this suite for a values attribute
+  containing a URL returns nothing.
+
+  Writing it needs a deliberate design rather than an extension of this file,
+  because animation timing makes a reftest unreliable: the animation should be
+  driven to a fixed point with setCurrentTime from script instead of relying on
+  wall-clock progress. Sketch: an SVG image element whose href is animated with
+  values holding one URL that contains an escaped semicolon inside svgView(), the
+  document time set past the animation's start, and the reference being the view
+  that URL names. If the semicolon were unescaped the list would split into two
+  malformed URLs and neither view would be selected.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(100,0,100,100)%3BpreserveAspectRatio(none))" width="100" height="50" alt="">

--- a/svg/linking/reftests/svgview-img-element-ref.html
+++ b/svg/linking/reftests/svgview-img-element-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Reference: the top-right quadrant of support/squares.svg, 100x100</title>
+
+<!--
+  A flat block of the top-right quadrant's colour, #2a9d8f. The test scales that
+  quadrant into a 100x100 img with matching aspect ratio, so the result is this
+  colour edge to edge and the comparison does not depend on scaling quality.
+-->
+
+<style>
+  body { margin: 0; }
+  div { width: 100px; height: 100px; background-color: #2a9d8f; }
+</style>
+
+<div></div>

--- a/svg/linking/reftests/svgview-img-element.html
+++ b/svg/linking/reftests/svgview-img-element.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: svgView() applies to an img element</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-img-element-ref.html">
+<meta name="assert" content="An svgView(viewBox(...)) fragment on the src of an img element selects that view of the referenced SVG. support/squares.svg is a 200x200 sprite of four coloured quadrants; viewBox(100,0,100,100) selects the top-right one, so the 100x100 img must be filled by that quadrant's colour alone.">
+
+<!--
+  The reference is a solid block of the top-right quadrant's colour, so the test
+  fails visibly if the fragment is ignored: the whole four-quadrant sprite would
+  be drawn instead, and three of the four colours would be wrong.
+
+  The img is 100x100 and the selected view is 100x100, so the aspect ratios match
+  and the default preserveAspectRatio of xMidYMid meet scales the view to fill the
+  element exactly. No letterboxing, so the comparison is a flat colour and does
+  not depend on scaling quality.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(100,0,100,100))" width="100" height="100" alt="">

--- a/svg/linking/reftests/svgview-preserveaspectratio-meet-ref.html
+++ b/svg/linking/reftests/svgview-preserveaspectratio-meet-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Reference: a fitted square view in a 2:1 box, with the neighbour visible</title>
+
+<!--
+  Three bands across 100x50, built with CSS so no SVG is involved on this side:
+
+      x  0 to 25    #d46847 terracotta, user space left of the view
+      x 25 to 75    #2a9d8f teal, the selected quadrant
+      x 75 to 100   nothing, past the edge of the referenced document
+-->
+
+<style>
+  body { margin: 0; }
+  .box { position: relative; width: 100px; height: 50px; }
+  .box i { position: absolute; top: 0; height: 50px; display: block; }
+  .left { left: 0; width: 25px; background-color: #d46847; }
+  .view { left: 25px; width: 50px; background-color: #2a9d8f; }
+</style>
+
+<div class="box"><i class="left"></i><i class="view"></i></div>

--- a/svg/linking/reftests/svgview-preserveaspectratio-meet.html
+++ b/svg/linking/reftests/svgview-preserveaspectratio-meet.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: preserveAspectRatio(meet) inside svgView()</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute">
+<link rel="match" href="svgview-preserveaspectratio-meet-ref.html">
+<meta name="assert" content="AspectParams in an svgView() specification are the parameter values of the preserveAspectRatio attribute. With xMidYMid meet a square view is scaled to fit a 2:1 box and centred, occupying the middle half. viewBox is a transform rather than a clip, and the outermost svg viewport is not clipped to it, so user space to the left of the selected quadrant remains visible in the left-hand quarter of the box.">
+
+<!--
+  support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  viewBox(100,0,100,100) selects the teal quadrant. The img is 100x50, so with
+  xMidYMid meet the scale is min(100/100, 50/100) = 0.5 and the 100x100 view lands
+  as a 50x50 area centred horizontally, at x=25 to 75.
+
+  What fills the rest of the box is the point of pairing this with
+  svgview-preserveaspectratio.html, which asserts the stretched case. viewBox is a
+  transform, not a clip, and the user agent style sheet applies overflow: hidden to
+  nested viewports only, not to the outermost svg. So user space outside the view
+  still paints wherever it lands inside the viewport:
+
+      x  0 to 25    user x 50 to 100, the right half of the terracotta quadrant
+      x 25 to 75    the selected teal quadrant
+      x 75 to 100   user x 200 onwards, past the edge of the document, so nothing
+
+  A test that asserted only the stretched case would pass in an implementation that
+  ignored AspectParams entirely and always filled the box, which is why this
+  companion exists.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(100,0,100,100);preserveAspectRatio(xMidYMid meet))" width="100" height="50" alt="">

--- a/svg/linking/reftests/svgview-preserveaspectratio.html
+++ b/svg/linking/reftests/svgview-preserveaspectratio.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: preserveAspectRatio() inside svgView()</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-teal-100x50-ref.html">
+<meta name="assert" content="AspectParams in an svgView() specification are the parameter values of the preserveAspectRatio attribute. With preserveAspectRatio(none) a 1:1 view is stretched to fill a 2:1 box, so the box is filled edge to edge by the selected quadrant.">
+
+<!--
+support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  viewBox(100,0,100,100) selects the teal quadrant, which is square, and the img is
+  2:1. Without preserveAspectRatio(none) the view would be letterboxed, so a flat
+  colour across the whole box is only possible if the second attribute took effect.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(100,0,100,100);preserveAspectRatio(none))" width="100" height="50" alt="">

--- a/svg/linking/reftests/svgview-spaces-around-semicolon.html
+++ b/svg/linking/reftests/svgview-spaces-around-semicolon.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: spaces are allowed around an svgView() attribute separator</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-teal-100x50-ref.html">
+<meta name="assert" content="SVG 2 states that spaces are allowed in fragment specifications, and that semicolons separate svgView() attributes. A space either side of that semicolon must therefore be permitted, so svgView(viewBox(100,0,100,100) ; preserveAspectRatio(none)) must select the top-right quadrant of support/squares.svg and stretch it to fill the 2:1 img.">
+
+<!--
+  support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  Companion to svgview-spaces.html, which puts the space immediately inside the
+  svgView parentheses. This one varies only the space around the semicolon.
+
+  The img is 2:1 and the selected view is square, so preserveAspectRatio(none) is
+  what fills the box edge to edge, and the reference is a flat block of the
+  quadrant's colour. Two distinguishable failure modes, which is the reason for
+  choosing this geometry:
+
+    the whole specification is discarded  -> all four quadrants appear
+    only the semicolon-separated second attribute is lost -> the quadrant appears
+                                             but is letterboxed rather than stretched
+
+  Both differ from the reference, so either failure is caught, and the rendering
+  says which one happened.
+
+  The specification's own example of a multi-attribute specification is
+  #svgView(viewBox(0,0,200,200);preserveAspectRatio(none)), written without
+  spaces. The sentence permitting spaces is general and does not exclude this
+  position.
+
+  A literal space in a fragment is percent-encoded to %20 when the URL is
+  serialised, so an implementation failing this test may be rejecting the space or
+  may never decode %20. Comparing against the same fragment written with explicit
+  %20 separates those two causes.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(100,0,100,100) ; preserveAspectRatio(none))" width="100" height="50" alt="">

--- a/svg/linking/reftests/svgview-spaces.html
+++ b/svg/linking/reftests/svgview-spaces.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: spaces are allowed in an svgView() specification</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-img-element-ref.html">
+<meta name="assert" content="SVG 2 states that spaces are allowed in fragment specifications. A space immediately inside the svgView parentheses must therefore be permitted, and svgView( viewBox(100,0,100,100) ) must select the same view as the same specification written without those spaces, filling the img with the top-right quadrant of support/squares.svg.">
+
+<!--
+  support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  viewBox(100,0,100,100) selects the teal quadrant. The img is 100x100 and the
+  view is square, so the quadrant fills the element and the reference is a flat
+  block of that colour. A rendering showing all four quadrants means the whole
+  specification was discarded.
+
+  The relevant sentence is in the definition of an SVG fragment identifier:
+
+      Spaces are allowed in fragment specifications. Commas are used to separate
+      numeric values within an SVG view specification (e.g.,
+      #svgView(viewBox(0,0,200,200))) and semicolons are used to separate
+      attributes.
+
+  This test varies one thing only: a space immediately inside the svgView
+  parentheses. Spaces between the numeric parameters are deliberately NOT used
+  here, because those are parsed by the viewBox attribute parser rather than by the
+  fragment grammar and are already handled; mixing the two would make a failure
+  ambiguous about which space caused it.
+
+  A note for anyone triaging this. A literal space in a fragment is percent-encoded
+  to %20 when the URL is serialised, so an implementation that fails this test may
+  be rejecting the space character or may simply never decode %20. Those have
+  different causes and the same appearance. Writing the same fragment with explicit
+  %20 sequences and comparing the two results separates them.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView( viewBox(100,0,100,100) )" width="100" height="100" alt="">

--- a/svg/linking/reftests/svgview-teal-100x50-ref.html
+++ b/svg/linking/reftests/svgview-teal-100x50-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Reference: a solid 100x50 block of #2a9d8f</title>
+
+<!-- The top-right quadrant of support/squares.svg stretched into a 2:1 box. Shared by the
+     preserveAspectRatio, attribute-order and escaped-semicolon tests, which must all
+     produce the same rendering by different routes. -->
+
+<style>
+  body { margin: 0; }
+  div { width: 100px; height: 50px; background-color: #2a9d8f; }
+</style>
+
+<div></div>

--- a/svg/linking/reftests/svgview-terracotta-100x100-ref.html
+++ b/svg/linking/reftests/svgview-terracotta-100x100-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Reference: a solid 100x100 block of #d46847</title>
+
+<!-- The top-left quadrant of support/squares.svg filling the box. Shared by the two
+     transform() tests. -->
+
+<style>
+  body { margin: 0; }
+  div { width: 100px; height: 100px; background-color: #d46847; }
+</style>
+
+<div></div>

--- a/svg/linking/reftests/svgview-timesegment.html
+++ b/svg/linking/reftests/svgview-timesegment.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: svgView() may be followed by a time segment</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-img-element-ref.html">
+<meta name="assert" content="The grammar permits an SVGViewSpec followed by an ampersand and a time segment, so svgView(viewBox(...))&t=0 must apply the view. The document has no animation, so the time segment changes nothing visible and only the view is observable.">
+
+<!--
+support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  The reference is the plain 100x100 teal block also used by svgview-img-element.html,
+  because the view selected here is the same one; only the trailing &t=0 differs.
+  A whole-sprite rendering would mean the combined fragment was rejected.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(100,0,100,100))&t=0" width="100" height="100" alt="">

--- a/svg/linking/reftests/svgview-transform.html
+++ b/svg/linking/reftests/svgview-transform.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: transform() inside svgView()</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-terracotta-100x100-ref.html">
+<meta name="assert" content="TransformParams in an svgView() specification are the parameter values of the transform property. scale(2) doubles the view, so with the authored viewBox of 0 0 200 200 only the top-left quadrant remains inside the viewport and fills it.">
+
+<!--
+support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  No viewBox() in the fragment, so the root viewBox of 0 0 200 200 still applies and
+  scale(2) is the only change. The terracotta quadrant occupies 0,0 to 100,100, which
+  after doubling covers the whole viewport. A four-colour rendering means transform()
+  was ignored.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(transform(scale(2)))" width="100" height="100" alt="">

--- a/svg/linking/reftests/svgview-viewbox-then-transform.html
+++ b/svg/linking/reftests/svgview-viewbox-then-transform.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG fragment identifier: svgView() applies viewBox() before transform()</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">
+<link rel="match" href="svgview-terracotta-100x100-ref.html">
+<meta name="assert" content="SVG view box parameters are applied in order: the view is established by ViewBoxParams and then transformed by TransformParams. Restating the authored viewBox and then scaling by 2 must therefore give the same result as scaling alone.">
+
+<!--
+support/squares.svg is 200x200 with four solid quadrants:
+
+        #d46847 terracotta | #2a9d8f teal
+        #264653 indigo     | #e9c46a sand
+
+  viewBox(0,0,200,200) is the value the root already carries, so this fragment differs
+  from svgview-transform.html only by stating it explicitly. Both must render the same
+  quadrant. Applying the transform first and the viewBox afterwards would discard the
+  scale and show all four colours.
+-->
+
+<style>
+  body { margin: 0; }
+  img { display: block; border: none; }
+</style>
+
+<img src="support/squares.svg#svgView(viewBox(0,0,200,200);transform(scale(2)))" width="100" height="100" alt="">


### PR DESCRIPTION
WebKit export from bug: [Extend WPT coverage for svgview() fragment identifiers](https://bugs.webkit.org/show_bug.cgi?id=322178)