### PR TITLE
[wdspec] Add tests on releasing actions with modifiers

### DIFF
--- a/webdriver/tests/bidi/input/release_actions/sequence.py
+++ b/webdriver/tests/bidi/input/release_actions/sequence.py
@@ -36,6 +36,7 @@ async def test_release_char_sequence_sends_keyup_events_in_reverse(
     (events, expected) = filter_supported_key_events(all_events, expected)
     assert events == expected
 
+
 async def test_release_char_sequence_with_modifier_sends_keyup_events_in_reverse(
     bidi_session, top_context, load_static_test_page, get_focused_key_input
 ):

--- a/webdriver/tests/bidi/input/release_actions/sequence.py
+++ b/webdriver/tests/bidi/input/release_actions/sequence.py
@@ -3,6 +3,7 @@ from webdriver.bidi.modules.input import Actions, get_element_origin
 from webdriver.bidi.modules.script import ContextTarget
 
 from tests.support.helpers import filter_dict, filter_supported_key_events
+from tests.support.keys import Keys
 from .. import get_events
 
 pytestmark = pytest.mark.asyncio
@@ -29,6 +30,34 @@ async def test_release_char_sequence_sends_keyup_events_in_reverse(
     await bidi_session.input.release_actions(context=top_context["context"])
     expected = [
         {"code": "KeyB", "key": "b", "type": "keyup"},
+        {"code": "KeyA", "key": "a", "type": "keyup"},
+    ]
+    all_events = await get_events(bidi_session, top_context["context"])
+    (events, expected) = filter_supported_key_events(all_events, expected)
+    assert events == expected
+
+async def test_release_char_sequence_with_modifier_sends_keyup_events_in_reverse(
+    bidi_session, top_context, load_static_test_page, get_focused_key_input
+):
+    await load_static_test_page(page="test_actions.html")
+    await get_focused_key_input()
+
+    actions = Actions()
+    actions.add_key().key_down("a").key_down(Keys.SHIFT).key_down("b")
+    await bidi_session.input.perform_actions(
+        actions=actions, context=top_context["context"]
+    )
+
+    # Reset so we only see the release events
+    await bidi_session.script.evaluate(
+        expression="resetEvents()",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+    await bidi_session.input.release_actions(context=top_context["context"])
+    expected = [
+        {"code": "KeyB", "key": "B", "type": "keyup"},
+        {"code": "ShiftLeft", "key": "Shift", "type": "keyup"},
         {"code": "KeyA", "key": "a", "type": "keyup"},
     ]
     all_events = await get_events(bidi_session, top_context["context"])

--- a/webdriver/tests/classic/release_actions/sequence.py
+++ b/webdriver/tests/classic/release_actions/sequence.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.classic.release_actions.support.refine import get_events, get_keys
 from tests.support.helpers import filter_supported_key_events
+from tests.support.keys import Keys
 
 
 def test_release_no_actions_sends_no_events(session, key_reporter):
@@ -22,6 +23,26 @@ def test_release_char_sequence_sends_keyup_events_in_reverse(
     session.actions.release()
     expected = [
         {"code": "KeyB", "key": "b", "type": "keyup"},
+        {"code": "KeyA", "key": "a", "type": "keyup"},
+    ]
+    all_events = get_events(session)
+    (events, expected) = filter_supported_key_events(all_events, expected)
+    assert events == expected
+
+def test_release_char_sequence_with_modifier_sends_keyup_events_in_reverse(
+    session, key_reporter, key_chain
+):
+    key_chain \
+        .key_down("a") \
+        .key_down(Keys.SHIFT) \
+        .key_down("b") \
+        .perform()
+    # reset so we only see the release events
+    session.execute_script("resetEvents();")
+    session.actions.release()
+    expected = [
+        {"code": "KeyB", "key": "B", "type": "keyup"},
+        {"code": "ShiftLeft", "key": "Shift", "type": "keyup"},
         {"code": "KeyA", "key": "a", "type": "keyup"},
     ]
     all_events = get_events(session)

--- a/webdriver/tests/classic/release_actions/sequence.py
+++ b/webdriver/tests/classic/release_actions/sequence.py
@@ -29,6 +29,7 @@ def test_release_char_sequence_sends_keyup_events_in_reverse(
     (events, expected) = filter_supported_key_events(all_events, expected)
     assert events == expected
 
+
 def test_release_char_sequence_with_modifier_sends_keyup_events_in_reverse(
     session, key_reporter, key_chain
 ):


### PR DESCRIPTION
Add an extra test for both bidi and classic with a modifier in the middle of the sequence to be released, to check whether the input cancel list is treating both regular keys and modifiers in reversed order.

During the review of a WebKit fix for the `Release Actions` command in https://github.com/WebKit/WebKit/pull/70362, we found out that the current test only covers releasing regular keys, but not modifiers like `Keys.SHIFT`.

This is passing in Firefox 152, but Chrome 154 is failing with different behaviors in both classic and bidi tests.