### PR TITLE
Rename customelementregistry to scopedcustomelementregistry

### DIFF
--- a/custom-elements/registries/scoped-custom-element-registry-content-attribute-in-xhtml.xhtml
+++ b/custom-elements/registries/scoped-custom-element-registry-content-attribute-in-xhtml.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
-<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-initialize"/>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#attr-scopedcustomelementregistry"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -14,30 +14,30 @@ customElements.define('c-d', class ABElement extends HTMLElement { });
 
 ]]>
 </script>
-<div id="container"><a-b customelementregistry=""></a-b><c-d customelementregistry=""></c-d></div>
+<div id="container"><a-b scopedcustomelementregistry=""></a-b><c-d scopedcustomelementregistry=""></c-d></div>
 <script>
 <![CDATA[
 
 const container = document.getElementById('container');
 test((test) => {
     assert_equals(container.querySelector('a-b').customElementRegistry, null);
-}, `XHTML parser should create a custom element candidate with null registry if customelementregistry is set`);
+}, `XHTML parser should create a custom element candidate with null registry if scopedcustomelementregistry is set`);
 
 test((test) => {
     assert_equals(container.querySelector('c-d').customElementRegistry, null);
-}, `XHTML parser should create a defined custom element with null registry if customelementregistry is set`);
+}, `XHTML parser should create a defined custom element with null registry if scopedcustomelementregistry is set`);
 
 test((test) => {
-    container.setHTMLUnsafe(`<a-b customelementregistry></a-b>`);
+    container.setHTMLUnsafe(`<a-b scopedcustomelementregistry></a-b>`);
     assert_equals(container.querySelector('a-b').customElementRegistry, null);
-}, `XHTML fragment parser should create a custom element candidate with null registry if customelementregistry is set`);
+}, `XHTML fragment parser should create a custom element candidate with null registry if scopedcustomelementregistry is set`);
 
 test((test) => {
     container.setHTMLUnsafe(`<c-d></c-d>`);
     assert_equals(container.querySelector('c-d').customElementRegistry, window.customElements);
-    container.setHTMLUnsafe(`<c-d customelementregistry></c-d>`);
+    container.setHTMLUnsafe(`<c-d scopedcustomelementregistry></c-d>`);
     assert_equals(container.querySelector('c-d').customElementRegistry, null);
-}, `XHTML fragment parser should create a defined custom element with null registry if customelementregistry is set`);
+}, `XHTML fragment parser should create a defined custom element with null registry if scopedcustomelementregistry is set`);
 
 ]]>
 </script>

--- a/custom-elements/registries/scoped-custom-element-registry-content-attribute-in-xhtml.xhtml
+++ b/custom-elements/registries/scoped-custom-element-registry-content-attribute-in-xhtml.xhtml
@@ -14,7 +14,7 @@ customElements.define('c-d', class ABElement extends HTMLElement { });
 
 ]]>
 </script>
