### PR TITLE
Remote context serve static pages

### DIFF
--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-static-page.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe-static-page.window.js
@@ -1,0 +1,26 @@
+// META: title=RemoteContextHelper addIframe with static page
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+// META: script=./resources/test-helper.js
+
+'use strict';
+
+const STATIC_PAGE =
+    '/html/browsers/browsing-the-web/remote-context-helper-tests/resources/simple-static-page.html';
+
+promise_test(async t => {
+  const rcHelper = new RemoteContextHelper();
+  const rc1 = await rcHelper.addWindow();
+  const rc2 = await rc1.addIframe({page: STATIC_PAGE});
+
+  await assertSimplestScriptRuns(rc2);
+
+  assert_equals(
+      await rc2.executeScript(() => document.title),
+      'Simple static page');
+  assert_equals(
+      await rc2.executeScript(() => document.querySelector('p').textContent),
+      'Hello from a static page');
+}, 'addIframe with static page config option');

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-static-page.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-static-page.window.js
@@ -1,0 +1,25 @@
+// META: title=RemoteContextHelper addWindow with static page
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+// META: script=./resources/test-helper.js
+
+'use strict';
+
+const STATIC_PAGE =
+    '/html/browsers/browsing-the-web/remote-context-helper-tests/resources/simple-static-page.html';
+
+promise_test(async t => {
+  const rcHelper = new RemoteContextHelper();
+  const rc1 = await rcHelper.addWindow({page: STATIC_PAGE});
+
+  await assertSimplestScriptRuns(rc1);
+
+  assert_equals(
+      await rc1.executeScript(() => document.title),
+      'Simple static page');
+  assert_equals(
+      await rc1.executeScript(() => document.querySelector('p').textContent),
+      'Hello from a static page');
+}, 'addWindow with static page config option');

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-static-page-bfcache.tentative.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-static-page-bfcache.tentative.window.js
@@ -1,0 +1,79 @@
+// META: title=RemoteContextHelper navigation to static page using BFCache
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+// META: script=./resources/test-helper.js
+// META: timeout=long
+
+"use strict";
+
+const STATIC_PAGE =
+  "/html/browsers/browsing-the-web/remote-context-helper-tests/resources/bfcache-static-page.html";
+
+promise_test(async (t) => {
+  const rcHelper = new RemoteContextHelper();
+
+  // Open the static page directly.
+  const rc1 = await rcHelper.addWindow(
+    { page: STATIC_PAGE },
+    { features: "noopener" },
+  );
+
+  await assertSimplestScriptRuns(rc1);
+
+  assert_equals(
+    await rc1.executeScript(() => document.title),
+    "Static page with in-flight image",
+  );
+  assert_equals(
+    await rc1.executeScript(() => document.querySelector("img") !== null),
+    true,
+    "img element exists",
+  );
+
+  // The image is still loading (10s delay), so load should not have fired yet.
+  assert_equals(
+    await rc1.executeScript(() => window.loadFired),
+    undefined,
+    "load event should not have fired yet",
+  );
+
+  // Create a target context without navigating to it yet.
+  const rc2 = await rcHelper.createContext({});
+
+  // Navigate via a link click instead of window.location. A click on an <a>
+  // is treated as a push navigation even when the load event hasn't fired.
+  await rc1.clickTo(rc2.url);
+
+  await assertSimplestScriptRuns(rc2);
+
+  // Navigate back.
+  await rc2.historyBack();
+
+  // Check if the page was restored from BFCache.
+  assert_implements_optional(
+    await rc1.executeScript(() => {
+      return window.pageshowEvent && window.pageshowEvent.persisted;
+    }),
+    "BFCache not supported",
+  );
+
+  // After restore, wait for the load event to eventually fire.
+  // This is in underspeced territory. Load event do not fire for BFCache restore
+  // but as this test proves, it never fires, its completely dropped (unless browser is passing)
+  await rc1.executeScript(() => {
+    return new Promise((resolve) => {
+      if (window.loadFired) {
+        resolve();
+      } else {
+        window.addEventListener("load", resolve);
+      }
+    });
+  });
+  assert_equals(
+    await rc1.executeScript(() => window.loadFired),
+    true,
+    "load event should have fired after BFCache restore",
+  );
+}, "Static page with in-flight image can be BFCached");

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/resources/bfcache-static-page.html
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/resources/bfcache-static-page.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head><title>Static page with in-flight image</title></head>
+<body>
+<img src="/html/browsers/browsing-the-web/remote-context-helper-tests/resources/slow-image.py?delay=10">
+<script>
+window.addEventListener('pageshow', (event) => {
+  window.pageshowEvent = event;
+});
+
+window.addEventListener('load', () => {
+  window.loadFired = true;
+});
+</script>
+</body>
+</html>

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/resources/simple-static-page.html
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/resources/simple-static-page.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Simple static page</title></head>
+<body>
+<p>Hello from a static page</p>
+</body>
+</html>

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/resources/slow-image.py
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/resources/slow-image.py
@@ -1,0 +1,29 @@
+import struct
+import time
+import zlib
+
+def make_png(width=1, height=1):
+    def chunk(ctype, data):
+        c = ctype + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+    raw = b"\x00\xff\x00\x00"
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+IMAGE_PNG = make_png()
+
+def main(request, response):
+    delay = float(request.GET.first(b"delay", 3)) / 1000
+
+    response.headers.set(b"Content-Type", b"image/png")
+    response.headers.set(b"Content-Length", str(len(IMAGE_PNG)))
+    response.headers.set(b"Cache-Control", b"no-store")
+    response.write_status_headers()
+    # Simulate a slow connection. Useful when we want an <img> to cause
+    # load event to be fired when we want to.
+    time.sleep(delay)
+    response.writer.write_content(IMAGE_PNG)

