### PR TITLE
wpt: Make more `touch-action` pointerevents tests work under 800x600

### DIFF
--- a/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html
@@ -13,6 +13,9 @@
         <script src="/resources/testdriver-vendor.js"></script>
         <script src="pointerevent_support.js"></script>
         <style>
+            .scroller {
+            height: 200px;
+            }
             .scroller > div {
             touch-action: pan-x;
             }

--- a/pointerevents/pointerevent_touch-action-none-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-none-css_touch.html
@@ -14,7 +14,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: none;
             }
         </style>

--- a/pointerevents/pointerevent_touch-action-pan-down-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-down-css_touch.html
@@ -14,7 +14,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: pan-down;
             }
         </style>

--- a/pointerevents/pointerevent_touch-action-pan-left-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-left-css_touch.html
@@ -14,7 +14,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: pan-left;
             }
         </style>

--- a/pointerevents/pointerevent_touch-action-pan-right-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-right-css_touch.html
@@ -15,7 +15,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: pan-right;
             }
         </style>

--- a/pointerevents/pointerevent_touch-action-pan-up-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-up-css_touch.html
@@ -14,7 +14,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: pan-up;
             }
         </style>

--- a/pointerevents/pointerevent_touch-action-pan-x-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-x-css_touch.html
@@ -14,7 +14,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: pan-x;
             }
         </style>

--- a/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html
@@ -12,6 +12,9 @@
         <script src="/resources/testdriver-vendor.js"></script>
         <script src="pointerevent_support.js"></script>
         <style>
+            .scroller {
+            height: 200px;
+            }
             .scroller > div {
             touch-action: pan-x pan-y;
             }

--- a/pointerevents/pointerevent_touch-action-pan-y-css_touch.html
+++ b/pointerevents/pointerevent_touch-action-pan-y-css_touch.html
@@ -15,7 +15,7 @@
         <style>
             #target0 {
             width: 700px;
-            height: 430px;
+            height: 200px;
             touch-action: pan-y;
             }
         </style>


### PR DESCRIPTION
Updated 9 more tests in similar fashion to https://github.com/web-platform-tests/wpt/pull/62498.
I missed these in first patch as I was only focusing on [try run here](https://github.com/servo/servo/actions/runs/33942192665).

Testing: [Safari](https://staging.wpt.fyi/results/pointerevents?diff&filter=ADC&run_id=6439498222141440&run_id=4750065521393664) and Servo no longer WebDriver out of bound, and checked in Firefox under 800x600. Updated expectations. Some new passing is due to https://github.com/servo/servo/pull/47043 earlier.
Fixes: https://github.com/web-platform-tests/wpt/issues/62481

Reviewed in servo/servo#47890