### PR TITLE
Fetch: redirects after a CORS-preflight are followed

### DIFF
--- a/fetch/api/cors/cors-preflight-redirect.any.js
+++ b/fetch/api/cors/cors-preflight-redirect.any.js
@@ -21,7 +21,14 @@ function corsPreflightRedirect(desc, redirectUrl, redirectLocation, redirectStat
   promise_test(function(test) {
     return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
       assert_equals(resp.status, 200, "Clean stash response's status is 200");
-      return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
+      if (redirectPreflight) {
+        return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
+      }
+      return fetch(url + urlParameters, requestInit).then(function(resp) {
+        assert_equals(resp.status, 200, "Response's status is 200");
+        assert_equals(resp.headers.get("x-did-preflight"), "1",
+                      "Preflight request has been made for the redirect target");
+      });
     });
   }, desc);
 }
@@ -32,6 +39,6 @@ var locationUrl =  get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathnam
 for (var code of [301, 302, 303, 307, 308]) {
   /* preflight should not follow the redirection */
   corsPreflightRedirect("Redirection " + code + " on preflight failed", redirectUrl, locationUrl, code, true);
-  /* preflight is done before redirection: preflight force redirect to error */
-  corsPreflightRedirect("Redirection " + code + " after preflight failed", redirectUrl, locationUrl, code, false);
+  /* preflight is done before redirection: the redirection is followed and preflighted again */
+  corsPreflightRedirect("Redirection " + code + " after preflight succeeded", redirectUrl, locationUrl, code, false);
 }

--- a/fetch/api/cors/cors-preflight-redirect.any.js
+++ b/fetch/api/cors/cors-preflight-redirect.any.js
@@ -33,8 +33,8 @@ function corsPreflightRedirect(desc, redirectUrl, redirectLocation, redirectStat
   }, desc);
 }
 
-var redirectUrl = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
-var locationUrl =  get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+var redirectUrl = get_host_info().REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
+var locationUrl =  get_host_info().REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
 for (var code of [301, 302, 303, 307, 308]) {
   /* preflight should not follow the redirection */


### PR DESCRIPTION
Fetch removed the redirect mode "error" override for preflighted requests in whatwg/fetch#204, so a redirect after a successful CORS-preflight is followed and the new URL gets its own preflight. Redirecting the preflight itself is still a network error.

All three engines already implement this and carry failure expectations for the "after preflight failed" subtests.