### PR TITLE
script: Invoke decodeAudioData error callback for detached buffers

### DIFF
--- a/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
+++ b/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test to verify decodeAudioData() invokes the error callback for a detached ArrayBuffer</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body></body>
+<script>
+promise_test(async t => {
+  const context = new AudioContext();
+  t.add_cleanup(() => context.close());
+
+  // create a detached ArrayBuffer
+  const audioData = new ArrayBuffer(4);
+  structuredClone({}, { transfer: [audioData] });
+
+  // save a reference to the promise res
+  let resolve;
+  const errorInvoked = new Promise(res => { resolve = res; });
+
+  // create decodeAudioData() promise with success and error callbacks
+  const success = t.unreached_func('success callback should not run');
+  const error = t.step_func(err => { resolve(err); });
+  const promise = context.decodeAudioData(audioData, success, error);
+
+  // assert promise rejects with DataCloneError and await pending errorInvoked promise
+  const [, err] = await Promise.all([
+    promise_rejects_dom(t, 'DataCloneError', promise),
+    errorInvoked,
+  ]);
+
+  // err must be a DataCloneError DOMException
+  assert_true(err instanceof DOMException, 'error callback argument is a DOMException');
+  assert_equals(err.name, 'DataCloneError');
+
+}, 'error callback is invoked with DataCloneError');
+</script>


### PR DESCRIPTION
Previously, the detached ArrayBuffer branch only rejected the promise and the `decodeErrorCallback` was never invoked.

Now, we detect if the ArrayBuffer is detached with `IsDetachedArrayBufferObject`, and synchronously reject the promise with `DataCloneError` before enqueuing a media element task to invoke the callback. We use a uuid clone to insert the callback in `decode_resolvers` and use the uuid in the task to find the callback. Because `decode_error_callback` is Rc and not Send, which Task expects, it cannot be moved into the queued closure (so we store the callback in the map and enqueue the Task).

Added Step 1 from the spec to reject with `InvalidStateError` when the document is not fully active.

Updated the `decodeAudioData` success callback and error callback to be optional nullable to match the Web Audio IDL, so we can pass null for an unused callback.

Testing:

- WebIDL and code changes compiles in release build: `.\mach build -r`

- Call `decodeAudioData` after detaching `AudioContext` iframe: `.\mach test-wpt -r tests/wpt/tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-detached-execution-context.html`
- Call `decodeAudioData` after detaching `OfflineAudioContext` iframe: `.\mach test-wpt -r tests/wpt/tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-detached-execution-context.html`

- Call `decodeAudioData`on a closed context: `.\mach test-wpt -r tests/wpt/tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume-close.html`

- Manually detach buffer with null success callback:

Using console in FireFox Dev Tools:
`.\mach run -r --devtools=6080`

```js
  var ctx = new AudioContext();
  var ab = new ArrayBuffer(4);
  structuredClone({}, { transfer: [ab] });
  var called = false;
  ctx.decodeAudioData(ab, null, function () { called = true; })
    .catch(function (e) { console.log("reject", e.name, e.message); });
  setTimeout(function () { console.log("callback called?", called); }, 500);
```

Fixes #<!-- nolink -->46602.
Reviewed in servo/servo#46870