-<div id="container"><a-b scopedcustomelementregistry=""></a-b><c-d scopedcustomelementregistry=""></c-d></div>
+<div id="container"><a-b scopedcustomelementregistry=""></a-b><c-d scopedcustomelementregistry=""></c-d><a-b id="non-empty" scopedcustomelementregistry="named"></a-b></div>
 <script>
 <![CDATA[
 
@@ -26,6 +26,12 @@ test((test) => {
 test((test) => {
     assert_equals(container.querySelector('c-d').customElementRegistry, null);
 }, `XHTML parser should create a defined custom element with null registry if scopedcustomelementregistry is set`);
+
+test(() => {
+    const element = document.getElementById('non-empty');
+    assert_equals(element.customElementRegistry, null);
+    assert_equals(element.scopedCustomElementRegistry, 'named');
+}, `XHTML parser should use null registry for a non-empty scopedcustomelementregistry value`);
 
 test((test) => {
     container.setHTMLUnsafe(`<a-b scopedcustomelementregistry></a-b>`);

--- a/custom-elements/registries/scoped-custom-element-registry-content-attribute.html
+++ b/custom-elements/registries/scoped-custom-element-registry-content-attribute.html
@@ -2,15 +2,15 @@
 <html>
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
-<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-initialize">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#attr-scopedcustomelementregistry">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-<!-- Elements with customelementregistry attribute parsed during initial document load -->
-<div id="builtin-with-attr" customelementregistry></div>
-<custom-elem id="candidate-with-attr" customelementregistry></custom-elem>
-<div id="parent-with-attr" customelementregistry>
+<!-- Elements with scopedcustomelementregistry attribute parsed during initial document load -->
+<div id="builtin-with-attr" scopedcustomelementregistry></div>
+<custom-elem id="candidate-with-attr" scopedcustomelementregistry></custom-elem>
+<div id="parent-with-attr" scopedcustomelementregistry>
   <div id="child-of-attr"></div>
   <custom-elem id="candidate-child-of-attr"></custom-elem>
   <div id="nested-parent">
@@ -18,12 +18,12 @@
   </div>
 </div>
 
-<!-- Elements without customelementregistry attribute for comparison -->
+<!-- Elements without scopedcustomelementregistry attribute for comparison -->
 <div id="builtin-without-attr"></div>
 <custom-elem id="candidate-without-attr"></custom-elem>
 
 <!-- Elements for upgrade testing -->
-<upgrade-elem id="upgrade-with-attr" customelementregistry></upgrade-elem>
+<upgrade-elem id="upgrade-with-attr" scopedcustomelementregistry></upgrade-elem>
 <upgrade-elem id="upgrade-without-attr"></upgrade-elem>
 
 <script>
@@ -41,20 +41,30 @@ function makeIframeWithABElement(test) {
     return [doc, win];
 }
 
+test(() => {
+    const element = document.createElement('div');
+    assert_false(element.hasAttribute('scopedcustomelementregistry'));
+    assert_equals(element.scopedCustomElementRegistry, '');
+
+    element.scopedCustomElementRegistry = 'named';
+    assert_equals(element.getAttribute('scopedcustomelementregistry'), 'named');
+    assert_equals(element.scopedCustomElementRegistry, 'named');
+}, 'scopedCustomElementRegistry reflects as a string');
+
 function runBasicTests(makeIframe, elementName, elementDescription) {
     test((test) => {
         const [doc, win] = makeIframe(test);
-        doc.documentElement.setHTMLUnsafe(`<${elementName} customelementregistry></${elementName}>`);
+        doc.documentElement.setHTMLUnsafe(`<${elementName} scopedcustomelementregistry></${elementName}>`);
         assert_equals(doc.querySelector(elementName).customElementRegistry, null);
-    }, `HTML parser should create a ${elementDescription} with null registry if customelementregistry is set`);
+    }, `HTML parser should create a ${elementDescription} with null registry if scopedcustomelementregistry is set`);
 
     test((test) => {
         const [doc, win] = makeIframe(test);
         const element = doc.createElement(elementName);
         assert_equals(element.customElementRegistry, win.customElements);
-        element.setAttribute('customelementregistry', '');
+        element.setAttribute('scopedcustomelementregistry', '');
         assert_equals(element.customElementRegistry, win.customElements);
-    }, `Setting customelementregistry content attribute after a ${elementDescription} had finishsed parsing should not set null registry`);
+    }, `Setting scopedcustomelementregistry content attribute after a ${elementDescription} had finished parsing should not set null registry`);
 
     test((test) => {
         const [doc, win] = makeIframe(test);
@@ -62,10 +72,10 @@ function runBasicTests(makeIframe, elementName, elementDescription) {
         assert_equals(element.customElementRegistry, null);
         assert_equals(element.cloneNode(false).customElementRegistry, null);
 
-        doc.documentElement.setHTMLUnsafe(`<${elementName} customelementregistry></${elementName}>`);
+        doc.documentElement.setHTMLUnsafe(`<${elementName} scopedcustomelementregistry></${elementName}>`);
         assert_equals(doc.querySelector(elementName).customElementRegistry, null);
         assert_equals(doc.querySelector(elementName).cloneNode(true).customElementRegistry, null);
-    }, `Cloning a ${elementDescription} with null regsitry should create an element with null registry`);
+    }, `Cloning a ${elementDescription} with null registry should create an element with null registry`);
 }
 
 runBasicTests(makeIframe, 'div', 'builtin element');
@@ -76,11 +86,11 @@ test((test) => {
     const [doc, win] = makeIframe(test);
     win.customElements.define('c-d', class CDElement extends win.HTMLElement { });
     const container = doc.createElement('div', {customElementRegistry: null});
-    container.innerHTML = '<a-b><c-d></c-d><e-f customelementregistry></e-f></a-b>';
+    container.innerHTML = '<a-b><c-d></c-d><e-f scopedcustomelementregistry></e-f></a-b>';
     assert_equals(container.querySelector('a-b').customElementRegistry, null);
     assert_equals(container.querySelector('c-d').customElementRegistry, null);
     assert_equals(container.querySelector('e-f').customElementRegistry, null);
-}, 'Descendants of an element with customelementregistry should use null registry');
+}, 'Descendants of an element with scopedcustomelementregistry should use null registry');
 
 test((test) => {
     const [doc, win] = makeIframe(test);
@@ -96,9 +106,9 @@ test((test) => {
     win.customElements.define('a-b', class ABElement extends win.HTMLElement {
         constructor() {
             super();
-            this.setAttribute('customelementregistry', '');
+            this.setAttribute('scopedcustomelementregistry', '');
             customElementRegistryDuringConstruction = this.customElementRegistry;
-            this.removeAttribute('customelementregistry', '');
+            this.removeAttribute('scopedcustomelementregistry', '');
         }
     });
     assert_equals(customElementRegistryDuringConstruction, win.customElements);
@@ -115,7 +125,7 @@ test((test) => {
     win.customElements.upgrade(upgradeCandidate);
     assert_equals(customElementRegistryDuringConstruction, win.customElements);
     assert_equals(element.customElementRegistry, win.customElements);
-}, `Setting customelementregistry content attribute during constructor should not make it use null registry`);
+}, `Setting scopedcustomelementregistry content attribute during constructor should not make it use null registry`);
 
 function iframeFromSrcdoc(test, srcdoc) {
     return new Promise((resolve) => {
@@ -127,83 +137,83 @@ function iframeFromSrcdoc(test, srcdoc) {
     });
 }
 
-// Tests for customelementregistry attribute on body tag during initial document parse.
+// Tests for scopedcustomelementregistry attribute on body tag during initial document parse.
 
 promise_test(async (test) => {
     const [doc, win] = await iframeFromSrcdoc(test,
-        '<!DOCTYPE html><body customelementregistry><div></div></body>');
-    assert_equals(doc.body.getAttribute('customelementregistry'), '',
-        'body should have the customelementregistry attribute');
+        '<!DOCTYPE html><body scopedcustomelementregistry><div></div></body>');
+    assert_equals(doc.body.getAttribute('scopedcustomelementregistry'), '',
+        'body should have the scopedcustomelementregistry attribute');
     assert_equals(doc.body.customElementRegistry, null,
         'body should have null registry');
     assert_equals(doc.querySelector('div').customElementRegistry, null,
-        'div child of body with customelementregistry should have null registry');
-}, 'Body with customelementregistry attribute during initial parse should have null registry and propagate to children');
+        'div child of body with scopedcustomelementregistry should have null registry');
+}, 'Body with scopedcustomelementregistry attribute during initial parse should have null registry and propagate to children');
 
 promise_test(async (test) => {
     const [doc, win] = await iframeFromSrcdoc(test,
-        '<!DOCTYPE html><body customelementregistry><a-b></a-b></body>');
+        '<!DOCTYPE html><body scopedcustomelementregistry><a-b></a-b></body>');
     const ab = doc.querySelector('a-b');
     assert_equals(ab.customElementRegistry, null,
-        'custom element candidate child of body with customelementregistry should have null registry');
-}, 'Custom element candidate child of body with customelementregistry should have null registry during initial parse');
+        'custom element candidate child of body with scopedcustomelementregistry should have null registry');
+}, 'Custom element candidate child of body with scopedcustomelementregistry should have null registry during initial parse');
 
 promise_test(async (test) => {
     const [doc, win] = await iframeFromSrcdoc(test,
-        '<!DOCTYPE html><body customelementregistry><div><a-b></a-b></div></body>');
+        '<!DOCTYPE html><body scopedcustomelementregistry><div><a-b></a-b></div></body>');
     assert_equals(doc.querySelector('div').customElementRegistry, null,
         'div child should have null registry');
     assert_equals(doc.querySelector('a-b').customElementRegistry, null,
         'nested custom element candidate should have null registry');
-}, 'Descendants of body with customelementregistry should all have null registry during initial parse');
+}, 'Descendants of body with scopedcustomelementregistry should all have null registry during initial parse');
 
 promise_test(async (test) => {
     const [doc, win] = await iframeFromSrcdoc(test,
-        '<!DOCTYPE html><html><head></head><body customelementregistry><div></div></body></html>');
+        '<!DOCTYPE html><html><head></head><body scopedcustomelementregistry><div></div></body></html>');
     assert_equals(doc.body.customElementRegistry, null,
         'body should have null registry');
     assert_equals(doc.querySelector('div').customElementRegistry, null,
         'div child should have null registry');
-}, 'Body with customelementregistry in a complete document structure should have null registry');
+}, 'Body with scopedcustomelementregistry in a complete document structure should have null registry');
 
