### PR TITLE
Wait for stylesheet load before checking request count

### DIFF
--- a/html/semantics/document-metadata/the-link-element/document-without-browsing-context.html
+++ b/html/semantics/document-metadata/the-link-element/document-without-browsing-context.html
@@ -16,12 +16,20 @@
     xhr.send();
   }
 
+  function countAfterLoad(link, id, t) {
+    link.addEventListener('load', t.step_func(function() {
+      // Allow an incorrect extra request from the document without a browsing context to reach the server.
+      t.step_timeout(function() { count(id, t) }, 500);
+    }), { once: true });
+    link.addEventListener('error', t.unreached_func());
+  }
+
   async_test(function(t) {
     var id = token();
     var doc = (new DOMParser()).parseFromString('<link rel="stylesheet" href="stylesheet.py?id=' + id + '"></link>', 'text/html');
     var link = doc.querySelector('link');
+    countAfterLoad(link, id, t);
     document.head.appendChild(link);
-    t.step_timeout(function() { count(id, t) }, 500);
   }, 'Create a document, adopt the node');
 
   async_test(function(t) {
@@ -29,7 +37,7 @@
     var d = document.createElement('div');
     document.body.appendChild(d);
     d.innerHTML = '<link rel="stylesheet" href="stylesheet.py?id=' + id + '"></link>';
-    t.step_timeout(function() { count(id, t) }, 500);
+    countAfterLoad(d.querySelector('link'), id, t);
   }, 'Create a stylesheet in innerHTML document');
 </script>
 </body>


### PR DESCRIPTION
Start the settling delay after the expected stylesheet load completes so slow resource handling cannot let the request-count query overtake it. Retain the delay to detect an extra fetch from the document without a browsing context.

---

This test was flaky on jsdom CI, sometimes getting back a "0" from the server because the control group with-a-browsing-context document's stylesheet had not yet reached the server. By delaying, we avoid this failure mode.