### PR TITLE
[wdspec] test `emulation.setScrollbarTypeOverride`

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/emulation.py
+++ b/tools/webdriver/webdriver/bidi/modules/emulation.py
@@ -143,3 +143,16 @@ class Emulation(BidiModule):
             "contexts": contexts,
             "userContexts": user_contexts,
         }
+
+    @command
+    def set_scrollbar_type_override(
+            self,
+            scrollbar_type: Nullable[Literal["classic", "overlay"]],
+            contexts: Maybe[List[str]] = UNDEFINED,
+            user_contexts: Maybe[List[str]] = UNDEFINED,
+    ) -> Mapping[str, Any]:
+        return {
+            "scrollbarType": scrollbar_type,
+            "contexts": contexts,
+            "userContexts": user_contexts,
+        }

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/__init__.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/__init__.py
@@ -1,0 +1,1 @@
+# Web Platform Tests for emulation.setScrollbarTypeOverride

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/conftest.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/conftest.py
@@ -1,0 +1,56 @@
+import pytest_asyncio
+
+from webdriver.bidi.modules.script import ContextTarget
+
+
+@pytest_asyncio.fixture
+async def get_scrollbar_width(bidi_session):
+    async def get_scrollbar_width(context):
+        context_id = context["context"] if isinstance(context, dict) else context
+        result = await bidi_session.script.call_function(
+            function_declaration="""() => {
+                const outer = document.createElement('div');
+                outer.style.visibility = 'hidden';
+                outer.style.width = '100px';
+                outer.style.height = '100px';
+                outer.style.overflow = 'scroll';
+                document.body.appendChild(outer);
+                const width = outer.offsetWidth - outer.clientWidth;
+                outer.parentNode.removeChild(outer);
+                return width;
+            }""",
+            target=ContextTarget(context_id),
+            await_promise=False,
+        )
+        return result["value"]
+
+    return get_scrollbar_width
+
+
+@pytest_asyncio.fixture
+async def default_scrollbar_width(top_context, get_scrollbar_width):
+    """Return the baseline scrollbar width in an unmodified context."""
+    return await get_scrollbar_width(top_context)
+
+
+@pytest_asyncio.fixture(
+    params=["default", "new"], ids=["Default user context", "Custom user context"]
+)
+async def target_user_context(request):
+    return request.param
+
+
+@pytest_asyncio.fixture
+async def affected_user_context(target_user_context, create_user_context):
+    """Returns either a new or default user context."""
+    if target_user_context == "default":
+        return "default"
+    return await create_user_context()
+
+
+@pytest_asyncio.fixture
+async def not_affected_user_context(target_user_context, create_user_context):
+    """Returns opposite to affected_user_context."""
+    if target_user_context == "new":
+        return "default"
+    return await create_user_context()

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/contexts.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/contexts.py
@@ -1,0 +1,158 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_contexts(
+    bidi_session, top_context, get_scrollbar_width, default_scrollbar_width
+):
+    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+
+    # Verify baseline state.
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width
+    assert await get_scrollbar_width(new_context) == default_scrollbar_width
+
+    # Apply override only to new_context.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context["context"]],
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(new_context) == 0
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width
+
+    # Create another context and verify isolation.
+    another_context = await bidi_session.browsing_context.create(type_hint="tab")
+    assert await get_scrollbar_width(another_context) == default_scrollbar_width
+
+    # Clear context-level override.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(new_context) == default_scrollbar_width
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width
+    assert await get_scrollbar_width(another_context) == default_scrollbar_width
+
+
+async def test_multiple_contexts(
+    bidi_session, top_context, get_scrollbar_width, default_scrollbar_width
+):
+    new_context_1 = await bidi_session.browsing_context.create(type_hint="tab")
+    new_context_2 = await bidi_session.browsing_context.create(type_hint="tab")
+
+    # Apply override to multiple contexts simultaneously.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context_1["context"], new_context_2["context"]],
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(new_context_1) == 0
+    assert await get_scrollbar_width(new_context_2) == 0
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width
+
+    # Clear override on both contexts.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context_1["context"], new_context_2["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(new_context_1) == default_scrollbar_width
+    assert await get_scrollbar_width(new_context_2) == default_scrollbar_width
+
+
+@pytest.mark.parametrize("domain", ["", "alt"], ids=["same_origin", "cross_origin"])
+async def test_nested_contexts(
+    bidi_session,
+    url,
+    create_iframe,
+    domain,
+    get_scrollbar_width,
+    default_scrollbar_width,
+):
+    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+
+    # Apply override to new_context.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context["context"]],
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(new_context) == 0
+
+    # Verify inheritance in child iframe.
+    iframe_id = await create_iframe(new_context, url("/", domain=domain))
+    assert await get_scrollbar_width(iframe_id) == 0
+
+    # Clear override on new_context and verify iframe falls back.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(new_context) == default_scrollbar_width
+    assert await get_scrollbar_width(iframe_id) == default_scrollbar_width
+
+
+async def test_overrides_user_contexts(
+    bidi_session, affected_user_context, get_scrollbar_width, default_scrollbar_width
+):
+    context_in_user_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=affected_user_context
+    )
+
+    # Set context-level and user-context-level overrides.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[context_in_user_context["context"]],
+        scrollbar_type="classic",
+    )
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[affected_user_context],
+        scrollbar_type="overlay",
+    )
+
+    # Context-level override takes precedence.
+    assert await get_scrollbar_width(context_in_user_context) > 0
+
+    # Clearing context-level setting falls back to user-context setting.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[context_in_user_context["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(context_in_user_context) == 0
+
+    # Clearing user-context setting reverts to default.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[affected_user_context],
+        scrollbar_type=None,
+    )
+    assert (
+        await get_scrollbar_width(context_in_user_context)
+        == default_scrollbar_width
+    )
+
+
+async def test_overrides_global(
+    bidi_session, get_scrollbar_width, default_scrollbar_width
+):
+    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+
+    # Set context-level and global-level overrides.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context["context"]],
+        scrollbar_type="classic",
+    )
+    await bidi_session.emulation.set_scrollbar_type_override(
+        scrollbar_type="overlay",
+    )
+
+    # Context-level override takes precedence over global.
+    assert await get_scrollbar_width(new_context) > 0
+
+    # Clearing context-level setting falls back to global setting.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[new_context["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(new_context) == 0
+
+    # Clearing global setting reverts to default.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(new_context) == default_scrollbar_width

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/global.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/global.py
@@ -1,0 +1,40 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_global(
+    bidi_session,
+    affected_user_context,
+    get_scrollbar_width,
+    default_scrollbar_width,
+):
+    affected_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=affected_user_context
+    )
+
+    # Verify baseline state.
+    assert (
+        await get_scrollbar_width(affected_context) == default_scrollbar_width
+    )
+
+    # Apply global override.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(affected_context) == 0
+
+    # Verify newly created context inherits global override.
+    another_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=affected_user_context
+    )
+    assert await get_scrollbar_width(another_context) == 0
+
+    # Clear global override.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        scrollbar_type=None,
+    )
+    assert (
+        await get_scrollbar_width(affected_context) == default_scrollbar_width
+    )
+    assert await get_scrollbar_width(another_context) == default_scrollbar_width

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/invalid.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/invalid.py
@@ -1,0 +1,131 @@
+import pytest
+
+import webdriver.bidi.error as error
+from tests.bidi import get_invalid_cases
+from webdriver.bidi.undefined import UNDEFINED
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("list"))
+async def test_params_contexts_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            contexts=value,
+        )
+
+
+async def test_params_contexts_empty_list(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            contexts=[],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("string"))
+async def test_params_contexts_entry_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            contexts=[value],
+        )
+
+
+async def test_params_contexts_entry_invalid_value(bidi_session):
+    with pytest.raises(error.NoSuchFrameException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            contexts=["_invalid_"],
+        )
+
+
+async def test_params_contexts_iframe(bidi_session, new_tab, get_test_page):
+    url = get_test_page(as_frame=True)
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url, wait="complete"
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"]
+    )
+    assert len(contexts) == 1
+    frames = contexts[0]["children"]
+    assert len(frames) == 1
+
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            contexts=[frames[0]["context"]],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("list"))
+async def test_params_user_contexts_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            user_contexts=value,
+        )
+
+
+async def test_params_user_contexts_empty_list(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            user_contexts=[],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("string"))
+async def test_params_user_contexts_entry_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            user_contexts=[value],
+        )
+
+
+async def test_params_user_contexts_entry_invalid_value(bidi_session):
+    with pytest.raises(error.NoSuchUserContextException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            user_contexts=["_invalid_"],
+        )
+
+
+async def test_params_contexts_and_user_contexts(bidi_session, top_context):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=None,
+            contexts=[top_context["context"]],
+            user_contexts=["default"],
+        )
+
+
+async def test_params_scrollbar_type_missing(bidi_session, top_context):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=UNDEFINED,
+            contexts=[top_context["context"]],
+        )
+
+
+@pytest.mark.parametrize("value", get_invalid_cases("string", nullable=True))
+async def test_params_scrollbar_type_invalid_type(
+    bidi_session, top_context, value
+):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type=value,
+            contexts=[top_context["context"]],
+        )
+
+
+async def test_params_scrollbar_type_invalid_value(bidi_session, top_context):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.emulation.set_scrollbar_type_override(
+            scrollbar_type="somestring",
+            contexts=[top_context["context"]],
+        )

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/scrollbar_type.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/scrollbar_type.py
@@ -1,0 +1,42 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_scrollbar_type_overlay(
+    bidi_session, top_context, get_scrollbar_width, default_scrollbar_width
+):
+    # Verify baseline state.
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width
+
+    # Apply overlay scrollbar type override.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[top_context["context"]],
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(top_context) == 0
+
+    # Reset override to verify fallback.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[top_context["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width
+
+
+async def test_scrollbar_type_classic(
+    bidi_session, top_context, get_scrollbar_width, default_scrollbar_width
+):
+    # Apply classic scrollbar type override.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[top_context["context"]],
+        scrollbar_type="classic",
+    )
+    assert await get_scrollbar_width(top_context) > 0
+
+    # Reset override to verify fallback.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        contexts=[top_context["context"]],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(top_context) == default_scrollbar_width

