### PR TITLE
Sanitizer: fix the javascript: URL tests and cover the default configuration

### DIFF
--- a/sanitizer-api/sanitizer-javascript-url.html
+++ b/sanitizer-api/sanitizer-javascript-url.html
@@ -213,10 +213,15 @@ for (const group of document.querySelectorAll("script[type='html5lib-testcases']
     }
 
     // 2. Unsafe methods with javascriptURLs: false -> URLs must be removed (same as safe result).
+    // The default configuration has javascriptURLs: false as well, but its element and attribute
+    // allow lists remove nearly all the markup above, so it cannot be compared against these
+    // expectations. It is covered separately below.
+    const afterRemoveUnsafe = new Sanitizer({});
+    afterRemoveUnsafe.removeUnsafe();
     const unsafeDisallowedConfigs = [
       ["{ sanitizer: { javascriptURLs: false } }", { sanitizer: { javascriptURLs: false } }],
       ["{ sanitizer: new Sanitizer({ javascriptURLs: false }) }", { sanitizer: new Sanitizer({ javascriptURLs: false }) }],
-      ["{ sanitizer: new Sanitizer() }", { sanitizer: new Sanitizer() }],
+      ["{ sanitizer: new Sanitizer({}) } after removeUnsafe()", { sanitizer: afterRemoveUnsafe }],
     ];
 
     for (const [name, config] of unsafeDisallowedConfigs) {
@@ -233,7 +238,68 @@ for (const group of document.querySelectorAll("script[type='html5lib-testcases']
   });
 }
 
-// 3. Unsafe methods with javascriptURLs: true -> URLs must be preserved.
+// 3. Unsafe methods with the default configuration -> URLs must be removed.
+//
+// The default configuration has javascriptURLs: false, so the unsafe methods remove javascript:
+// URLs as well. Its element and attribute allow lists remove nearly all the markup in the
+// testcases above though, so it cannot be run against those expectations. HTML a/href and SVG
+// a/href are the only pairs from the built-in navigating URL attributes list that the default
+// configuration keeps at all; for every other pair the attribute is gone either way and
+// javascriptURLs makes no observable difference.
+const defaultConfigTestcases = [
+  { selector: "a", markup: (url) => `<a href="${url}"></a>` },
+  { selector: "svg a", markup: (url) => `<svg><a href="${url}"></a></svg>` },
+];
+
+const javascriptURL = "javascript:alert(1)";
+const otherURL = "https://example.com/";
+
+function assert_href(root, selector, expected, description) {
+  const element = root.querySelector(selector);
+  assert_not_equals(element, null, `${description} (${selector} is kept)`);
+  assert_equals(element.getAttribute("href"), expected, description);
+}
+
+for (const { selector, markup } of defaultConfigTestcases) {
+  for (const [name, config] of [
+    [`{ sanitizer: "default" }`, { sanitizer: "default" }],
+    ["{ sanitizer: new Sanitizer() }", { sanitizer: new Sanitizer() }],
+  ]) {
+    test((_) => {
+      const div = document.createElement("div");
+      div.setHTMLUnsafe(markup(javascriptURL), config);
+      assert_href(div, selector, null, "javascript: URL is removed");
+
+      // href is allowed by the default configuration, so what removed it above is javascriptURLs
+      // and not the attribute allow list.
+      div.setHTMLUnsafe(markup(otherURL), config);
+      assert_href(div, selector, otherURL, "other URL is kept");
+    }, `setHTMLUnsafe ${name} default configuration, "${markup(javascriptURL)}"`);
+
+    test((_) => {
+      assert_href(Document.parseHTMLUnsafe("<body>" + markup(javascriptURL), config).body,
+                  selector, null, "javascript: URL is removed");
+      assert_href(Document.parseHTMLUnsafe("<body>" + markup(otherURL), config).body,
+                  selector, otherURL, "other URL is kept");
+    }, `parseHTMLUnsafe ${name} default configuration, "${markup(javascriptURL)}"`);
+  }
+
+  test((_) => {
+    const sanitizer = new Sanitizer();
+    assert_true(sanitizer.setJavascriptURLs(true), "javascriptURLs defaults to false");
+
+    const div = document.createElement("div");
+    div.setHTMLUnsafe(markup(javascriptURL), { sanitizer });
+    assert_href(div, selector, javascriptURL, "unsafe method keeps the URL");
+
+    const safeSanitizer = new Sanitizer();
+    safeSanitizer.setJavascriptURLs(true);
+    div.setHTML(markup(javascriptURL), { sanitizer: safeSanitizer });
+    assert_href(div, selector, null, "safe method removes the URL anyway");
+  }, `setJavascriptURLs(true) on the default configuration, "${markup(javascriptURL)}"`);
+}
+
+// 4. Unsafe methods with javascriptURLs: true -> URLs must be preserved.
 test(() => {
   const unsafeAllowedConfigs = [
     ["{ sanitizer: {} }", { sanitizer: {} }],
@@ -295,7 +361,7 @@ test(() => {
   }
 }, "javascript: URLs preserved in unsafe methods when javascriptURLs is true");
 
-// 4. Modifier method setJavascriptURLs() effects on sanitization
+// 5. Modifier method setJavascriptURLs() effects on sanitization
 test(() => {
   let s = new Sanitizer();
   s.setJavascriptURLs(true);
@@ -309,7 +375,7 @@ test(() => {
   assert_false(div2.querySelector("a").hasAttribute("href"));
 }, "sanitizer.setJavascriptURLs() controls URL preservation in setHTMLUnsafe");
 
-// 5. Template and ShadowRoot handling with javascriptURLs
+// 6. Template and ShadowRoot handling with javascriptURLs
 test(() => {
   const tplHTML = '<template><a href="javascript:alert(1)"></a></template>';
 

--- a/sanitizer-api/sanitizer-javascript-url.html
+++ b/sanitizer-api/sanitizer-javascript-url.html
@@ -336,6 +336,7 @@ test(() => {
   shadow.setHTML('<a href="javascript:alert(1)"></a>', { sanitizer: { javascriptURLs: true } });
   assert_false(shadow.querySelector("a").hasAttribute("href"));
 }, "Template and ShadowRoot handling with javascriptURLs");
+</script>
 </head>
 <body>
 </body>

--- a/sanitizer-api/sanitizer-javascript-url.html
+++ b/sanitizer-api/sanitizer-javascript-url.html
@@ -290,12 +290,10 @@ for (const { selector, markup } of defaultConfigTestcases) {
 
     const div = document.createElement("div");
     div.setHTMLUnsafe(markup(javascriptURL), { sanitizer });
-    assert_href(div, selector, javascriptURL, "unsafe method keeps the URL");
+    assert_href(div, selector, javascriptURL, "unsafe method keeps the javascript: URL");
 
-    const safeSanitizer = new Sanitizer();
-    safeSanitizer.setJavascriptURLs(true);
-    div.setHTML(markup(javascriptURL), { sanitizer: safeSanitizer });
-    assert_href(div, selector, null, "safe method removes the URL anyway");
+    div.setHTML(markup(javascriptURL), { sanitizer });
+    assert_href(div, selector, null, "safe method removes the javascript: URL anyway");
   }, `setJavascriptURLs(true) on the default configuration, "${markup(javascriptURL)}"`);
 }
 


### PR DESCRIPTION
Follow-up to #62421, addressing https://github.com/web-platform-tests/wpt/pull/62421#discussion_r2937019033.

**Restore the `</script>` end tag.** #62421 removed it, so the tokenizer reaches EOF in the script data state, which sets the script element's *already started* to true. None of the tests in the file were running.

**Stop running the shared html5lib expectations against `{ sanitizer: new Sanitizer() }`.** Those expectations assume a configuration that allows everything, as the comment #62421 replaced used to say. The default configuration's allow lists drop `area`, `button`, `form`, `input`, the SVG animation elements, `nothref`, `attributeName` and `xlink:href`, so 15 of the 30 testcases could not pass — for reasons that have nothing to do with `javascriptURLs`.

**Test the default configuration on its own terms instead.** HTML `a`/`href` and SVG `a`/`href` are the only pairs from the [built-in navigating URL attributes list](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#built-in-navigating-url-attributes-list) that the default configuration keeps at all, so for those, over `{ sanitizer: "default" }` and `{ sanitizer: new Sanitizer() }`, across `setHTMLUnsafe()` and `parseHTMLUnsafe()`:

* a `javascript:` URL is removed;
* a non-`javascript:` URL in the same attribute is kept, which is both the control and a guard against the test silently passing on an absent element;
* `setJavascriptURLs(true)` makes the unsafe methods keep the URL and the safe methods remove it anyway, which is what shows `javascriptURLs` is doing the work rather than the attribute allow list.

**Also cover `removeUnsafe()`.** A `Sanitizer` that has had `removeUnsafe()` called on it now runs against the shared expectations, since that is the case https://github.com/whatwg/html/pull/12898 was for and it was untested. It is compatible with those expectations: `removeUnsafe()` only touches the Unsafe-category elements, `frame`, SVG `script`/`use` and event handler content attributes, and none of the testcases involve any of those.

/cc @noamr @tannal @otherdaniel