### PR TITLE
Set a Content-Type on the frame-ancestors report helper

### DIFF
--- a/content-security-policy/reporting/support/not-embeddable-frame.py
+++ b/content-security-policy/reporting/support/not-embeddable-frame.py
@@ -1,5 +1,5 @@
 def main(request, response):
-    headers = []
+    headers = [(b'Content-Type', b'text/html')]
     if request.GET.first(b'xFrameOptions', None):
         headers.append((b'X-Frame-Options', request.GET[b'xFrameOptions']))
 
@@ -8,4 +8,4 @@ def main(request, response):
     report_uri_base = request.GET.first(b'reportUriBase', b'')
     headers.append((csp_header, b"frame-ancestors 'none'; report-uri " + report_uri_base + b"/reporting/resources/report.py?op=put&reportID=" + request.GET[b'reportID']))
 
-    return headers, b'{}'
+    return headers, b'<!DOCTYPE html><title>Not embeddable.</title>'


### PR DESCRIPTION
not-embeddable-frame.py sent no Content-Type header. wptserve adds no default one. Each browser then guessed the type of the two-byte body. That guess decided whether the iframe loaded a document or started a download. Only a loaded document sends the violation report that these tests wait for.

The tests pass in every browser today. Firefox passes them now, but a browser guess must not decide the result, so this change sets Content-Type: text/html. The old body was two bytes of JSON that no test reads, so it now holds a small HTML document.