### PR TITLE
WebMCP: tentative input validation tests for #92

### DIFF
--- a/webmcp/imperative/executeTool-input-validation.tentative.https.html
+++ b/webmcp/imperative/executeTool-input-validation.tentative.https.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>WebMCP executeTool input validation (tentative)</title>
+<link rel="author" href="mailto:arnab@example.com">
+<link rel="help" href="https://webmachinelearning.github.io/webmcp/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+// Missing required → DataError with path "/field", reason "required"
+promise_test(async t => {
+  const controller = new AbortController();
+  t.add_cleanup(() => controller.abort());
+  const tool = {
+    name: "mcp-missing-required",
+    description: "test tool",
+    inputSchema: {
+      type: "object",
+      properties: { field: { type: "string" } },
+      required: ["field"]
+    },
+    execute: t.unreached_func("execute must not be called on validation failure")
+  };
+  await document.modelContext.registerTool(tool, { signal: controller.signal });
+  const [registered] = (await document.modelContext.getTools()).filter(x => x.name === tool.name);
+  assert_true(!!registered, "tool registered");
+
+  let err;
+  try {
+    await document.modelContext.executeTool(registered, {});
+    assert_unreached("should have rejected");
+  } catch (e) {
+    err = e;
+  }
+  assert_equals(err.name, "DataError");
+  const m = JSON.parse(err.message);
+  assert_equals(m.path, "/field");
+  assert_equals(m.reason, "required");
+  assert_equals(m.schemaPath, "/required");
+}, "missing required field rejects with DataError");
+
+// Enum mismatch → DataError, execute not called; valid enum succeeds in same file as second test
+promise_test(async t => {
+  const controller = new AbortController();
+  t.add_cleanup(() => controller.abort());
+  const tool = {
+    name: "mcp-enum",
+    description: "test tool",
+    inputSchema: {
+      type: "object",
+      properties: { color: { type: "string", enum: ["red", "green"] } },
+      required: ["color"]
+    },
+    execute: t.unreached_func("execute must not be called on enum mismatch")
+  };
+  await document.modelContext.registerTool(tool, { signal: controller.signal });
+  const [registered] = (await document.modelContext.getTools()).filter(x => x.name === tool.name);
+
+  let err;
+  try {
+    await document.modelContext.executeTool(registered, { color: "blue" });
+    assert_unreached("should have rejected");
+  } catch (e) {
+    err = e;
+  }
+  assert_equals(err.name, "DataError");
+  const m = JSON.parse(err.message);
+  assert_equals(m.path, "/color");
+  assert_equals(m.reason, "enum");
+  assert_equals(m.schemaPath, "/enum");
+}, "enum mismatch rejects with DataError");
+
+promise_test(async t => {
+  const controller = new AbortController();
+  t.add_cleanup(() => controller.abort());
+  const tool = {
+    name: "mcp-enum-valid",
+    description: "test tool",
+    inputSchema: {
+      type: "object",
+      properties: { color: { type: "string", enum: ["red", "green"] } }
+    },
+    execute: async ({ color }) => JSON.stringify({ ok: color })
+  };
+  await document.modelContext.registerTool(tool, { signal: controller.signal });
+  const [registered] = (await document.modelContext.getTools()).filter(x => x.name === tool.name);
+  const result = await document.modelContext.executeTool(registered, { color: "red" });
+  assert_equals(result, JSON.stringify({ ok: "red" }));
+}, "valid enum value succeeds");
+
+// Pattern mismatch → DataError
+promise_test(async t => {
+  const controller = new AbortController();
+  t.add_cleanup(() => controller.abort());
+  const tool = {
+    name: "mcp-pattern",
+    description: "test tool",
+    inputSchema: {
+      type: "object",
+      properties: { code: { type: "string", pattern: "^[a-z]+$" } },
+      required: ["code"]
+    },
+    execute: t.unreached_func("execute must not be called on pattern mismatch")
+  };
+  await document.modelContext.registerTool(tool, { signal: controller.signal });
+  const [registered] = (await document.modelContext.getTools()).filter(x => x.name === tool.name);
+
+  let err;
+  try {
+    await document.modelContext.executeTool(registered, { code: "ABC123" });
+    assert_unreached("should have rejected");
+  } catch (e) {
+    err = e;
+  }
+  assert_equals(err.name, "DataError");
+  const m = JSON.parse(err.message);
+  assert_equals(m.path, "/code");
+  assert_equals(m.reason, "pattern");
+  assert_equals(m.schemaPath, "/pattern");
+}, "pattern mismatch rejects with DataError");
+
+// Valid complex schema (prefixItems/items + additionalProperties:false)
+promise_test(async t => {
+  const controller = new AbortController();
+  t.add_cleanup(() => controller.abort());
+  let executed = false;
+  const tool = {
+    name: "mcp-valid-complex",
+    description: "complex valid",
+    inputSchema: {
+      type: "object",
+      properties: {
+        count: { type: "integer", minimum: 1, maximum: 10 },
+        name: { type: "string", minLength: 1, maxLength: 20 },
+        tags: { type: "array", prefixItems: [{ type: "string" }], items: { type: "string" } },
+        mode: { type: "string", enum: ["a", "b"] }
+      },
+      required: ["count", "name", "tags"],
+      additionalProperties: false
+    },
+    execute: async (input) => {
+      executed = true;
+      return JSON.stringify(input);
+    }
+  };
+  await document.modelContext.registerTool(tool, { signal: controller.signal });
+  const [registered] = (await document.modelContext.getTools()).filter(x => x.name === tool.name);
+  const result = await document.modelContext.executeTool(registered, { count: 5, name: "hello", tags: ["x", "y"], mode: "a" });
+  assert_true(executed, "execute called");
+  const parsed = JSON.parse(result);
+  assert_equals(parsed.count, 5);
+  assert_equals(parsed.name, "hello");
+}, "valid complex schema succeeds");
+
+// Retry / self-correction: invalid → DataError → retry succeeds, execute not called on first attempt
+promise_test(async t => {
+  const controller = new AbortController();
+  t.add_cleanup(() => controller.abort());
+  let callCount = 0;
+  const tool = {
+    name: "mcp-retry",
+    description: "retry test",
+    inputSchema: {
+      type: "object",
+      properties: { age: { type: "integer", minimum: 0, maximum: 120 } },
+      required: ["age"]
+    },
+    execute: async ({ age }) => {
+      callCount++;
+      return JSON.stringify({ age });
+    }
+  };
+  await document.modelContext.registerTool(tool, { signal: controller.signal });
+  const [registered] = (await document.modelContext.getTools()).filter(x => x.name === tool.name);
+
+  let err;
+  try {
+    await document.modelContext.executeTool(registered, { age: "old" });
+    assert_unreached("should have rejected");
+  } catch (e) {
+    err = e;
+  }
+  assert_equals(err.name, "DataError");
+  const m = JSON.parse(err.message);
+  assert_equals(m.path, "/age");
+  assert_equals(m.reason, "type");
+  assert_equals(callCount, 0, "execute not called on validation failure");
+
+  const result = await document.modelContext.executeTool(registered, { age: 30 });
+  assert_equals(JSON.parse(result).age, 30);
+  assert_equals(callCount, 1, "execute called after correction");
+}, "invalid → DataError → retry with corrected input succeeds");
+</script>

