### PR TITLE
Web Platform Tests for HTML video poster image source

### DIFF
--- a/html/semantics/embedded-content/the-video-element/resources/record-referrer.py
+++ b/html/semantics/embedded-content/the-video-element/resources/record-referrer.py
@@ -1,0 +1,19 @@
+import base64
+
+# A 1x1 transparent PNG, so the poster image source <img> loads successfully
+# and we can focus the assertions on which Referer header the request carried.
+TRANSPARENT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+def main(request, response):
+    if b"take" in request.GET:
+        token = request.GET.first(b"take")
+        value = request.server.stash.take(token)
+        return [(b"Content-Type", b"text/plain")], value or b""
+
+    token = request.GET.first(b"record")
+    referer = request.headers.get(b"Referer", b"")
+    request.server.stash.put(token, referer)
+    return [(b"Content-Type", b"image/png")], TRANSPARENT_PNG

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-alt-text.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-alt-text.tentative.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body></body>
+
+<script>
+  const altText = 'A theater with rows of empty seats';
+  const video = document.createElement('video');
+  const img = document.createElement('img');
+  video.src = '/media/A4.webm';
+  video.controls = true;
+  video.muted = true;
+  video.posterFromImg = true;
+  img.src = '/media/poster.png';
+  img.alt = altText;
+  video.appendChild(img);
+
+  document.body.appendChild(video);
+
+  test(function () {
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+    assert_equals(img.alt, altText);
+    assert_false(img.hidden);
+  }, 'Poster image source element keeps its alt text and is not hidden while the poster is shown');
+
+  promise_test(async function (t) {
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+    const eventWatcher = new EventWatcher(t, video, ['playing']);
+    const playPromise = video.play();
+    if (playPromise) {
+      playPromise.catch(t.unreached_func('play rejected'));
+    }
+    await eventWatcher.wait_for(['playing']);
+
+    assert_true(img.hidden);
+  }, 'When video plays, poster image source element should be hidden, removing it from the accessibility tree');
+</script>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-attributes.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-attributes.tentative.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+
+<body></body>
+
+<script>
+  const { HTTP_REMOTE_ORIGIN } = get_host_info();
+
+  const assertCurrentPosterSupported = () =>
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+
+  const createVideo = () => {
+    const video = document.createElement('video');
+    video.src = '/media/A4.webm';
+    video.posterFromImg = true;
+    return document.body.appendChild(video);
+  };
+
+  const waitForEvent = (target, event) =>
+    new Promise((resolve) => target.addEventListener(event, resolve, { once: true }));
+
+  const recordReferrerUrl = (token) =>
+    `${location.origin}/html/semantics/embedded-content/the-video-element/resources/record-referrer.py?record=${token}`;
+
+  const takeRecordedReferrer = async (token) => {
+    const response = await fetch(
+      `${location.origin}/html/semantics/embedded-content/the-video-element/resources/record-referrer.py?take=${token}`
+    );
+    return response.text();
+  };
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = document.createElement('img');
+    img.src = HTTP_REMOTE_ORIGIN + '/media/poster.png?attrs=noCrossOrigin&t=' + Date.now();
+    video.appendChild(img);
+
+    const event = await Promise.race([waitForEvent(img, 'load'), waitForEvent(img, 'error')]);
+    assert_equals(event.type, 'load', 'img without crossorigin should load a cross-origin resource with no CORS check');
+
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, "Poster image source without crossorigin loads a cross-origin poster with no CORS check");
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = document.createElement('img');
+    img.crossOrigin = 'anonymous';
+    img.src = HTTP_REMOTE_ORIGIN + '/media/poster.png?attrs=crossOriginAnonymous&t=' + Date.now();
+    video.appendChild(img);
+
+    const event = await Promise.race([waitForEvent(img, 'load'), waitForEvent(img, 'error')]);
+    assert_equals(
+      event.type,
+      'error',
+      "img.crossOrigin='anonymous' should fail the CORS check when the cross-origin resource sends no Access-Control-Allow-Origin header"
+    );
+
+    // A failed CORS check still selects a source, so currentSrc is set even
+    // though the fetch failed; the poster image source should still win over
+    // `poster`.
+    assert_not_equals(img.currentSrc, '');
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, "Poster image source's own crossorigin attribute is honored for the poster fetch, independent of the video");
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const token = 'poster-image-src-referrer-no-referrer-' + Date.now() + Math.random();
+    const video = createVideo();
+    const img = document.createElement('img');
+    img.referrerPolicy = 'no-referrer';
+    img.src = recordReferrerUrl(token);
+    video.appendChild(img);
+
+    await waitForEvent(img, 'load');
+    assert_equals(video.currentPoster, img.currentSrc);
+
+    const referrer = await takeRecordedReferrer(token);
+    assert_equals(
+      referrer,
+      '',
+      "The poster image source's own referrerpolicy=no-referrer should suppress the Referer header on the poster fetch"
+    );
+  }, "Poster image source's referrerpolicy=no-referrer is honored for the poster fetch");
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const token = 'poster-image-src-referrer-default-' + Date.now() + Math.random();
+    const video = createVideo();
+    const img = document.createElement('img');
+    img.src = recordReferrerUrl(token);
+    video.appendChild(img);
+
+    await waitForEvent(img, 'load');
+    assert_equals(video.currentPoster, img.currentSrc);
+
+    const referrer = await takeRecordedReferrer(token);
+    assert_not_equals(
+      referrer,
+      '',
+      'Without an explicit referrerpolicy, the poster fetch should carry a Referer header like an ordinary same-origin img request'
+    );
+  }, "Poster image source's poster fetch sends a Referer header by default when no referrerpolicy is set");
+
+  test(function () {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = document.createElement('img');
+    img.fetchPriority = 'high';
+    img.src = '/media/poster.png?attrs=fetchPriority';
+    video.appendChild(img);
+
+    assert_equals(img.fetchPriority, 'high', "the poster image source's own fetchPriority should reflect normally");
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, "Poster image source's fetchpriority attribute is unaffected by acting as the poster image source");
+
+  test(function () {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = document.createElement('img');
+    img.decoding = 'sync';
+    img.src = '/media/poster.png?attrs=decoding';
+    video.appendChild(img);
+
+    assert_equals(img.decoding, 'sync', "the poster image source's own decoding should reflect normally");
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, "Poster image source's decoding attribute is unaffected by acting as the poster image source");
+</script>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-current-poster.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-current-poster.tentative.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script>
+    test(function () {
+      assert_own_property(HTMLVideoElement.prototype, 'currentPoster');
+    }, 'HTMLVideoElement interface should have a currentPoster property');
+    test(function () {
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+      assert_readonly(HTMLVideoElement.prototype, 'currentPoster');
+    }, 'HTMLVideoElement.currentPoster is readonly');
+    test(function () {
+      assert_own_property(HTMLVideoElement.prototype, 'posterFromImg');
+    }, 'HTMLVideoElement interface should have a posterFromImg property');
+    test(function () {
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+      const video = document.createElement('video');
+      assert_equals(typeof video.currentPoster, 'string');
+      assert_equals(video.currentPoster, '');
+    }, 'HTMLVideoElement.currentPoster is a string and defaults to the empty string');
+    test(function () {
+      assert_implements(
+        'posterFromImg' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.posterFromImg is not supported'
+      );
+      const video = document.createElement('video');
+      assert_false(video.posterFromImg);
+      assert_false(video.hasAttribute('posterfromimg'));
+
+      video.posterFromImg = true;
+      assert_true(video.hasAttribute('posterfromimg'));
+
+      video.posterFromImg = false;
+      assert_false(video.hasAttribute('posterfromimg'));
+    }, 'HTMLVideoElement.posterFromImg reflects the posterfromimg content attribute');
+    test(function () {
+      assert_implements(
+        'posterFromImg' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.posterFromImg is not supported'
+      );
+      const video = document.createElement('video');
+
+      video.setAttribute('posterfromimg', '');
+      assert_true(video.posterFromImg, 'empty string value maps to true');
+
+      video.setAttribute('posterfromimg', 'posterfromimg');
+      assert_true(video.posterFromImg, 'canonical value maps to true');
+
+      video.setAttribute('posterfromimg', 'false');
+      assert_true(
+        video.posterFromImg,
+        'boolean attributes are true for any value, including "false"'
+      );
+
+      video.removeAttribute('posterfromimg');
+      assert_false(video.posterFromImg, 'removing the attribute maps to false');
+    }, 'posterfromimg content attribute reflects as a boolean attribute regardless of its value');
+    test(function () {
+      assert_implements(
+        'posterFromImg' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.posterFromImg is not supported'
+      );
+      const video = document.createElement('video');
+
+      video.posterFromImg = true;
+      assert_equals(
+        video.getAttribute('posterfromimg'),
+        '',
+        'setting the IDL attribute to true sets the empty-string value'
+      );
+
+      video.posterFromImg = 'a truthy string';
+      assert_true(video.posterFromImg, 'assigned values are coerced to boolean');
+
+      video.posterFromImg = 0;
+      assert_false(
+        video.hasAttribute('posterfromimg'),
+        'assigning a falsy value removes the content attribute'
+      );
+    }, 'HTMLVideoElement.posterFromImg coerces assigned values to boolean');
+  </script>
+</body>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-fallbacks.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-fallbacks.tentative.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script>
+    const assertCurrentPosterSupported = () =>
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+
+    const createVideo = ({ posterFromImg = true } = {}) => {
+      const video = document.createElement('video');
+      video.src = '/media/A4.webm';
+      video.controls = true;
+      video.posterFromImg = posterFromImg;
+      return document.body.appendChild(video);
+    };
+
+    const createPosterImg = () => {
+      const img = document.createElement('img');
+      img.src = '/media/poster.png?posterImageSrc=true';
+      return img;
+    };
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+
+      assert_equals(video.currentPoster, '');
+    }, 'HTMLVideoElement.currentPoster is empty if no poster attribute or poster image source is present');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+
+      assert_equals(video.currentPoster, video.poster);
+    }, 'HTMLVideoElement.currentPoster is HTMLVideoElement.poster if no poster image source is present');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+      video.appendChild(document.createElement('picture'));
+
+      assert_equals(video.currentPoster, video.poster);
+    }, 'HTMLVideoElement.currentPoster is HTMLVideoElement.poster if child picture element does not have an img');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+
+      const img = createPosterImg();
+      video.appendChild(img);
+
+      assert_equals(video.currentPoster, img.currentSrc);
+      assert_not_equals(video.currentPoster, video.poster);
+    }, 'HTMLVideoElement.currentPoster picks HTMLImageElement.currentSrc over HTMLVideoElement.poster');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+
+      const img = createPosterImg();
+      const a = document.createElement('a');
+      a.appendChild(img);
+      video.appendChild(a);
+
+      assert_equals(video.currentPoster, video.poster);
+      assert_not_equals(video.currentPoster, img.currentSrc);
+    }, 'HTMLVideoElement.currentPoster picks HTMLVideoElement.poster when img is incorrectly nested inside a non-picture element');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+
+      const source = document.createElement('source');
+      source.src = '/media/poster.png?posterImageSrc=true';
+      video.appendChild(source);
+
+      assert_equals(video.currentPoster, video.poster);
+      assert_not_equals(video.currentPoster, source.src);
+    }, 'HTMLVideoElement.currentPoster does not use images in a source element');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+
+      const track = document.createElement('track');
+      track.src = '/media/poster.png?posterImageSrc=true';
+
+      video.appendChild(track);
+      assert_equals(video.currentPoster, video.poster);
+      assert_not_equals(video.currentPoster, track.src);
+    }, 'HTMLVideoElement.currentPoster does not use images in a track element');
+
+    test(function (t) {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+
+      const img = createPosterImg();
+      video.appendChild(img);
+      assert_equals(video.currentPoster, img.currentSrc);
+      assert_not_equals(video.currentPoster, video.poster);
+
+      video.poster = '/media/poster.png';
+
+      assert_equals(video.currentPoster, img.currentSrc);
+      assert_not_equals(video.currentPoster, video.poster);
+    }, 'Setting HTMLVideoElement.poster while a poster image source is present should not update HTMLVideoElement.currentPoster');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo({ posterFromImg: false });
+      video.poster = '/media/poster.png';
+
+      const img = createPosterImg();
+      video.appendChild(img);
+
+      assert_equals(video.currentPoster, video.poster);
+      assert_not_equals(video.currentPoster, img.currentSrc);
+    }, 'HTMLVideoElement.currentPoster ignores a child img and uses HTMLVideoElement.poster when posterfromimg is not set');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = createVideo({ posterFromImg: false });
+
+      const img = createPosterImg();
+      video.appendChild(img);
+
+      assert_equals(video.currentPoster, '');
+      assert_not_equals(video.currentPoster, img.currentSrc);
+    }, 'HTMLVideoElement.currentPoster is empty and ignores a child img when posterfromimg is not set and no poster attribute is present');
+
+    promise_test(async function (t) {
+      assertCurrentPosterSupported();
+      const video = createVideo({ posterFromImg: false });
+      video.poster = '/media/poster.png';
+
+      const img = createPosterImg();
+      video.appendChild(img);
+      assert_equals(video.currentPoster, video.poster);
+
+      video.posterFromImg = true;
+
+      await t.step_wait(() => video.currentPoster === img.currentSrc);
+      assert_equals(video.currentPoster, img.currentSrc);
+      assert_not_equals(video.currentPoster, video.poster);
+    }, 'Setting posterfromimg on a video with a child img should update HTMLVideoElement.currentPoster to img.currentSrc');
+
+    promise_test(async function (t) {
+      assertCurrentPosterSupported();
+      const video = createVideo();
+      video.poster = '/media/poster.png';
+
+      const img = createPosterImg();
+      video.appendChild(img);
+      assert_equals(video.currentPoster, img.currentSrc);
+
+      video.posterFromImg = false;
+
+      await t.step_wait(() => video.currentPoster === video.poster);
+      assert_equals(video.currentPoster, video.poster);
+      assert_not_equals(video.currentPoster, img.currentSrc);
+    }, 'Removing posterfromimg from a video with a child img should update HTMLVideoElement.currentPoster to HTMLVideoElement.poster');
+  </script>
+</body>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-is-first-img.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-is-first-img.tentative.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script>
+    const assertCurrentPosterSupported = () =>
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+
+    const video = document.createElement('video');
+    const img0 = document.createElement('img');
+    const img1 = document.createElement('img');
+    video.src = '/media/A4.webm';
+    video.controls = true;
+    video.posterFromImg = true;
+    img0.src = '/media/poster.png';
+    img1.src = '/media/poster.png?second=true';
+    video.appendChild(img0);
+    video.appendChild(img1);
+
+    document.body.appendChild(video);
+
+    test(function () {
+      assertCurrentPosterSupported();
+      assert_equals(video.currentPoster, img0.currentSrc);
+      assert_not_equals(video.currentPoster, img1.currentSrc);
+      assert_true(
+        img1.checkVisibility(),
+        'The ignored second img is ordinary fallback content and should render normally, unlike the poster image source'
+      );
+    }, 'HTMLVideoElement.currentPoster matches only the first img.currentSrc');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = document.createElement('video');
+      video.src = '/media/A4.webm';
+      video.controls = true;
+      video.posterFromImg = true;
+
+      const picture0 = document.createElement('picture');
+      const img0 = document.createElement('img');
+      img0.src = '/media/poster.png?picture=0';
+      picture0.appendChild(img0);
+
+      const picture1 = document.createElement('picture');
+      const img1 = document.createElement('img');
+      img1.src = '/media/poster.png?picture=1';
+      picture1.appendChild(img1);
+
+      video.appendChild(picture0);
+      video.appendChild(picture1);
+      document.body.appendChild(video);
+
+      assert_equals(video.currentPoster, img0.currentSrc);
+      assert_not_equals(video.currentPoster, img1.currentSrc);
+      assert_true(
+        img1.checkVisibility(),
+        'The ignored second picture is ordinary fallback content and should render normally, unlike the poster image source'
+      );
+    }, 'HTMLVideoElement.currentPoster matches only the first picture>img; a second picture is ignored as fallback content');
+
+    test(function () {
+      assertCurrentPosterSupported();
+      const video = document.createElement('video');
+      video.src = '/media/A4.webm';
+      video.controls = true;
+      video.posterFromImg = true;
+
+      const img0 = document.createElement('img');
+      img0.src = '/media/poster.png?order=bareImgFirst';
+
+      const picture1 = document.createElement('picture');
+      const img1 = document.createElement('img');
+      img1.src = '/media/poster.png?order=pictureSecond';
+      picture1.appendChild(img1);
+
+      video.appendChild(img0);
+      video.appendChild(picture1);
+      document.body.appendChild(video);
+
+      assert_equals(video.currentPoster, img0.currentSrc);
+      assert_not_equals(video.currentPoster, img1.currentSrc);
+    }, 'HTMLVideoElement.currentPoster matches a bare img over a subsequent picture>img');
+  </script>
+</body>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-is-img-src.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-is-img-src.tentative.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body></body>
+
+<script>
+  const assertCurrentPosterSupported = () =>
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+
+  const createVideo = () => {
+    const video = document.createElement('video');
+    video.src = '/media/A4.webm';
+    video.controls = true;
+    video.posterFromImg = true;
+    return document.body.appendChild(video);
+  };
+
+  const createPosterImg = () => {
+    const img = document.createElement('img');
+    img.src = '/media/poster.png?posterImageSrc=true';
+    return img;
+  };
+
+  test(function () {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = createPosterImg();
+    video.appendChild(img);
+
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, 'HTMLVideoElement.currentPoster matches img.currentSrc');
+
+  test(function () {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = createPosterImg();
+    const picture = document.createElement('picture');
+
+    video.appendChild(picture.appendChild(img));
+
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, 'HTMLVideoElement.currentPoster matches img.currentSrc inside a picture element');
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    video.poster = '/media/poster.png';
+    assert_equals(video.currentPoster, video.poster);
+
+    const img = createPosterImg();
+    video.appendChild(img);
+
+    await t.step_wait(() => video.currentPoster === img.currentSrc);
+    assert_equals(video.currentPoster, img.currentSrc);
+    assert_not_equals(video.currentPoster, video.poster);
+  }, 'Inserting a poster image source into a video should update HTMLVideoElement.currentPoster');
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    video.poster = '/media/poster.png';
+    const img = createPosterImg();
+
+    video.appendChild(img);
+    assert_equals(video.currentPoster, img.currentSrc);
+    assert_not_equals(video.currentPoster, video.poster);
+
+    img.remove();
+
+    await t.step_wait(() => !img.isConnected);
+    assert_equals(video.currentPoster, video.poster);
+  }, 'Removing a poster image source from a video should update HTMLVideoElement.currentPoster');
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    const img = createPosterImg();
+    video.appendChild(img);
+
+    await t.step_wait(() => video.currentPoster === img.currentSrc);
+    const firstSrc = img.currentSrc;
+
+    img.src = '/media/poster.png?posterImageSrc=updated';
+
+    await t.step_wait(
+      () => video.currentPoster === img.currentSrc && img.currentSrc !== firstSrc
+    );
+    assert_equals(video.currentPoster, img.currentSrc);
+  }, "Changing the poster image source's src should update HTMLVideoElement.currentPoster");
+
+  promise_test(async function (t) {
+    assertCurrentPosterSupported();
+    const video = createVideo();
+    video.poster = '/media/poster.png';
+
+    const picture = document.createElement('picture');
+    const img = createPosterImg();
+    picture.appendChild(img);
+
+    video.appendChild(picture);
+    await t.step_wait(() => video.currentPoster === img.currentSrc);
+    assert_equals(video.currentPoster, img.currentSrc);
+    assert_not_equals(video.currentPoster, video.poster);
+
+    picture.remove();
+
+    await t.step_wait(() => !picture.isConnected);
+    assert_equals(video.currentPoster, video.poster);
+  }, 'Inserting and removing a picture-wrapped poster image source should update HTMLVideoElement.currentPoster');
+</script>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-lazy-load-disconnected.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-lazy-load-disconnected.tentative.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    const createDisconnectedVideo = () => {
+      const video = document.createElement('video');
+      const img = document.createElement('img');
+
+      video.loading = 'lazy';
+      video.src = '/media/A4.webm';
+      video.posterFromImg = true;
+
+      video.appendChild(img);
+
+      img.loading = 'lazy';
+      img.src = '/media/poster.png?posterImageSrc=true';
+
+      return { video, img };
+    };
+
+    promise_test(async function (t) {
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+      const { img } = createDisconnectedVideo();
+
+      let loaded = false;
+      img.addEventListener('load', () => { loaded = true; }, { once: true });
+
+      const start = performance.now();
+      await t.step_wait(
+        () => loaded || performance.now() - start > 300,
+        'Wait for a poster fetch opportunity while disconnected'
+      );
+      assert_false(
+        loaded,
+        'Disconnected video with loading=lazy should not load the poster image'
+      );
+    }, 'Poster image source should not load if video is disconnected');
+
+    promise_test(async function () {
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+      const { video, img } = createDisconnectedVideo();
+
+      assert_equals(video.currentPoster, img.currentSrc);
+    }, 'Disconnected video has HTMLVideoElement.currentPoster set to the poster image source');
+  </script>
+</body>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-lazy-load-when-visible.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-lazy-load-when-visible.tentative.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .below-viewport {
+    margin-top: 1000vh;
+  }
+</style>
+<body>
+  <script>
+    promise_test(async function (t) {
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+
+      const video = document.createElement('video');
+      video.loading = 'lazy';
+      video.src = '/media/A4.webm';
+      video.posterFromImg = true;
+      video.className = 'below-viewport';
+
+      const img = document.createElement('img');
+      img.src = '/media/poster.png?lazyPosterImageSrcVisible=true&t=' + Date.now();
+      video.appendChild(img);
+
+      const imgUrl = new URL(img.src, location.href).href;
+
+      const posterEntries = [];
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.name === imgUrl) {
+            posterEntries.push(entry);
+          }
+        }
+      });
+      observer.observe({ entryTypes: ['resource'] });
+
+      document.body.appendChild(video);
+
+      // The poster image source <img> is never itself rendered, so this only
+      // passes if the lazy-load decision is keyed off the video's layout box.
+      const start = performance.now();
+      await t.step_wait(
+        () => posterEntries.length > 0 || performance.now() - start > 300,
+        'Wait for initial poster fetch opportunity while offscreen'
+      );
+      assert_equals(
+        posterEntries.length,
+        0,
+        'Poster image should not be fetched while the video is not visible'
+      );
+
+      const entriesBeforeScroll = posterEntries.length;
+      video.scrollIntoView();
+
+      await t.step_wait(
+        () => posterEntries.length > entriesBeforeScroll,
+        'Poster image should be fetched after the video scrolls into view',
+        3000,
+        50
+      );
+      observer.disconnect();
+    }, "Video with loading=lazy and a poster image source does not fetch the poster image while off-screen, then fetches once the video scrolls into view");
+  </script>
+</body>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-load-failure.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-load-failure.tentative.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body></body>
+
+<script>
+  promise_test(async function (t) {
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+    const video = document.createElement('video');
+    video.src = '/media/A4.webm';
+    video.posterFromImg = true;
+    video.poster = '/media/poster.png';
+
+    const img = document.createElement('img');
+    img.src = '/media/does-not-exist.png?posterImageSrc=failure';
+    video.appendChild(img);
+
+    document.body.appendChild(video);
+
+    await new Promise((resolve) => {
+      img.addEventListener('error', resolve, { once: true });
+    });
+
+    // currentSrc is set as part of source selection, before the fetch
+    // resolves, so it remains set even though the fetch failed. The poster
+    // frame algorithm's early-return is keyed on currentSrc being non-empty,
+    // not on fetch success, so it should still win over the poster attribute.
+    assert_not_equals(img.currentSrc, '');
+    assert_equals(video.currentPoster, img.currentSrc);
+    assert_not_equals(
+      video.currentPoster,
+      video.poster,
+      'A failed poster image source should not fall back to the poster attribute'
+    );
+  }, 'HTMLVideoElement.currentPoster keeps the poster image source currentSrc even after it fails to load');
+</script>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-load-image.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-load-image.tentative.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    promise_test(async function (t) {
+      assert_implements(
+        'currentPoster' in HTMLVideoElement.prototype,
+        'HTMLVideoElement.currentPoster is not supported'
+      );
+
+      let loadedFromImgSrc = false;
+      let loadedFromPoster = false;
+      const video = document.createElement('video');
+      const img = document.createElement('img');
+      const poster = '/media/poster.png';
+      const imgPoster = '/media/poster.png?posterImageSrc=true';
+
+      video.src = '/media/A4.webm';
+      video.poster = poster;
+      video.posterFromImg = true;
+      img.src = imgPoster;
+      video.appendChild(img);
+
+      // Resolve both URLs up front; img.currentSrc may still be empty when
+      // the observer callback runs.
+      const posterUrl = new URL(poster, location.href).href;
+      const imgPosterUrl = new URL(imgPoster, location.href).href;
+
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.name === posterUrl) {
+            loadedFromPoster = true;
+          }
+          if (entry.name === imgPosterUrl) {
+            loadedFromImgSrc = true;
+          }
+        }
+      });
+
+      observer.observe({ entryTypes: ['resource'] });
+
+      document.body.appendChild(video);
+
+      await t.step_wait(() => loadedFromImgSrc);
+
+      assert_false(
+        loadedFromPoster,
+        'Poster attribute should not be fetched when a poster image source is present'
+      );
+      observer.disconnect();
+    }, 'Only the poster image source should load');
+  </script>
+</body>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-loading-precedence.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-loading-precedence.tentative.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .below-viewport {
+    margin-top: 1000vh;
+  }
+</style>
+<body></body>
+
+<script>
+  const assertCurrentPosterSupported = () =>
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+
+  const observeFetch = (url) => {
+    const entries = [];
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.name === url) entries.push(entry);
+      }
+    });
+    observer.observe({ entryTypes: ['resource'] });
+    return entries;
+  };
+
+  promise_test(async (t) => {
+    assertCurrentPosterSupported();
+    window.scrollTo(0, 0);
+
+    const video = document.createElement('video');
+    video.src = '/media/A4.webm';
+    video.loading = 'eager';
+    video.posterFromImg = true;
+    video.className = 'below-viewport';
+
+    const img = document.createElement('img');
+    img.loading = 'lazy';
+    img.src =
+      '/media/poster.png?loadingPrecedence=eagerVideoLazyImg&t=' + Date.now();
+    video.appendChild(img);
+
+    const imgUrl = new URL(img.src, location.href).href;
+    const entries = observeFetch(imgUrl);
+
+    document.body.appendChild(video);
+
+    const start = performance.now();
+    await t.step_wait(
+      () => entries.length > 0 || performance.now() - start > 300,
+      'Wait for a poster fetch opportunity while the video is below the viewport'
+    );
+    assert_equals(
+      entries.length,
+      0,
+      'Poster image source with loading=lazy should not fetch while the video is below the viewport, even though video.loading is eager'
+    );
+
+    video.scrollIntoView();
+    await t.step_wait(() => entries.length > 0);
+  }, 'Poster image source loading=lazy takes precedence over video loading=eager and defers the poster fetch');
+
+  promise_test(async (t) => {
+    assertCurrentPosterSupported();
+    window.scrollTo(0, 0);
+
+    const video = document.createElement('video');
+    video.src = '/media/A4.webm';
+    video.loading = 'lazy';
+    video.posterFromImg = true;
+    video.className = 'below-viewport';
+
+    const img = document.createElement('img');
+    img.loading = 'eager';
+    img.src =
+      '/media/poster.png?loadingPrecedence=lazyVideoEagerImg&t=' + Date.now();
+    video.appendChild(img);
+
+    const imgUrl = new URL(img.src, location.href).href;
+    const entries = observeFetch(imgUrl);
+
+    document.body.appendChild(video);
+
+    await t.step_wait(
+      () => entries.length > 0,
+      'Poster image source with loading=eager should fetch immediately, even though the video is below the viewport and video.loading is lazy'
+    );
+  }, 'Poster image source loading=eager takes precedence over video loading=lazy and fetches the poster immediately');
+</script>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-media-queries.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-media-queries.tentative.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<link rel="help" href="https://html.spec.whatwg.org/#reacting-to-environment-changes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body></body>
+
+<script>
+  const sizes = [600, 400, 200];
+
+  promise_test(async (t) => {
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+
+    const iframe = document.createElement('iframe');
+    iframe.width = '100';
+    iframe.height = '600';
+    iframe.frameborder = '0';
+
+    iframe.srcdoc = `<video id="video0" controls posterfromimg>
+      <picture>
+        ${sizes.map((size) => `<source srcset="/media/poster.png?width=${size}" media="(min-width: ${size}px)" width="102" height="77" id="source-${size}">`).join('')}
+        <img src="/media/poster.png" width="102" height="77" id="img0">
+      </picture>
+    </video>`;
+
+    const loaded = new Promise((resolve) =>
+      iframe.addEventListener('load', resolve, { once: true })
+    );
+    document.body.appendChild(iframe);
+    await loaded;
+
+    const video = iframe.contentDocument.getElementById('video0');
+    const img = video.querySelector('img');
+
+    for (const size of sizes) {
+      const source = video.querySelector(`#source-${size}`);
+      const srcSetUrl = new URL(source.srcset, location.href).href;
+
+      iframe.width = size;
+
+      await t.step_wait(
+        () => img.currentSrc === srcSetUrl,
+        `img.currentSrc should update to the <source> matching the media query at ${size}px`
+      );
+
+      assert_equals(
+        video.currentPoster,
+        img.currentSrc,
+        `HTMLVideoElement.currentPoster matches img.currentSrc at ${size}px`
+      );
+      assert_equals(
+        video.currentPoster,
+        srcSetUrl,
+        `HTMLVideoElement.currentPoster matches <source>.srcset at ${size}px`
+      );
+    }
+  }, 'HTMLVideoElement.currentPoster uses the <source> matching the media query as the iframe resizes');
+</script>

