### PR TITLE
Patch aioquic so that it sends a truthful max_udp_payload_size

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import dataclasses
 import logging
 import os
 import ssl
@@ -17,6 +18,7 @@ from aioquic.asyncio.client import connect
 from aioquic.asyncio.protocol import QuicStreamAdapter
 from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, SettingsError
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived
+from aioquic.quic import connection as quic_connection
 from aioquic.quic.configuration import QuicConfiguration
 from aioquic.quic.connection import logger as quic_connection_logger
 from aioquic.quic.connection import (
@@ -24,6 +26,7 @@ from aioquic.quic.connection import (
     stream_is_unidirectional,
 )
 from aioquic.quic.events import QuicEvent, ProtocolNegotiated, ConnectionTerminated, StreamReset
+from aioquic.quic.packet import QuicTransportParameters
 from aioquic.tls import SessionTicket
 
 from tools import localpaths  # noqa: F401
@@ -47,6 +50,39 @@ _doc_root: str = ""
 # Set aioquic's log level to WARNING to suppress some INFO logs which are
 # recorded every connection close.
 quic_connection_logger.setLevel(logging.WARNING)
+
+# aioquic 1.2.0 cannot handle UDP payloads larger than 1500 bytes (PACKET_LENGTH_MAX in
+# its _crypto.c), but it does not send any max_udp_payload_size parameter (which
+# defaults to 65527). As a result of this, peers may send us datagrams larger than what
+# it supports, which it then drops.
+#
+# This patches aioquic to advertise its limit by injecting max_udp_payload_size as
+# the transport parameters are serialized, via the name bound in aioquic.quic.connection
+# rather than the one in aioquic.quic.packet so that only the send path is affected:
+# _serialize_transport_parameters() is the sole caller. Received parameters are built by
+# pull_quic_transport_parameters() and stay untouched.
+#
+# See also: https://github.com/aiortc/aioquic/pull/648
+
+_push_quic_transport_parameters = quic_connection.push_quic_transport_parameters
+
+
+def _push_quic_transport_parameters_with_max_udp_payload_size(
+        buf: Buffer, params: QuicTransportParameters) -> None:
+    params = dataclasses.replace(
+        params,
+        max_udp_payload_size=(
+            1500
+            if params.max_udp_payload_size is None
+            else max(1500, params.max_udp_payload_size)
+        ),
+    )
+    _push_quic_transport_parameters(buf, params)
+
+
+quic_connection.push_quic_transport_parameters = (
+    _push_quic_transport_parameters_with_max_udp_payload_size
+)
 
 
 class H3DatagramSetting(IntEnum):


### PR DESCRIPTION
https://github.com/aiortc/aioquic/pull/648 is open for this, but with aioquic having [dropped support for Python 3.9](https://github.com/aiortc/aioquic/commit/cbde38d799c46c675d83025ae8ec6866a3594874), we'd need to fork (and ship wheels, etc.).

Thus, as an immediately workable alternative, we patch aioquic at runtime to fix the issue.

This impacts https://wpt.fyi/results/webtransport?label=master&label=experimental&aligned&view=interop&q=label%3Ainterop-2026-webtransport%20streams-echo%20or%20echo-large-bidirectional, when using Apple's Network framework, which uses the min of the remote's `max_udp_payload_size` and ~9K as the max datagram size for loopback — and then, on those tests, when it tries to send a datagram greater than 1500, aioquic drops the packet, and the test eventually times out.

The relevant code in aioquic, for reference, is: https://github.com/aiortc/aioquic/blob/1.2.0/src/aioquic/_crypto.c#L126-L129 and  https://github.com/aiortc/aioquic/blob/1.2.0/src/aioquic/quic/connection.py#L939-L950
