### PR TITLE
Add .well-known/email-verification endpoint

### DIFF
--- a/.well-known/email-verification
+++ b/.well-known/email-verification
@@ -1,0 +1,15 @@
+import json
+
+def main(request, response):
+  response.headers.set(b"Content-Type", b"application/json")
+  response.headers.set(b"Access-Control-Allow-Origin", b"*")
+
+  port = request.server.config.ports["https"][0]
+  hostname = request.url_parts.hostname
+  base_url = f"https://{hostname}:{port}"
+
+  return json.dumps({
+    "issuance_endpoint": f"{base_url}/fedcm/support/delegation-issuance.py",
+    "jwks_uri": f"{base_url}/fedcm/support/delegation-jwks.py",
+    "signing_alg_values_supported": ["EdDSA", "ES256", "RS256"]
+  })

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -970,6 +970,7 @@ class RoutesBuilder:
             ("GET", "/.well-known/web-app-origin-association", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
             ("*", "/.well-known/device-bound-sessions", handlers.PythonScriptHandler),
+            ("*", "/.well-known/email-verification", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)
         ]


### PR DESCRIPTION
Adds server routing and an endpoint handler for `/.well-known/email-verification` to support testing the Email Verification Protocol (EVP) / Email Verification Token (EVT) specification.

https://dickhardt.github.io/email-verification/draft-hardt-email-verification.html#section-3.3