-// Tests for customelementregistry attribute on elements during initial document parse.
+// Tests for scopedcustomelementregistry attribute on elements during initial document parse.
 
 test(() => {
   const element = document.getElementById('builtin-with-attr');
   assert_equals(element.customElementRegistry, null,
-    'Built-in element with customelementregistry attribute should have null registry');
-}, 'Initial parse: built-in element with customelementregistry has null registry');
+    'Built-in element with scopedcustomelementregistry attribute should have null registry');
+}, 'Initial parse: built-in element with scopedcustomelementregistry has null registry');
 
 test(() => {
   const element = document.getElementById('candidate-with-attr');
   assert_equals(element.customElementRegistry, null,
-    'Custom element candidate with customelementregistry attribute should have null registry');
-}, 'Initial parse: custom element candidate with customelementregistry has null registry');
+    'Custom element candidate with scopedcustomelementregistry attribute should have null registry');
+}, 'Initial parse: custom element candidate with scopedcustomelementregistry has null registry');
 
 test(() => {
   const element = document.getElementById('builtin-without-attr');
   assert_equals(element.customElementRegistry, window.customElements,
-    'Built-in element without customelementregistry should use the global registry');
-}, 'Initial parse: built-in element without customelementregistry uses global registry');
+    'Built-in element without scopedcustomelementregistry should use the global registry');
+}, 'Initial parse: built-in element without scopedcustomelementregistry uses global registry');
 
 test(() => {
   const element = document.getElementById('candidate-without-attr');
   assert_equals(element.customElementRegistry, window.customElements,
-    'Custom element candidate without customelementregistry should use the global registry');
-}, 'Initial parse: custom element candidate without customelementregistry uses global registry');
+    'Custom element candidate without scopedcustomelementregistry should use the global registry');
+}, 'Initial parse: custom element candidate without scopedcustomelementregistry uses global registry');
 
 // Tests for descendants inheriting null registry.
 
 test(() => {
   const child = document.getElementById('child-of-attr');
   assert_equals(child.customElementRegistry, null,
-    'Child of element with customelementregistry should have null registry');
-}, 'Initial parse: child of element with customelementregistry inherits null registry');
+    'Child of element with scopedcustomelementregistry should have null registry');
+}, 'Initial parse: child of element with scopedcustomelementregistry inherits null registry');
 
 test(() => {
   const child = document.getElementById('candidate-child-of-attr');
   assert_equals(child.customElementRegistry, null,
-    'Custom element candidate child of element with customelementregistry should have null registry');
+    'Custom element candidate child of element with scopedcustomelementregistry should have null registry');
 }, 'Initial parse: custom element candidate child inherits null registry from parent');
 
 test(() => {
@@ -212,7 +222,7 @@ test(() => {
     'Deeply nested custom element candidate should have null registry');
 }, 'Initial parse: deeply nested descendant inherits null registry');
 
-// Test that custom element with a definition is NOT upgraded when customelementregistry is present.
+// Test that custom element with a definition is NOT upgraded when scopedcustomelementregistry is present.
 
 test(() => {
   const withAttr = document.getElementById('upgrade-with-attr');
@@ -224,8 +234,8 @@ test(() => {
 
   const withoutAttr = document.getElementById('upgrade-without-attr');
   assert_true(withoutAttr instanceof customElements.get('upgrade-elem'),
-    'Custom element candidate without customelementregistry should be upgraded');
-}, 'Initial parse: global registry define only upgrades elements without customelementregistry');
+    'Custom element candidate without scopedcustomelementregistry should be upgraded');
+}, 'Initial parse: global registry define only upgrades elements without scopedcustomelementregistry');
 
 </script>
 </body>

