### PR TITLE
Add style query tests for powerless color components (CSS Color 4 step 1)

### DIFF
--- a/css/css-conditional/container-queries/query-style-color-powerless.html
+++ b/css/css-conditional/container-queries/query-style-color-powerless.html
@@ -26,9 +26,12 @@
      step 4 can produce the result. c4 and c5 are reachable by step 1 or by the
      sRGB grouping, since hsl() and hwb() are considered to be in srgb.
 
-     c7 to c11 sit exactly on each space's epsilon, where the inclusive
-     comparison decides the answer. c8 is one step outside the lch() epsilon,
-     pinning it from the other side. */
+     c7 and c9 sit exactly on the lch() and oklch() epsilon, where the inclusive
+     comparison decides the answer, and c8 is one step outside the lch() epsilon,
+     pinning it from the other side. There are deliberately no epsilon-boundary
+     cases for hsl() and hwb(): those resolve to sRGB colors, and at the boundary
+     the residual hue leaves the two sRGB values exactly 1e-5 apart, which the
+     implementation-defined epsilon of step 2 may or may not treat as equal. */
 
   #c1 { --c: oklch(50% 0 40); }
   #c2 { --c: lch(50% 0.001 30); }
@@ -39,8 +42,6 @@
   #c7 { --c: lch(50% 0.0015 30); }
   #c8 { --c: lch(50% 0.0016 30); }
   #c9 { --c: oklch(50% 0.000004 40); }
