### PR TITLE
[css-inline] Fix `text-box-trim-first-line-pseudo-002-ref.html`

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-first-line-pseudo-002-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-first-line-pseudo-002-ref.html
@@ -10,6 +10,10 @@
 .small-line {
   font: 20px/2 Ahem;
   text-box: trim-start text;
+  /* The test's containing block has font: 40px/2, so the strut provides a 28px
+     descent on the first line (half-leading 20px + font descent 8px), which is
+     14px larger than small-line's 14px descent (half-leading 10px + font descent 4px). */
+  margin-bottom: 14px;
 }
 .big-line {
   font: 40px/2 Ahem;


### PR DESCRIPTION
This patch fixes an error in the ref file.