--- a/custom-elements/registries/scoped-custom-element-registry-content-attribute.html
+++ b/custom-elements/registries/scoped-custom-element-registry-content-attribute.html
@@ -9,6 +9,7 @@
 <body>
 <!-- Elements with scopedcustomelementregistry attribute parsed during initial document load -->
 <div id="builtin-with-attr" scopedcustomelementregistry></div>
+<div id="builtin-with-named-attr" scopedcustomelementregistry="named"></div>
 <custom-elem id="candidate-with-attr" scopedcustomelementregistry></custom-elem>
 <div id="parent-with-attr" scopedcustomelementregistry>
   <div id="child-of-attr"></div>
@@ -45,11 +46,39 @@ test(() => {
     const element = document.createElement('div');
     assert_false(element.hasAttribute('scopedcustomelementregistry'));
     assert_equals(element.scopedCustomElementRegistry, '');
+    assert_equals(element.customElementRegistry, customElements);
 
     element.scopedCustomElementRegistry = 'named';
     assert_equals(element.getAttribute('scopedcustomelementregistry'), 'named');
     assert_equals(element.scopedCustomElementRegistry, 'named');
+    assert_equals(element.customElementRegistry, customElements);
 }, 'scopedCustomElementRegistry reflects as a string');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(
+        '<div scopedcustomelementregistry="named"><span></span></div>');
+    const element = container.firstElementChild;
+    assert_equals(element.scopedCustomElementRegistry, 'named');
+    assert_equals(element.customElementRegistry, null);
+    assert_equals(element.firstElementChild.customElementRegistry, null);
+}, 'A non-empty scopedcustomelementregistry value has boolean attribute semantics');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(
+        '<div scopedcustomelementregistry><span></span></div>');
+    const element = container.firstElementChild;
+    const registry = new CustomElementRegistry();
+
+    registry.initialize(element);
+    assert_equals(element.customElementRegistry, registry);
+    assert_equals(element.firstElementChild.customElementRegistry, registry);
+
+    const clone = element.cloneNode(true);
+    assert_equals(clone.customElementRegistry, registry);
+    assert_equals(clone.firstElementChild.customElementRegistry, registry);
+}, 'A scoped registry can initialize and clone an intentionally null registry subtree');
 
 function runBasicTests(makeIframe, elementName, elementDescription) {
     test((test) => {
@@ -176,6 +205,79 @@ promise_test(async (test) => {
         'div child should have null registry');
 }, 'Body with scopedcustomelementregistry in a complete document structure should have null registry');
 
+promise_test(async (test) => {
+    const [doc] = await iframeFromSrcdoc(test,
+        '<!DOCTYPE html><div id="target" scopedcustomelementregistry="named"><span></span></div>');
+    const element = doc.querySelector('#target');
+    assert_equals(element.customElementRegistry, null);
+    assert_equals(element.firstElementChild.customElementRegistry, null);
+
+    document.adoptNode(element);
+    assert_equals(element.customElementRegistry, null);
+    assert_equals(element.firstElementChild.customElementRegistry, null);
+    assert_equals(element.scopedCustomElementRegistry, 'named');
+}, 'Adoption preserves a parser-created intentionally null registry subtree');
+
+promise_test(async (test) => {
+    const [doc] = await iframeFromSrcdoc(test, '<!DOCTYPE html>');
+    const element = doc.createElement('div', {customElementRegistry: null});
+    assert_equals(element.customElementRegistry, null);
+
+    document.adoptNode(element);
+    assert_equals(element.customElementRegistry, customElements);
+}, 'Adoption resolves an unflagged null registry from the destination document');
+
+promise_test(async (test) => {
+    const [doc] = await iframeFromSrcdoc(test,
+        '<!DOCTYPE html><div id="target" scopedcustomelementregistry><span></span></div>');
+    const clone = doc.querySelector('#target').cloneNode(true);
+    assert_equals(clone.customElementRegistry, null);
+    assert_equals(clone.firstElementChild.customElementRegistry, null);
+
+    document.adoptNode(clone);
+    assert_equals(clone.customElementRegistry, null);
+    assert_equals(clone.firstElementChild.customElementRegistry, null);
+}, 'Cloning and adopting preserves a parser-created intentionally null registry subtree');
+
+promise_test(async (test) => {
+    const [doc] = await iframeFromSrcdoc(test,
+        '<!DOCTYPE html><div id="target" scopedcustomelementregistry><span></span></div>');
+    const imported = document.importNode(doc.querySelector('#target'), true);
+    assert_equals(imported.customElementRegistry, null);
+    assert_equals(imported.firstElementChild.customElementRegistry, null);
+}, 'Importing does not apply a fallback registry to an intentionally null registry subtree');
+
+promise_test(async (test) => {
+    const [doc] = await iframeFromSrcdoc(test, '<!DOCTYPE html>');
+    const element = doc.createElement('div', {customElementRegistry: null});
+    const imported = document.importNode(element);
+    assert_equals(imported.customElementRegistry, customElements);
+}, 'Importing applies the destination fallback registry to an unflagged null registry element');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(`
+      <div scopedcustomelementregistry>
+        <template shadowrootmode="open"><span></span></template>
+      </div>`);
+    const host = container.firstElementChild;
+    assert_equals(host.customElementRegistry, null);
+    assert_equals(host.shadowRoot.customElementRegistry, customElements);
+    assert_equals(host.shadowRoot.firstElementChild.customElementRegistry, customElements);
+}, 'scopedcustomelementregistry does not set a declarative shadow root registry to null');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(`
+      <div scopedcustomelementregistry>
+        <template shadowrootmode="open" shadowrootcustomelementregistry><span></span></template>
+      </div>`);
+    const host = container.firstElementChild;
+    assert_equals(host.customElementRegistry, null);
+    assert_equals(host.shadowRoot.customElementRegistry, null);
+    assert_equals(host.shadowRoot.firstElementChild.customElementRegistry, null);
+}, 'Element and shadow root null registry attributes compose');
+
 // Tests for scopedcustomelementregistry attribute on elements during initial document parse.
 
 test(() => {
@@ -183,6 +285,12 @@ test(() => {
   assert_equals(element.customElementRegistry, null,
     'Built-in element with scopedcustomelementregistry attribute should have null registry');
 }, 'Initial parse: built-in element with scopedcustomelementregistry has null registry');
+
+test(() => {
+  const element = document.getElementById('builtin-with-named-attr');
+  assert_equals(element.customElementRegistry, null);
+  assert_equals(element.scopedCustomElementRegistry, 'named');
+}, 'Initial parse: a non-empty scopedcustomelementregistry value has boolean semantics');
 
 test(() => {
   const element = document.getElementById('candidate-with-attr');

--- a/custom-elements/registries/scoped-custom-element-registry-content-attribute.html
+++ b/custom-elements/registries/scoped-custom-element-registry-content-attribute.html
@@ -3,6 +3,7 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#attr-scopedcustomelementregistry">
+<link rel="help" href="https://dom.spec.whatwg.org/#element-keep-custom-element-registry-null">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -63,6 +64,19 @@ test(() => {
     assert_equals(element.customElementRegistry, null);
     assert_equals(element.firstElementChild.customElementRegistry, null);
 }, 'A non-empty scopedcustomelementregistry value has boolean attribute semantics');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(`
+      <svg scopedcustomelementregistry><g></g></svg>
+      <math scopedcustomelementregistry><mi></mi></math>`);
+    const [svg, math] = container.children;
+
+    assert_equals(svg.customElementRegistry, customElements);
+    assert_equals(svg.firstElementChild.customElementRegistry, customElements);
+    assert_equals(math.customElementRegistry, customElements);
+    assert_equals(math.firstElementChild.customElementRegistry, customElements);
+}, 'scopedcustomelementregistry has no parser effect on non-HTML elements');
 
 test(() => {
     const container = document.createElement('div');
@@ -277,6 +291,46 @@ test(() => {
     assert_equals(host.shadowRoot.customElementRegistry, null);
     assert_equals(host.shadowRoot.firstElementChild.customElementRegistry, null);
 }, 'Element and shadow root null registry attributes compose');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(
+        '<div scopedcustomelementregistry><span></span></div>');
+    const element = container.firstElementChild;
+    element.removeAttribute('scopedcustomelementregistry');
+
+    assert_equals(element.customElementRegistry, null);
+    assert_equals(element.firstElementChild.customElementRegistry, null);
+    assert_equals(
+        container.innerHTML,
+        '<div scopedcustomelementregistry=""><span></span></div>');
+
+    element.setAttribute('scopedcustomelementregistry', 'named');
+    assert_equals(element.customElementRegistry, null);
+    assert_equals(element.scopedCustomElementRegistry, 'named');
+}, 'Changing the attribute after parsing does not change the established registry boundary');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(
+        '<div scopedcustomelementregistry><template shadowrootmode="open" ' +
+        'shadowrootserializable></template></div>');
+    assert_equals(
+        container.getHTML({serializableShadowRoots: true}),
+        '<div scopedcustomelementregistry=""><template shadowrootmode="open" ' +
+        'shadowrootserializable=""></template></div>');
+}, 'Element and global shadow root registry boundaries serialize independently');
+
+test(() => {
+    const container = document.createElement('div');
+    container.setHTMLUnsafe(
+        '<div scopedcustomelementregistry><template shadowrootmode="open" ' +
+        'shadowrootserializable shadowrootcustomelementregistry></template></div>');
+    assert_equals(
+        container.getHTML({serializableShadowRoots: true}),
+        '<div scopedcustomelementregistry=""><template shadowrootmode="open" ' +
+        'shadowrootserializable="" shadowrootcustomelementregistry=""></template></div>');
+}, 'Element and null shadow root registry boundaries serialize independently');
 
 // Tests for scopedcustomelementregistry attribute on elements during initial document parse.
 

