### PR TITLE
Add parser tests for foster parenting into a template

### DIFF
--- a/html/semantics/scripting-1/the-template-element/template-for/template-for-foster-parenting.html
+++ b/html/semantics/scripting-1/the-template-element/template-for/template-for-foster-parenting.html
@@ -6,11 +6,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
-// Content that is misnested in a table inside a <template for> is foster
-// parented. Because the <template for> is older on the stack of open elements
-// than the <table>, foster parenting resolves to the target (before the table),
-// not to the template's own (empty) contents. The fostered content must
-// therefore end up in the target, not be lost.
+// Content misnested inside a <template for> is foster parented, and must end up
+// in the target rather than in the template's own (empty) contents.
 async function parseToRoot(method, html) {
   switch (method) {
     case "iframe": {
@@ -45,6 +42,8 @@ function processingInstructions(root) {
   return result;
 }
 
+// The template is older on the stack of open elements than the table, so this
+// resolves through the last table, to before it.
 for (const method of ["iframe", "innerHTML", "stream"]) {
   promise_test(async () => {
     const root = await parseToRoot(method,
@@ -67,6 +66,30 @@ for (const method of ["iframe", "innerHTML", "stream"]) {
       Node.DOCUMENT_POSITION_FOLLOWING,
       "fostered content is inserted before the table");
   }, `Foster parenting inside <template for> keeps content in the target (${method})`);
+}
+
+// With no table on the stack of open elements this resolves through the last
+// template instead, which must still honor its insertion target.
+for (const method of ["iframe", "innerHTML", "stream"]) {
+  promise_test(async () => {
+    const root = await parseToRoot(method,
+      `<div id="target"><?start name="p">Old<?end></div>` +
+      `<template for="p"><tr><div id="fostered">X</div></tr></template>`);
+    const target = root.querySelector("#target");
+    const tr = target.querySelector("tr");
+    const fostered = root.querySelector("#fostered");
+
+    assert_equals(processingInstructions(root).length, 0,
+      "markers should be removed");
+    assert_not_equals(tr, null, "the tr should be inserted at the target");
+    assert_equals(tr.parentNode, target);
+    assert_not_equals(fostered, null, "fostered content should not be lost");
+    assert_equals(fostered.parentNode, target,
+      "fostered content should be a child of the target");
+    assert_equals(fostered.textContent, "X");
+    assert_array_equals([...target.children].map(el => el.localName),
+      ["tr", "div"], "fostered content follows the tr in the target");
+  }, `Foster parenting out of a tr inside <template for> keeps content in the target (${method})`);
 }
 </script>
 </body>

--- a/html/syntax/parsing/foster-parenting-into-template-element.html
+++ b/html/syntax/parsing/foster-parenting-into-template-element.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Foster parenting when the table's parent is a template element</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#appropriate-place-for-inserting-a-node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/adoption-agency-reparenting.js"></script>
+<body>
+<script>
+// The inline script makes a script-created <template> element the parent of the
+// on-stack <table>, so foster parenting resolves to a template element and must
+// redirect into its contents. There is no insertion target, so the position
+// before the table is dropped and the content appended.
+const SRCDOC = `<table><tr><script>
+  window.tmpl = document.createElement("template");
+  document.body.appendChild(window.tmpl);
+  window.tmpl.appendChild(document.querySelector("table"));
+<\/script><b id="fostered">x</b>FOSTERTEXT`;
+
+promise_test(async t => {
+  const iframe = await parseInIframe(t, SRCDOC);
+  const tmpl = iframe.contentWindow.tmpl;
+  const table = tmpl.querySelector("table");
+
+  assert_equals(tmpl.parentNode, iframe.contentDocument.body,
+    "the template element stayed where the script put it");
+  assert_not_equals(table, null, "the table was moved into the template element");
+  assert_equals(table.parentNode, tmpl,
+    "the table is a child of the template element, not of its contents");
+
+  const where = tmpl.content.querySelector("#fostered") ? "template-contents"
+              : tmpl.querySelector("#fostered") ? "template-element"
+              : iframe.contentDocument.getElementById("fostered") ? "elsewhere"
+              : "dropped";
+  const detail = `tmpl.content=${tree(tmpl.content)}, tmpl=${tree(tmpl)}`;
+  assert_equals(where, "template-contents",
+    `the foster-parented element goes into the template's contents (${detail})`);
+  assert_equals(tree(tmpl.content), `<b#fostered>["x"]"FOSTERTEXT"`,
+    "foster-parented text follows it into the same contents");
+}, "Foster parenting redirects into the template contents when the table's parent is a template element");
+</script>
+</body>

--- a/html/syntax/parsing/resources/template.dat
+++ b/html/syntax/parsing/resources/template.dat
@@ -633,6 +633,23 @@ foster-parented /div
 |         <div>
 
 #data
+<table><template><tr><div></div></tr></template>
+#errors
+no doctype
+foster-parented div
+foster-parented /div
+eof in table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <template>
+|         content
+|           <tr>
+|           <div>
+
+#data
 <body><template><tr></tr><td></td></template>
 #errors
 no doctype


### PR DESCRIPTION
Three foster parenting paths that had no coverage. Found while reviewing https://github.com/whatwg/html/pull/12831, which rewrites "appropriate place for inserting a node".

**`template-for-foster-parenting.html`** gains a second case: foster parenting out of a `<tr>` inside a `<template for>`, where the template is the last `template` on the stack of open elements and there is no `table` on the stack at all. The content has to go to the template's insertion target — a `<template for>` element is never inserted into the DOM, so resolving to its template contents loses the content, which is the same failure the existing case in that file was written to catch. The existing case only covers the shape where the template is *older* than the table and foster parenting therefore resolves through the last table instead.

**`template.dat`** gains `<table><template><tr><div></div></tr></template>`, the same shape for a plain `<template>` nested in a `<table>` so that the last table is non-null. It sits next to the existing `<body><template><tr><div></div></tr></template>` case, which has no table.

**`foster-parenting-into-template-element.html`** is new: script makes a `template` element the parent of the last table, so foster parenting resolves to a template element and has to redirect into its contents. The template has no insertion target, so the position before the table is dropped and the content appended.

Results in the three engines:

| | Chrome Canary 154 | Safari | Firefox |
|---|---|---|---|
| `template-for-foster-parenting.html` | pass | — | — |
| `template.dat` | pass | — | — |
| `foster-parenting-into-template-element.html` | fail (dropped) | pass | fail |

The last row is a known divergence, not a new requirement: Chrome and Firefox drop the element rather than inserting it. That is what keeping the reference child across the template redirect would produce, since the table is not a child of the template contents; the spec resets it to null. Filed here as-is since Safari matches the specification.