### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323798

### DIFF
--- a/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html
+++ b/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html
@@ -10,4 +10,4 @@
   }
 </style>
 
-<img src="circle-with-parameters.svg#param(--color, green)">
+<img src="circle-with-parameters.svg#:~:param(--color,green)">

--- a/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html
+++ b/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html
@@ -8,7 +8,7 @@
   .image-with-params {
   width:100px;
   height:100px;
-  background-image: url("circle-with-parameters.svg#param(--color,red)" param(--color, green));
+  background-image: url("circle-with-parameters.svg#:~:param(--color,red)" param(--color, green));
   }
 </style>
 <div class="image-with-params"></div>

--- a/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html
+++ b/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html
@@ -4,4 +4,4 @@
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
 <link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
 <link rel="match" href="circle-green-ref.html"/>
-<img src="circle-with-parameters.svg#param(--color, green)">
+<img src="circle-with-parameters.svg#:~:param(--color,green)">

--- a/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html
+++ b/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html
@@ -4,4 +4,4 @@
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
 <link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
 <link rel="match" href="circle-green-with-stroke-ref.html"/>
-<img src="circle-with-parameters.svg#param(--color, green), param(--stroke, blue)">
+<img src="circle-with-parameters.svg#:~:param(--color,green)&amp;param(--stroke,blue)">


### PR DESCRIPTION
WebKit export from bug: [Update css-link-params URL fragment tests to the :~: fragment directive syntax](https://bugs.webkit.org/show_bug.cgi?id=323798)