### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=289633

### DIFF
--- a/css/css-nesting/nested-declarations-cssom.html
+++ b/css/css-nesting/nested-declarations-cssom.html
@@ -139,7 +139,7 @@
       a {
         & { --x:1; }
         width: 100px;
-        height: 200px;
+        z-index: 3;
         color:hover {}
         --y: 2;
       }
@@ -148,7 +148,7 @@
     let outer = s.cssRules[0];
     assert_equals(outer.cssRules.length, 4);
     assert_equals(outer.cssRules[0].cssText, `& { --x: 1; }`);
-    assert_equals(outer.cssRules[1].cssText, `width: 100px; height: 200px;`);
+    assert_equals(outer.cssRules[1].cssText, `width: 100px; z-index: 3;`);
     assert_equals(outer.cssRules[2].cssText, `& color:hover { }`);
     assert_equals(outer.cssRules[3].cssText, `--y: 2;`);
   }, 'Inner rule starting with an ident');
@@ -161,11 +161,11 @@
     assert_equals(a_rule.cssRules.length, 0);
     a_rule.insertRule(`
       width: 100px;
-      height: 200px;
+      z-index: 3;
     `);
     assert_equals(a_rule.cssRules.length, 1);
     assert_true(a_rule.cssRules[0] instanceof CSSNestedDeclarations);
