### PR TITLE
HTML: test CORS and the <link> stylesheet MIME type quirk

### DIFF
--- a/css/css-cascade/import-mime-type-quirks.html
+++ b/css/css-cascade/import-mime-type-quirks.html
@@ -1,0 +1,85 @@
+<!-- No DOCTYPE: this test must run in quirks mode. -->
+<meta charset="utf-8">
+<title>@import: MIME type quirk in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#content-type">
+<link rel="author" title="Simon Pieters" href="mailto:zcorpan@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<div id="log"></div>
+<script>
+assert_equals(document.compatMode, "BackCompat", "must be in quirks mode");
+
+const CSS_FILE = "/css/css-cascade/resources/quirks-mime-type.css";
+const SAME_ORIGIN = location.origin + CSS_FILE;
+const CROSS_ORIGIN = get_host_info().REMOTE_ORIGIN + CSS_FILE;
+const WRONG_MIME = "?pipe=header(Content-Type,text/plain)";
+const CORS = "|header(Access-Control-Allow-Origin,*)";
+
+function redirectTo(origin, target, enableCors) {
+  return origin + "/common/redirect.py?" + (enableCors ? "enable-cors&" : "") +
+    "location=" + encodeURIComponent(target);
+}
+
+// The style element fires load or error once the @import has settled; engines
+// disagree about which, so wait for either.
+function importStylesheet(href) {
+  return new Promise(resolve => {
+    const style = document.createElement("style");
+    style.textContent = `@import url("${href}");`;
+    style.onload = style.onerror = () => resolve(style);
+    document.head.appendChild(style);
+  });
+}
+
+// quirks-mime-type.css sets body { padding: 10px }.
+function sheetApplied() {
+  return getComputedStyle(document.body).paddingTop == "10px";
+}
+
+promise_test(async t => {
+  const style = await importStylesheet(SAME_ORIGIN);
+  t.add_cleanup(() => style.remove());
+  assert_true(sheetApplied(), "styles should apply");
+}, "Same-origin @import with text/css");
+
+promise_test(async t => {
+  const style = await importStylesheet(CROSS_ORIGIN);
+  t.add_cleanup(() => style.remove());
+  assert_true(sheetApplied(), "styles should apply");
+}, "Cross-origin @import with text/css");
+
+promise_test(async t => {
+  const style = await importStylesheet(SAME_ORIGIN + WRONG_MIME);
+  t.add_cleanup(() => style.remove());
+  assert_true(sheetApplied(), "styles should apply");
+}, "Same-origin @import with wrong MIME type");
+
+promise_test(async t => {
+  const style = await importStylesheet(CROSS_ORIGIN + WRONG_MIME);
+  t.add_cleanup(() => style.remove());
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Cross-origin @import with wrong MIME type");
+
+promise_test(async t => {
+  const style = await importStylesheet(CROSS_ORIGIN + WRONG_MIME + CORS);
+  t.add_cleanup(() => style.remove());
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Cross-origin @import with wrong MIME type, with CORS");
+
+// The response is same-origin with the document, but it is not CORS-same-origin,
+// so the quirk must not apply.
+promise_test(async t => {
+  const href = redirectTo(get_host_info().REMOTE_ORIGIN, SAME_ORIGIN + WRONG_MIME, false);
+  const style = await importStylesheet(href);
+  t.add_cleanup(() => style.remove());
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Cross-origin redirect to same-origin @import with wrong MIME type");
+
+promise_test(async t => {
+  const href = redirectTo(location.origin, CROSS_ORIGIN + WRONG_MIME, false);
+  const style = await importStylesheet(href);
+  t.add_cleanup(() => style.remove());
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Same-origin redirect to cross-origin @import with wrong MIME type");
+</script>

--- a/css/css-cascade/resources/quirks-mime-type.css
+++ b/css/css-cascade/resources/quirks-mime-type.css
@@ -1,0 +1,1 @@
+body { padding: 10px }

--- a/css/cssom/stylesheet-cross-origin-redirect-quirks.sub.html
+++ b/css/cssom/stylesheet-cross-origin-redirect-quirks.sub.html
@@ -1,16 +1,8 @@
 <!--
   No DOCTYPE: this test must run in quirks mode.
 
-  https://html.spec.whatwg.org/#link-type-stylesheet
-
-     Quirk: If the document has been set to quirks mode, has the same origin as
-     the URL of the external resource, and the Content-Type metadata of the
-     external resource is not a supported style sheet type, the user agent must
-     instead assume it to be text/css.
-
-  This tests direct cross-origin URLs but also cross-origin to same-origin
-  redirects, which are tainted and already get blocked from e.g. accessing
-  .cssRules across browsers.
+  None of these responses are CORS-same-origin, so the quirks-mode MIME type
+  quirk in https://html.spec.whatwg.org/#link-type-stylesheet does not apply.
 -->
 <meta charset="utf-8">
 <title>CSSOM - Cross-origin redirects and MIME type in quirks mode</title>

--- a/html/semantics/document-metadata/the-link-element/link-style-data-url-quirks.html
+++ b/html/semantics/document-metadata/the-link-element/link-style-data-url-quirks.html
@@ -5,17 +5,8 @@
 <link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
 <link rel="author" href="https://mozilla.com" title="Mozilla">
 <!--
-  Quirk: If the document has been set to quirks mode, has the same origin as the
-  URL of the external resource, and the Content-Type metadata of the external
-  resource is not a supported style sheet type, the user agent must instead
-  assume it to be text/css.
-
-  [otherwise]:
-
-  If the resource's Content-Type metadata is not text/css, then set success to
-  false.
-
-  data: URLs have opaque origins, so the quirk never applies to them.
+  data: URLs have opaque origins, so the quirks-mode MIME type quirk in
+  https://html.spec.whatwg.org/#link-type-stylesheet never applies to them.
 -->
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/semantics/document-metadata/the-link-element/link-style-quirks-crossorigin.html
+++ b/html/semantics/document-metadata/the-link-element/link-style-quirks-crossorigin.html
@@ -1,0 +1,91 @@
+<!-- No DOCTYPE: this test must run in quirks mode. -->
+<meta charset="utf-8">
+<title>link: MIME type quirk with CORS in quirks mode</title>
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet">
+<link rel="author" title="Simon Pieters" href="mailto:zcorpan@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<div id="log"></div>
+<script>
+assert_equals(document.compatMode, "BackCompat", "must be in quirks mode");
+
+const CSS_PY = "/html/semantics/document-metadata/the-link-element/resources/css.py";
+const SAME_ORIGIN_CSS_PY = new URL(CSS_PY, location).href;
+const CROSS_ORIGIN_CSS_PY = get_host_info().REMOTE_ORIGIN + CSS_PY;
+
+function redirectTo(origin, target, enableCors) {
+  return origin + "/common/redirect.py?" + (enableCors ? "enable-cors&" : "") +
+    "location=" + encodeURIComponent(target);
+}
+
+function loadStylesheet(href, crossOrigin) {
+  return new Promise(resolve => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    if (crossOrigin !== undefined) {
+      link.crossOrigin = crossOrigin;
+    }
+    link.href = href;
+    link.onload = () => resolve({ link, event: "load" });
+    link.onerror = () => resolve({ link, event: "error" });
+    document.head.appendChild(link);
+  });
+}
+
+// css.py serves "body { background:red }".
+function sheetApplied() {
+  return getComputedStyle(document.body).backgroundColor == "rgb(255, 0, 0)";
+}
+
+promise_test(async t => {
+  const { link, event } = await loadStylesheet(SAME_ORIGIN_CSS_PY + "?content_type=text/plain");
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "load", "same-origin with wrong MIME type should fire load");
+  assert_true(sheetApplied(), "styles should apply");
+}, "Same-origin stylesheet with wrong MIME type, no CORS");
+
+promise_test(async t => {
+  const { link, event } =
+    await loadStylesheet(SAME_ORIGIN_CSS_PY + "?cors&content_type=text/plain", "anonymous");
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "load", "same-origin with wrong MIME type should fire load");
+  assert_true(sheetApplied(), "styles should apply");
+}, "Same-origin stylesheet with wrong MIME type, with CORS");
+
+promise_test(async t => {
+  const { link, event } =
+    await loadStylesheet(CROSS_ORIGIN_CSS_PY + "?cors&content_type=text/css", "anonymous");
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "load", "cross-origin with text/css should fire load");
+  assert_true(sheetApplied(), "styles should apply");
+}, "Cross-origin stylesheet with text/css, with CORS");
+
+promise_test(async t => {
+  const { link, event } =
+    await loadStylesheet(CROSS_ORIGIN_CSS_PY + "?cors&content_type=text/plain", "anonymous");
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "error", "cross-origin with wrong MIME type should fire error");
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Cross-origin stylesheet with wrong MIME type, with CORS");
+
+// The quirk is evaluated against the response's URL, so a redirect decides
+// whether it applies.
+promise_test(async t => {
+  const href = redirectTo(get_host_info().REMOTE_ORIGIN,
+                          SAME_ORIGIN_CSS_PY + "?cors&content_type=text/plain", true);
+  const { link, event } = await loadStylesheet(href, "anonymous");
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "load", "redirect to same-origin with wrong MIME type should fire load");
+  assert_true(sheetApplied(), "styles should apply");
+}, "Cross-origin redirect to same-origin stylesheet with wrong MIME type, with CORS");
+
+promise_test(async t => {
+  const href = redirectTo(location.origin,
+                          CROSS_ORIGIN_CSS_PY + "?cors&content_type=text/plain", false);
+  const { link, event } = await loadStylesheet(href, "anonymous");
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "error", "redirect to cross-origin with wrong MIME type should fire error");
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Same-origin redirect to cross-origin stylesheet with wrong MIME type, with CORS");
+</script>

--- a/html/semantics/document-metadata/the-link-element/resources/css.py
+++ b/html/semantics/document-metadata/the-link-element/resources/css.py
@@ -4,4 +4,6 @@ def main(request, response):
     response.writer.write_header(b"Content-Type", request.GET.first(b"content_type"))
   if b"nosniff" in request.GET:
   	response.writer.write_header(b"x-content-type-options", b"nosniff")
+  if b"cors" in request.GET:
+    response.writer.write_header(b"Access-Control-Allow-Origin", b"*")
   response.writer.write_content(u"body { background:red }")


### PR DESCRIPTION
No test set the `crossorigin` attribute on a style sheet with a bad MIME type, so nothing distinguished the quirk's same-origin condition from its CORS-same-origin condition. A CORS-enabled cross-origin style sheet is CORS-same-origin, but its response's URL is not same origin with the document, so the quirk must not apply to it, and a redirect that crosses origins in either direction decides whether it applies.

Also add a `cors` knob to `resources/css.py`, and trim the spec text quoted in two existing tests.

For https://github.com/whatwg/html/pull/12468.