--- a/custom-elements/registries/scoped-custom-element-registry-serialization.html
+++ b/custom-elements/registries/scoped-custom-element-registry-serialization.html
@@ -153,4 +153,45 @@ test(() => {
       target.firstElementChild.firstElementChild.customElementRegistry, null);
   assert_equals(target.lastElementChild.customElementRegistry, customElements);
 }, 'A serialized null registry boundary survives reparsing without redundant markers');
+
+test(() => {
+  const registry = new CustomElementRegistry();
+  const source = document.createElement('div');
+  const element = elementWithRegistry('section', registry);
+  source.append(element);
+
+  assert_false(element.hasAttribute('scopedcustomelementregistry'));
+  const serialized = source.innerHTML;
+  assert_equals(
+      serialized, '<section scopedcustomelementregistry=""></section>');
+
+  const target = document.createElement('div');
+  target.setHTMLUnsafe(serialized);
+  const parsedElement = target.firstElementChild;
+  assert_equals(parsedElement.customElementRegistry, null);
+
+  registry.initialize(parsedElement);
+  assert_equals(parsedElement.customElementRegistry, registry);
+}, 'A serialized scoped registry boundary reparses as null and can be initialized');
+
+test(() => {
+  const nullParent = elementWithRegistry('div', null);
+  nullParent.setHTMLUnsafe('<svg><g></g></svg>');
+  const svg = nullParent.firstElementChild;
+  assert_equals(svg.customElementRegistry, null);
+
+  const globalParent = document.createElement('div');
+  globalParent.append(svg);
+  assert_equals(svg.customElementRegistry, null);
+  assert_equals(globalParent.innerHTML, '<svg><g></g></svg>');
+}, 'A registry boundary on a non-HTML element does not synthesize the attribute');
+
+test(() => {
+  const parent = document.createElement('div');
+  parent.setHTMLUnsafe('<svg scopedcustomelementregistry></svg>');
+  const svg = parent.firstElementChild;
+  assert_equals(svg.customElementRegistry, customElements);
+  assert_equals(
+      parent.innerHTML, '<svg scopedcustomelementregistry=""></svg>');
+}, 'A literal attribute on a non-HTML element serializes without registry semantics');
 </script>

