### PR TITLE
sw.https.window.js is expecting a specific range request generation behaviour from media loading engines.

### DIFF
--- a/fetch/range/sw.https.window.js
+++ b/fetch/range/sw.https.window.js
@@ -23,13 +23,15 @@ async function setupRegistration(t, scope) {
   return reg;
 }
 
-function awaitMessage(obj, id) {
-  return new Promise(resolve => {
+function awaitMessage(test, obj, id, maxTimeout) {
+  return new Promise((resolve, reject) => {
     obj.addEventListener('message', function listener(event) {
       if (event.data.id !== id) return;
       obj.removeEventListener('message', listener);
       resolve(event.data);
     });
+    if (maxTimeout)
+      test.step_timeout(() => reject("awaiting message timed out"), maxTimeout);
   });
 }
 
@@ -71,7 +73,7 @@ promise_test(async t => {
   const iframe = await with_iframe(scope);
   const w = iframe.contentWindow;
   const id = Math.random() + '';
-  const storedRangeResponse = awaitMessage(w.navigator.serviceWorker, id);
+  const storedRangeResponse = awaitMessage(t, w.navigator.serviceWorker, id);
 
   // Trigger a cross-origin range request using media
   const url = new URL('partial-script.py', w.location);
@@ -101,7 +103,7 @@ promise_test(async t => {
   const iframe = await with_iframe(scope);
   const w = iframe.contentWindow;
   const id = Math.random() + '';
-  const storedRangeResponse = awaitMessage(w.navigator.serviceWorker, id);
+  const storedRangeResponse = awaitMessage(t, w.navigator.serviceWorker, id);
 
   // Trigger a range request using media
   const url = new URL('partial-script.py', w.location);
@@ -128,9 +130,9 @@ promise_test(async t => {
   const iframe = await with_iframe(scope);
   const w = iframe.contentWindow;
   const fetchId = Math.random() + '';
-  const fetchBroadcast = awaitMessage(w.navigator.serviceWorker, fetchId);
+  const fetchBroadcast = awaitMessage(t, w.navigator.serviceWorker, fetchId);
   const audioId = Math.random() + '';
-  const audioBroadcast = awaitMessage(w.navigator.serviceWorker, audioId);
+  const audioBroadcast = awaitMessage(t, w.navigator.serviceWorker, audioId);
 
   const url = new URL('long-wav.py', w.location);
   url.searchParams.set('action', 'broadcast-accept-encoding');
@@ -160,7 +162,7 @@ promise_test(async t => {
   // test a single range request size
   async function testSizedRange(size, partialResponseCode) {
     const rangeId = Math.random() + '';
-    const rangeBroadcast = awaitMessage(w.navigator.serviceWorker, rangeId);
+    const rangeBroadcast = awaitMessage(t, w.navigator.serviceWorker, rangeId, 1000);
 
     // Create a bogus audio element to trick the browser into sending
     // cross-origin range requests that can be manipulated by the service worker.


### PR DESCRIPTION
WebKit engine does not behave as expected by the test, hence a timeout. We update the test to move from a timeout to a failure.