### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=322115

### DIFF
--- a/wasm/webapi/esm-integration/exported-names.tentative.html
+++ b/wasm/webapi/esm-integration/exported-names.tentative.html
@@ -10,7 +10,8 @@ assert_array_equals(Object.getOwnPropertyNames(mod).sort(),
                     ["func", "glob", "mem", "tab"]);
 assert_true(mod.func instanceof Function);
 assert_true(mod.mem instanceof WebAssembly.Memory);
-assert_true(mod.glob instanceof WebAssembly.Global);
+assert_false(mod.glob instanceof WebAssembly.Global);
+assert_equals(typeof mod.glob, "number");
 assert_true(mod.tab instanceof WebAssembly.Table);
 assert_throws_js(TypeError, () => { mod.func = 2; });
 done();

--- a/wasm/webapi/esm-integration/resources/js-wasm-cycle.js
+++ b/wasm/webapi/esm-integration/resources/js-wasm-cycle.js
@@ -2,8 +2,8 @@ function f() { return 42; }
 export { f };
 
 import { mem, tab, glob, func } from "./js-wasm-cycle.wasm";
-assert_true(glob instanceof WebAssembly.Global);
-assert_equals(glob.valueOf(), 1);
+assert_false(glob instanceof WebAssembly.Global, "imported global should be unwrapped in ESM integration");
+assert_equals(glob, 1, "unwrapped global should have direct value");
 assert_true(mem instanceof WebAssembly.Memory);
 assert_true(tab instanceof WebAssembly.Table);
 assert_true(func instanceof Function);

--- a/wasm/webapi/esm-integration/wasm-js-cycle.tentative.html
+++ b/wasm/webapi/esm-integration/wasm-js-cycle.tentative.html
@@ -10,8 +10,8 @@ import * as js from "./resources/wasm-js-cycle.js";
 
 js.mutateBindings();
 
-assert_true(wasm.wasmGlob instanceof WebAssembly.Global);
-assert_equals(wasm.wasmGlob.valueOf(), 24);
+assert_false(wasm.wasmGlob instanceof WebAssembly.Global);
+assert_equals(wasm.wasmGlob, 24);
 
 assert_true(wasm.wasmFunc instanceof Function);
 assert_equals(wasm.wasmFunc(), 43);


### PR DESCRIPTION
WebKit export from bug: [[JSC][Wasm] Unwrap immutable globals in the ESM module namespace](https://bugs.webkit.org/show_bug.cgi?id=322115)

Landed in WebKit as [319544@main](https://commits.webkit.org/319544@main) / [WebKit#71954](https://github.com/WebKit/WebKit/pull/71954).

These three `webapi/` tests still expect ESM namespace globals to be `WebAssembly.Global` wrappers. That predates [esm-integration#104](https://github.com/WebAssembly/esm-integration/pull/104) (merged 2025-04). `ExecuteModule` now does `InitializeBinding(name, ToJSValue(global_read(...)))` for global exports. Mutable globals stay live via `GetBindingValue` → `ToJSValue(global_read)`. `Instance.exports` is unchanged (still wrapped).

`wasm/jsapi/esm-integration/exports.tentative.any.js` and `global-exports.tentative.any.js` already assert the unwrapped values. This brings the older `webapi/` copies in line with those tests and the spec.

How to check:
- `import { glob } from "./mod.wasm"` → number / bigint, not `WebAssembly.Global`
- `instance.exports.glob` → still a `WebAssembly.Global`
- v128 / exnref namespace bindings stay TDZ (not covered by these three files)