### PR TITLE
improve coverage of IPv4-in-IPv6 parsing failure cases

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -7581,6 +7581,18 @@
     "hash": ""
   },
   "# IPv6 tests",
+  "IPv4 pieces embedded in IPv6 addresses must not have leading zeroes",
+  {
+    "input": "https://[0:1:2:3:4:5:192.0.02.1]/",
+    "base": null,
+    "failure": true
+  },
+  "An embedded IPv4 address must end the IPv6 address",
+  {
+    "input": "https://[192.0.2.1::]/",
+    "base": null,
+    "failure": true
+  },
   {
     "input": "http://[1:0::]",
     "base": "http://example.net/",


### PR DESCRIPTION
In the process of creating an independent URL parser implementation, I got to a point where it passed the full `urltestdata.json` conformance suite but I still discovered two separate bugs. My implementation incorrectly accepted both of the following inputs:

1. `https://[0:1:2:3:4:5:192.0.02.1]/`
1. `https://[192.0.2.1::]/`

For the first, [the IPv6 parser](https://url.spec.whatwg.org/#concept-ipv6-parser) fails when another digit follows an `ipv4Piece` whose value is `0` (step 6.5.5.4.3):

> Otherwise, if ipv4Piece is 0, IPv4-in-IPv6-invalid-code-point validation error, return failure.

The existing leading-zero case, `[0:1.00.0.0.0]`, also contains five dotted parts. Because this case had more than one kind of error, my parser rejected it based on the part count without having to reject it for the leading zero. The new case has exactly four dotted parts and is otherwise structurally valid.

For `192.0.2.1::`, the IPv6 parser’s embedded IPv4 loop accepts a separator only when it is `.` and fewer than four parts have been seen. After four parts, the next input must be EOF (step 6.7):

> Otherwise, if c is not the EOF code point, IPv6-invalid-code-point validation error, return failure.

My parser initially incorrectly split around `::` before parsing the IPv4 component. The existing related cases don't cover `::` following an IPv4 component:

| category | cases |
| --- | --- |
| non-numeric or empty initial parts  | `[www.google.com]`, `[google.com]`, `[::.1.2]`, `[::.1]`, `[0:.0]` |
| too few or empty trailing parts | `[::1.]`, `[::1.2.]`, `[::1.2.3.]`, `[0:1.23.23]` |
| trailing characters | `[::1.2.3.4x]`, `[::127.0.0.1.]` |
| excessive dotted parts | `[::127.0.0.0.1]` | 
| too many IPv6 pieces | `[0:1:2:3:4:5:6:7.0.0.0.1]` |
| an out-of-range part | `[0:1.290.0.0.0]` |
| leading zero combined with excessive dotted parts | `[0:1.00.0.0.0]` |

I've run the linter and confirmed each failure against node.js's `URL` implementation.

Disclaimer: I've used an LLM while implementing my URL parser, analysing the missing WPT coverage and URL specification requirements, and drafting this PR. All of these words are my own and I've manually reviewed the LLM-reported missing coverage.