### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323198

### DIFF
--- a/css/css-values/attr-invalidation-after-stylesheet-change.html
+++ b/css/css-values/attr-invalidation-after-stylesheet-change.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: attr() invalidation after a style sheet change</title>
+<meta name="assert" content="attr() keeps invalidating on attribute change after the style resolver is rebuilt by a style sheet change">
+<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #target {
+    width: attr(data-foo type(<length>));
+  }
+</style>
+<div id="target" data-foo="10px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target).width, "10px");
+
+  target.setAttribute("data-foo", "20px");
+  assert_equals(getComputedStyle(target).width, "20px");
+
+  // Rebuilds the rule sets, which is where the attr() dependency used to live. The style has to
+  // reach the resolver before the next attribute change, otherwise the change is invalidated
+  // against the old rule sets and the dependency is still there.
+  const style = document.createElement("style");
+  style.textContent = "#unrelated { color: red }";
+  document.head.appendChild(style);
+  getComputedStyle(document.body).color;
+
+  target.setAttribute("data-foo", "30px");
+  assert_equals(getComputedStyle(target).width, "30px");
+
+  target.setAttribute("data-foo", "40px");
+  assert_equals(getComputedStyle(target).width, "40px");
+}, "attr() invalidates on attribute change after a style sheet is added");
+</script>

--- a/css/css-values/attr-invalidation-after-view-transition.html
+++ b/css/css-values/attr-invalidation-after-view-transition.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: attr() invalidation after a view transition</title>
+<meta name="assert" content="attr() keeps invalidating on attribute change after a view transition has torn down its dynamically generated styles">
+<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/#dom-document-startviewtransition">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* No view-transition-name here on purpose. A participating element gets re-resolved by the
+     transition itself, which would hide a lost attr() dependency. Only the root participates. */
+  #target {
+    width: attr(data-foo type(<length>));
+    height: 10px;
+  }
+</style>
+<div id="target" data-foo="10px"></div>
+<script>
+promise_test(async () => {
+  assert_equals(getComputedStyle(target).width, "10px");
+
+  for (const width of ["20px", "30px", "40px"]) {
+    const transition = document.startViewTransition(() => {
+      target.setAttribute("data-foo", width);
+    });
+    await transition.finished;
+    assert_equals(getComputedStyle(target).width, width);
+  }
+}, "attr() invalidates on attribute change across repeated view transitions");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[css-values-5\] attr() stops invalidating on attribute change after a view transition](https://bugs.webkit.org/show_bug.cgi?id=323198)