### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=323934

### DIFF
--- a/css/css-text/animations/hyphen-no-interpolation.html
+++ b/css/css-text/animations/hyphen-no-interpolation.html
@@ -3,6 +3,7 @@
 <link rel=help href="https://github.com/w3c/csswg-drafts/issues/4441">
 <link rel=help href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-character">
 <link rel=help href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-chars">
+<link rel=help href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
 <link rel=help href="https://drafts.csswg.org/css-text/#hyphens-property">
 <link rel=help href="https://drafts.csswg.org/css-transitions-2/#transition-property-property">
 <script src="/resources/testharness.js"></script>
@@ -21,6 +22,12 @@ test_no_interpolation({
   property: 'hyphenate-limit-chars',
   from: 'initial',
   to: '10'
+});
+
+test_no_interpolation({
+  property: 'hyphenate-limit-lines',
+  from: 'initial',
+  to: '4'
 });
 
 test_no_interpolation({

--- a/css/css-text/animations/hyphenate-limit-lines-interpolation.html
+++ b/css/css-text/animations/hyphenate-limit-lines-interpolation.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>hyphenate-limit-lines interpolation</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
+<meta name="assert" content="hyphenate-limit-lines supports animation as an integer between two integer values.">
+
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<style>
+.parent {
+  hyphenate-limit-lines: 30;
+}
+.target {
+  hyphenate-limit-lines: 10;
+}
+</style>
+
+<body></body>
+
+<script>
+test_interpolation({
+  property: 'hyphenate-limit-lines',
+  from: neutralKeyframe,
+  to: '20',
+}, [
+  {at: -0.5, expect: '5'},
+  {at: 0, expect: '10'},
+  {at: 0.3, expect: '13'},
+  {at: 0.7, expect: '17'},
+  {at: 1, expect: '20'},
+  {at: 1.5, expect: '25'},
+]);
+
+test_interpolation({
+  property: 'hyphenate-limit-lines',
+  from: 'inherit',
+  to: '20',
+}, [
+  {at: -0.5, expect: '35'},
+  {at: 0, expect: '30'},
+  {at: 0.3, expect: '27'},
+  {at: 0.7, expect: '23'},
+  {at: 1, expect: '20'},
+  {at: 1.5, expect: '15'},
+]);
+
+test_interpolation({
+  property: 'hyphenate-limit-lines',
+  from: 'unset',
+  to: '20',
+}, [
+  {at: -0.5, expect: '35'},
+  {at: 0, expect: '30'},
+  {at: 0.3, expect: '27'},
+  {at: 0.7, expect: '23'},
+  {at: 1, expect: '20'},
+  {at: 1.5, expect: '15'},
+]);
+
+test_interpolation({
+  property: 'hyphenate-limit-lines',
+  from: '10',
+  to: '0',
+}, [
+  {at: -0.5, expect: '15'},
+  {at: 0, expect: '10'},
+  {at: 0.3, expect: '7'},
+  {at: 0.7, expect: '3'},
+  {at: 1, expect: '0'},
+  // Only non-negative integers are valid.
+  {at: 1.5, expect: '0'},
+]);
+</script>

--- a/css/css-text/hyphens/hyphenate-limit-lines-001.html
+++ b/css/css-text/hyphens/hyphenate-limit-lines-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Text: 'hyphenate-limit-lines' limits the number of successive hyphenated lines</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
+<link rel="match" href="reference/hyphenate-limit-lines-001-ref.html">
+<meta name="assert" content="hyphenate-limit-lines caps the number of consecutive lines that may end with a hyphenation break; once the limit is reached, hyphenation is suspended until a line breaks without hyphenating.">
+<style>
+#container > div {
+  border: black solid 1px;
+  font-family: monospace;
+  font-size: 32px;
+  line-height: 1;
+  width: 6ch;
+  margin-bottom: 1em;
+  hyphens: auto;
+  hyphenate-character: '-';
+}
+</style>
+<body lang="en">
+  <div id="container">
+    <div style="hyphenate-limit-lines: no-limit">implementation</div>
+    <div style="hyphenate-limit-lines: 2">implementation</div>
+    <div style="hyphenate-limit-lines: 1">implementation</div>
+    <div style="hyphenate-limit-lines: 0">implementation</div>
+  </div>
+</body>

--- a/css/css-text/hyphens/hyphenate-limit-lines-dynamic-001.html
+++ b/css/css-text/hyphens/hyphenate-limit-lines-dynamic-001.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>CSS Text: changing 'hyphenate-limit-lines' triggers a layout</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
+<meta name="assert" content="Changing the computed value of hyphenate-limit-lines must invalidate layout so line breaking is recomputed with the new limit.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#target {
+  border: solid 1px;
+  font: 32px/1 monospace;
+  width: 6ch;
+  hyphens: auto;
+  hyphenate-limit-lines: 0;
+}
+</style>
+<body lang="en">
+<div id="target">implementation</div>
+<script>
+test(() => {
+  const target = document.getElementById("target");
+
+  // With hyphenation suspended from the first line, "implementation" cannot
+  // be hyphenated, so it renders as a single (overflowing) line.
+  const heightBefore = target.offsetHeight;
+
+  target.style.hyphenateLimitLines = "no-limit";
+
+  // With hyphenation now unrestricted, "implementation" wraps (with hyphens)
+  // across 3 lines, so the box must grow taller. If changing
+  // hyphenate-limit-lines failed to invalidate layout, offsetHeight would
+  // incorrectly still report the single-line height.
+  const heightAfter = target.offsetHeight;
+
+  assert_greater_than(heightAfter, heightBefore, "the element should now span 3 lines after style change");
+}, "Changing 'hyphenate-limit-lines' via CSSOM triggers a layout");
+</script>