--- a/html/browsers/browsing-the-web/remote-context-helper/resources/executor-window.py
+++ b/html/browsers/browsing-the-web/remote-context-helper/resources/executor-window.py
@@ -1,6 +1,46 @@
 import html
 import json
+import os
 from urllib import parse
+
+EXECUTOR_SCRIPTS = """\
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/html/browsers/browsing-the-web/remote-context-helper/resources/executor-common.js"></script>
+<script src="/html/browsers/browsing-the-web/remote-context-helper/resources/executor-window.js"></script>
+"""
+
+class PreProcessingError(Exception):
+  def __init__(self, status, body):
+    self.response = (status, [], body)
+
+def read_static_page(query, request):
+  page = query.get("page", [None])[0]
+  if not page:
+    return None
+
+  if ".." in page or page.startswith("/"):
+    page = page.lstrip("/")
+
+  if ".." in page:
+    raise PreProcessingError(400, "Invalid 'page' parameter")
+
+  file_path = os.path.join(request.doc_root, page)
+  if not os.path.isfile(file_path):
+    raise PreProcessingError(404, f"Page not found: {page}")
+
+  with open(file_path, "r") as f:
+    return f.read()
+
+def stamp_executor_block(scripts_s, initRequestHeaders, uuid, start_on_s):
+  return f"""\
+{EXECUTOR_SCRIPTS}
+{scripts_s}
+<script>
+window.__requestHeaders = new Headers();
+{initRequestHeaders}
+requestExecutor("{uuid}", {start_on_s});
+</script>
+"""
 
 def main(request, response):
   initRequestHeaders = ""
@@ -14,6 +54,12 @@ def main(request, response):
       else:
             status = 200
   query = parse.parse_qs(request.url_parts.query)
+
+  try:
+    page_content = read_static_page(query, request)
+  except PreProcessingError as e:
+    return e.response
+
   scripts = []
   for script in query.get("script", []):
     scripts.append(f"<script src='{html.escape(script)}'></script>")
@@ -26,20 +72,22 @@ def main(request, response):
 
   headers = [("Content-Type", "text/html")]
 
