### PR TITLE
Add tests for the origin of documents created by the parsing APIs

### DIFF
--- a/domparsing/parsed-document-origin.window.js
+++ b/domparsing/parsed-document-origin.window.js
@@ -1,0 +1,41 @@
+// META: title=Documents created by the parsing APIs inherit the creating document's origin
+
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsehtml
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsehtmlunsafe
+// https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
+// https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
+
+test(() => {
+  assert_not_equals(document.domain, "");
+}, "This document has a tuple origin (prerequisite for the tests below)");
+
+test(() => {
+  const doc = new DOMParser().parseFromString("", "text/html");
+  assert_equals(doc.domain, document.domain);
+}, "DOMParser's parseFromString() with text/html");
+
+test(() => {
+  const doc = new DOMParser().parseFromString("<x/>", "text/xml");
+  assert_equals(doc.domain, document.domain);
+}, "DOMParser's parseFromString() with text/xml");
+
+test(() => {
+  const doc = Document.parseHTML("");
+  assert_equals(doc.domain, document.domain);
+}, "Document.parseHTML()");
+
+test(() => {
+  const doc = Document.parseHTMLUnsafe("");
+  assert_equals(doc.domain, document.domain);
+}, "Document.parseHTMLUnsafe()");
+
+test(() => {
+  const doc = document.implementation.createDocument(null, "");
+  assert_equals(doc.domain, document.domain);
+}, "createDocument()");
+
+test(() => {
+  const doc = document.implementation.createHTMLDocument("");
+  assert_equals(doc.domain, document.domain);
+}, "createHTMLDocument()");


### PR DESCRIPTION
document.domain is the only way to directly observe the origin of a document without a browsing context, and it was untested for these APIs.

For https://github.com/whatwg/html/pull/12881