### PR TITLE
layout: Change default table elements border color to black (servo#44391)

### DIFF
--- a/html/rendering/non-replaced-elements/tables/table-bordercolor-useragent-default.html
+++ b/html/rendering/non-replaced-elements/tables/table-bordercolor-useragent-default.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="help" href="https://github.com/servo/servo/issues/44391" />
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <table style="border-collapse: collapse">
+    <thead style="border-style: solid; border-width: 10px">
+      <tr>
+        <td>This should default to having a black border</td>
+      </tr>
+    </thead>
+  </table>
+
+  <script>
+    test(() => {
+      const table = document.querySelector("table");
+      const thead = document.querySelector("thead");
+      const td = document.querySelector("td");
+
+      assert_equals(
+        window.getComputedStyle(table).borderColor,
+        "rgb(0, 0, 0)",
+        "table border color should default to black",
+      );
+      assert_equals(
+        window.getComputedStyle(thead).borderColor,
+        "rgb(0, 0, 0)",
+        "thead border color should default to black",
+      );
+      assert_equals(
+        window.getComputedStyle(td).borderColor,
+        "rgb(0, 0, 0)",
+        "td border color should default to black",
+      );
+    }, "Table and its parts should default border color to black");
+  </script>
+</body>


### PR DESCRIPTION
layout: Change default table elements border color to black (servo#44391)

Testing: Includes new WPT test case that checks that the user agent defaults border color to
black/rgb(0, 0, 0) for table, thead and td elements.

Fixes: servo#<!-- nolink -->44391

Reviewed in servo/servo#47684