-  # This sets a base href so that even if this content e.g. data or blob URLs
-  # document, relative URLs will resolve.
-  return (status, headers, f"""
-<!DOCTYPE HTML>
-<base href="{html.escape(request.url)}">
-<script src="/common/dispatcher/dispatcher.js"></script>
-<script src="./executor-common.js"></script>
-<script src="./executor-window.js"></script>
+  if page_content is not None:
+    executor_block = stamp_executor_block(scripts_s, initRequestHeaders, uuid, start_on_s)
+    lower = page_content.lower()
+    body_open = lower.find("<body>")
+    if body_open != -1:
+      insert_pos = body_open + len("<body>")
+      combined = page_content[:insert_pos] + executor_block + page_content[insert_pos:]
+    else:
+      combined = executor_block + page_content
 
-{scripts_s}
-<body>
-<script>
-window.__requestHeaders = new Headers();
-{initRequestHeaders}
-requestExecutor("{uuid}", {start_on_s});
-</script>
+    return (status, headers, combined)
+
+  # Dynamic page mode: generate a minimal executor page.
+  # Base href ensures relative URLs resolve even for data/blob URL documents.
+  executor_block = stamp_executor_block(scripts_s, initRequestHeaders, uuid, start_on_s)
+  return (status, headers, f"""<!DOCTYPE HTML>
+<base href="{html.escape(request.url)}">
+{executor_block}<body>
 """)

--- a/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+++ b/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
@@ -119,15 +119,19 @@
      *     document content will be written to the initial empty document using
      *     `document.open()`, `document.write()`, and `document.close()`. If not
      *     supplied, the default is 'origin'.
+     * @param {string} [options.page] If supplied, the executor will serve the
+     *     given static page (a path relative to the WPT root, e.g.
+     *     '/common/blank.html') with executor scripts injected into it.
      */
     constructor(
-        {origin, scripts = [], headers = [], startOn, status, urlType} = {}) {
+        {origin, scripts = [], headers = [], startOn, status, urlType, page} = {}) {
       this.origin = origin;
       this.scripts = scripts;
       this.headers = headers;
       this.startOn = startOn;
       this.status = status;
       this.urlType = urlType;
+      this.page = page;
     }
 
     /**
@@ -168,10 +172,14 @@
       if (extraConfig.urlType) {
         urlType = extraConfig.urlType;
       }
+      let page = this.page;
+      if (extraConfig.page) {
+        page = extraConfig.page;
+      }
       const headers = this.headers.concat(extraConfig.headers);
       const scripts = this.scripts.concat(extraConfig.scripts);
       return new RemoteContextConfig(
-          {origin, headers, scripts, startOn, status, urlType});
+          {origin, headers, scripts, startOn, status, urlType, page});
     }
 
     /**
@@ -188,6 +196,10 @@
 
       // UUID is needed for executor.
       url.searchParams.append('uuid', uuid);
+
+      if (this.page && !isWorker) {
+        url.searchParams.append('page', this.page);
+      }
 
       if (this.headers) {
         addHeaders(url, this.headers);

--- a/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
+++ b/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
@@ -588,6 +588,22 @@
     }
 
     /**
+     * Navigates by inserting and clicking a link. Unlike location.href,
+     * a link click is treated as a push navigation even when the load
+     * event has not yet fired.
+     * @param {string|URL} url The URL to navigate to.
+     * @returns {Promise<undefined>}
+     */
+    clickTo(url) {
+      return this.navigate(url => {
+        const a = document.createElement('a');
+        a.href = url;
+        document.body.appendChild(a);
+        a.click();
+      }, [url.toString()]);
+    }
+
+    /**
      * Navigates the context to a new document running an executor.
      * @param {RemoteContextConfig} [extraConfig]
      * @returns {Promise<RemoteContextWrapper>} The remote context.


### PR DESCRIPTION
Closes #62559

Also introduces test for #62561 

The feature introduced here is a `page` field that gets passed to the python handler, that then reads that static html and injects the remote context executor block scripts and serves it.