### PR TITLE
script: Fully support `Content-Language`

### DIFF
--- a/html/dom/elements/global-attributes/the-lang-attribute-011.html
+++ b/html/dom/elements/global-attributes/the-lang-attribute-011.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Multiple Content-Language HTTP headers</title>
+<link rel='help' href='https://html.spec.whatwg.org/multipage/#the-lang-and-xml:lang-attributes'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='dom'>
+<style type='text/css'>
+    #colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+    #colonlangcontroltest:lang(xx) { display:none; }
+.test div { width: 50px; }
+#box:lang(ko) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.</p>
+
+
+<!--Notes:
+
+This test uses :lang to detect whether the language has been set. If :lang is not supported, a message will appear and the test will fail.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "If there are multiple Content-Language HTTP headers, the UA will recognize the language declared in the first header.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
@@ -1,1 +1,2 @@
-Content-Language: ko,zh,ja
+Content-Language: ko
+Content-Language: ja

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-removal.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-removal.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>Removal of meta element with content-language should not reset pragma directive</title>
+<meta http-equiv=content-language content=de-DE>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    document.querySelector('meta').remove();
+    assert_equals(document.querySelector(":root:lang(de-DE)"), document.documentElement);
+  }, "Removal of <meta> with content-language should not reset pragma directive");
+</script>

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-after-comma.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-after-comma.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Comma should always make content-language invalid, even if it has whitespace before</title>
+<meta http-equiv=content-language content="de-DE ,nl-NL">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    assert_equals(document.querySelector(":root:lang(de-DE)"), null);
+  }, "Comma should always make content-language invalid, even if it has whitespace before");
+</script>

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-end.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-end.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Whitespace at end of content attribute should be ignored for content-language</title>
+<meta http-equiv=content-language content="de-DE ">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    assert_equals(document.querySelector(":root:lang(de-DE)"), document.documentElement);
+  }, "Whitespace at end of content attribute should be ignored for content-language");
+</script>

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-start.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-start.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Whitespace at start of content attribute should be ignored for content-language</title>
+<meta http-equiv=content-language content=" de-DE">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    assert_equals(document.querySelector(":root:lang(de-DE)"), document.documentElement);
+  }, "Whitespace at start of content attribute should be ignored for content-language");
+</script>


### PR DESCRIPTION
This is supported both for `<meta>` as well as the HTTP header. It adds several new tests that weren't covered. Notably the tests regarding whitespace (which is what the spec states) pass in Firefox but fail in Chrome. We follow Firefox' behavior as specced.

This fixes the last test we were failing in
`html/semantics/document-metadata/the-meta-element/` :tada:

Testing: new WPT tests added and passing
Reviewed in servo/servo#47930