### PR TITLE
Credential Management: test opaque-origin rejection for origin-bound credentials

### DIFF
--- a/credential-management/origin-bound-opaque-origin-top-level-allow-same-origin.https.html
+++ b/credential-management/origin-bound-opaque-origin-top-level-allow-same-origin.https.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Credential Management: a top-level sandboxed page with allow-same-origin is
+  not treated as opaque
+</title>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-request"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // Served with `Content-Security-Policy: sandbox allow-scripts allow-same-origin`
+    // (see the .headers file): sandboxed, but the page keeps its real origin, so it
+    // is not opaque and the opaque-origin check must not fire.
+    promise_test(async (t) => {
+      assert_implements(self.PasswordCredential, "PasswordCredential");
+      let name = "resolved";
+      try {
+        await navigator.credentials.get({ password: true });
+      } catch (error) {
+        name = error.name;
+      }
+      assert_not_equals(
+        name,
+        "SecurityError",
+        "a sandboxed top-level page that keeps its origin must not be rejected as opaque"
+      );
+    }, "get() from a top-level sandboxed page with allow-same-origin is not rejected as opaque");
+  </script>
+</body>

--- a/credential-management/origin-bound-opaque-origin-top-level-allow-same-origin.https.html
+++ b/credential-management/origin-bound-opaque-origin-top-level-allow-same-origin.https.html
@@ -8,6 +8,14 @@
   rel="help"
   href="https://w3c.github.io/webappsec-credential-management/#algorithm-request"
 />
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-create"
+/>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-store"
+/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
@@ -15,19 +23,43 @@
     // Served with `Content-Security-Policy: sandbox allow-scripts allow-same-origin`
     // (see the .headers file): sandboxed, but the page keeps its real origin, so it
     // is not opaque and the opaque-origin check must not fire.