--- a/html/semantics/embedded-content/the-video-element/video-poster-image-src-should-not-render.tentative.html
+++ b/html/semantics/embedded-content/the-video-element/video-poster-image-src-should-not-render.tentative.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="author" title="Squarespace" href="https://www.squarespace.com/">
+<link rel="help" href="https://github.com/whatwg/html/pull/12585">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body></body>
+
+<script>
+  const createVideo = ({ posterFromImg }) => {
+    const video = document.createElement('video');
+    video.src = '/media/A4.webm';
+    video.controls = true;
+    video.posterFromImg = posterFromImg;
+
+    const img = document.createElement('img');
+    img.src = '/media/poster.png?posterImageSrc=true';
+    video.appendChild(img);
+
+    document.body.appendChild(video);
+    return { video, img };
+  };
+
+  test(function () {
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+    const { img } = createVideo({ posterFromImg: true });
+
+    assert_false(img.checkVisibility());
+  }, 'Poster image source for HTMLVideoElement.currentPoster should not render when posterfromimg is set');
+
+  test(function () {
+    assert_implements(
+      'currentPoster' in HTMLVideoElement.prototype,
+      'HTMLVideoElement.currentPoster is not supported'
+    );
+    const { img } = createVideo({ posterFromImg: false });
+
+    assert_true(img.checkVisibility());
+  }, 'A child img renders normally when posterfromimg is not set');
+</script>


