### PR TITLE
script: Return actual placeholder container element if it exists.

### DIFF
--- a/html/semantics/forms/the-input-element/placeholder-update-no-value-ref.html
+++ b/html/semantics/forms/the-input-element/placeholder-update-no-value-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type=text placeholder=pass>

--- a/html/semantics/forms/the-input-element/placeholder-update-no-value.html
+++ b/html/semantics/forms/the-input-element/placeholder-update-no-value.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://github.com/servo/servo/issues/47616">
+<link rel="match" href="placeholder-update-no-value-ref.html">
+<body>
+<input id=input type=text placeholder=fail>
+<script>
+input.placeholder = "pass";
+</script>
+</body>
+</html>


### PR DESCRIPTION
init_placeholder_container_if_necessary is supposed to return the placeholder container if it exists. Instead, we returned the root element of the container if it exists, probably because of confusion around the word `root` when attempting to return a rooted element.

Testing: New reftest added.
Fixes: #<!-- nolink -->47616

Reviewed in servo/servo#47761