### PR TITLE
css: Determine effective `touch-action` from the touched element chain; Only apply to spec-allowed elements

### DIFF
--- a/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html
+++ b/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html
@@ -12,7 +12,7 @@
   </style>
   <link rel="help" href="crbug.com/1031745">
   <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
-  <link rel="help" href="https://w3c.github.io/pointerevents/#determining-supported-touch-behavior">
+  <link rel="help" href="w3c.github.io/pointerevents/#determining-supported-direct-manipulation-behavior">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>


### PR DESCRIPTION
1. Compute the effective value by intersecting the touched element's touch-action with its ancestors up to the first scroll container, by inject accumulated restriction into hit-test tag, then combine it with the scroll node's own value in the compositor.
2. Make sure `touch-action` does not apply to non-replaced inline elements, table rows, row groups, column groups, and columns

Testing: 
1. Only new passing, no new failure.
2. Updated outdated spec url for a test.

Fixes: #<!-- nolink -->47737
Fixes: #<!-- nolink -->47801
Reviewed in servo/servo#47821