### PR TITLE
Computed role -wip

### DIFF
--- a/intersection-observer/display-contents.html
+++ b/intersection-observer/display-contents.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://www.w3.org/TR/intersection-observer/#calculate-intersection-rect-algo">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<style>
+  #wrapper { display: contents; }
+  #target { width: 100px; height: 100px; background: green; }
+</style>
+<div id="wrapper"><div id="target"></div></div>
+<script>
+// An ancestor with display: contents generates no box, so walking from the target
+// to its containing block has to step over it rather than stop or spin.
+let t = async_test("A target is observed through an ancestor with display: contents");
+new IntersectionObserver(t.step_func_done(function(entries) {
+  assert_equals(entries.length, 1);
+  assert_true(entries[0].isIntersecting);
+})).observe(document.querySelector("#target"));
+</script>

--- a/intersection-observer/slotted-target.html
+++ b/intersection-observer/slotted-target.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://www.w3.org/TR/intersection-observer/#calculate-intersection-rect-algo">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3">
+<style>
+  #target { width: 100px; height: 100px; background: green; }
+</style>
+<div id="host"><div id="target"></div></div>
+<script>
+// The UA stylesheet gives slot { display: contents }, so the flat tree parent of
+// slotted content generates no box. This needs no author style to reproduce.
+document.querySelector("#host")
+        .attachShadow({ mode: "open" })
+        .innerHTML = "<div><slot></slot></div>";
+
+let t = async_test("A slotted target is observed, though its flat tree parent is a slot");
+new IntersectionObserver(t.step_func_done(function(entries) {
+  assert_equals(entries.length, 1);
+  assert_true(entries[0].isIntersecting);
+})).observe(document.querySelector("#target"));
+</script>


### PR DESCRIPTION
This is the first part to https://github.com/servo/servo/issues/43734, this allows the current tests to pass with the hashmap table.

We are now creating a relationship between a DOM node and an AccessKit node and querying the AK node for the role, which allow the current tests to pass. We still need to implement the AAM algorithms for computing the roles for each element.

cc @alice (I can't add reviewers so just drawing your attention to this)
Reviewed in servo/servo#47339