--- a/webmcp/imperative/register_tool_invalid_subset_schema.tentative.https.html
+++ b/webmcp/imperative/register_tool_invalid_subset_schema.tentative.https.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>WebMCP registerTool meta-validation: invalid subset schema (tentative)</title>
+<link rel="author" href="mailto:arnab@example.com">
+<link rel="help" href="https://webmachinelearning.github.io/webmcp/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+function test_invalid_subset(inputSchema, testName) {
+  promise_test(t => {
+    return promise_rejects_js(
+      t,
+      TypeError,
+      document.modelContext.registerTool({
+        name: "mcp-" + testName.replace(/[^a-z0-9]/gi, "-"),
+        description: "test",
+        inputSchema,
+        execute: () => {}
+      }),
+      "should reject with TypeError"
+    );
+  }, testName);
+}
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { $ref: "#/foo" } }
+  },
+  "registerTool rejects $ref (remote/DAG, excluded)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string", format: "email" } }
+  },
+  "registerTool rejects format (excluded)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string" } },
+    additionalProperties: true
+  },
+  "registerTool rejects additionalProperties:true (only false allowed)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string" } },
+    additionalProperties: { type: "string" }
+  },
+  "registerTool rejects additionalProperties schema (only false allowed)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string" } },
+    unevaluatedProperties: false
+  },
+  "registerTool rejects unevaluatedProperties (excluded)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string" } },
+    dependentRequired: { x: ["y"] }
+  },
+  "registerTool rejects dependentRequired (excluded)"
+);
+
+test_invalid_subset(
+  {
+    type: "string",
+    pattern: "["
+  },
+  "registerTool rejects invalid pattern (throws on RegExp)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string", $defs: {} } }
+  },
+  "registerTool rejects $defs (excluded)"
+);
+
+test_invalid_subset(
+  {
+    type: "object",
+    properties: { x: { type: "string", contentEncoding: "base64" } }
+  },
+  "registerTool rejects contentEncoding (excluded)"
+);
+</script>


### PR DESCRIPTION
Adds 
1. DataError validation for executeTool (missing-required/enum/pattern/valid/retry)
2. TypeError meta-validation for registerTool (invalid subset $ref/format/additionalProperties etc.) 

Written per webmachinelearning/webmcp#289 and CG resolution 2026-03-05#f5bd (Draft 2020-12 subset). Two tentative files under webmcp/imperative/.

<details>
<summary>LLM assistance</summary>

1. Initial drafts generated via Muse Spark 1.2 + opencode + ponytail reviews.
2. Reviewing and editing for WPT conventions.
</details>
