### PR TITLE
[css-color] Add RGB rounding tests for `hsl()` and `hwb()`

### DIFF
--- a/css/css-color/parsing/color-valid-hsl.html
+++ b/css/css-color/parsing/color-valid-hsl.html
@@ -34,6 +34,11 @@ tests = [
     ["hsl(none 100% 50%)", "hsl(none 100 50)"],
     ["hsl(0 100% 50%)", "rgb(255, 0, 0)"],
 
+    // G = 42.5, this should be rounded UP to 43, not down to 42.
+    ["hsl(10 100% 50%)", "rgb(255, 43, 0)"],
+    ["hsl(0 0% 49.99999%)", "rgb(127, 127, 127)"],
+    ["hsl(0 0% 49.999999%)", "rgb(128, 128, 128)"],
+
     // Test with number components.
     ["hsl(120 30 50)", "rgb(89, 166, 89)"],
     ["hsl(120 30 50 / 0.5)", "rgba(89, 166, 89, 0.5)"],

--- a/css/css-color/parsing/color-valid-hwb.html
+++ b/css/css-color/parsing/color-valid-hwb.html
@@ -46,7 +46,10 @@ tests = [
     // Test that rounding happens properly. hwb(320deg 30% 40%) in sRGB has a blue
     // channel of exactly one-half.
     // 0.5 * 255 = 127.5. This value should be rounded UP to 128, not down to 127.
-    ["hwb(320deg 30% 40%)", "rgb(153, 77, 128)"],
+    ["hwb(320deg 30% 40%)", "rgb(153, 77, 128)"], // B = 127.5
+    ["hwb(0deg 10% 50%)", "rgb(128, 26, 26)"],    // R = 127.5
+    ["hwb(120deg 10% 50%)", "rgb(26, 128, 26)"],  // G = 127.5
+    ["hwb(0 20% 100%)", "rgb(43, 43, 43)"],
 
     // In  hsl(calc(-infinity) 0 0) or  hsl(calc(infinity) 0 0), the <hue> component is again normalized to 0 degrees.
     // See: https://drafts.csswg.org/css-color-4/#example-hue-normalization


### PR DESCRIPTION
Chrome originally added `hwb(320deg 30% 40%)` in [CL 4507865](https://chromium-review.googlesource.com/c/chromium/src/+/4507865) , but that implementation only covered the case where `B = 127.5`, so I extended the alignment.

Taking `hwb(120deg 10% 50%)` as an example, the computed values in each browser are as follows:
- Chrome 155: `rgb(26, 128, 26)`
- Firefox 151:    `rgb(26, 127, 26)`
- Safari: TP 251   `rgb(26, 127, 26)`
