### PR TITLE
script: Fix crash when first child of head is selected for delete

### DIFF
--- a/editing/crashtests/delete-at-start-of-head.html
+++ b/editing/crashtests/delete-at-start-of-head.html
@@ -1,0 +1,22 @@
+<html>
+<head></head>
+<body>
+<script>
+addEventListener("load", () => {
+  document.documentElement.contentEditable = true;
+  const head = document.querySelector("head");
+  // Add a non-editable node in between the div and the head parent
+  head.appendChild(document.createElement('template'));
+  const div = document.createElement("div");
+  div.innerText = "This text will be selected";
+  head.appendChild(div);
+  getSelection().collapse(div.firstChild);
+  // At this point, we should not delete anything, since there is nothing in front of the div
+  // Note that it is important for this crash to not have a doctype, as that would be a comment
+  // that would otherwise exist. Thus, there should be no node before in tree order of the
+  // non-editable element, in this test case the template.
+  document.execCommand("delete");
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes a crash observed when combined with keybinding support. This is also tested in various ways in
`delete-in-child-of-head.tentative.html`, but requires quite a bit of machinery. The new test is more straightforward and uses fewer features, in line with WPT philosophy.

Part of #<!-- nolink -->25005

Testing: new WPT crash test
Reviewed in servo/servo#47784