-    assert_equals(a_rule.cssRules[0].cssText, `width: 100px; height: 200px;`);
+    assert_equals(a_rule.cssRules[0].cssText, `width: 100px; z-index: 3;`);
   }, 'Inserting a CSSNestedDeclaration rule into style rule');
 
   test(() => {
@@ -178,11 +178,11 @@
     assert_equals(media_rule.cssRules.length, 0);
     media_rule.insertRule(`
       width: 100px;
-      height: 200px;
+      z-index: 3;
     `);
     assert_equals(media_rule.cssRules.length, 1);
     assert_true(media_rule.cssRules[0] instanceof CSSNestedDeclarations);
-    assert_equals(media_rule.cssRules[0].cssText, `width: 100px; height: 200px;`);
+    assert_equals(media_rule.cssRules[0].cssText, `width: 100px; z-index: 3;`);
   }, 'Inserting a CSSNestedDeclaration rule into nested group rule');
 
   test(() => {

--- a/css/css-page/parsing/size-invalid.html
+++ b/css/css-page/parsing/size-invalid.html
@@ -1,25 +1,31 @@
 <!DOCTYPE html>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="author" title="Andrew Martinez" href="https://github.com/AndrewJMart">
 <link rel="help" href="https://drafts.csswg.org/css-page-3/#descdef-page-size">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/parsing-testcommon.js"></script>
 <script>
-  // size is not a property, but a descriptor. test_invalid_value() tries to specify
-  // it on an element, and this should fail, even when using a valid
-  // value. size is only valid as a descriptor inside an @page rule.
-  test_invalid_value("size", "initial");
-  test_invalid_value("size", "inherit");
-  test_invalid_value("size", "revert");
-  test_invalid_value("size", "revert-layer");
-  test_invalid_value("size", "unset");
-  test_invalid_value("size", "640px 480px");
-  test_invalid_value("size", "8.5in 11in");
-  test_invalid_value("size", "a4");
-  test_invalid_value("size", "3in 10in");
-  test_invalid_value("size", "jis-b5");
-  test_invalid_value("size", "auto");
-  test_invalid_value("size", "landscape");
-  test_invalid_value("size", "letter");
-  test_invalid_value("size", "legal landscape");
+// size is a property and a descriptor. Property-only values
+// used as the @page descriptor should be invalid.
+function test_invalid_descriptor(value) {
+  test(() => {
+    const style = document.createElement("style");
+    document.head.append(style);
+    try {
+      const sheet = style.sheet;
+      sheet.insertRule(`@page { size: ${value}; }`);
+      assert_equals(sheet.cssRules[0].style.getPropertyValue("size"), "",
+        `size: ${value} should be invalid as an @page descriptor`);
+    } finally {
+      style.remove();
+    }
+  }, `@page { size: ${value} } is invalid`);
+}
+
+test_invalid_descriptor("50%");
+test_invalid_descriptor("10px 50%");
+test_invalid_descriptor("min-content");
+test_invalid_descriptor("max-content");
+test_invalid_descriptor("fit-content(100px)");
+test_invalid_descriptor("min-content max-content");
 </script>

--- a/css/css-sizing/parsing/size-invalid.html
+++ b/css/css-sizing/parsing/size-invalid.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Andrew Martinez" href="https://github.com/AndrewJMart">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-properties">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  // size is a property and a descriptor. test_invalid_value() specifies
+  // @page size's descriptor values on a property, which should be invalid.
+  test_invalid_value("size", "a4");
+  test_invalid_value("size", "jis-b5");
+  test_invalid_value("size", "landscape");
+  test_invalid_value("size", "letter");
+  test_invalid_value("size", "legal landscape");
+  // size accepts at most two values.
+  test_invalid_value("size", "100px 200px 300px");
+</script>

--- a/css/css-sizing/parsing/size-shorthand.html
+++ b/css/css-sizing/parsing/size-shorthand.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<link rel="author" title="Andrew Martinez" href="https://github.com/AndrewJMart">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-properties">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+<script>
+    // size is a property and a descriptor. The size property is a shorthand
+    // for width and height.
+    test_shorthand_value("size", "100px", {
+        "width": "100px",
+        "height": "100px"
+    });
+    test_shorthand_value("size", "100px 100px", {
+        "width": "100px",
+        "height": "100px"
+    });
+    test_shorthand_value("size", "100px 200px", {
+        "width": "100px",
+        "height": "200px"
+    });
+    test_shorthand_value("size", "auto", {
+        "width": "auto",
+        "height": "auto"
+    });
+</script>

--- a/css/css-sizing/parsing/size-valid.html
+++ b/css/css-sizing/parsing/size-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Andrew Martinez" href="https://github.com/AndrewJMart">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-properties">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  // size is a property and descriptor. test_valid_value() specifies
+  // property values on an element, which should yield as valid.
+  test_valid_value("size", "initial");
+  test_valid_value("size", "inherit");
+  test_valid_value("size", "revert");
+  test_valid_value("size", "revert-layer");
+  test_valid_value("size", "unset");
+  test_valid_value("size", "640px 480px");
+  test_valid_value("size", "8.5in 11in");
+  test_valid_value("size", "3in 10in");
+  test_valid_value("size", "auto");
+  // Identical dimensions serialize as a single value.
+  test_valid_value("size", "100px 100px", "100px");
+</script>

--- a/css/cssom/page-descriptors.html
+++ b/css/cssom/page-descriptors.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <link rel="author" title="Mozilla" href="https://mozilla.org">
+  <link rel="author" title="Andrew Martinez" href="https://github.com/AndrewJMart">
   <link rel="help" href="https://drafts.csswg.org/cssom/#the-cssstyledeclaration-interface">
   <title>CSSPageDescriptors properties tests</title>
   <script src="/resources/testharness.js"></script>
@@ -21,13 +22,13 @@
   </style>
 </head>
 <body>
-<div id="target"></div>
 <script>
 'use strict';
 
-let element = document.getElementById("target");
-let computedStyle = window.getComputedStyle(element);
-let style = element.style;
+// `size` is both an @page descriptor and a width/height shorthand property, with no
+// relation between the two (w3c/csswg-drafts#820). The split is covered by
+// css/css-sizing/parsing/size-invalid.html, so it is not retested here.
+
 let styleSheet = document.styleSheets[0];
 let marginNames = ["left", "right", "top", "bottom"];
 let pageDescriptors = ["margin", "page-orientation", "size"];
@@ -36,36 +37,27 @@ marginNames.forEach(function(n){
     pageDescriptors.push("margin" + n[0].toUpperCase() + n.slice(1));
 });
 
-test(t => {
-    // Check that size isn't exposed on all CSS style declarations.
-    assert_equals(computedStyle.size, undefined,
-        "computed style should not have size property");
-    assert_equals(computedStyle.getPropertyValue("size"), "",
-        "computed style getPropertyValue(\"size\") should be empty");
-
-    assert_equals(style.size, undefined,
-        "style should not have size property");
-    assert_equals(style.getPropertyValue("size"), "",
-        "style getPropertyValue(\"size\") should be empty");
-    for(const val of ["initial", "auto", "100px"]){
-        style.setProperty("size", val);
-        assert_false(CSS.supports("size", val));
-        assert_equals(style.size, undefined,
-            "style should not have size property after assigning size=" + val);
-        assert_equals(style.getPropertyValue("size"), "",
-            "style getPropertyValue(\"size\") should be empty after assigning size=" + val);
-    }
-    pageDescriptors.forEach(function(prop){
+// One test per descriptor so an unimplemented one doesn't hide the rest.
+pageDescriptors.forEach(function(prop){
+    test(() => {
         assert_own_property(styleSheet.cssRules[0].style.__proto__, prop,
             "CSSPageDescriptors should have property " + prop);
-    });
+    }, `CSSPageDescriptors exposes "${prop}"`);
+});
+
+test(() => {
     assert_equals(styleSheet.cssRules[0].style.size, "a3");
+    assert_equals(styleSheet.cssRules[1].style.size, "jis-b5 landscape");
+    assert_equals(styleSheet.cssRules[2].style.size, "216mm");
+}, "@page size descriptor is parsed and serialized from CSS");
+
+test(() => {
     assert_equals(styleSheet.cssRules[0].style.pageOrientation, "rotate-right");
     assert_equals(styleSheet.cssRules[0].style.getPropertyValue("page-orientation"), "rotate-right",
         'Value of page-orientation should match pageOrientation from CSS');
-    assert_equals(styleSheet.cssRules[1].style.size, "jis-b5 landscape");
-    assert_equals(styleSheet.cssRules[2].style.size, "216mm");
+}, "@page page-orientation descriptor is parsed and serialized from CSS");
 
+test(() => {
     // Ensure we can set the size property to a valid value.
     styleSheet.cssRules[2].style.size = "portrait";
     assert_equals(styleSheet.cssRules[2].style.size, "portrait",
@@ -74,7 +66,9 @@ test(t => {
     styleSheet.cssRules[2].style.size = "notarealsize";
     assert_equals(styleSheet.cssRules[2].style.size, "portrait",
         'Should not have been able to set size property to "notarealsize" on CSSPageDescriptors');
+}, "@page size descriptor can be set from script");
 
+test(() => {
     // Ensure we can set the orientation property to a valid value.
     styleSheet.cssRules[2].style.pageOrientation = "rotate-left";
     assert_equals(styleSheet.cssRules[2].style.pageOrientation, "rotate-left",
@@ -85,16 +79,23 @@ test(t => {
     styleSheet.cssRules[2].style.pageOrientation = "schmotate-schmeft";
     assert_equals(styleSheet.cssRules[2].style.pageOrientation, "rotate-left",
         'Should not have been able to set pageOrientation property to "schmotate-schmeft" on CSSPageDescriptors');
+}, "@page page-orientation descriptor can be set from script");
 
+test(() => {
     // Ensure we cannot set invalid page properties.
     styleSheet.cssRules[2].style.setProperty("float", "left");
     assert_equals(styleSheet.cssRules[2].style.cssFloat, undefined);
+}, "CSSPageDescriptors does not expose properties that are not @page descriptors");
 
+test(() => {
     assert_equals(styleSheet.cssRules[0].style.marginLeft, "101.5mm");
     assert_equals(styleSheet.cssRules[0].style.marginRight, "24px");
     assert_equals(styleSheet.cssRules[0].style.marginTop, "1em");
     assert_equals(styleSheet.cssRules[0].style.marginBottom, "2in");
-    marginNames.forEach(function(name){
+}, "@page margin descriptor expands to its longhands");
+
+marginNames.forEach(function(name){
+    test(() => {
         let name1 = "margin-" + name;
         let name2 = "margin" + name[0].toUpperCase() + name.slice(1);
         assert_equals(styleSheet.cssRules[0].style[name1],
@@ -111,7 +112,7 @@ test(t => {
             "Should have been able to set " + name2 + " property on CSSPageDescriptors");
         assert_equals(styleSheet.cssRules[0].style[name1], "216px",
             "Setting " + name2 + " on CSSPageDescriptors should also set " + name1);
-    });
+    }, `@page margin-${name} and margin${name[0].toUpperCase() + name.slice(1)} are aliases`);
 });
 </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [\[css-sizing\] Add a `size` shorthand for `width`/`height`](https://bugs.webkit.org/show_bug.cgi?id=289633)