### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323871

### DIFF
--- a/css/selectors/attribute-selectors/attribute-case/cssom.html
+++ b/css/selectors/attribute-selectors/attribute-case/cssom.html
@@ -29,6 +29,9 @@ var tests = [
   ['[foo="bar" /**/ s]', '[foo="bar" s]'],
   ['[foo="bar"/**/s]', '[foo="bar" s]'],
   ['[*|foo="bar" s]', '[*|foo="bar" s]'],
+  ['[class~="bar"]', '[class~="bar"]'],
+  ['[class~="bar" i]', '[class~="bar" i]'],
+  ['[class~="bar" s]', '[class~="bar" s]'],
 ]
 
 tests.forEach(function(arr) {


### PR DESCRIPTION
WebKit export from bug: [Optimize attribute selector\[class~=foo\] like class selector](https://bugs.webkit.org/show_bug.cgi?id=323871)