--- a/webdriver/tests/bidi/emulation/set_scrollbar_type_override/user_contexts.py
+++ b/webdriver/tests/bidi/emulation/set_scrollbar_type_override/user_contexts.py
@@ -1,0 +1,131 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_user_contexts(
+    bidi_session,
+    affected_user_context,
+    not_affected_user_context,
+    get_scrollbar_width,
+    default_scrollbar_width,
+):
+    affected_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=affected_user_context
+    )
+    not_affected_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=not_affected_user_context
+    )
+
+    # Verify baseline state.
+    assert await get_scrollbar_width(affected_context) == default_scrollbar_width
+    assert await get_scrollbar_width(not_affected_context) == default_scrollbar_width
+
+    # Apply override to affected_user_context.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[affected_user_context],
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(affected_context) == 0
+    assert await get_scrollbar_width(not_affected_context) == default_scrollbar_width
+
+    # Verify newly created context in affected_user_context inherits override.
+    another_affected_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=affected_user_context
+    )
+    another_not_affected_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=not_affected_user_context
+    )
+    assert await get_scrollbar_width(another_affected_context) == 0
+    assert (
+        await get_scrollbar_width(another_not_affected_context)
+        == default_scrollbar_width
+    )
+
+    # Clear user context override.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[affected_user_context],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(affected_context) == default_scrollbar_width
+    assert await get_scrollbar_width(not_affected_context) == default_scrollbar_width
+    assert (
+        await get_scrollbar_width(another_affected_context)
+        == default_scrollbar_width
+    )
+    assert (
+        await get_scrollbar_width(another_not_affected_context)
+        == default_scrollbar_width
+    )
+
+
+async def test_multiple_user_contexts(
+    bidi_session,
+    create_user_context,
+    get_scrollbar_width,
+    default_scrollbar_width,
+):
+    user_context_1 = await create_user_context()
+    user_context_2 = await create_user_context()
+
+    context_1 = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=user_context_1
+    )
+    context_2 = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=user_context_2
+    )
+
+    # Apply override to multiple user contexts.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[user_context_1, user_context_2],
+        scrollbar_type="overlay",
+    )
+    assert await get_scrollbar_width(context_1) == 0
+    assert await get_scrollbar_width(context_2) == 0
+
+    # Clear override on both user contexts.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[user_context_1, user_context_2],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(context_1) == default_scrollbar_width
+    assert await get_scrollbar_width(context_2) == default_scrollbar_width
+
+
+async def test_overrides_global(
+    bidi_session,
+    affected_user_context,
+    get_scrollbar_width,
+    default_scrollbar_width,
+):
+    context_in_user_context = await bidi_session.browsing_context.create(
+        type_hint="tab", user_context=affected_user_context
+    )
+
+    # Set user-context-level and global-level overrides.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[affected_user_context],
+        scrollbar_type="classic",
+    )
+    await bidi_session.emulation.set_scrollbar_type_override(
+        scrollbar_type="overlay",
+    )
+
+    # User-context-level override takes precedence over global.
+    assert await get_scrollbar_width(context_in_user_context) > 0
+
+    # Clearing user-context setting falls back to global setting.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        user_contexts=[affected_user_context],
+        scrollbar_type=None,
+    )
+    assert await get_scrollbar_width(context_in_user_context) == 0
+
+    # Clearing global setting reverts to default.
+    await bidi_session.emulation.set_scrollbar_type_override(
+        scrollbar_type=None,
+    )
+    assert (
+        await get_scrollbar_width(context_in_user_context)
+        == default_scrollbar_width
+    )


### PR DESCRIPTION
- Spec: https://w3c.github.io/webdriver-bidi/#commands-emulationsetscrollbartypeoverride
- Add `set_scrollbar_type_override` command to `wpt_tools` Emulation
  module.
- Add WPT tests for `emulation.setScrollbarTypeOverride` parameter
  values (`classic`, `overlay`).
- Add scoping tests covering browsing context, user context, and global
  isolation and precedence.
- Add invalid parameter and scope validation tests.