### PR TITLE
aamtests: Refactor find_node to share implementation

### DIFF
--- a/core-aam/aamtests/support/api_wrapper.py
+++ b/core-aam/aamtests/support/api_wrapper.py
@@ -36,6 +36,24 @@ class ApiWrapper(Generic[ApiNode], abc.ABC):
     def _find_browser(self) -> Optional[ApiNode]:
         pass
 
+    @abc.abstractmethod
+    def _find_tab(self) -> Optional[ApiNode]:
+        """Find the tab with the test url. Only returns it once it's ready.
+
+        :return: The node representing the test document, or None.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _find_node_by_id(self, root: ApiNode, dom_id: str) -> Optional[ApiNode]:
+        """Find the node with a specified dom_id.
+
+        :param root: The root node to search from.
+        :param dom_id: The DOM identifier.
+        :return: The node, or None if not found.
+        """
+        pass
+
     def _poll_for(self, find: Callable[[], Optional[PollResult]], error: str) -> PollResult:
         """Poll until the `find` function returns something.
 
@@ -51,3 +69,20 @@ class ApiWrapper(Generic[ApiNode], abc.ABC):
             found = find()
 
         return found
+
+    def find_node(self, dom_id: str, url: str) -> ApiNode:
+        """Find the node under test with a specified dom_id.
+
+        :param dom_id: The DOM identifier.
+        :param url: The url of the test.
+        """
+        if self.test_url != url or not self.document:
+            self.test_url = url
+            self.document = self._poll_for(
+                self._find_tab, f"Timeout looking for url: {self.test_url}"
+            )
+
+        return self._poll_for(
+            lambda: self._find_node_by_id(self.document, dom_id),
+            f"Timeout looking for node with id '{dom_id}' in accessibility API {self.api_name}.",
+        )

--- a/core-aam/aamtests/support/atspi_wrapper.py
+++ b/core-aam/aamtests/support/atspi_wrapper.py
@@ -25,23 +25,6 @@ class AtspiWrapper(ApiWrapper[Atspi.Accessible]):
     def __getattr__(self, name: str) -> Any:
         return getattr(Atspi, name)
 
-    def find_node(self, dom_id: str, url: str) -> Atspi.Accessible:
-        """
-        :param dom_id: The dom id of the node to test.
-        :param url: The url of the test.
-        """
-        if self.test_url != url or not self.document:
-            self.test_url = url
-            self.document = self._poll_for(
-                self._find_fully_loaded_document, f"Timeout looking for url: {self.test_url}"
-            )
-
-        test_node = self._find_node_by_id(self.document, dom_id);
-        if not test_node:
-            raise Exception(f"Did not find node with id '{dom_id}' in accessibility API ATSPI.")
-
-        return test_node
-
     def get_relations_dictionary_helper(
         self, node: Atspi.Accessible
     ) -> Dict[str, List[str]]:
@@ -104,7 +87,7 @@ class AtspiWrapper(ApiWrapper[Atspi.Accessible]):
                 return app
         return None
 
-    def _find_fully_loaded_document(self) -> Optional[Atspi.Accessible]:
+    def _find_tab(self) -> Optional[Atspi.Accessible]:
         """Find the document with the test url. Only returns it when it is ready.
 
         :return: Atspi.Accessible representing test document or None.

--- a/core-aam/aamtests/support/axapi_wrapper.py
+++ b/core-aam/aamtests/support/axapi_wrapper.py
@@ -28,25 +28,6 @@ class AxapiWrapper(ApiWrapper[AXUIElement]):
     def AXUIElementCopyAttributeValue(self):
         return AXUIElementCopyAttributeValue
 
-    def find_node(self, dom_id: str, url: str) -> AXUIElement:
-        """
-        :param dom_id: The dom id of the node to test.
-        :param url: The url of the test.
-        """
-        if self.test_url != url or not self.document:
-            self.test_url = url
-            self.document = self._poll_for(
-                self._find_tab,
-                f"Timeout looking for url: {self.test_url}",
-            )
-
-        test_node = self._poll_for(
-            lambda: self._find_node_by_id(self.document, dom_id),
-            f"Timeout looking for node with id {dom_id} in accessibility API AXAPI.",
-        )
-
-        return test_node
-
     def _find_browser(self) -> Optional[AXUIElement]:
         """Find the AXUIElement representing the browser.
 

--- a/core-aam/aamtests/support/ia2_wrapper.py
+++ b/core-aam/aamtests/support/ia2_wrapper.py
@@ -93,25 +93,6 @@ class Ia2Wrapper(ApiWrapper[IAccessible2Ptr]):
     def api_name(self) -> str:
         return "IA2"
 
-    def find_node(self, dom_id: str, url: str) -> IAccessible2Ptr:
-        """
-        :param dom_id: The dom id of the node to test.
-        :param url: The url of the test.
-        """
-        if self.test_url != url or not self.document:
-            self.test_url = url
-            self.document = self._poll_for(
-                self._find_tab,
-                f"Timeout looking for url: {self.test_url}",
-            )
-
-        test_node = self._poll_for(
-            lambda: self._find_node_by_id(self.document, dom_id),
-            f"Timeout looking for node with id {dom_id} in accessibility API IA2.",
-        )
-
-        return test_node
-
     def get_hyperlink_interface(self, node: IAccessible2Ptr) -> IAccessibleHyperlinkPtr:
         service = node.QueryInterface(IServiceProvider)
         return service.QueryService(IAccessible._iid_, IAccessibleHyperlink)

--- a/core-aam/aamtests/support/uia_wrapper.py
+++ b/core-aam/aamtests/support/uia_wrapper.py
@@ -217,25 +217,6 @@ class UiaWrapper(ApiWrapper[UiaObject]):
     def api_name(self) -> str:
         return "UIA"
 
-    def find_node(self, dom_id: str, url: str) -> Optional[UiaObject]:
-        """
-        :param dom_id: The dom id of the node to test.
-        :param url: The url of the test.
-        """
-        if self.test_url != url or not self.document:
-            self.test_url = url
-            self.document = self._poll_for(
-                self._find_tab,
-                f"Timeout looking for url: {self.test_url}",
-            )
-
-        test_node = self._poll_for(
-            lambda: self._find_node_by_id(self.document, dom_id),
-            f"Timeout looking for node with id {dom_id} in accessibility API UIA.",
-        )
-
-        return test_node
-
     def _find_browser(self) -> Optional[UiaObject]:
         """Find the UIA element representing the browser's top level window.
 


### PR DESCRIPTION
Each platform wrapper was re-implementing this method. This patch moves it to ApiWrapper so the code is shared.

The only behavioral change is that AT-SPI wasn't using _poll_for() when searching for the element (the other platforms already do it). This seems a better option in case the node isn't exposed yet, and makes tests more consistent across platforms.