### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=322843

### DIFF
--- a/css/css-overflow/text-overflow-string-in-input-notref.html
+++ b/css/css-overflow/text-overflow-string-in-input-notref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-overflow: &lt;string&gt; in text inputs - not reference</title>
+<input value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">

--- a/css/css-overflow/text-overflow-string-in-input.html
+++ b/css/css-overflow/text-overflow-string-in-input.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-overflow: &lt;string&gt; in text inputs</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#text-overflow">
+<link rel="mismatch" href="text-overflow-string-in-input-notref.html">
+<input value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" style="text-overflow: '[...]'">


### PR DESCRIPTION
WebKit export from bug: [\[css-overflow-4\] `text-overflow: <string>` should work on `<input>`](https://bugs.webkit.org/show_bug.cgi?id=322843)