### PR TITLE
[css-flexbox] Add intrinsic-size reftest for negative margins on inflexible items

### DIFF
--- a/css/css-flexbox/intrinsic-size/col-flex-grow-negative-margin-001.html
+++ b/css/css-flexbox/intrinsic-size/col-flex-grow-negative-margin-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="author" title="Nico Burns" href="mailto:nico@nicoburns.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="a negative block-axis margin on a flexible item is subtracted from a column flex container's automatic block size instead of being ignored" />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id=reference-overlapped-red></div>
+
+<div style="display: flex; flex-direction: column; width: 100px; background: green;">
+  <div style="height: 124px; flex-grow: 1; flex-shrink: 0; margin-top: -24px;"></div>
+</div>

--- a/css/css-flexbox/intrinsic-size/col-negative-margin-hidden-grid-item-001.html
+++ b/css/css-flexbox/intrinsic-size/col-negative-margin-hidden-grid-item-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="author" title="Nico Burns" href="mailto:nico@nicoburns.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="a negative block-axis margin on a flex item is subtracted from a column flex container's automatic block size even when the item contains a grid item with overflow hidden" />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id=reference-overlapped-red></div>
+
+<div style="display: flex; flex-direction: column; width: 100px; background: green;">
+  <div style="display: flex; flex-direction: column; margin-top: -32px;">
+    <div style="display: grid; grid-template-columns: 100px;">
+      <div style="display: flex; flex-direction: column; overflow: hidden;">
+        <div style="width: 100px; height: 132px;"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/css/css-flexbox/intrinsic-size/row-009.html
+++ b/css/css-flexbox/intrinsic-size/row-009.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="author" title="Nico Burns" href="mailto:nico@nicoburns.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="negative margins on inflexible items subtract their resolved length from the container's max-content size instead of scaling the items' contributions" />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id=reference-overlapped-red></div>
+
+<div style="display: flex; width: max-content; height: 100px; background: green;">
+  <div style="width: 60px; flex-shrink: 0;"></div>
+  <div style="width: 50px; flex-shrink: 0; margin-left: -10px;"></div>
+</div>

--- a/css/css-flexbox/intrinsic-size/row-010.html
+++ b/css/css-flexbox/intrinsic-size/row-010.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="author" title="Nico Burns" href="mailto:nico@nicoburns.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="negative margins on flexible items subtract their resolved length from the container's max-content size instead of being ignored" />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id=reference-overlapped-red></div>
+
+<div style="display: flex; width: max-content; height: 100px; background: green;">
+  <div style="width: 60px; flex-grow: 1; flex-shrink: 0;"></div>
+  <div style="width: 50px; flex-grow: 1; flex-shrink: 0; margin-left: -10px;"></div>
+</div>


### PR DESCRIPTION
The flexbox algorithm specifies that the items [scaled flex shrink factor](https://drafts.csswg.org/css-flexbox-1/#scaled-flex-shrink-factor) can become negative infinity. In that case a naive implementation of step 4 (multiply the scaled flex shrink factor by base size) will fail in the case of base size = 0 where the result should be 0.

Browsers already agree on this result, but there is no test covering it.

See https://github.com/DioxusLabs/taffy/pull/1152 for context.

---

This test was entirely generated by an LLM. It has been reviewed by me.
