### PR TITLE
[css-borders] Fix duplicate fuzzy metadata breaking the manifest build

### DIFF
--- a/css/css-borders/corner-shape/corner-shape-superellipse-concave-outset.html
+++ b/css/css-borders/corner-shape/corner-shape-superellipse-concave-outset.html
@@ -3,9 +3,8 @@
 <meta charset="utf-8">
 <title>CSS Borders and Box Decorations 4: mixed concave superellipse corners, outset box-shadow, outset outline and inset outline</title>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
-<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-1196">
-<link rel="match" href="corner-shape-superellipse-concave-outset-ref.html">
 <meta name="fuzzy" content="maxDifference=0-199; totalPixels=0-1216">
+<link rel="match" href="corner-shape-superellipse-concave-outset-ref.html">
 <style>
     body { margin: 0; background: white; }
     .row { display: flex; gap: 60px; padding: 40px; }


### PR DESCRIPTION
`css/css-borders/corner-shape/corner-shape-superellipse-concave-outset.html` declares two `<meta name="fuzzy">` tags, neither keyed to a specific reference. Both map to the same (unkeyed) entry, so `./wpt manifest` fails:

    File "tools/manifest/sourcefile.py", line 667, in fuzzy
        raise ValueError("Got multiple fuzzy values for key %s" % (key,))
    ValueError: Got multiple fuzzy values for key None

This takes down the `build-and-tag` job on master for every commit since the test was added in #62123, e.g. https://github.com/web-platform-tests/wpt/actions/runs/33240733911/job/99069530837.
@tcl3 flagged it [in review on that PR](https://github.com/web-platform-tests/wpt/pull/62123#discussion_r3885605698), but it landed before it was addressed.

This keeps a single fuzzy value, using the wider of the two ranges
(`maxDifference=0-199; totalPixels=0-1216`), which subsumes the other. If the narrower bound was intended, let me know.

Pinging @cupidsity as the original author on https://github.com/WebKit/WebKit/pull/72063