### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323707

### DIFF
--- a/svg/types/scripted/SVGGraphicsElement.getBBox-06.html
+++ b/svg/types/scripted/SVGGraphicsElement.getBBox-06.html
@@ -22,19 +22,53 @@
     assert_equals(bbox.height, height, id + ".getBBox().height");
   }
 
-  // Per resolution (issue #1018): non-rendered elements return zero bbox
-  // instead of throwing InvalidStateError.
+  // coords.html #BoundingBoxes says a non-rendered element still has one:
+  //
+  //   "Even if an element is not in the rendering tree - due to it being
+  //   'display: none', within a 'defs' element, not usually rendered like a
+  //   'symbol' element or not currently present in the document tree - it
+  //   still has a bounding box. A call to getBBox on the element will return
+  //   the same rectangle as if the element were rendered. However, an element
+  //   that is not in the rendering tree does not contribute to the bounding
+  //   box of any ancestor element."
+  //
+  // TWO SEPARATE REQUIREMENTS, and each gets its own test below rather than
+  // being bundled with the other. Measured 2026-09-08: Chrome returns the
+  // container's box as {50,60,100,150}, the child's own rectangle, where the
+  // second sentence requires {0,0,0,0}. Firefox returns {0,0,0,0} for the
+  // child, where the first sentence requires {50,60,100,150}. A single test
+  // asserting both would go red in Chrome and in Firefox and say nothing
+  // about which sentence each one broke.
+  //
+  // svgwg issue #1018 is a SEPARATE rule again and does not reach these
+  // cases. It covers an element whose own geometric attributes are missing or
+  // invalid, and it landed in types.html as "If the element's geometric
+  // attributes are missing or have invalid values (e.g. negative width or
+  // height), such that the element is not rendered, then a SVGRect with x, y,
+  // width and height all set to 0 is returned." Every rect below has valid
+  // geometry, so that sentence does not apply to it.
 
   test(() => {
     assert_bbox("symbol1", 0, 0, 0, 0);
-    assert_bbox("symbol1_rect", 0, 0, 0, 0);
-  }, "Non-rendered symbol with rect returns zero bbox");
+  }, "symbol: the non-rendered container reports zero");
+
+  test(() => {
+    assert_bbox("symbol1_rect", 50, 60, 100, 150);
+  }, "symbol: the rect child reports the geometry it would have if rendered");
 
   test(() => {
     assert_bbox("g_none", 0, 0, 0, 0);
-    assert_bbox("g_none_rect", 0, 0, 0, 0);
-  }, "display:none <g> with rect returns zero bbox");
+  }, "display:none <g>: the non-rendered container reports zero");
 
+  test(() => {
+    assert_bbox("g_none_rect", 70, 80, 200, 250);
+  }, "display:none <g>: the rect child reports the geometry it would have if rendered");
+
+  // DELIBERATELY LEFT ASSERTING ZERO, and it contradicts the paragraph quoted
+  // above, which asks for {90, 100, 20, 25} here just as it does for the two
+  // children above. All three engines return zero, so this is a convergence
+  // against the prose rather than a single engine's bug, and which side should
+  // move is a question for the WG, not something to settle by editing a test.
   test(() => {
     assert_bbox("none_rect", 0, 0, 0, 0);
   }, "display:none <rect> returns zero bbox");

--- a/svg/types/scripted/SVGGraphicsElement.getBBox-07.html
+++ b/svg/types/scripted/SVGGraphicsElement.getBBox-07.html
@@ -254,9 +254,17 @@ test_bbox("use_zero_ref", 0, 0, 0, 0,
   "use element referencing zero-dimension rect returns zero bbox");
 
 // ========================================================================
-// F. Non-rendered elements — getBBox must NOT throw (issue #1018)
-// Per resolution: remove throwing for invalid getBBox(), return 0 values
-// for x, y, width, height instead of throwing InvalidStateError.
+// F. Non-rendered ANCESTRY: getBBox must not throw, and returns the
+// rectangle the element would have if it were rendered.
+//
+// coords.html #BoundingBoxes: "Even if an element is not in the rendering
+// tree [...] it still has a bounding box. A call to getBBox on the element
+// will return the same rectangle as if the element were rendered."
+//
+// svgwg issue #1018 is a different rule and does not reach these cases. It
+// covers an element whose OWN geometric attributes are missing or invalid;
+// see none_neg_w further down for that case. Every element below has valid
+// geometry and is non-rendered only because of where it sits.
 // ========================================================================
 
 test(function() {
@@ -265,47 +273,47 @@ test(function() {
   // Must not throw an InvalidStateError.
   assert_not_equals(el, null, "element exists");
   bbox = el.getBBox();
-  assert_equals(bbox.x, 0, "x");
-  assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside defs does not throw and returns zero bbox");
+  assert_equals(bbox.x, 10, "x");
+  assert_equals(bbox.y, 20, "y");
+  assert_equals(bbox.width, 100, "width");
+  assert_equals(bbox.height, 50, "height");
+}, "getBBox on rect inside defs returns the rect it would have if rendered");
 
 test(function() {
   var el = document.getElementById("defs_circle");
   var bbox = el.getBBox();
-  assert_equals(bbox.x, 0, "x");
-  assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on circle inside defs does not throw and returns zero bbox");
+  assert_equals(bbox.x, 25, "x");
+  assert_equals(bbox.y, 25, "y");
+  assert_equals(bbox.width, 50, "width");
+  assert_equals(bbox.height, 50, "height");
+}, "getBBox on circle inside defs returns the circle it would have if rendered");
 
 test(function() {
   var el = document.getElementById("defs_g_rect");
   var bbox = el.getBBox();
   assert_equals(bbox.x, 0, "x");
   assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside group inside defs does not throw and returns zero bbox");
+  assert_equals(bbox.width, 30, "width");
+  assert_equals(bbox.height, 30, "height");
+}, "getBBox on rect inside group inside defs returns the rect it would have if rendered");
 
 test(function() {
   var el = document.getElementById("clip_rect");
   var bbox = el.getBBox();
   assert_equals(bbox.x, 0, "x");
   assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside clipPath does not throw and returns zero bbox");
+  assert_equals(bbox.width, 80, "width");
+  assert_equals(bbox.height, 80, "height");
+}, "getBBox on rect inside clipPath returns the rect it would have if rendered");
 
 test(function() {
   var el = document.getElementById("mask_rect");
   var bbox = el.getBBox();
   assert_equals(bbox.x, 0, "x");
   assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside mask does not throw and returns zero bbox");
+  assert_equals(bbox.width, 60, "width");
+  assert_equals(bbox.height, 60, "height");
+}, "getBBox on rect inside mask returns the rect it would have if rendered");
 
 // Non-rendered element with invalid dimensions: should not throw,
 // should return zero bbox per resolution.


### PR DESCRIPTION
WebKit export from bug: [WPT getBBox tests wrongly expect a zero bbox for a non-rendered ancestor](https://bugs.webkit.org/show_bug.cgi?id=323707)