-  #c10 { --c: hsl(0 0.001% 50%); }
-  #c11 { --c: hwb(30 59.999% 40%); }
 
   @container style(--c: oklch(50% 0 200)) { #t1 { color: green; } }
   @container style(--c: lch(50% 0.001 200)) { #t2 { color: green; } }
@@ -51,8 +52,6 @@
   @container style(--c: lch(50% 0.0015 200)) { #t7 { color: green; } }
   @container style(--c: lch(50% 0.0016 200)) { #t8 { color: green; } }
   @container style(--c: oklch(50% 0.000004 200)) { #t9 { color: green; } }
-  @container style(--c: hsl(200 0.001% 50%)) { #t10 { color: green; } }
-  @container style(--c: hwb(200 59.999% 40%)) { #t11 { color: green; } }
 </style>
 <div id="c1"><div id="t1"></div></div>
 <div id="c2"><div id="t2"></div></div>
@@ -63,8 +62,6 @@
 <div id="c7"><div id="t7"></div></div>
 <div id="c8"><div id="t8"></div></div>
 <div id="c9"><div id="t9"></div></div>
-<div id="c10"><div id="t10"></div></div>
-<div id="c11"><div id="t11"></div></div>
 <script>
   setup(() => assert_implements_style_container_queries());
 
@@ -106,12 +103,4 @@
   test(() => {
     assert_equals(getComputedStyle(t9).color, green);
   }, "oklch() hues are powerless when the chroma is exactly the epsilon of 0.000004");
-
-  test(() => {
-    assert_equals(getComputedStyle(t10).color, green);
-  }, "hsl() hues are powerless when the saturation is exactly the epsilon of 0.001");
-
-  test(() => {
-    assert_equals(getComputedStyle(t11).color, green);
-  }, "hwb() hues are powerless when whiteness and blackness sum to exactly 99.999");
 </script>

--- a/css/css-conditional/container-queries/query-style-color-powerless.html
+++ b/css/css-conditional/container-queries/query-style-color-powerless.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Container Queries Test: powerless components in registered color style queries</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#style-container">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#comparing-color-values">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#powerless-color-component">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  @property --c {
+    syntax: "<color>";
+    inherits: false;
+    initial-value: transparent;
+  }
+
+  /* Step 1 of CSS Color 4 § 12 converts powerless components to missing
+     components before anything is compared. A hue is powerless when the color
+     is achromatic, by the epsilon each color space defines for it, and § 4.4.1
+     makes that test inclusive: powerless when the colorfulness is less than or
+     equal to the epsilon. Two colors that differ only in a powerless hue are
+     therefore equivalent colors.
+
+     c1 and c2 isolate step 1: both colors of each pair are in the same
+     <color-space>, so neither the sRGB grouping nor the conversion to oklab in
+     step 4 can produce the result. c4 and c5 are reachable by step 1 or by the
+     sRGB grouping, since hsl() and hwb() are considered to be in srgb.
+
+     c7 to c11 sit exactly on each space's epsilon, where the inclusive
+     comparison decides the answer. c8 is one step outside the lch() epsilon,
+     pinning it from the other side. */
+
+  #c1 { --c: oklch(50% 0 40); }
+  #c2 { --c: lch(50% 0.001 30); }
+  #c3 { --c: lch(50% 0.002 30); }
+  #c4 { --c: hsl(0 0% 50%); }
+  #c5 { --c: hwb(30 60% 40%); }
+  #c6 { --c: oklch(50% 0.2 40); }
+  #c7 { --c: lch(50% 0.0015 30); }
+  #c8 { --c: lch(50% 0.0016 30); }
+  #c9 { --c: oklch(50% 0.000004 40); }
+  #c10 { --c: hsl(0 0.001% 50%); }
+  #c11 { --c: hwb(30 59.999% 40%); }
+
+  @container style(--c: oklch(50% 0 200)) { #t1 { color: green; } }
+  @container style(--c: lch(50% 0.001 200)) { #t2 { color: green; } }
+  @container style(--c: lch(50% 0.002 200)) { #t3 { color: green; } }
+  @container style(--c: hsl(200 0% 50%)) { #t4 { color: green; } }
+  @container style(--c: hwb(200 60% 40%)) { #t5 { color: green; } }
+  @container style(--c: oklch(50% 0.2 200)) { #t6 { color: green; } }
+  @container style(--c: lch(50% 0.0015 200)) { #t7 { color: green; } }
+  @container style(--c: lch(50% 0.0016 200)) { #t8 { color: green; } }
+  @container style(--c: oklch(50% 0.000004 200)) { #t9 { color: green; } }
+  @container style(--c: hsl(200 0.001% 50%)) { #t10 { color: green; } }
+  @container style(--c: hwb(200 59.999% 40%)) { #t11 { color: green; } }
+</style>
+<div id="c1"><div id="t1"></div></div>
+<div id="c2"><div id="t2"></div></div>
+<div id="c3"><div id="t3"></div></div>
+<div id="c4"><div id="t4"></div></div>
+<div id="c5"><div id="t5"></div></div>
+<div id="c6"><div id="t6"></div></div>
+<div id="c7"><div id="t7"></div></div>
+<div id="c8"><div id="t8"></div></div>
+<div id="c9"><div id="t9"></div></div>
+<div id="c10"><div id="t10"></div></div>
+<div id="c11"><div id="t11"></div></div>
+<script>
+  setup(() => assert_implements_style_container_queries());
+
+  const green = "rgb(0, 128, 0)";
+  const black = "rgb(0, 0, 0)";
+
+  test(() => {
+    assert_equals(getComputedStyle(t1).color, green);
+  }, "oklch() hues are powerless when the chroma is zero");
+
+  test(() => {
+    assert_equals(getComputedStyle(t2).color, green);
+  }, "lch() hues are powerless when the chroma is within the epsilon of 0.0015");
+
+  test(() => {
+    assert_equals(getComputedStyle(t3).color, black);
+  }, "lch() hues are not powerless when the chroma is above the epsilon of 0.0015");
+
+  test(() => {
+    assert_equals(getComputedStyle(t4).color, green);
+  }, "hsl() hues are powerless when the saturation is zero");
+
+  test(() => {
+    assert_equals(getComputedStyle(t5).color, green);
+  }, "hwb() hues are powerless when whiteness and blackness sum to 100");
+
+  test(() => {
+    assert_equals(getComputedStyle(t6).color, black);
+  }, "oklch() hues are not powerless when the chroma is large");
+
+  test(() => {
+    assert_equals(getComputedStyle(t7).color, green);
+  }, "lch() hues are powerless when the chroma is exactly the epsilon of 0.0015");
+
+  test(() => {
+    assert_equals(getComputedStyle(t8).color, black);
+  }, "lch() hues are not powerless when the chroma is just above the epsilon of 0.0015");
+
+  test(() => {
+    assert_equals(getComputedStyle(t9).color, green);
+  }, "oklch() hues are powerless when the chroma is exactly the epsilon of 0.000004");
+
+  test(() => {
+    assert_equals(getComputedStyle(t10).color, green);
+  }, "hsl() hues are powerless when the saturation is exactly the epsilon of 0.001");
+
+  test(() => {
+    assert_equals(getComputedStyle(t11).color, green);
+  }, "hwb() hues are powerless when whiteness and blackness sum to exactly 99.999");
+</script>


### PR DESCRIPTION
`style()` container queries on a custom property registered as `<color>` match when the two values are [equivalent colors](https://drafts.csswg.org/css-color-4/#comparing-color-values). Step 1 of that algorithm converts [powerless components](https://drafts.csswg.org/css-color-4/#powerless-color-component) to missing components before anything is compared, so two colors that differ only in a powerless hue are equivalent.

There is no existing coverage for this. `query-style-color.html` compares many spellings of `black` against each other, which exercises the sRGB grouping and the conversion to oklab in step 4, but every pair in it differs in notation. Nothing tests two colors in the **same** `<color-space>` whose hues differ but are powerless — which is precisely the case both engines currently get wrong.

### What the test covers

| container | queried | expected | why |
|---|---|---|---|
| `oklch(50% 0 40)` | `oklch(50% 0 200)` | match | chroma 0, hue powerless |
| `lch(50% 0.001 30)` | `lch(50% 0.001 200)` | match | chroma inside the ε of 0.0015 |
| `lch(50% 0.002 30)` | `lch(50% 0.002 200)` | **no match** | chroma above the ε — control |
| `hsl(0 0% 50%)` | `hsl(200 0% 50%)` | match | saturation 0, hue powerless |
| `hwb(30 60% 40%)` | `hwb(200 60% 40%)` | match | W + B = 100, hue powerless |
| `oklch(50% 0.2 40)` | `oklch(50% 0.2 200)` | **no match** | chromatic — control |
| `lch(50% 0.0015 30)` | `lch(50% 0.0015 200)` | match | chroma exactly the `lch()` ε |
| `lch(50% 0.0016 30)` | `lch(50% 0.0016 200)` | **no match** | one step above that ε — control |
| `oklch(50% 0.000004 40)` | `oklch(50% 0.000004 200)` | match | chroma exactly the `oklch()` ε |

The `oklch()` and `lch()` positive cases isolate step 1: both colors of each pair are in the same `<color-space>`, so neither the sRGB grouping nor step 4's conversion to oklab can produce the result. The `hsl()` and `hwb()` cases are reachable by step 1 or by the sRGB grouping, since those notations are considered to be in `srgb`.

The three negative controls keep the test from passing vacuously in an implementation that never matches anything, and the `lch()` pair at 0.0015 and 0.0016 pins that ε from both sides.

### The epsilon is inclusive

The `lch()` and `oklch()` boundary subtests sit exactly on those spaces' ε. That is well defined: § 4.4.1 says a hue is powerless when the colorfulness "is less than or equal to the epsilon (ε) specified for that color space", matching the per-space tables — `hsl()` S <= 0.001, `hwb()` W + B >= 99.999, `lch()` C <= 0.0015, `oklch()` C <= 0.000004. The prose previously read "is less than the epsilon", which contradicted the tables at exactly ε; that was fixed in https://github.com/w3c/csswg-drafts/commit/18434b34.

There are deliberately **no ε-boundary subtests for `hsl()` and `hwb()`**. Those notations resolve to sRGB colors, and at the boundary the residual hue leaves the two resolved sRGB values exactly 1e-5 apart — so whether they compare as equal depends on step 2's *implementation-defined* ε, which the spec does not pin down. `lch()` and `oklch()` do not have this problem: they keep their own color space, so their hues stay 170 degrees apart and only step 1 can make them equal.

### Current results

Measured on Edge 152 (Chromium) and Firefox Nightly 157: **3 pass, 6 fail** in each, agreeing on every subtest. The three that pass are the negative controls; every positive subtest fails. The failures are interoperable, so this is not a case of one engine lagging another: step 1 appears unimplemented in both.

Filed against implementations:

- Chromium: https://issues.chromium.org/issues/559142618
- Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2070595

### Related

- `query-style-color.html`, added for https://github.com/w3c/csswg-drafts/issues/13157
- CSS Color 4 [§ 12](https://drafts.csswg.org/css-color-4/#comparing-color-values), [§ 4.4.1](https://drafts.csswg.org/css-color-4/#powerless-color-component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