### PR DESCRIPTION
## Summary

Adds WPT coverage for the proposed `<video>` poster controller feature (whatwg/html#12585): the `posterfromimg` attribute, `HTMLVideoElement.currentPoster`, and the first-`<img>`/`<picture>`-descendant resolution algorithm.

- **Core semantics** - `currentPoster` reflection, precedence over `poster`, first-img/first-picture selection, `source`/`track` exclusion, mutation handling (insert/remove/`src` reassignment)
- **Accessibility** - controller exposed with `alt` text, hidden while playing
- **Rendering** - controller `<img>` never paints itself
- **Responsive selection** - `<picture>`/`<source media>` reselection on resize
- **Loading** - lazy-load keyed on the video's layout box even when disconnected/off-screen; controller's own `loading` takes precedence over the video's for the poster fetch
- **Failure handling** - a failed controller image still wins over `poster`, since `currentSrc` is set at selection time regardless of fetch success
- **Per-attribute behavior** - `crossorigin`, `referrerpolicy`, `fetchpriority`, `decoding` are read from the controller `<img>`

## Notes for reviewers

- All poster-controller tests are `.tentative.html` — no browser implements this yet, so they're expected to fail/timeout until it ships.
- `-attributes` uses `/common/get-host-info.sub.js` for a cross-origin host (`crossorigin` cases) and `resources/record-referrer.py` (stash `put`/`take`, same pattern as `html/syntax/speculative-parsing/resources/stash.py`) to observe the `Referer` header for the referrer-policy cases.

## Test plan

- [ ] Run under `wpt run` once a browser implements the feature.
- [x] `node --check` on all script blocks; `py_compile` on the new Python resource.