-    promise_test(async (t) => {
-      assert_implements(self.PasswordCredential, "PasswordCredential");
-      let name = "resolved";
-      try {
-        await navigator.credentials.get({ password: true });
-      } catch (error) {
-        name = error.name;
-      }
-      assert_not_equals(
-        name,
-        "SecurityError",
-        "a sandboxed top-level page that keeps its origin must not be rejected as opaque"
+    const data = { id: "id", password: "pencil" };
+
+    function assertSupported() {
+      assert_implements_optional(
+        navigator.credentials,
+        "navigator.credentials is not supported"
       );
-    }, "get() from a top-level sandboxed page with allow-same-origin is not rejected as opaque");
+      assert_implements_optional(
+        self.PasswordCredential,
+        "PasswordCredential is not supported"
+      );
+    }
+
+    async function settle(operation) {
+      try {
+        await operation();
+        return "resolved";
+      } catch (error) {
+        return error.name;
+      }
+    }
+
+    const OPERATIONS = {
+      get: () => navigator.credentials.get({ password: true }),
+      create: () => navigator.credentials.create({ password: data }),
+      store: () => navigator.credentials.store(new PasswordCredential(data)),
+    };
+
+    for (const [name, operation] of Object.entries(OPERATIONS)) {
+      promise_test(async () => {
+        assertSupported();
+        assert_not_equals(
+          await settle(operation),
+          "SecurityError",
+          "a sandboxed top-level page that keeps its origin must not be rejected as opaque"
+        );
+      }, `${name}() from a top-level sandboxed page with allow-same-origin is not rejected as opaque`);
+    }
   </script>
 </body>

--- a/credential-management/origin-bound-opaque-origin-top-level-allow-same-origin.https.html.headers
+++ b/credential-management/origin-bound-opaque-origin-top-level-allow-same-origin.https.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts allow-same-origin

--- a/credential-management/origin-bound-opaque-origin-top-level.https.html
+++ b/credential-management/origin-bound-opaque-origin-top-level.https.html
@@ -27,8 +27,22 @@
     // requirement is vacuously satisfied here. The opaque-origin check is the
     // only thing that can reject these calls, which the framed cases in
     // origin-bound-opaque-origin.https.html cannot establish on their own.
+
+    function assertSupported() {
+      assert_implements_optional(
+        navigator.credentials,
+        "navigator.credentials is not supported"
+      );
+      assert_implements_optional(
+        self.PasswordCredential,
+        "PasswordCredential is not supported"
+      );
+    }
+
+    const data = { id: "id", password: "pencil" };
+
     promise_test((t) => {
-      assert_implements(self.PasswordCredential, "PasswordCredential");
+      assertSupported();
       return promise_rejects_dom(
         t,
         "SecurityError",
@@ -37,22 +51,17 @@
     }, "get() with a PasswordCredential from a top-level opaque origin rejects with SecurityError");
 
     promise_test((t) => {
-      assert_implements(self.PasswordCredential, "PasswordCredential");
+      assertSupported();
       return promise_rejects_dom(
         t,
         "SecurityError",
-        navigator.credentials.create({
-          password: { id: "id", password: "pencil" },
-        })
+        navigator.credentials.create({ password: data })
       );
     }, "create() with a PasswordCredential from a top-level opaque origin rejects with SecurityError");
 
     promise_test((t) => {
-      assert_implements(self.PasswordCredential, "PasswordCredential");
-      const credential = new PasswordCredential({
-        id: "id",
-        password: "pencil",
-      });
+      assertSupported();
+      const credential = new PasswordCredential(data);
       return promise_rejects_dom(
         t,
         "SecurityError",

--- a/credential-management/origin-bound-opaque-origin-top-level.https.html
+++ b/credential-management/origin-bound-opaque-origin-top-level.https.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Credential Management: PasswordCredential from a top-level opaque origin
+</title>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-request"
+/>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-create"
+/>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-store"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <script>
+    // Served with `Content-Security-Policy: sandbox allow-scripts` (see the
+    // accompanying .headers file), so this top-level document has an opaque
+    // origin while remaining a secure context.
+    //
+    // A top-level document has no ancestors, so any same-origin-with-ancestors
+    // requirement is vacuously satisfied here. The opaque-origin check is the
+    // only thing that can reject these calls, which the framed cases in
+    // origin-bound-opaque-origin.https.html cannot establish on their own.
+    promise_test((t) => {
+      assert_implements(self.PasswordCredential, "PasswordCredential");
+      return promise_rejects_dom(
+        t,
+        "SecurityError",
+        navigator.credentials.get({ password: true })
+      );
+    }, "get() with a PasswordCredential from a top-level opaque origin rejects with SecurityError");
+
+    promise_test((t) => {
+      assert_implements(self.PasswordCredential, "PasswordCredential");
+      return promise_rejects_dom(
+        t,
+        "SecurityError",
+        navigator.credentials.create({
+          password: { id: "id", password: "pencil" },
+        })
+      );
+    }, "create() with a PasswordCredential from a top-level opaque origin rejects with SecurityError");
+
+    promise_test((t) => {
+      assert_implements(self.PasswordCredential, "PasswordCredential");
+      const credential = new PasswordCredential({
+        id: "id",
+        password: "pencil",
+      });
+      return promise_rejects_dom(
+        t,
+        "SecurityError",
+        navigator.credentials.store(credential)
+      );
+    }, "store() with a PasswordCredential from a top-level opaque origin rejects with SecurityError");
+  </script>
+</body>

--- a/credential-management/origin-bound-opaque-origin-top-level.https.html.headers
+++ b/credential-management/origin-bound-opaque-origin-top-level.https.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/credential-management/origin-bound-opaque-origin.https.html
+++ b/credential-management/origin-bound-opaque-origin.https.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+  Credential Management: origin-bound credentials and opaque origins
+</title>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-request"
+/>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-create"
+/>
+<link
+  rel="help"
+  href="https://w3c.github.io/webappsec-credential-management/#algorithm-store"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+  const SUPPORT = "/credential-management/support/";
+
+  // PasswordCredential is origin bound, so get(), create() and store() must all
+  // reject with SecurityError when the calling document has an opaque origin.
+
+  function awaitReport(id) {
+    return new Promise((resolve) => {
+      addEventListener("message", function handler(event) {
+        if (event.data && event.data.id === id) {
+          removeEventListener("message", handler);
+          resolve(event.data);
+        }
+      });
+    });
+  }
+
+  function runInFrame(id, configure) {
+    const frame = document.createElement("iframe");
+    configure(frame, id);
+    document.body.appendChild(frame);
+    return awaitReport(id);
+  }
+
+  const OPAQUE = [
+    [
+      "sandboxed iframe",
+      (frame, id) => {
+        frame.sandbox = "allow-scripts";
+        frame.src = SUPPORT + "origin-bound-report.html?id=" + id;
+      },
+    ],
+    [
+      "iframe whose document has a Content-Security-Policy: sandbox header",
+      (frame, id) => {
+        frame.src = SUPPORT + "origin-bound-report-csp-sandbox.html?id=" + id;
+      },
+    ],
+  ];
+
+  for (const [label, configure] of OPAQUE) {
+    for (const operation of ["get", "create", "store"]) {
+      promise_test(async () => {
+        const report = await runInFrame(
+          `opaque-${operation}-${label}`,
+          configure
+        );
+        assert_equals(report.origin, "null", "expected an opaque origin");
+        assert_equals(
+          report[operation],
+          "SecurityError",
+          `${operation}() from an opaque origin must reject with SecurityError`
+        );
+      }, `${operation}() with an origin-bound credential from an opaque origin (${label}) rejects with SecurityError`);
+    }
+  }
+
+  // A document that is sandboxed but keeps its origin must not be caught by the
+  // opaque-origin check.
+  for (const operation of ["get", "create", "store"]) {
+    promise_test(async () => {
+      const report = await runInFrame(
+        `nonopaque-${operation}`,
+        (frame, id) => {
+          frame.sandbox = "allow-scripts allow-same-origin";
+          frame.src = SUPPORT + "origin-bound-report.html?id=" + id;
+        }
+      );
+      assert_not_equals(
+        report.origin,
+        "null",
+        "expected a normal (non-opaque) origin"
+      );
+      assert_not_equals(
+        report[operation],
+        "SecurityError",
+        `${operation}() from a non-opaque origin must not be rejected as opaque`
+      );
+    }, `${operation}() with an origin-bound credential from a non-opaque origin (sandboxed iframe with allow-same-origin) is not rejected as opaque`);
+  }
+</script>

--- a/credential-management/origin-bound-opaque-origin.https.html
+++ b/credential-management/origin-bound-opaque-origin.https.html
@@ -28,7 +28,7 @@
 
   function runInFrame(test, id, operation, configure) {
     const frame = document.createElement("iframe");
-    configure(frame, `id=${id}&op=${operation}`);
+    configure(frame, new URLSearchParams({ id, op: operation }).toString());
     const report = new Promise((resolve) => {
       addEventListener("message", function handler(event) {
         if (event.data && event.data.id === id) {
@@ -36,25 +36,25 @@
           resolve(event.data);
         }
       });
-      frame.addEventListener("error", () =>
-        resolve({ id, error: "the support frame failed to load" })
-      );
     });
     test.add_cleanup(() => frame.remove());
     document.body.appendChild(frame);
     return report;
   }
 
-  // A frame that never reports leaves `report` pending and the subtest times out
-  // with no explanation, so surface the two ways that can happen.
+  // The support frame reports its own failures rather than the result of an
+  // operation. Treating those as results would let a subtest pass without ever
+  // exercising the check under test.
   function assertReported(report) {
-    assert_false(
-      "error" in report,
-      report.error || "the support frame did not report"
-    );
-    assert_true(
+    assert_implements_optional(
       report.supported,
       "PasswordCredential is not supported, so nothing was exercised"
+    );
+    assert_false(
+      report.result.startsWith("construction-failed:") ||
+        report.result.startsWith("harness-error:") ||
+        report.result === "unknown-op",
+      `the support frame failed before the operation ran: ${report.result}`
     );
   }
 

--- a/credential-management/origin-bound-opaque-origin.https.html
+++ b/credential-management/origin-bound-opaque-origin.https.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8" />
 <title>
-  Credential Management: origin-bound credentials and opaque origins
+  Credential Management: PasswordCredential and opaque origins
 </title>
 <link
   rel="help"
@@ -24,22 +24,36 @@
   // PasswordCredential is origin bound, so get(), create() and store() must all
   // reject with SecurityError when the calling document has an opaque origin.
 
-  function awaitReport(id) {
-    return new Promise((resolve) => {
+  function runInFrame(test, id, configure) {
+    const frame = document.createElement("iframe");
+    configure(frame, id);
+    const report = new Promise((resolve) => {
       addEventListener("message", function handler(event) {
         if (event.data && event.data.id === id) {
           removeEventListener("message", handler);
           resolve(event.data);
         }
       });
+      frame.addEventListener("error", () =>
+        resolve({ id, error: "the support frame failed to load" })
+      );
     });
+    test.add_cleanup(() => frame.remove());
+    document.body.appendChild(frame);
+    return report;
   }
 
-  function runInFrame(id, configure) {
-    const frame = document.createElement("iframe");
-    configure(frame, id);
-    document.body.appendChild(frame);
-    return awaitReport(id);
+  // A frame that never reports leaves `report` pending and the subtest times
+  // out with no explanation, so surface the two ways that can happen.
+  function assertReported(report) {
+    assert_false(
+      "error" in report,
+      report.error || "the support frame did not report"
+    );
+    assert_true(
+      report.supported,
+      "PasswordCredential is not supported, so nothing was exercised"
+    );
   }
 
   const OPAQUE = [
@@ -60,32 +74,36 @@
 
   for (const [label, configure] of OPAQUE) {
     for (const operation of ["get", "create", "store"]) {
-      promise_test(async () => {
+      promise_test(async (t) => {
         const report = await runInFrame(
+          t,
           `opaque-${operation}-${label}`,
           configure
         );
+        assertReported(report);
         assert_equals(report.origin, "null", "expected an opaque origin");
         assert_equals(
           report[operation],
           "SecurityError",
           `${operation}() from an opaque origin must reject with SecurityError`
         );
-      }, `${operation}() with an origin-bound credential from an opaque origin (${label}) rejects with SecurityError`);
+      }, `${operation}() with a PasswordCredential from an opaque origin (${label}) rejects with SecurityError`);
     }
   }
 
   // A document that is sandboxed but keeps its origin must not be caught by the
   // opaque-origin check.
   for (const operation of ["get", "create", "store"]) {
-    promise_test(async () => {
+    promise_test(async (t) => {
       const report = await runInFrame(
+        t,
         `nonopaque-${operation}`,
         (frame, id) => {
           frame.sandbox = "allow-scripts allow-same-origin";
           frame.src = SUPPORT + "origin-bound-report.html?id=" + id;
         }
       );
+      assertReported(report);
       assert_not_equals(
         report.origin,
         "null",
@@ -96,6 +114,6 @@
         "SecurityError",
         `${operation}() from a non-opaque origin must not be rejected as opaque`
       );
-    }, `${operation}() with an origin-bound credential from a non-opaque origin (sandboxed iframe with allow-same-origin) is not rejected as opaque`);
+    }, `${operation}() with a PasswordCredential from a non-opaque origin (sandboxed iframe with allow-same-origin) is not rejected as opaque`);
   }
 </script>

--- a/credential-management/origin-bound-opaque-origin.https.html
+++ b/credential-management/origin-bound-opaque-origin.https.html
@@ -23,10 +23,12 @@
 
   // PasswordCredential is origin bound, so get(), create() and store() must all
   // reject with SecurityError when the calling document has an opaque origin.
+  // Each subtest gets its own frame running only the operation it asserts on, so
+  // no subtest depends on another operation settling first.
 
-  function runInFrame(test, id, configure) {
+  function runInFrame(test, id, operation, configure) {
     const frame = document.createElement("iframe");
-    configure(frame, id);
+    configure(frame, `id=${id}&op=${operation}`);
     const report = new Promise((resolve) => {
       addEventListener("message", function handler(event) {
         if (event.data && event.data.id === id) {
@@ -43,8 +45,8 @@
     return report;
   }
 
-  // A frame that never reports leaves `report` pending and the subtest times
-  // out with no explanation, so surface the two ways that can happen.
+  // A frame that never reports leaves `report` pending and the subtest times out
+  // with no explanation, so surface the two ways that can happen.
   function assertReported(report) {
     assert_false(
       "error" in report,
@@ -59,15 +61,15 @@
   const OPAQUE = [
     [
       "sandboxed iframe",
-      (frame, id) => {
+      (frame, query) => {
         frame.sandbox = "allow-scripts";
-        frame.src = SUPPORT + "origin-bound-report.html?id=" + id;
+        frame.src = `${SUPPORT}origin-bound-report.html?${query}`;
       },
     ],
     [
       "iframe whose document has a Content-Security-Policy: sandbox header",
-      (frame, id) => {
-        frame.src = SUPPORT + "origin-bound-report-csp-sandbox.html?id=" + id;
+      (frame, query) => {
+        frame.src = `${SUPPORT}origin-bound-report-csp-sandbox.html?${query}`;
       },
     ],
   ];
@@ -78,12 +80,13 @@
         const report = await runInFrame(
           t,
           `opaque-${operation}-${label}`,
+          operation,
           configure
         );
         assertReported(report);
         assert_equals(report.origin, "null", "expected an opaque origin");
         assert_equals(
-          report[operation],
+          report.result,
           "SecurityError",
           `${operation}() from an opaque origin must reject with SecurityError`
         );
@@ -98,9 +101,10 @@
       const report = await runInFrame(
         t,
         `nonopaque-${operation}`,
-        (frame, id) => {
+        operation,
+        (frame, query) => {
           frame.sandbox = "allow-scripts allow-same-origin";
-          frame.src = SUPPORT + "origin-bound-report.html?id=" + id;
+          frame.src = `${SUPPORT}origin-bound-report.html?${query}`;
         }
       );
       assertReported(report);
@@ -110,7 +114,7 @@
         "expected a normal (non-opaque) origin"
       );
       assert_not_equals(
-        report[operation],
+        report.result,
         "SecurityError",
         `${operation}() from a non-opaque origin must not be rejected as opaque`
       );

--- a/credential-management/support/origin-bound-report-csp-sandbox.html
+++ b/credential-management/support/origin-bound-report-csp-sandbox.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script src="origin-bound-report.js"></script>

--- a/credential-management/support/origin-bound-report-csp-sandbox.html.headers
+++ b/credential-management/support/origin-bound-report-csp-sandbox.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/credential-management/support/origin-bound-report.html
+++ b/credential-management/support/origin-bound-report.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<body></body>
+<script src="origin-bound-report.js"></script>

--- a/credential-management/support/origin-bound-report.js
+++ b/credential-management/support/origin-bound-report.js
@@ -1,18 +1,24 @@
 // Reports how get(), create() and store() settle for an origin-bound credential
-// type, so an opaque-origin frame can report back to the top-level test.
+// type, so an opaque-origin frame can report its result to the top-level test.
 //
-// PasswordCredential is origin bound, so all three are expected to reject with
-// SecurityError from an opaque origin. A non-opaque frame must not see that error.
+// PasswordCredential is origin bound, so from an opaque origin all three are
+// expected to reject with SecurityError. Each operation is reported separately,
+// along with whether the machinery it needs is even present, so a browser that
+// does not implement PasswordCredential reports "unsupported" rather than a
+// result that could be mistaken for conformance.
 (async () => {
   const id = new URL(location.href).searchParams.get("id");
   const report = {
     id,
     origin: String(self.origin),
     secure: self.isSecureContext,
-    get: "resolved",
-    create: "resolved",
-    store: "resolved",
+    supported: false,
+    get: "unsupported",
+    create: "unsupported",
+    store: "unsupported",
   };
+
+  const post = () => (window.top || window.parent).postMessage(report, "*");
 
   const settle = async (operation) => {
     try {
@@ -23,26 +29,37 @@
     }
   };
 
-  if (!(navigator.credentials && navigator.credentials.get)) {
-    report.get = report.create = report.store = "unavailable";
-    (window.top || window.parent).postMessage(report, "*");
-    return;
+  try {
+    if (!self.PasswordCredential || !navigator.credentials) {
+      post();
+      return;
+    }
+    report.supported = true;
+
+    const data = { id: "id", password: "pencil" };
+
+    report.get = await settle(() =>
+      navigator.credentials.get({ password: true })
+    );
+
+    report.create = await settle(() =>
+      navigator.credentials.create({ password: data })
+    );
+
+    // Construct outside settle() so a constructor failure is never reported as
+    // a store() result.
+    let credential;
+    try {
+      credential = new PasswordCredential(data);
+    } catch (error) {
+      report.store = "construction-failed:" + error.name;
+      post();
+      return;
+    }
+    report.store = await settle(() => navigator.credentials.store(credential));
+  } catch (error) {
+    report.get = report.create = report.store = "harness-error:" + error.name;
   }
 
-  report.get = await settle(() => navigator.credentials.get({ password: true }));
-
-  const data = { id: "id", password: "pencil" };
-  report.create = await settle(() =>
-    navigator.credentials.create({ password: data })
-  );
-
-  // store() needs a credential object. Constructing one is independent of the
-  // opaque-origin check, so fall back to reporting the construction failure
-  // rather than a misleading store() result.
-  report.store = await settle(async () => {
-    const credential = new PasswordCredential(data);
-    await navigator.credentials.store(credential);
-  });
-
-  (window.top || window.parent).postMessage(report, "*");
+  post();
 })();

--- a/credential-management/support/origin-bound-report.js
+++ b/credential-management/support/origin-bound-report.js
@@ -1,15 +1,6 @@
-// Reports how one of get(), create() or store() settles for an origin-bound
-// credential type, so an opaque-origin frame can report its result to the
-// top-level test.
-//
 // The operation is chosen by the `op` search parameter, and only that operation
 // runs: a subtest must not depend on an earlier operation settling, and store()
 // has a side effect that should not fire for the get() and create() subtests.
-//
-// PasswordCredential is origin bound, so from an opaque origin the operation is
-// expected to reject with SecurityError. `supported` reports whether the
-// machinery was present at all, so a browser without PasswordCredential says so
-// rather than producing a result that could be mistaken for conformance.
 (async () => {
   const params = new URL(location.href).searchParams;
   const id = params.get("id");

--- a/credential-management/support/origin-bound-report.js
+++ b/credential-management/support/origin-bound-report.js
@@ -1,33 +1,29 @@
-// Reports how get(), create() and store() settle for an origin-bound credential
-// type, so an opaque-origin frame can report its result to the top-level test.
+// Reports how one of get(), create() or store() settles for an origin-bound
+// credential type, so an opaque-origin frame can report its result to the
+// top-level test.
 //
-// PasswordCredential is origin bound, so from an opaque origin all three are
-// expected to reject with SecurityError. Each operation is reported separately,
-// along with whether the machinery it needs is even present, so a browser that
-// does not implement PasswordCredential reports "unsupported" rather than a
-// result that could be mistaken for conformance.
+// The operation is chosen by the `op` search parameter, and only that operation
+// runs: a subtest must not depend on an earlier operation settling, and store()
+// has a side effect that should not fire for the get() and create() subtests.
+//
+// PasswordCredential is origin bound, so from an opaque origin the operation is
+// expected to reject with SecurityError. `supported` reports whether the
+// machinery was present at all, so a browser without PasswordCredential says so
+// rather than producing a result that could be mistaken for conformance.
 (async () => {
-  const id = new URL(location.href).searchParams.get("id");
+  const params = new URL(location.href).searchParams;
+  const id = params.get("id");
+  const op = params.get("op");
   const report = {
     id,
+    op,
     origin: String(self.origin),
     secure: self.isSecureContext,
     supported: false,
-    get: "unsupported",
-    create: "unsupported",
-    store: "unsupported",
+    result: "unsupported",
   };
 
   const post = () => (window.top || window.parent).postMessage(report, "*");
-
-  const settle = async (operation) => {
-    try {
-      await operation();
-      return "resolved";
-    } catch (error) {
-      return error.name;
-    }
-  };
 
   try {
     if (!self.PasswordCredential || !navigator.credentials) {
@@ -38,27 +34,37 @@
 
     const data = { id: "id", password: "pencil" };
 
-    report.get = await settle(() =>
-      navigator.credentials.get({ password: true })
-    );
-
-    report.create = await settle(() =>
-      navigator.credentials.create({ password: data })
-    );
-
-    // Construct outside settle() so a constructor failure is never reported as
-    // a store() result.
-    let credential;
-    try {
-      credential = new PasswordCredential(data);
-    } catch (error) {
-      report.store = "construction-failed:" + error.name;
+    // Built before the operation runs so a constructor failure is never
+    // reported as a store() result.
+    let operation;
+    if (op === "get") {
+      operation = () => navigator.credentials.get({ password: true });
+    } else if (op === "create") {
+      operation = () => navigator.credentials.create({ password: data });
+    } else if (op === "store") {
+      let credential;
+      try {
+        credential = new PasswordCredential(data);
+      } catch (error) {
+        report.result = "construction-failed:" + error.name;
+        post();
+        return;
+      }
+      operation = () => navigator.credentials.store(credential);
+    } else {
+      report.result = "unknown-op";
       post();
       return;
     }
-    report.store = await settle(() => navigator.credentials.store(credential));
+
+    try {
+      await operation();
+      report.result = "resolved";
+    } catch (error) {
+      report.result = error.name;
+    }
   } catch (error) {
-    report.get = report.create = report.store = "harness-error:" + error.name;
+    report.result = "harness-error:" + error.name;
   }
 
   post();

--- a/credential-management/support/origin-bound-report.js
+++ b/credential-management/support/origin-bound-report.js
@@ -1,0 +1,48 @@
+// Reports how get(), create() and store() settle for an origin-bound credential
+// type, so an opaque-origin frame can report back to the top-level test.
+//
+// PasswordCredential is origin bound, so all three are expected to reject with
+// SecurityError from an opaque origin. A non-opaque frame must not see that error.
+(async () => {
+  const id = new URL(location.href).searchParams.get("id");
+  const report = {
+    id,
+    origin: String(self.origin),
+    secure: self.isSecureContext,
+    get: "resolved",
+    create: "resolved",
+    store: "resolved",
+  };
+
+  const settle = async (operation) => {
+    try {
+      await operation();
+      return "resolved";
+    } catch (error) {
+      return error.name;
+    }
+  };
+
+  if (!(navigator.credentials && navigator.credentials.get)) {
+    report.get = report.create = report.store = "unavailable";
+    (window.top || window.parent).postMessage(report, "*");
+    return;
+  }
+
+  report.get = await settle(() => navigator.credentials.get({ password: true }));
+
+  const data = { id: "id", password: "pencil" };
+  report.create = await settle(() =>
+    navigator.credentials.create({ password: data })
+  );
+
+  // store() needs a credential object. Constructing one is independent of the
+  // opaque-origin check, so fall back to reporting the construction failure
+  // rather than a misleading store() result.
+  report.store = await settle(async () => {
+    const credential = new PasswordCredential(data);
+    await navigator.credentials.store(credential);
+  });
+
+  (window.top || window.parent).postMessage(report, "*");
+})();


### PR DESCRIPTION
Tests that `get()`, `create()` and `store()` reject with `SecurityError` when an origin-bound credential is requested from an opaque origin, and that a sandboxed frame with `allow-same-origin` is not caught by that check. Uses `PasswordCredential`, since it and `FederatedCredential` are the origin-bound types Credential Management declares itself.

For https://github.com/w3c/webappsec-credential-management/pull/304. Chrome currently fails six of the nine subtests: `get()` and `store()` reject with `NotAllowedError` rather than `SecurityError`, and `create()` from an opaque origin does not reject at all.
