### PR TITLE
layout: preserve intrinsic width for text inputs

### DIFF
--- a/html/rendering/widgets/input-auto-width-size.html
+++ b/html/rendering/widgets/input-auto-width-size.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Text input automatic width honours the size attribute</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input id="default-size" type="text" style="width: auto">
+<input id="small-size" type="search" size="1" style="width: auto">
+<input id="email-size" type="email" style="width: auto">
+<input id="url-size" type="url" style="width: auto">
+<input id="explicit-width" type="search" style="width: 3px">
+<input id="button" type="button" value="button" style="width: auto">
+<input id="checkbox" type="checkbox" style="width: auto">
+
+<script>
+test(() => {
+  const defaultWidth = document.querySelector('#default-size').getBoundingClientRect().width;
+  const smallWidth = document.querySelector('#small-size').getBoundingClientRect().width;
+  assert_greater_than(defaultWidth, smallWidth);
+}, 'An author width of auto preserves the text control default preferred size');
+
+test(() => {
+  const defaultWidth = document.querySelector('#default-size').getBoundingClientRect().width;
+  for (const id of ['email-size', 'url-size']) {
+    assert_greater_than_equal(
+      document.querySelector(`#${id}`).getBoundingClientRect().width,
+      defaultWidth,
+      `${id} uses the text-entry preferred size`,
+    );
+  }
+}, 'Domain-specific text controls receive the default preferred size');
+
+test(() => {
+  assert_equals(document.querySelector('#explicit-width').getBoundingClientRect().width, 3);
+}, 'An explicit CSS width remains authoritative');
+
+test(() => {
+  const textWidth = document.querySelector('#default-size').getBoundingClientRect().width;
+  assert_less_than(document.querySelector('#button').getBoundingClientRect().width, textWidth);
+  assert_less_than(document.querySelector('#checkbox').getBoundingClientRect().width, textWidth);
+}, 'Non-text controls do not receive the text-entry preferred size');
+</script>


### PR DESCRIPTION
## Summary

Text-entry inputs with an automatic inline size can collapse to their padding when their internal shadow content contributes no measurable width. This is visible with text and search controls that should remain usable without an author-specified width.

I maintain Solipsism Browser, an open-source Android browser that embeds Servo for experimental testing. While integrating Servo, I reduced this to a generic layout case and implemented the fix here without any host-, product-, or site-specific logic.

## Expected behaviour

- Text-entry and domain-specific input controls retain the HTML default preferred width of approximately 20 characters.
- The HTML `size` attribute changes that preferred width.
- An explicit CSS width remains authoritative.
- Non-text controls do not receive the text-entry default.

## Implementation

- Carry text-entry classification and the parsed `size` value into fragment metadata.
- During intrinsic inline-size calculation, contribute the standards-defined character-based preferred width only when the computed inline size is automatic.
- Add a WPT regression test covering text, search, email, URL, explicit-width, and non-text controls.

## Standards

This follows the WHATWG HTML rendering requirements for text-entry and domain-specific widgets, CSS Sizing Level 3 intrinsic sizing, CSS Basic User Interface widget behaviour, and Servo WPT conventions. The implementation uses font metrics, so exact pixels remain font-dependent as they are in other browser engines.

## Validation

- WPT manifest regenerated with `./mach update-manifest`.
- `git diff --check` passes.
- Targeted layout code was built successfully in the downstream integration tree.
- Full local Servo WPT execution requires a locally built Servo binary; CI can provide the complete upstream run.

Closes no site-specific issue; this is a general standards compliance fix.
Reviewed in servo/servo#47621