### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=291164

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-hidden-and-float-inside-skipped-subtree-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-hidden-and-float-inside-skipped-subtree-ref.html
@@ -1,0 +1,13 @@
+<!doctype HTML>
+<meta charset="utf8">
+
+<style>
+div {
+  background: green;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+Test passes if the red float box is not visible.
+<div></div>

--- a/css/css-contain/content-visibility/content-visibility-hidden-and-float-inside-skipped-subtree.html
+++ b/css/css-contain/content-visibility/content-visibility-hidden-and-float-inside-skipped-subtree.html
@@ -1,0 +1,43 @@
+<!doctype HTML>
+<html class="reftest-wait">
+<meta charset="utf8">
+<title>Content Visibility: hidden float box</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="content-visibility-hidden-and-float-inside-skipped-subtree-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+#hideThis {
+  background: green;
+  width: 100px;
+  height: 100px;
+}
+
+.floatBox {
+  float: left;
+  width: 50px;
+  height: 50px;
+  background-color: red;
+}
+.hidden {
+  content-visibility: hidden;
+}
+</style>
+
+<div>Test passes if the red float box is not visible.</div>
+<div id=hideThis><div class=floatBox></div></div>
+
+<script>
+async function runTest() {
+  hideThis.classList.add("hidden");
+  requestAnimationFrame(takeScreenshot);
+}
+
+window.onload = () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(runTest);
+  });
+};
+</script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[content-visibility\] Do not paint float boxes inside skipped subtree](https://bugs.webkit.org/show_bug.cgi?id=291164)