### PR TITLE
Wait for the pending candidate before updating the pointer

### DIFF
--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-insert-br.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-insert-br.html
@@ -15,19 +15,30 @@ var c = 0;
  ></video
 >
 <script>
-async_test(function(t) {
+promise_test(async function(t) {
   var video = document.querySelector('video');
+  var sourceB = video.querySelector('[onerror="b++"]');
+  var loaded = new Promise(function(resolve) { window.addEventListener('load', resolve); });
+
+  // currentSrc is set in the "process candidate" step, after the pointer has
+  // advanced and before the resource fetch algorithm runs, so waiting for it is
+  // how we observe that the pointer is (b | c) with b pending. Polling rather
+  // than mutating from a parse-time script keeps this robust whether the UA runs
+  // the synchronous section at a microtask checkpoint (as specified) or in a task.
+  await t.step_wait(function() { return video.currentSrc == sourceB.src; },
+                    'source b selected as candidate', 3000, 5);
+  assert_equals(b, 0, 'source b is still pending when the pointer is updated');
+
   // add br elements
   var br = document.createElement('br');
   video.insertBefore(br, video.querySelector('[onerror="a++"]'));
-  video.insertBefore(br.cloneNode(false), video.querySelector('[onerror="b++"]'));
+  video.insertBefore(br.cloneNode(false), sourceB);
   video.insertBefore(br.cloneNode(false), video.querySelector('[onerror="c++"]'));
   video.appendChild(br.cloneNode(false));
-  window.onload = t.step_func(function() {
-    assert_equals(a, 1, 'error events on a');
-    assert_equals(b, 1, 'error events on b');
-    assert_equals(c, 1, 'error events on c');
-    t.done();
-  });
+
+  await loaded;
+  assert_equals(a, 1, 'error events on a');
+  assert_equals(b, 1, 'error events on b');
+  assert_equals(c, 1, 'error events on c');
 });
 </script>

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-insert-source.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-insert-source.html
@@ -19,26 +19,39 @@ var x4 = 0;
  ></video
 >
 <script>
-async_test(function(t) {
+promise_test(async function(t) {
   var video = document.querySelector('video');
+  var sourceB = video.querySelector('[onerror="b++"]');
+  var loaded = new Promise(function(resolve) { window.addEventListener('load', resolve); });
+
+  // currentSrc is set in the "process candidate" step, after the pointer has
+  // advanced and before the resource fetch algorithm runs, so waiting for it is
+  // how we observe that the pointer is (b | c) with b pending. Polling rather
+  // than mutating from a parse-time script keeps this robust whether the UA runs
+  // the synchronous section at a microtask checkpoint (as specified) or in a task.
+  await t.step_wait(function() { return video.currentSrc == sourceB.src; },
+                    'source b selected as candidate', 3000, 5);
+  assert_equals(b, 0, 'source b is still pending when the pointer is updated');
+
   // add source elements
   var source1 = document.createElement('source'); source1.onerror = function() { x1++; };
   var source2 = document.createElement('source'); source2.onerror = function() { x2++; };
   var source3 = document.createElement('source'); source3.onerror = function() { x3++; };
   var source4 = document.createElement('source'); source4.onerror = function() { x4++; };
   video.insertBefore(source1, video.querySelector('[onerror="a++"]'));
-  video.insertBefore(source2, video.querySelector('[onerror="b++"]'));
+  video.insertBefore(source2, sourceB);
   video.insertBefore(source3, video.querySelector('[onerror="c++"]'));
   video.appendChild(source4);
-  window.onload = t.step_func(function() {
-    assert_equals(a, 1, 'error events on a');
-    assert_equals(b, 1, 'error events on b');
-    assert_equals(c, 1, 'error events on c');
-    assert_equals(x1, 0, 'error events on x1');
-    assert_equals(x2, 0, 'error events on x2');
-    assert_equals(x3, 1, 'error events on x3');
-    assert_equals(x4, 1, 'error events on x4');
-    t.done();
-  });
+
+  await loaded;
+  assert_equals(a, 1, 'error events on a');
+  assert_equals(b, 1, 'error events on b');
+  assert_equals(c, 1, 'error events on c');
+  // source1 and source2 are inserted before the pointer, so they are never processed
+  assert_equals(x1, 0, 'error events on x1');
+  assert_equals(x2, 0, 'error events on x2');
+  // source3 is inserted at the pointer and source4 after it, so both are processed
+  assert_equals(x3, 1, 'error events on x3');
+  assert_equals(x4, 1, 'error events on x4');
 });
 </script>

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-insert-text.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-insert-text.html
@@ -15,19 +15,30 @@ var c = 0;
  ></video
 >
 <script>
-async_test(function(t) {
+promise_test(async function(t) {
   var video = document.querySelector('video');
+  var sourceB = video.querySelector('[onerror="b++"]');
+  var loaded = new Promise(function(resolve) { window.addEventListener('load', resolve); });
+
+  // currentSrc is set in the "process candidate" step, after the pointer has
+  // advanced and before the resource fetch algorithm runs, so waiting for it is
+  // how we observe that the pointer is (b | c) with b pending. Polling rather
+  // than mutating from a parse-time script keeps this robust whether the UA runs
+  // the synchronous section at a microtask checkpoint (as specified) or in a task.
+  await t.step_wait(function() { return video.currentSrc == sourceB.src; },
+                    'source b selected as candidate', 3000, 5);
+  assert_equals(b, 0, 'source b is still pending when the pointer is updated');
+
   // add text nodes
   var text = document.createTextNode('x');
   video.insertBefore(text, video.querySelector('[onerror="a++"]'));
-  video.insertBefore(text.cloneNode(false), video.querySelector('[onerror="b++"]'));
+  video.insertBefore(text.cloneNode(false), sourceB);
   video.insertBefore(text.cloneNode(false), video.querySelector('[onerror="c++"]'));
   video.appendChild(text.cloneNode(false));
-  window.onload = t.step_func(function() {
-    assert_equals(a, 1, 'error events on a');
-    assert_equals(b, 1, 'error events on b');
-    assert_equals(c, 1, 'error events on c');
-    t.done();
-  });
+
+  await loaded;
+  assert_equals(a, 1, 'error events on a');
+  assert_equals(b, 1, 'error events on b');
+  assert_equals(c, 1, 'error events on c');
 });
 </script>

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-remove-source-after.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-remove-source-after.html
@@ -23,34 +23,33 @@ var x4 = 0;
  ></video
 >
 <script>
-var v;
-var t = async_test(function(t) {
-  v = document.querySelector('video');
-  v.removeChild(document.querySelector('[onerror="x1++"]'));
-  window.onload = t.step_func(function() {
-    assert_equals(a, 1, 'error events on a');
-    assert_equals(b, 1, 'error events on b');
-    assert_equals(c, 1, 'error events on c');
-    assert_equals(x1, 0, 'error events on x1');
-    assert_equals(x2, 0, 'error events on x2');
-    assert_equals(x3, 0, 'error events on x3');
-    assert_equals(x4, 0, 'error events on x4');
-    t.done();
-  });
-});
-</script>
-<script>
-t.step(function() {
-  v.removeChild(document.querySelector('[onerror="x2++"]'));
-});
-</script>
-<script>
-t.step(function() {
-  v.removeChild(document.querySelector('[onerror="x3++"]'));
-});
-</script>
-<script>
-t.step(function() {
-  v.removeChild(document.querySelector('[onerror="x4++"]'));
+promise_test(async function(t) {
+  var video = document.querySelector('video');
+  var sourceB = video.querySelector('[onerror="b++"]');
+  var loaded = new Promise(function(resolve) { window.addEventListener('load', resolve); });
+
+  // currentSrc is set in the "process candidate" step, after the pointer has
+  // advanced and before the resource fetch algorithm runs, so waiting for it is
+  // how we observe that the pointer is (b | x1) with b pending. Polling rather
+  // than mutating from a parse-time script keeps this robust whether the UA runs
+  // the synchronous section at a microtask checkpoint (as specified) or in a task.
+  await t.step_wait(function() { return video.currentSrc == sourceB.src; },
+                    'source b selected as candidate', 3000, 5);
+  assert_equals(b, 0, 'source b is still pending when the pointer is updated');
+
+  // Remove the node after the pointer, repeatedly. Each removal should move the
+  // pointer onto the next node, so that c ends up being the next candidate.
+  for (var i = 1; i <= 4; ++i) {
+    video.removeChild(video.querySelector('[onerror="x' + i + '++"]'));
+  }
+
+  await loaded;
+  assert_equals(a, 1, 'error events on a');
+  assert_equals(b, 1, 'error events on b');
+  assert_equals(c, 1, 'error events on c');
+  assert_equals(x1, 0, 'error events on x1');
+  assert_equals(x2, 0, 'error events on x2');
+  assert_equals(x3, 0, 'error events on x3');
+  assert_equals(x4, 0, 'error events on x4');
 });
 </script>

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-remove-source.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-remove-source.html
@@ -23,21 +23,34 @@ var x4 = 0;
  ></video
 >
 <script>
-async_test(function(t) {
+promise_test(async function(t) {
   var video = document.querySelector('video');
+  var sourceB = video.querySelector('[onerror="b++"]');
+  var loaded = new Promise(function(resolve) { window.addEventListener('load', resolve); });
+
+  // currentSrc is set in the "process candidate" step, after the pointer has
+  // advanced and before the resource fetch algorithm runs, so waiting for it is
+  // how we observe that the pointer is (b | x3) with b pending. Polling rather
+  // than mutating from a parse-time script keeps this robust whether the UA runs
+  // the synchronous section at a microtask checkpoint (as specified) or in a task.
+  await t.step_wait(function() { return video.currentSrc == sourceB.src; },
+                    'source b selected as candidate', 3000, 5);
+  assert_equals(b, 0, 'source b is still pending when the pointer is updated');
+
   // remove the xn elements
   [].forEach.call(document.querySelectorAll('[onerror^="x"]'), function(elm) {
     video.removeChild(elm);
   });
-  window.onload = t.step_func(function() {
-    assert_equals(a, 1, 'error events on a');
-    assert_equals(b, 1, 'error events on b');
-    assert_equals(c, 1, 'error events on c');
-    assert_equals(x1, 1, 'error events on x1');
-    assert_equals(x2, 1, 'error events on x2');
-    assert_equals(x3, 0, 'error events on x3');
-    assert_equals(x4, 0, 'error events on x4');
-    t.done();
-  });
+
+  await loaded;
+  assert_equals(a, 1, 'error events on a');
+  assert_equals(b, 1, 'error events on b');
+  assert_equals(c, 1, 'error events on c');
+  // x1 and x2 are before the pointer and were already processed before removal
+  assert_equals(x1, 1, 'error events on x1');
+  assert_equals(x2, 1, 'error events on x2');
+  // x3 and x4 are removed before the pointer reaches them
+  assert_equals(x3, 0, 'error events on x3');
+  assert_equals(x4, 0, 'error events on x4');
 });
 </script>

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-remove-text.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-pointer-remove-text.html
@@ -15,19 +15,31 @@ var c = 0;
  >x</video
 >
 <script>
-async_test(function(t) {
+promise_test(async function(t) {
   var video = document.querySelector('video');
+  var sourceB = video.querySelector('[onerror="b++"]');
+  var loaded = new Promise(function(resolve) { window.addEventListener('load', resolve); });
+
+  // currentSrc is set in the "process candidate" step, after the pointer has
+  // advanced and before the resource fetch algorithm runs, so waiting for it is
+  // how we observe that the pointer is (b | text) with b pending. Polling rather
+  // than mutating from a parse-time script keeps this robust whether the UA runs
+  // the synchronous section at a microtask checkpoint (as specified) or in a task.
+  await t.step_wait(function() { return video.currentSrc == sourceB.src; },
+                    'source b selected as candidate', 3000, 5);
+  assert_equals(b, 0, 'source b is still pending when the pointer is updated');
+
   // remove the text nodes
-  [].forEach.call(video.childNodes, function(node) {
+  [].forEach.call([].slice.call(video.childNodes), function(node) {
     if (node.nodeType == node.TEXT_NODE) {
       video.removeChild(node);
     }
   });
-  window.onload = t.step_func(function() {
-    assert_equals(a, 1, 'error events on a');
-    assert_equals(b, 1, 'error events on b');
-    assert_equals(c, 1, 'error events on c');
-    t.done();
-  });
+  assert_equals(video.childNodes.length, 3, 'all text nodes removed');
+
+  await loaded;
+  assert_equals(a, 1, 'error events on a');
+  assert_equals(b, 1, 'error events on b');
+  assert_equals(c, 1, 'error events on c');
 });
 </script>


### PR DESCRIPTION
These tests mutate the media element while the resource selection algorithm is parked on a candidate, then check which sources get processed. They did the mutation from a script that runs during parsing. Per spec that is late enough: [await a stable state](https://html.spec.whatwg.org/#await-a-stable-state) queues a microtask, and the parser performs a microtask checkpoint at `</script>`, so the pointer is `(b | c)` with `b` pending by then.

No engine appears to resume there (whatwg/html#12835), so the mutation landed before the algorithm had started and the tests measured tree order rather than the pointer update rules. `pointer-insert-source` and `pointer-remove-source` failed for that reason alone, on `x1`. The other four happened to expect the same result under either timing, so they passed without testing anything about the pointer.

They now wait for `video.currentSrc` to become source `b`'s URL, which is set in the "process candidate" step, after the pointer has advanced and before the resource fetch algorithm runs. Polling is used rather than an event because no event works: `loadstart` is queued before the mode-specific steps, and engines disagree on whether a source's `error` task is dispatched before or after the pointer advances (whatwg/html#12836). Each test also asserts that `b` is still pending at that point, so a wrong sync point fails loudly instead of silently measuring something else.

| | before | after |
|---|---|---|
| Firefox Nightly | 4 pass, 2 fail | 6 pass |
| Chrome Canary | 6 fail | 6 fail |
| Safari TP | 6 fail | 6 fail |

Chrome Canary and Safari TP still fail all six on `error events on c`. That is unrelated to this change: both fail the unmodified `resource-selection-pointer-control.html` the same way, apparently because a `source` with no `src` that follows a failed `src`-bearing source never fires `error`.

Two incidental fixes:

* `pointer-remove-text.html` iterated a live `childNodes` while removing from it, which skipped entries and removed all four text nodes only by coincidence of the alternating markup. It now snapshots the list and asserts the removal happened.
* `pointer-remove-source-after.html` did its four removals in four separate parse-time scripts, which collapse into one step under the new sync point.

#60466 applies the same fix to the `moveBefore()` pointer tests.
