### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323237

### DIFF
--- a/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative.html
+++ b/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - currentcolor as a parameter value resolves against the linking element</title>
+<link rel="author" title="Taher Ali" href="mailto:taher_ali@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#link-param-prop">
+<link rel="match" href="circle-green-ref.html"/>
+<style>
+  img {
+    color: green;
+    link-parameters: param(--color, currentcolor);
+  }
+</style>
+
+<img src="circle-with-parameters.svg">


### PR DESCRIPTION
WebKit export from bug: [\[css-link-params\] Add a tentative test for currentcolor as a parameter value](https://bugs.webkit.org/show_bug.cgi?id=323237)