### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323401

### DIFF
--- a/service-workers/cache-storage/cache-delete.https.any.js
+++ b/service-workers/cache-storage/cache-delete.https.any.js
@@ -161,4 +161,13 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
   },
   'Cache.delete with ignoreSearch option (when it is specified as false)');
 
+cache_test(function(cache, test) {
+    return promise_rejects_js(
+      test,
+      TypeError,
+      cache.delete('https://user:password@example.com/'),
+      'Cache.delete should reject with the exception thrown when constructing ' +
+      'a Request from the given URL string fails.');
+  }, 'Cache.delete with a string that cannot construct a Request');
+
 done();

--- a/service-workers/cache-storage/cache-keys.https.any.js
+++ b/service-workers/cache-storage/cache-keys.https.any.js
@@ -209,4 +209,13 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
         });
   }, 'Cache.keys with a HEAD Request');
 
+cache_test(function(cache, test) {
+    return promise_rejects_js(
+      test,
+      TypeError,
+      cache.keys('https://user:password@example.com/'),
+      'Cache.keys should reject with the exception thrown when constructing ' +
+      'a Request from the given URL string fails.');
+  }, 'Cache.keys with a string that cannot construct a Request');
+
 done();


### PR DESCRIPTION
WebKit export from bug: [Cache.delete() and Cache.keys() swallow exceptions thrown while constructing a Request from a URL string](https://bugs.webkit.org/show_bug.cgi?id=323401)