--- a/css/css-text/hyphens/reference/hyphenate-limit-lines-001-ref.html
+++ b/css/css-text/hyphens/reference/hyphenate-limit-lines-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Text: 'hyphenate-limit-lines' limits the number of successive hyphenated lines</title>
+<style>
+#container > div {
+  border: black solid 1px;
+  font-family: monospace;
+  font-size: 32px;
+  line-height: 1;
+  width: 6ch;
+  margin-bottom: 1em;
+}
+</style>
+<body lang="en">
+  <div id="container">
+    <div>imple-<br>menta-<br>tion</div>
+    <div>imple-<br>menta-<br>tion</div>
+    <div>imple-<br>mentation</div>
+    <div>implementation</div>
+  </div>
+</body>

--- a/css/css-text/parsing/hyphenate-limit-lines-computed.html
+++ b/css/css-text/parsing/hyphenate-limit-lines-computed.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Text: hyphenate-limit-lines with computed values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<div id="target"></div>
+<script>
+test_computed_value("hyphenate-limit-lines", "no-limit");
+test_computed_value("hyphenate-limit-lines", "0");
+test_computed_value("hyphenate-limit-lines", "4");
+test_computed_value("hyphenate-limit-lines", "calc(2 + 2)", "4");
+test_computed_value("hyphenate-limit-lines", "calc(4.1)", "4");
+</script>

--- a/css/css-text/parsing/hyphenate-limit-lines-invalid.html
+++ b/css/css-text/parsing/hyphenate-limit-lines-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Text: parsing hyphenate-limit-lines with invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
+<meta name="assert" content="hyphenate-limit-lines supports only the grammar 'no-limit | <integer [0,∞]>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+test_invalid_value("hyphenate-limit-lines", "auto");
+test_invalid_value("hyphenate-limit-lines", "none");
+test_invalid_value("hyphenate-limit-lines", "-1");
+test_invalid_value("hyphenate-limit-lines", "1.2");
+test_invalid_value("hyphenate-limit-lines", "1px");
+test_invalid_value("hyphenate-limit-lines", "\"1\"");
+test_invalid_value("hyphenate-limit-lines", "no-limit 2");
+test_invalid_value("hyphenate-limit-lines", "1 2");
+</script>

--- a/css/css-text/parsing/hyphenate-limit-lines-valid.html
+++ b/css/css-text/parsing/hyphenate-limit-lines-valid.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Text: parsing hyphenate-limit-lines with valid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-lines">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+test_valid_value("hyphenate-limit-lines", "no-limit");
+test_valid_value("hyphenate-limit-lines", "0");
+test_valid_value("hyphenate-limit-lines", "4");
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[css-text\] Unprefix -webkit-hyphenate-limit-lines](https://bugs.webkit.org/show_bug.cgi?id=323934)