--- a/custom-elements/registries/scoped-custom-element-registry-serialization.html
+++ b/custom-elements/registries/scoped-custom-element-registry-serialization.html
@@ -33,8 +33,11 @@ test(() => {
   const child = elementWithRegistry('span', registry);
   parent.append(child);
   assert_equals(child.customElementRegistry, registry);
-  assert_equals(parent.innerHTML, '<span scopedcustomelementregistry=""></span>');
-}, 'A scoped registry child of a global registry parent serializes the attribute');
+  const expected = '<span scopedcustomelementregistry=""></span>';
+  assert_equals(parent.innerHTML, expected);
+  assert_equals(parent.getHTML(), expected);
+  assert_equals(child.outerHTML, expected);
+}, 'Serialization entry points agree for a scoped registry boundary');
 
 test(() => {
   const parent = elementWithRegistry('div', null);
@@ -51,7 +54,17 @@ test(() => {
   parent.append(child);
   assert_equals(child.customElementRegistry, registry);
   assert_equals(parent.innerHTML, '<span></span>');
-}, 'A child using the same scoped registry as its parent does not serialize the attribute');
+  assert_equals(parent.getHTML(), '<span></span>');
+  assert_equals(child.outerHTML, '<span></span>');
+}, 'Serialization entry points omit a child using the same scoped registry as its parent');
+
+test(() => {
+  const parent = elementWithRegistry('div', null);
+  const child = elementWithRegistry('span', null);
+  parent.append(child);
+  assert_equals(child.customElementRegistry, null);
+  assert_equals(child.outerHTML, '<span></span>');
+}, 'outerHTML omits the attribute when a null registry matches its parent');
 
 test(() => {
   const parent = elementWithRegistry('div', new CustomElementRegistry());
@@ -103,6 +116,7 @@ test(() => {
   shadow.append(child);
   assert_equals(child.customElementRegistry, null);
   assert_equals(shadow.innerHTML, '<span></span>');
+  assert_equals(shadow.getHTML(), '<span></span>');
 }, 'A shadow tree child compares against its null registry ShadowRoot');
 
 test(() => {
@@ -111,8 +125,38 @@ test(() => {
   const child = elementWithRegistry('span', null);
   shadow.append(child);
   assert_equals(child.customElementRegistry, null);
-  assert_equals(shadow.innerHTML, '<span scopedcustomelementregistry=""></span>');
+  const expected = '<span scopedcustomelementregistry=""></span>';
+  assert_equals(shadow.innerHTML, expected);
+  assert_equals(shadow.getHTML(), expected);
 }, 'A null registry shadow tree child serializes a boundary from a global registry ShadowRoot');
+
+test(() => {
+  const registry = new CustomElementRegistry();
+  const host = elementWithRegistry('div', registry);
+  const shadow = host.attachShadow({mode: 'open', customElementRegistry: registry});
+  const child = elementWithRegistry('span', registry);
+  shadow.append(child);
+  assert_equals(child.customElementRegistry, registry);
+  assert_equals(shadow.innerHTML, '<span></span>');
+  assert_equals(shadow.getHTML(), '<span></span>');
+}, 'ShadowRoot serialization omits a child using the same scoped registry');
+
+test(() => {
+  const template = document.createElement('template');
+  template.innerHTML = '<span></span>';
+  assert_equals(template.content.firstElementChild.customElementRegistry, null);
+  assert_equals(template.innerHTML, '<span></span>');
+  assert_equals(template.getHTML(), '<span></span>');
+}, 'Template serialization uses the template contents registry');
+
+test(() => {
+  const parent = document.createElement('div');
+  parent.innerHTML = '<template><span></span></template>';
+  assert_equals(
+      parent.innerHTML, '<template><span></span></template>');
+  assert_equals(
+      parent.getHTML(), '<template><span></span></template>');
+}, 'Nested template serialization uses the template contents registry');
 
 test(() => {
   const parent = document.createElement('div');

--- a/custom-elements/registries/scoped-custom-element-registry-serialization.html
+++ b/custom-elements/registries/scoped-custom-element-registry-serialization.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Serialization of scoped custom element registry boundaries</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#serialising-html-fragments">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#attr-scopedcustomelementregistry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+function elementWithRegistry(localName, registry) {
+  return document.createElement(localName, {customElementRegistry: registry});
+}
+
+test(() => {
+  const parent = document.createElement('div');
+  const child = document.createElement('span');
+  parent.append(child);
+  assert_equals(child.customElementRegistry, customElements);
+  assert_equals(parent.innerHTML, '<span></span>');
+}, 'A global registry child of a global registry parent does not serialize the attribute');
+
+test(() => {
+  const parent = document.createElement('div');
+  const child = elementWithRegistry('span', null);
+  parent.append(child);
+  assert_equals(child.customElementRegistry, null);
+  assert_equals(parent.innerHTML, '<span scopedcustomelementregistry=""></span>');
+}, 'A null registry child of a global registry parent serializes the attribute');
+
+test(() => {
+  const parent = document.createElement('div');
+  const registry = new CustomElementRegistry();
+  const child = elementWithRegistry('span', registry);
+  parent.append(child);
+  assert_equals(child.customElementRegistry, registry);
+  assert_equals(parent.innerHTML, '<span scopedcustomelementregistry=""></span>');
+}, 'A scoped registry child of a global registry parent serializes the attribute');
+
+test(() => {
+  const parent = elementWithRegistry('div', null);
+  const child = elementWithRegistry('span', null);
+  parent.append(child);
+  assert_equals(child.customElementRegistry, null);
+  assert_equals(parent.innerHTML, '<span></span>');
+}, 'A null registry child of a null registry parent does not redundantly serialize the attribute');
+
+test(() => {
+  const registry = new CustomElementRegistry();
+  const parent = elementWithRegistry('div', registry);
+  const child = elementWithRegistry('span', registry);
+  parent.append(child);
+  assert_equals(child.customElementRegistry, registry);
+  assert_equals(parent.innerHTML, '<span></span>');
+}, 'A child using the same scoped registry as its parent does not serialize the attribute');
+
+test(() => {
+  const parent = elementWithRegistry('div', new CustomElementRegistry());
+  const childRegistry = new CustomElementRegistry();
+  const child = elementWithRegistry('span', childRegistry);
+  parent.append(child);
+  assert_equals(child.customElementRegistry, childRegistry);
+  assert_equals(parent.innerHTML, '<span scopedcustomelementregistry=""></span>');
+}, 'A different scoped registry child serializes the attribute');
+
+test(() => {
+  const parent = elementWithRegistry('div', null);
+  const child = document.createElement('span');
+  parent.append(child);
+  assert_equals(child.customElementRegistry, customElements);
+  assert_equals(parent.innerHTML, '<span></span>');
+}, 'A global registry child of a null registry parent does not serialize an inverse marker');
+
+test(() => {
+  const parent = elementWithRegistry('div', new CustomElementRegistry());
+  const child = document.createElement('span');
+  parent.append(child);
+  assert_equals(child.customElementRegistry, customElements);
+  assert_equals(parent.innerHTML, '<span></span>');
+}, 'A global registry child of a scoped registry parent does not serialize an inverse marker');
+
+test(() => {
+  const element = document.createElement('div');
+  assert_equals(element.outerHTML, '<div></div>');
+}, 'A detached global registry element does not serialize the attribute');
+
+test(() => {
+  const element = elementWithRegistry('div', null);
+  assert_equals(element.customElementRegistry, null);
+  assert_equals(element.outerHTML, '<div scopedcustomelementregistry=""></div>');
+}, 'A detached null registry element serializes the attribute');
+
+test(() => {
+  const registry = new CustomElementRegistry();
+  const element = elementWithRegistry('div', registry);
+  assert_equals(element.customElementRegistry, registry);
+  assert_equals(element.outerHTML, '<div scopedcustomelementregistry=""></div>');
+}, 'A detached scoped registry element serializes the attribute');
+
+test(() => {
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({mode: 'open', customElementRegistry: null});
+  const child = elementWithRegistry('span', null);
+  shadow.append(child);
+  assert_equals(child.customElementRegistry, null);
+  assert_equals(shadow.innerHTML, '<span></span>');
+}, 'A shadow tree child compares against its null registry ShadowRoot');
+
+test(() => {
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({mode: 'open'});
+  const child = elementWithRegistry('span', null);
+  shadow.append(child);
+  assert_equals(child.customElementRegistry, null);
+  assert_equals(shadow.innerHTML, '<span scopedcustomelementregistry=""></span>');
+}, 'A null registry shadow tree child serializes a boundary from a global registry ShadowRoot');
+
+test(() => {
+  const parent = document.createElement('div');
+  const child = elementWithRegistry('span', null);
+  child.id = 'target';
+  parent.append(child);
+  assert_equals(
+      parent.innerHTML,
+      '<span scopedcustomelementregistry="" id="target"></span>');
+}, 'A synthesized registry attribute precedes content attributes');
+
+test(() => {
+  const parent = document.createElement('div');
+  parent.setHTMLUnsafe('<span scopedcustomelementregistry="named"></span>');
+  assert_equals(
+      parent.innerHTML, '<span scopedcustomelementregistry="named"></span>');
+}, 'Serialization preserves an existing non-empty attribute value');
+
+test(() => {
+  const parent = document.createElement('div');
+  parent.setHTMLUnsafe(
+      '<section scopedcustomelementregistry><span></span></section>');
+  assert_equals(
+      parent.innerHTML,
+      '<section scopedcustomelementregistry=""><span></span></section>');
+}, 'Serialization does not repeat the attribute through a null registry subtree');
+
+test(() => {
+  const source = document.createElement('div');
+  const nullRoot = elementWithRegistry('section', null);
+  nullRoot.append(elementWithRegistry('span', null));
+  source.append(nullRoot, document.createElement('aside'));
+
+  const target = document.createElement('div');
+  target.setHTMLUnsafe(source.innerHTML);
+  assert_equals(target.firstElementChild.customElementRegistry, null);
+  assert_equals(
+      target.firstElementChild.firstElementChild.customElementRegistry, null);
+  assert_equals(target.lastElementChild.customElementRegistry, customElements);
+}, 'A serialized null registry boundary survives reparsing without redundant markers');
+</script>

--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -127,6 +127,7 @@ interface HTMLElement : Element {
   [CEReactions, ReflectSetter] attribute DOMString writingSuggestions;
   [CEReactions, ReflectSetter] attribute DOMString autocapitalize;
   [CEReactions] attribute boolean autocorrect;
+  [CEReactions, Reflect] attribute DOMString scopedCustomElementRegistry;
 
   [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
   [CEReactions] attribute [LegacyNullToEmptyString] DOMString outerText;


### PR DESCRIPTION
Renames the scoped custom element registry content attribute from `customelementregistry` to `scopedcustomelementregistry`, following the naming consensus in whatwg/html#12000.

Also updates the `HTMLElement` IDL member to `scopedCustomElementRegistry` with `DOMString` reflection and adds direct reflection coverage.

Specification: https://github.com/whatwg/html/pull/12000

DOM infrastructure: https://github.com/whatwg/dom/pull/1500


Coverage includes foreign-namespace behavior, post-parse mutation, adoption and cloning, declarative and serializable shadow roots, and explicit scoped registry serialize-parse-initialize behavior.
