### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321396

### DIFF
--- a/css/css-counter-styles/hebrew/css3-counter-styles-016.html
+++ b/css/css-counter-styles/hebrew/css3-counter-styles-016.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html  lang="en" >
 <head>
+<meta name="fuzzy" content="maxDifference=0-250; totalPixels=0-29">
 <meta charset="utf-8"/>
 <title>hebrew, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>

--- a/css/css-lists/list-marker-counter-style-fallback-rtl-ref.html
+++ b/css/css-lists/list-marker-counter-style-fallback-rtl-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+ol {
+  list-style-position: inside;
+  list-style-type: hebrew;
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+}
+</style>
+<ol start="14">
+  <li>text</li>
+</ol>

--- a/css/css-lists/list-marker-counter-style-fallback-rtl.html
+++ b/css/css-lists/list-marker-counter-style-fallback-rtl.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: marker reaching a right-to-left counter style through a fallback</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#counter-style-fallback">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-type-property">
+<link rel="match" href="list-marker-counter-style-fallback-rtl-ref.html">
+<meta name="assert" content="A counter style that cannot represent a value draws its fallback's text, so a marker falling back to a right-to-left counter style is laid out like that counter style rather than in logical order.">
+<style>
+@counter-style ltr-with-rtl-fallback {
+  system: fixed;
+  symbols: "a";
+  fallback: hebrew;
+}
+ol {
+  list-style-position: inside;
+  list-style-type: ltr-with-rtl-fallback;
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+}
+</style>
+<!-- The fixed system covers value 1 only, so 14 comes from hebrew: yod followed by dalet in logical
+     order, which has to be reordered to paint dalet first. -->
+<ol start="14">
+  <li>text</li>
+</ol>

--- a/css/css-lists/list-marker-counter-style-mutation-ref.html
+++ b/css/css-lists/list-marker-counter-style-mutation-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+@counter-style mutated { system: cyclic; symbols: "x"; }
+</style>
+<ol style="list-style-type: mutated"><li>text</li></ol>

--- a/css/css-lists/list-marker-counter-style-mutation.html
+++ b/css/css-lists/list-marker-counter-style-mutation.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Lists: marker follows a mutated @counter-style rule</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-type-property">
+<link rel="match" href="list-marker-counter-style-mutation-ref.html">
+<meta name="assert" content="Changing an @counter-style rule's symbols descriptor updates the markers of the list items using that counter style, including when the new symbols no longer need bidi resolution.">
+<style id="counterStyleSheet">
+@counter-style mutated { system: cyclic; symbols: "\627"; }
+</style>
+<ol style="list-style-type: mutated"><li>text</li></ol>
+<script src="/common/reftest-wait.js"></script>
+<script>
+addEventListener("load", () => {
+  document.body.offsetLeft;
+  document.getElementById("counterStyleSheet").sheet.cssRules[0].symbols = '"x"';
+  takeScreenshot();
+}, { once: true });
+</script>
+</html>

--- a/css/css-lists/list-marker-rtl-string-width-ref.html
+++ b/css/css-lists/list-marker-rtl-string-width-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+div {
+  margin: 0;
+  padding: 0;
+}
+span {
+  unicode-bidi: isolate;
+  white-space: pre;
+}
+</style>
+<div><span>&#x627;&#x644;</span>a</div>

--- a/css/css-lists/list-marker-rtl-string-width.html
+++ b/css/css-lists/list-marker-rtl-string-width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: marker box reserves the width of the glyphs it paints</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-type-property">
+<link rel="match" href="list-marker-rtl-string-width-ref.html">
+<meta name="assert" content="A list-style-type string of right-to-left text reserves the width of the glyphs actually painted, so the list item's content starts after the marker instead of overlapping it.">
+<style>
+ol {
+  list-style-position: inside;
+  list-style-type: "\627 \644 ";
+  margin: 0;
+  padding: 0;
+}
+</style>
+<!-- The marker text is two separate glyphs. Reversing it into lam-alef order would form a
+     narrower ligature; sizing the marker box from that would let "a" paint over the marker. -->
+<ol>
+  <li>a</li>
+</ol>

--- a/css/css-lists/list-style-type-string-003.html
+++ b/css/css-lists/list-style-type-string-003.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="fuzzy" content="maxDifference=0-86; totalPixels=0-428">
   <title>String value of list-style-type with RTL direction</title>
   <link rel="author" title="Oriol Brufau" href="mailto:obrufau@gmail.com">
   <link rel="help" href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-string">

--- a/css/css-pseudo/marker-unicode-bidi-default.html
+++ b/css/css-pseudo/marker-unicode-bidi-default.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-72">
 <meta charset="utf-8">
 <title>::marker has 'unicode-bidi: isolate' by default</title>
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />


### PR DESCRIPTION
WebKit export from bug: [\[list-marker\] List marker overlaps the list item content when the marker text is right-to-left](https://bugs.webkit.org/show_bug.cgi?id=321396)