### PR TITLE
Test noopener with special targets without a javascript: URL

### DIFF
--- a/html/browsers/the-window-object/window-open-noopener-existing-iframe.html
+++ b/html/browsers/the-window-object/window-open-noopener-existing-iframe.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>window.open() with "noopener" targeting an existing navigable does not set its opener</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+/**
+ * The name lookup in "the rules for choosing a navigable" happens regardless of
+ * noopener, so window.open() can pick an existing navigable even when noopener
+ * is set. When it does, the window open steps must not set that navigable's
+ * opener, which for a nested navigable such as an iframe means it has to stay
+ * null.
+ */
+async_test(function(t) {
+  var iframe = document.createElement("iframe");
+  iframe.name = "window-open-noopener-existing-iframe";
+  t.add_cleanup(function() { iframe.remove(); });
+
+  iframe.onload = t.step_func(function() {
+    assert_equals(iframe.contentWindow.opener, null,
+                  "A nested navigable has no opener to begin with");
+
+    iframe.onload = t.step_func_done(function() {
+      assert_equals(iframe.contentWindow.location.pathname, "/common/blank.html",
+                    "Should have navigated the existing iframe");
+      assert_equals(iframe.contentWindow.opener, null,
+                    "Should not have set the opener of the existing iframe");
+    });
+
+    assert_equals(window.open("/common/blank.html", iframe.name, "noopener"), null,
+                  "window.open() with noopener returns null");
+  });
+
+  document.body.append(iframe);
+}, "window.open() with noopener targeting an existing named iframe does not set its opener");
+</script>

--- a/html/browsers/the-window-object/window-open-noopener.html
+++ b/html/browsers/the-window-object/window-open-noopener.html
@@ -10,6 +10,7 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<div id=log></div>
 <script>
 var testData = [
   { testDescription: "window.open() with 'noopener' should reuse existing target",
@@ -108,20 +109,30 @@ function indexedTests() {
 }
 
 /**
- * Loop over the special targets that ignore noopener and check that doing a
- * window.open() with those targets correctly reuses the existing window.
+ * Check that a window.open() with one of the special targets that ignore
+ * noopener correctly reuses the existing window. The call is made from a
+ * same-origin iframe, so that _self names a different window than _parent and
+ * _top do. The URL is the empty string, so nothing is navigated and this only
+ * tests which window gets chosen.
  */
 function specialTargetTest(target) {
-  if (["_self", "_parent", "_top"].includes(target)) {
-    var t = async_test("noopener window.open targeting " + target);
-    t.openedWindow = window.open(`javascript:var w2 = window.open("", "${target}", "noopener"); this.checkValues(w2); this.close(); void(0);`);
-    assert_equals(t.openedWindow.opener, window);
-    t.openedWindow.checkValues = t.step_func_done(function(win) {
-      assert_equals(win, this.openedWindow);
-    });
-  } else {
+  if (!["_self", "_parent", "_top"].includes(target)) {
     throw 'testError: special target must be one of: _self, _parent, _top'
   }
+  async_test(function(t) {
+    var iframe = document.createElement("iframe");
+    t.add_cleanup(function() { iframe.remove(); });
+
+    window.reportOpenedWindow = t.step_func_done(function(win) {
+      assert_equals(win, target == "_self" ? iframe.contentWindow : window,
+                    "Should have reused the existing window");
+    });
+
+    iframe.srcdoc = `<script>
+      parent.reportOpenedWindow(window.open("", "${target}", "noopener"));
+    <\/script>`;
+    document.body.append(iframe);
+  }, "noopener window.open targeting " + target);
 }
 
 /**


### PR DESCRIPTION
The special target variants of window-open-noopener.html opened a popup
with a javascript: URL and assigned the callback the URL invokes only
after window.open() returned. That relies on the javascript: URL being
evaluated in a queued task, which is covered elsewhere, and it made all
three variants time out in WebKit rather than report anything about
noopener.

Make the call from a same-origin srcdoc iframe instead. This also lets
_self name a different window than _parent and _top do, which the popup
did not.

Additionally add a test that window.open() with noopener targeting an
existing named iframe does not set that iframe's opener, as required by
step 17.2 of the window open steps. The name lookup in "the rules for
choosing a navigable" ignores noopener, so this case is reachable, but
nothing covered it.

Depends on https://github.com/whatwg/html/pull/12844, which restores the name lookup that makes the new test reachable.


The special target change matches https://github.com/whatwg/html/pull/12845.
