### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=197369

### DIFF
--- a/encoding/json-document-utf8.html
+++ b/encoding/json-document-utf8.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="windows-1251">
+<title>JSON documents are decoded as UTF-8 by default</title>
+<link rel="help" href="https://datatracker.ietf.org/doc/html/rfc8259#section-8.1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+const utf8 = '{"text":"\u2603\u00e9"}';
+
+function loadJSON(query) {
+  return new Promise((resolve, reject) => {
+    const frame = document.createElement("iframe");
+    frame.onload = () => {
+      const text = frame.contentDocument.body.textContent;
+      frame.remove();
+      resolve(text);
+    };
+    frame.onerror = () => { frame.remove(); reject(new Error("load failed")); };
+    frame.src = "resources/json-charset.py" + query;
+    document.body.appendChild(frame);
+  });
+}
+
+promise_test(async () => {
+  assert_equals(await loadJSON(""), utf8);
+}, "application/json with no charset is decoded as UTF-8 under a windows-1251 parent frame");
+
+promise_test(async () => {
+  assert_equals(await loadJSON("?charset=utf-8"), utf8);
+}, "application/json;charset=utf-8 is decoded as UTF-8");
+
+promise_test(async () => {
+  assert_equals(await loadJSON("?type=text/json"), utf8);
+}, "text/json with no charset is decoded as UTF-8");
+
+promise_test(async () => {
+  assert_not_equals(await loadJSON("?charset=windows-1251"), utf8);
+}, "application/json;charset=windows-1251 honors the explicit charset");
+</script>
+</body>

--- a/encoding/resources/json-charset.py
+++ b/encoding/resources/json-charset.py
@@ -1,0 +1,8 @@
+def main(request, response):
+    content_type = request.GET.first(b"type", b"application/json")
+    charset = request.GET.first(b"charset", None)
+    if charset is not None:
+        content_type += b";charset=" + charset
+    response.headers.set(b"Content-Type", content_type)
+    response.headers.set(b"X-Content-Type-Options", b"nosniff")
+    response.content = '{"text":"☃é"}'.encode("utf-8")


### PR DESCRIPTION
WebKit export from bug: [JSON displayed with wrong encoding when loaded in a frame (browser default instead of UTF-8)](https://bugs.webkit.org/show_bug.cgi?id=197369)