### PR TITLE
[Extensions] Support Windows paths in extension WPT runner

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import os
-import posixpath
+import pathlib
 import socket
 import threading
 import traceback
@@ -1063,7 +1063,7 @@ class WebDriverWebExtensionsProtocolPart(WebExtensionsProtocolPart):
 
     def _resolve_path(self, path):
         if self.parent.test_path is not None:
-             # Handle Windows forward slashes.
+            # Handle Windows forward slashes.
             test_dir = pathlib.Path(self.parent.test_path).parent
             if test_dir.parts:
                 return f"{test_dir.as_posix()}/{path.lstrip('/')}"

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -463,9 +463,9 @@ class WebDriverBidiWebExtensionsProtocolPart(WebExtensionsProtocolPart):
     def _resolve_path(self, path):
         if self.parent.test_path is not None:
             # Handle Windows forward slashes.
-            dirname = posixpath.dirname(self.parent.test_path.replace("\\", "/"))
-            if dirname:
-                return f"{dirname}/{path.lstrip('/')}"
+            test_dir = pathlib.Path(self.parent.test_path).parent
+            if test_dir.parts:
+                return f"{test_dir.as_posix()}/{path.lstrip('/')}"
         return path
 
 class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
@@ -1064,9 +1064,9 @@ class WebDriverWebExtensionsProtocolPart(WebExtensionsProtocolPart):
     def _resolve_path(self, path):
         if self.parent.test_path is not None:
              # Handle Windows forward slashes.
-            dirname = posixpath.dirname(self.parent.test_path.replace("\\", "/"))
-            if dirname:
-                return f"{dirname}/{path.lstrip('/')}"
+            test_dir = pathlib.Path(self.parent.test_path).parent
+            if test_dir.parts:
+                return f"{test_dir.as_posix()}/{path.lstrip('/')}"
         return path
 
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import posixpath
 import socket
 import threading
 import traceback
@@ -461,7 +462,10 @@ class WebDriverBidiWebExtensionsProtocolPart(WebExtensionsProtocolPart):
 
     def _resolve_path(self, path):
         if self.parent.test_path is not None:
-            return self.parent.test_path.rsplit("/", 1)[0] + path
+            # Handle Windows forward slashes.
+            dirname = posixpath.dirname(self.parent.test_path.replace("\\", "/"))
+            if dirname:
+                return f"{dirname}/{path.lstrip('/')}"
         return path
 
 class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
@@ -1059,7 +1063,10 @@ class WebDriverWebExtensionsProtocolPart(WebExtensionsProtocolPart):
 
     def _resolve_path(self, path):
         if self.parent.test_path is not None:
-            return self.parent.test_path.rsplit("/", 1)[0] + path
+             # Handle Windows forward slashes.
+            dirname = posixpath.dirname(self.parent.test_path.replace("\\", "/"))
+            if dirname:
+                return f"{dirname}/{path.lstrip('/')}"
         return path
 
 


### PR DESCRIPTION
Before this CL, web-extension WPT tests (such as browser.alarms, browser.bookmarks, browser.browsingData, browser.idle, browser.runtime, and browser.storage), when running these tests on Windows, had `executorwebdriver._resolve_path` fail because it split `test_path` on "/" while Windows paths use backslashes.

This caused invalid concatenated extension paths like "web-extensions\browser.alarms.extension.html/resources/alarms/", leading to unhandled promise rejections during extension installation. After this CL, web-extension WPT tests resolve paths correctly across all platforms.

To accomplish this, executorwebdriver._resolve_path now normalizes Windows backslashes to forward slashes with posixpath.dirname and strips leading slashes before joining.