### PR TITLE
Test parser element insertion when a custom element reaction reparents nodes

### DIFF
--- a/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy.html
+++ b/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy.html
@@ -77,4 +77,31 @@ test(() => {
                 'moving its children.');
 }, 'Template content should throw exception when its ancestor in ' +
    'a different document but connected via host is being append.');
+
+test(() => {
+  const outer = document.createElement('template');
+  const inner = document.createElement('template');
+  const div = document.createElement('div');
+  const span = document.createElement('span');
+  outer.content.appendChild(inner);
+  inner.content.appendChild(div);
+  div.appendChild(span);
+
+  // outer is a host-including inclusive ancestor of everything in inner's
+  // contents, reached through two template content boundaries.
+  assert_throws_dom('HierarchyRequestError', () => {
+    inner.content.appendChild(outer);
+  }, 'Template content should throw if a template two boundaries up is being appended.');
+  assert_throws_dom('HierarchyRequestError', () => {
+    span.appendChild(outer);
+  }, 'Template content descendant should throw if a template two boundaries up is being appended.');
+  assert_throws_dom('HierarchyRequestError', () => {
+    span.appendChild(inner);
+  }, 'Template content descendant should throw if its own host is being appended.');
+
+  // A node that is not an ancestor is still accepted.
+  inner.content.appendChild(document.createElement('p'));
+  assert_equals(inner.content.lastChild.localName, 'p');
+}, 'Template content should throw when an ancestor across two template ' +
+   'boundaries is being appended.');
 </script>

--- a/html/syntax/parsing/custom-element-reparenting-shadow-cycle.html
+++ b/html/syntax/parsing/custom-element-reparenting-shadow-cycle.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Parser element insertion: a custom element constructor creates a cycle through its own shadow root</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// The constructor runs before the element is inserted. It cannot append the
+// intended parent to itself -- "create an element" rejects a constructed
+// element with children -- but it can move it into a shadow root, which makes
+// the element a host-including inclusive ancestor of the adjusted insertion
+// location. The element is dropped, but stays on the stack of open elements.
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { constructor() { super(); if (window.el) return; window.el = this; window.b = document.body; window.root = this.attachShadow({mode: 'open'}); window.root.appendChild(window.b) } })<\/script><body><x-a><p>x</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(d.body, null, "the html element no longer has a body child");
+  assert_array_equals([...d.documentElement.children].map(e => e.localName), ["head"],
+    "the document element is left with only its head child");
+  assert_equals(w.el.parentNode, null, "the custom element was dropped on the floor");
+  assert_equals(w.root.firstChild, w.b, "body stayed in the custom element's shadow root");
+  assert_equals(tree(w.b), ``, "the custom element was not inserted into body");
+  assert_equals(tree(w.el), `<p>["x"]`, "following content went into the dropped element");
+}, "Custom element constructor moves the intended parent into its own shadow root");
+</script>

--- a/html/syntax/parsing/custom-element-reparenting-template-cycle.html
+++ b/html/syntax/parsing/custom-element-reparenting-template-cycle.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Parser element insertion: a custom element constructor creates a cycle through a template element's contents</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// Like the shadow root case, but the loop is closed through a template
+// element's contents. Kept separate because insertion-time subtree traversal
+// descends into shadow trees and not into template contents, so the two are not
+// equivalent for implementations.
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { constructor() { super(); if (window.el) return; window.el = this; window.b = document.body; window.t = document.createElement('template'); window.t.content.appendChild(window.b); window.root = this.attachShadow({mode: 'open'}); window.root.appendChild(window.t) } })<\/script><body><x-a><p>x</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(d.body, null, "the html element no longer has a body child");
+  assert_array_equals([...d.documentElement.children].map(e => e.localName), ["head"],
+    "the document element is left with only its head child");
+  assert_equals(w.el.parentNode, null, "the custom element was dropped on the floor");
+  assert_equals(w.b.parentNode, w.t.content, "body stayed in the template element's contents");
+  assert_equals(tree(w.b), ``, "the custom element was not inserted into body");
+  assert_equals(tree(w.el), `<p>["x"]`, "following content went into the dropped element");
+}, "Custom element constructor moves the intended parent into a template element's contents");
+</script>

--- a/html/syntax/parsing/custom-element-reparenting.html
+++ b/html/syntax/parsing/custom-element-reparenting.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Parser element insertion when a custom element reaction reparents nodes</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// The custom element constructor, and attributeChangedCallback for the token's
+// attributes, both run before the element is inserted. These are the cases
+// where the resulting tree stays well-formed; the cycle-inducing variants live
+// in custom-element-reparenting-*-cycle.html.
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement {})<\/script><body><x-a><p>y</p></x-a>`);
+  assert_equals(tree(iframe.contentDocument.body), `<x-a>[<p>["y"]]`);
+}, "Baseline: a custom element that does not reparent anything");
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { static get observedAttributes() { return ['x'] } attributeChangedCallback() { if (window.el) return; window.el = this; document.head.appendChild(this) } })<\/script><body><x-a x=1><p>y</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(w.el.parentNode, d.head, "the custom element stayed where the callback put it");
+  assert_equals(tree(d.body), ``, "the custom element was not also inserted into body");
+  assert_equals(tree(w.el), `<p>["y"]`, "following content went into the custom element");
+}, "attributeChangedCallback gives the element a parent before it is inserted");
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { static get observedAttributes() { return ['x'] } attributeChangedCallback() { if (window.el) return; window.el = this; window.b = document.body; window.b.remove() } })<\/script><body><x-a x=1><p>y</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(d.body, null, "the html element no longer has a body child");
+  assert_equals(w.b.parentNode, null, "body stayed detached");
+  assert_equals(tree(w.b), `<x-a>[<p>["y"]]`, "the element was inserted into the detached body");
+}, "attributeChangedCallback detaches the intended parent before the element is inserted");
+
+// A shadow root that does not contain the intended parent must not prevent the
+// insertion; this is what an over-broad cycle guard would break.
+promise_test(async t => {
+  const iframe = await parseInIframe(t, `<script>customElements.define('x-a', class extends HTMLElement { constructor() { super(); window.el = this; window.root = this.attachShadow({mode: 'open'}); window.root.appendChild(document.createElement('span')) } })<\/script><body><x-a><p>y</p></x-a>`);
+  const w = iframe.contentWindow, d = iframe.contentDocument;
+  assert_equals(tree(d.body), `<x-a>[<p>["y"]]`, "the element was inserted normally");
+  assert_equals(w.root.firstChild.localName, "span", "its shadow root is untouched");
+}, "Custom element constructor attaches an unrelated shadow root");
+</script>


### PR DESCRIPTION
The custom element constructor, and attributeChangedCallback for the token's
attributes, both run while creating an element for the token, before the element
is inserted. They can give the element a parent, detach the intended parent, or
move the intended parent inside the element.

See https://github.com/whatwg/html/issues/12494 for context.
