### PR TITLE
[Extensions][Chrome] Actually fix Windows path handling and errors

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -5086,8 +5086,10 @@
             var message;
             if (e.reason && e.reason.message) {
                 message = "Unhandled rejection: " + e.reason.message;
+            } else if (typeof e.reason === 'string' && e.reason) {
+              message = 'Unhandled rejection: ' + e.reason;
             } else {
-                message = "Unhandled rejection";
+              message = 'Unhandled rejection';
             }
             var stack;
             if (e.reason && e.reason.stack) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -5086,10 +5086,10 @@
             var message;
             if (e.reason && e.reason.message) {
                 message = "Unhandled rejection: " + e.reason.message;
-            } else if (typeof e.reason === 'string' && e.reason) {
-              message = 'Unhandled rejection: ' + e.reason;
+            } else if (typeof e.reason === "string" && e.reason) {
+                message = "Unhandled rejection: " + e.reason;
             } else {
-              message = 'Unhandled rejection';
+                message = "Unhandled rejection";
             }
             var stack;
             if (e.reason && e.reason.stack) {

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -340,10 +340,7 @@ class ChromeBrowser(WebDriverBrowser):
         self._is_extension_test = (
             (test.testdriver_features is not None and
              "extensions" in test.testdriver_features) or
-            # Normalize path separators with `replace()` to handle Windows
-            # backslashes.
-            (test.path is not None and
-             "web-extensions/" in test.path.replace("\\", "/")))
+            (test.url is not None and "web-extensions/" in test.url))
         self._require_webdriver_bidi = (
             (test.testdriver_features is not None and
              ("bidi" in test.testdriver_features or

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -340,7 +340,10 @@ class ChromeBrowser(WebDriverBrowser):
         self._is_extension_test = (
             (test.testdriver_features is not None and
              "extensions" in test.testdriver_features) or
-            (test.path is not None and "web-extensions/" in test.path))
+            # Normalize path separators with `replace()` to handle Windows
+            # backslashes.
+            (test.path is not None and
+             "web-extensions/" in test.path.replace("\\", "/")))
         self._require_webdriver_bidi = (
             (test.testdriver_features is not None and
              ("bidi" in test.testdriver_features or

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -194,7 +194,7 @@
                 resolve(result);
             };
             const on_failure = data => {
-                reject(`${data.status}: ${data.message}`);
+                reject(new Error(`${data.status}: ${data.message}`));
             };
             pending.set(cmd_id, [on_success, on_failure]);
         });

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -194,7 +194,7 @@
                 resolve(result);
             };
             const on_failure = data => {
-                reject(new Error(`${data.status}: ${data.message}`));
+                reject(`${data.status}: ${data.message}`);
             };
             pending.set(cmd_id, [on_success, on_failure]);
         });


### PR DESCRIPTION
Following-up on #62224.

On Windows, web-extension WPT tests fail with an uninformative "Unhandled rejection" error during extension installation. This occurs because wptrunner in chrome.py checks for "web-extensions/" in test.path, which fails on Windows due to backslash separators. As a result, extension-enabling browser switches are omitted, require_webdriver_bidi is set to false, and wptrunner falls back to classic WebDriver. Classic ChromeDriver (WebDriver) does not support extension installation endpoints, raising UnknownCommandException ("Action install_web_extension not implemented"). In addition, testdriver-extra.js rejects with a primitive string rather than an Error instance, and testharness.js only extracts e.reason.message, swallowing string rejection reasons and printing only "Unhandled rejection".

After this change, web-extension tests on Windows properly detect the extension test directory, enabling the required command-line switches and activating WebDriver BiDi protocol so unpacked extension installation succeeds. In addition, testdriver-extra.js rejects with an Error object containing .message and stack traces, and testharness.js preserves string rejection reasons alongside Error instances, ensuring failure details are retained in test results while empty new Error() rejections continue to default to "Unhandled rejection".