### PR TITLE
Give each GitHub Actions wptreport a unique basename

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -111,8 +111,8 @@ jobs:
             --total-chunks "$TOTAL_CHUNKS" \
             --chunk-type hash \
             ${TEST_TYPE:+--test-types "$TEST_TYPE"} \
-            --log-wptreport ${{ runner.temp }}/wpt_report_"$CURRENT_CHUNK".json \
-            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_"$CURRENT_CHUNK".txt \
+            --log-wptreport ${{ runner.temp }}/wpt_report_"${TEST_TYPE:+${TEST_TYPE}_}$CURRENT_CHUNK".json \
+            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_"${TEST_TYPE:+${TEST_TYPE}_}$CURRENT_CHUNK".txt \
             --log-mach - \
             --log-mach-level info \
             --channel ${{ inputs.safari-technology-preview && 'preview' || 'stable' }} \


### PR DESCRIPTION
This "regressed" with 10a4cd69c6, when we started sharding by test type, which meant we now had multiple chunks numbered 1.

("Regressed" in quotation marks because this isn't really a bug on our side: it's a bug on the consuming side. See https://github.com/web-platform-tests/wpt.fyi/issues/5070.)

Fixes #62372.