### PR TITLE
Move symbols() function tests out of counter-style-at-rule folder

### DIFF
--- a/css/css-counter-styles/symbols-function-dynamic-ref.html
+++ b/css/css-counter-styles/symbols-function-dynamic-ref.html
@@ -2,7 +2,7 @@
 <meta charset="UTF-8">
 <title>CSS Reference: symbols() marker after a script style change</title>
 <link rel="author" title="Ananya Anand" href="mailto:t-anaanand@microsoft.com">
-<link rel="stylesheet" href="support/test-common.css">
+<link rel="stylesheet" href="counter-style-at-rule/support/test-common.css">
 <style type="text/css">
   @counter-style ref {
     system: symbolic;

--- a/css/css-counter-styles/symbols-function-dynamic.html
+++ b/css/css-counter-styles/symbols-function-dynamic.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Ananya Anand" href="mailto:t-anaanand@microsoft.com">
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#symbols-function">
 <link rel="match" href="symbols-function-dynamic-ref.html">
-<link rel="stylesheet" href="support/test-common.css">
+<link rel="stylesheet" href="counter-style-at-rule/support/test-common.css">
 <style id="test-style" type="text/css">
   #list {
     list-style-type: symbols('*');

--- a/css/css-counter-styles/symbols-function-invalid-ref.html
+++ b/css/css-counter-styles/symbols-function-invalid-ref.html
@@ -2,7 +2,7 @@
 <meta charset="UTF-8">
 <title>CSS Reference: symbols function, invalid</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
-<link rel="stylesheet" href="support/test-common.css">
+<link rel="stylesheet" href="counter-style-at-rule/support/test-common.css">
 <style type="text/css">
   .invalid {
     list-style-type: lower-greek;

--- a/css/css-counter-styles/symbols-function-invalid.html
+++ b/css/css-counter-styles/symbols-function-invalid.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#symbols-function">
 <link rel="match" href="symbols-function-invalid-ref.html">
-<link rel="stylesheet" href="support/test-common.css">
+<link rel="stylesheet" href="counter-style-at-rule/support/test-common.css">
 <style type="text/css">
   .invalid {
     list-style-type: lower-greek;

--- a/css/css-counter-styles/symbols-function-ref.html
+++ b/css/css-counter-styles/symbols-function-ref.html
@@ -2,7 +2,7 @@
 <meta charset="UTF-8">
 <title>CSS Reference: symbols function, invalid</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
-<link rel="stylesheet" href="support/test-common.css">
+<link rel="stylesheet" href="counter-style-at-rule/support/test-common.css">
 <style type="text/css">
   @counter-style cyclic {
     system: cyclic;

--- a/css/css-counter-styles/symbols-function.html
+++ b/css/css-counter-styles/symbols-function.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#symbols-function">
 <link rel="match" href="symbols-function-ref.html">
-<link rel="stylesheet" href="support/test-common.css">
+<link rel="stylesheet" href="counter-style-at-rule/support/test-common.css">
 <style type="text/css">
   .default {
     list-style-type: symbols('*' '\2020' '\2021' '\A7');


### PR DESCRIPTION
The symbols() function doesn't really involve @counter-style, but rather is a replacement for it.