### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=321994

### DIFF
--- a/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-001-ref.html
+++ b/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Highlight API Reference: highlight registered after a rendering update over an already-highlighted range</title>
+<style>
+  ::highlight(highlight-a) {
+    background-color: red;
+  }
+  ::highlight(highlight-b) {
+    background-color: lime;
+    text-decoration-line: underline;
+  }
+</style>
+<body><p id="text">This text is highlighted by two CSS Highlights.</p>
+<script>
+  const range = new Range();
+  range.selectNodeContents(document.getElementById("text"));
+
+  CSS.highlights.set("highlight-a", new Highlight(range));
+  CSS.highlights.set("highlight-b", new Highlight(range));
+</script>

--- a/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-001.html
+++ b/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-001.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="UTF-8">
+<title>CSS Highlight API Test: highlight registered after a rendering update over an already-highlighted range</title>
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/#painting">
+<link rel="match" href="custom-highlight-painting-two-highlights-same-range-001-ref.html">
+<meta name="assert" value="A highlight registered after a rendering update is painted even when its range is already used by a previously registered highlight.">
+<script src="/common/reftest-wait.js"></script>
+<style>
+  ::highlight(highlight-a) {
+    background-color: red;
+  }
+  ::highlight(highlight-b) {
+    background-color: lime;
+    text-decoration-line: underline;
+  }
+</style>
+<body><p id="text">This text is highlighted by two CSS Highlights.</p>
+<script>
+  /*
+    highlight-b is registered after a rendering update has already resolved the
+    positions of highlight-a, which shares its range. highlight-b has to be
+    painted over highlight-a, so no red may be visible.
+  */
+
+  const range = new Range();
+  range.selectNodeContents(document.getElementById("text"));
+
+  const highlightA = new Highlight(range);
+  const highlightB = new Highlight(range);
+
+  CSS.highlights.set("highlight-a", highlightA);
+
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    CSS.highlights.set("highlight-b", highlightB);
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  }));
+</script>
+</html>

--- a/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-002-ref.html
+++ b/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-002-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Highlight API Reference: re-registering a highlight whose range moved while it was unregistered</title>
+<style>
+  ::highlight(highlight-a) {
+    background-color: red;
+  }
+  ::highlight(highlight-b) {
+    background-color: lime;
+    text-decoration-line: underline;
+  }
+</style>
+<body><p id="text">ABCDE0123456789</p>
+<script>
+  const node = document.getElementById("text").firstChild;
+  const range = new Range();
+  range.setStart(node, 10);
+  range.setEnd(node, 15);
+
+  CSS.highlights.set("highlight-a", new Highlight(range));
+  CSS.highlights.set("highlight-b", new Highlight(range));
+</script>

--- a/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-002.html
+++ b/css/css-highlight-api/painting/custom-highlight-painting-two-highlights-same-range-002.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="UTF-8">
+<title>CSS Highlight API Test: re-registering a highlight whose range moved while it was unregistered</title>
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/#painting">
+<link rel="match" href="custom-highlight-painting-two-highlights-same-range-002-ref.html">
+<meta name="assert" value="A highlight re-registered after its range moved while it was unregistered is painted at the range's current position, not at a stale one.">
+<script src="/common/reftest-wait.js"></script>
+<style>
+  ::highlight(highlight-a) {
+    background-color: red;
+  }
+  ::highlight(highlight-b) {
+    background-color: lime;
+    text-decoration-line: underline;
+  }
+</style>
+<body><p id="text">0123456789</p>
+<script>
+  /*
+    While highlight-b is unregistered, the text insertion moves the range both
+    highlights share from "56789" onto the same characters at their new offsets.
+    Only highlight-a is registered, so it is the one that consumes the change
+    notification. highlight-b has to be repositioned when it is registered
+    again, otherwise it paints over "01234".
+  */
+
+  const node = document.getElementById("text").firstChild;
+  const range = new Range();
+  range.setStart(node, 5);
+  range.setEnd(node, 10);
+
+  const highlightA = new Highlight(range);
+  const highlightB = new Highlight(range);
+
+  CSS.highlights.set("highlight-a", highlightA);
+  CSS.highlights.set("highlight-b", highlightB);
+
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    CSS.highlights.delete("highlight-b");
+    node.insertData(0, "ABCDE");
+
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      CSS.highlights.set("highlight-b", highlightB);
+      requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+    }));
+  }));
+</script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Second CSS Highlight sharing a Range with an already-registered Highlight never paints](https://bugs.webkit.org/show_bug.cgi?id=321994)