### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323469

### DIFF
--- a/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative.html
+++ b/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Custom Highlight: ::highlight(*) computed style must not be confused with the escaped name \*</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9091">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #outer::highlight(\*) { color: red; }
+  #outer::highlight(*) { color: green; background-color: yellow; }
+</style>
+<div id="outer">text</div>
+<script>
+test(() => {
+  const style = getComputedStyle(outer, "::highlight(\\*)");
+  assert_equals(style.color, "rgb(255, 0, 0)");
+  assert_equals(style.backgroundColor, "rgb(255, 255, 0)");
+}, "::highlight(\\*) computed style is the escaped literal name's rule, merged with the universal base");
+</script>

--- a/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative.html
+++ b/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative.html
@@ -33,10 +33,4 @@ test(() => {
   assert_equals(style.color, "rgb(255, 0, 0)");
   assert_equals(style.backgroundColor, "rgb(255, 255, 0)");
 }, "named highlight without its own rule falls back to the universal style");
-
-test(() => {
-  const style = getComputedStyle(outer, "::highlight(*)");
-  assert_equals(style.color, "rgb(255, 0, 0)");
-  assert_equals(style.backgroundColor, "rgb(255, 255, 0)");
-}, "::highlight(*) computed style is exposed");
 </script>

--- a/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes.html
+++ b/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes.html
@@ -24,8 +24,11 @@ function test_valid_selector_combinations(pseudo) {
 test_valid_selector_combinations("::view-transition");
 
 for (const functionName of functionPseudoElements) {
+    // "\*" is an escaped <custom-ident> that spells the character "*". It must stay
+    // distinct from the literal, unescaped universal selector "*" instead of
+    // collapsing into it.
     for (const validArgument of
-        ["*.class", "*.class.class", "dashed-ident.someclass", "dash-id.dash-id", "foo.bar.baz"]) {
+        ["*.class", "\\*.class", "*.class.class", "\\*.class.class", "dashed-ident.someclass", "dash-id.dash-id", "foo.bar.baz"]) {
         test_valid_selector_combinations(`${functionName}(${validArgument})`);
         test_valid_selector_combinations(`${functionName}(${validArgument}):only-child`);
     }

--- a/css/css-view-transitions/parsing/pseudo-elements-valid.html
+++ b/css/css-view-transitions/parsing/pseudo-elements-valid.html
@@ -24,7 +24,10 @@ function test_valid_selector_combinations(pseudo) {
 test_valid_selector_combinations("::view-transition");
 
 for (const functionName of functionPseudoElements) {
-    for (const validArgument of ["*", "root", "dashed-ident"]) {
+    // "\*" is an escaped <custom-ident> that spells the character "*". It must stay
+    // distinct from the literal, unescaped universal selector "*" instead of
+    // collapsing into it.
+    for (const validArgument of ["*", "\\*", "root", "dashed-ident"]) {
         test_valid_selector_combinations(`${functionName}(${validArgument})`);
         test_valid_selector_combinations(`${functionName}(${validArgument}):only-child`);
     }

--- a/css/css-view-transitions/pseudo-escaped-star-specificity.html
+++ b/css/css-view-transitions/pseudo-escaped-star-specificity.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: an escaped \* selector should win over the universal * selector despite coming first in source order</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+}
+
+#target {
+  background: green;
+  view-transition-name: \*;
+}
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-play-state: paused;
+}
+
+/* "\*" is an ordinary name with normal specificity, unlike the universal "*"
+   selector below (which contributes 0 specificity). It must win this conflict
+   even though it comes first in source order. */
+::view-transition-new(\*),
+::view-transition-old(\*) {
+  left: 100px;
+}
+
+::view-transition-new(*),
+::view-transition-old(*) {
+  left: 0;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(takeScreenshot);
+});
+</script>

--- a/css/css-view-transitions/pseudo-escaped-star-view-transition-group.html
+++ b/css/css-view-transitions/pseudo-escaped-star-view-transition-group.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: group selector should match an escaped \* name</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+#target {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  background: green;
+  view-transition-name: \*;
+}
+
+:root::view-transition-group(*),
+:root::view-transition-image-pair(*),
+:root::view-transition-new(*),
+:root::view-transition-old(*) {
+  animation-play-state: paused;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*". It must match
+   the group whose view-transition-name computes to the literal string "*". */
+:root::view-transition-group(\*) {
+  left: 100px;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(() => requestAnimationFrame(() => takeScreenshot()));
+});
+</script>

--- a/css/css-view-transitions/pseudo-get-computed-style-escaped-star.html
+++ b/css/css-view-transitions/pseudo-get-computed-style-escaped-star.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: getComputedStyle() distinguishes ::view-transition-group(*) from the escaped name \*</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#target {
+  width: 100px;
+  height: 100px;
+  view-transition-name: target;
+}
+
+::view-transition-group(*) {
+  outline-color: green;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*", an ordinary name. It
+   must not be confused with the universal "*" selector above when queried through
+   getComputedStyle(), in either direction. */
+::view-transition-group(\*) {
+  outline-color: red;
+}
+</style>
+
+<div id=target></div>
+
+<script>
+promise_test(async () => {
+  assert_implements(document.startViewTransition, "Missing document.startViewTransition");
+  let transition = document.startViewTransition();
+  await transition.ready;
+
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").outlineColor, "rgb(0, 128, 0)", "a group with an ordinary name should still see the universal rule");
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(\\*)").outlineColor, "rgb(255, 0, 0)", "::view-transition-group(\\*) should reflect the escaped literal name's rule");
+
+  await transition.finished;
+}, "getComputedStyle() for ::view-transition-group(*) is not confused with the escaped name \\*");
+</script>

--- a/css/css-view-transitions/pseudo-match-escaped-star.html
+++ b/css/css-view-transitions/pseudo-match-escaped-star.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: selector should match an escaped \* name</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+}
+
+#target {
+  background: green;
+  view-transition-name: \*;
+}
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-play-state: paused;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*". It must match
+   the group whose view-transition-name computes to the literal string "*". */
+::view-transition-new(\*),
+::view-transition-old(\*) {
+  left: 100px;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(takeScreenshot);
+});
+</script>

--- a/css/css-view-transitions/pseudo-mismatch-escaped-star.html
+++ b/css/css-view-transitions/pseudo-mismatch-escaped-star.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: an escaped \* selector should not match a differently-named group</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+}
+
+#target {
+  background: green;
+  view-transition-name: target;
+}
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-play-state: paused;
+}
+
+::view-transition-new(*),
+::view-transition-old(*) {
+  left: 100px;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*", an ordinary
+   name. It must not match a group named "target". If it incorrectly collapsed
+   into the universal "*" selector, this would reset the square to left: 0. */
+::view-transition-new(\*),
+::view-transition-old(\*) {
+  left: 0;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(takeScreenshot);
+});
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[Custom Highlight\] Support `::highlight(*)`](https://bugs.webkit.org/show_bug.cgi?id=323469)