### PR TITLE
xpath: Fix `name`, `local-name` and `namespace-uri` to correctly process attributes

### DIFF
--- a/domxpath/fns-name-related.html
+++ b/domxpath/fns-name-related.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="help-name" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-name">
+<link rel="help-local-name" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-local-name">
+<link rel="help-namespace-uri" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-namespace-uri">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// Test the functions with various scenarios
+function testFunction(expression, xmlString, expected) {
+  const doc = (new DOMParser()).parseFromString(xmlString, 'text/xml');
+  test(() => {
+    const result = doc.evaluate(expression, doc.documentElement, null, XPathResult.STRING_TYPE, null);
+    assert_equals(result.resultType, XPathResult.STRING_TYPE);
+    assert_equals(result.stringValue, expected);
+  })
+}
+
+const context = '<root xmlns:alpha="http://example.com/alpha" xmlns:gamma="http://example.com/gamma"><alpha:beta gamma:delta="epsilon"></alpha:beta></root>';
+
+testFunction("name(./*[1])", context, "alpha:beta");
+testFunction("local-name(./*[1])", context, "beta");
+testFunction("namespace-uri(./*[1])", context, "http://example.com/alpha");
+testFunction("name(./*[1]/@*)", context, "gamma:delta");
+testFunction("local-name(./*[1]/@*)", context, "delta");
+testFunction("namespace-uri(./*[1]/@*)", context, "http://example.com/gamma");
+</script>
+</body>


### PR DESCRIPTION
Changed the implementation of each relevant function to include attributes as well as elements. Wasn't sure whether to introduce a new struct or just use tuples in `name_parts`. Advice from reviewers much appreciated. 

Advice also appreciated on use of shadowing in `if let Some(prefix) = prefix`.

Testing: Added a WPT in `domxpath` to cover these name-related functions. I don't know anything about the WPT upstreaming process but I assume this could be upstreamed?
Fixes: #<!-- nolink -->47798 

Behaviour before code change:
```
  ▶ OK /domxpath/fns-name-related.html
  │   ▶ FAIL [expected PASS] fns-name-related 3
  │   │   → assert_equals: expected "gamma:delta" but got ""
  │   │ 
  │   │ testFunction/<@http://web-platform.test:8000/domxpath/fns-name-related.html:15:18
  │   │ Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2869:25
  │   │ test@http://web-platform.test:8000/resources/testharness.js:633:30
  │   │ testFunction@http://web-platform.test:8000/domxpath/fns-name-related.html:12:7
  │   └ @http://web-platform.test:8000/domxpath/fns-name-related.html:24:13
  │   ▶ FAIL [expected PASS] fns-name-related 4
  │   │   → assert_equals: expected "delta" but got ""
  │   │ 
  │   │ testFunction/<@http://web-platform.test:8000/domxpath/fns-name-related.html:15:18
  │   │ Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2869:25
  │   │ test@http://web-platform.test:8000/resources/testharness.js:633:30
  │   │ testFunction@http://web-platform.test:8000/domxpath/fns-name-related.html:12:7
  │   └ @http://web-platform.test:8000/domxpath/fns-name-related.html:25:13
  │   ▶ FAIL [expected PASS] fns-name-related 5
  │   │   → assert_equals: expected "http://example.com/gamma" but got ""
  │   │ 
  │   │ testFunction/<@http://web-platform.test:8000/domxpath/fns-name-related.html:15:18
  │   │ Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2869:25
  │   │ test@http://web-platform.test:8000/resources/testharness.js:633:30
  │   │ testFunction@http://web-platform.test:8000/domxpath/fns-name-related.html:12:7
  └   └ @http://web-platform.test:8000/domxpath/fns-name-related.html:26:13
```

Reviewed in servo/servo#47912